### PR TITLE
Update PrintConfig.cpp

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2194,7 +2194,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Diameter of nozzle");
     def->sidetext = L("mm");
     def->mode = comAdvanced;
-    def->max = 1.0;
+    def->max = 1.8;
     def->set_default_value(new ConfigOptionFloats { 0.4 });
 
     def = this->add("host_type", coEnum);


### PR DESCRIPTION
#534 ; allow up to 1.8mm nozzle diameter (from 1.0 maximum originaly)