### PR TITLE
Sandwich wall mode can be optimized when perimeters are shared with multiple islands

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1195,7 +1195,8 @@ void PerimeterGenerator::process_arachne()
 
         bool is_outer_wall_first =
             this->config->wall_infill_order == WallInfillOrder::OuterInnerInfill ||
-            this->config->wall_infill_order == WallInfillOrder::InfillOuterInner;
+            this->config->wall_infill_order == WallInfillOrder::InfillOuterInner || 
+            this->config->wall_infill_order == WallInfillOrder::InnerOuterInnerInfill;
         if (is_outer_wall_first) {
             start_perimeter = 0;
             end_perimeter = int(perimeters.size());
@@ -1323,16 +1324,12 @@ void PerimeterGenerator::process_arachne()
         }
 
         
-        if (this->config->wall_infill_order == WallInfillOrder::InnerOuterInnerInfill)
-            if (ordered_extrusions.size() > 1) {
-                int last_outer = 0;
-                int outer      = 0;
-                for (; outer < ordered_extrusions.size(); ++outer)
-                    if (ordered_extrusions[outer].extrusion->inset_idx == 0 && outer - last_outer > 1) {
-                        std::swap(ordered_extrusions[outer], ordered_extrusions[outer - 1]);
-                        last_outer = outer;
-                    }
+        if (this->config->wall_infill_order == WallInfillOrder::InnerOuterInnerInfill){
+            if (ordered_extrusions.size() > 2) {
+                    std::swap(ordered_extrusions[0], ordered_extrusions[2]);
+                    std::swap(ordered_extrusions[1], ordered_extrusions[2]);
             }
+        }
 
         
         if (ExtrusionEntityCollection extrusion_coll = traverse_extrusions(*this, ordered_extrusions); !extrusion_coll.empty())


### PR DESCRIPTION
PR containing the change in approach to handling sandwich mode when using Arachne engine. 

In a nutshell instead of treating the perimeters as inside to outside and re-ordering the last extrusion it flips it to treat them as outside to inside and swaps the order of printing the third wall with the outer perimeter so the order is internal, external, internal.

This means that when less than 3 extrusions exist the wall is treated as outside to inside, leading to a better surface finish as there is no variation due to printing an external perimeter with and without an adjoining internal perimeter.

Pictures of the surface finish difference below:

Left benchy with current approach. Right benchy with the PR implemented. The red lines show the extra "squish" caused by the external wall being printed after the neighbouring internal wall.
![2](https://user-images.githubusercontent.com/59056762/231993570-c70d4d02-5278-43d1-bf08-361b38549bca.jpeg)


![1 (1)](https://user-images.githubusercontent.com/59056762/231993564-e3d4cc72-fafa-4fb8-bb86-07f304a5ba6a.jpeg)

For more information refer to issue #745 

Further topological optimisation can be performed by reviewing the Arachne Arachne::WallToolPaths::getRegionOrder function to implement this wall sort at the source of the engine to catch scenarios where two regions have shared internal walls that could be resequenced to print first instead of falling back to external perimeter first. However my slic3r codebase knowledge is limited to perform that change.
