### PR TITLE
Add a new placehoder `is_extruder_used` for IDEX printers

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1725,6 +1725,12 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     m_placeholder_parser.set("has_wipe_tower", has_wipe_tower);
     //m_placeholder_parser.set("has_single_extruder_multi_material_priming", has_wipe_tower && print.config().single_extruder_multi_material_priming);
     m_placeholder_parser.set("total_toolchanges", std::max(0, print.wipe_tower_data().number_of_toolchanges)); // Check for negative toolchanges (single extruder mode) and set to 0 (no tool change).
+
+    std::vector<unsigned char> is_extruder_used(print.config().filament_diameter.size(), 0);
+    for (unsigned int extruder : tool_ordering.all_extruders())
+        is_extruder_used[extruder] = true;
+    m_placeholder_parser.set("is_extruder_used", new ConfigOptionBools(is_extruder_used));
+
     Vec2f plate_offset = m_writer.get_xy_offset();
     {
         BoundingBoxf bbox(print.config().printable_area.values);

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -511,8 +511,9 @@ void TextCtrl::BUILD() {
     m_combine_side_text = !m_opt.multiline;
     if (parent_is_custom_ctrl && m_opt.height < 0)
         opt_height = (double) text_ctrl->GetSize().GetHeight() / m_em_unit;
-    if (m_opt.is_code) // BBS
-        temp->SetFont(Slic3r::GUI::wxGetApp().normal_font());
+    temp->SetFont(m_opt.is_code ?
+                    Slic3r::GUI::wxGetApp().code_font() :
+                    Slic3r::GUI::wxGetApp().normal_font());
 
 	wxGetApp().UpdateDarkUI(temp);
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -542,7 +542,11 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
             m_print_enable = get_enable_print_status();
             m_print_btn->Enable(m_print_enable);
             if (m_print_enable) {
-                wxPostEvent(m_plater, SimpleEvent(EVT_GLTOOLBAR_PRINT_PLATE));
+                PresetBundle &preset_bundle = *wxGetApp().preset_bundle;
+                if (preset_bundle.printers.get_edited_preset().is_bbl_vendor_preset(&preset_bundle))
+                    wxPostEvent(m_plater, SimpleEvent(EVT_GLTOOLBAR_PRINT_PLATE));
+                else
+                    wxPostEvent(m_plater, SimpleEvent(EVT_GLTOOLBAR_SEND_GCODE));
             }
             evt.Skip();
             return;


### PR DESCRIPTION
for IDEX printers, It is necessary to check whether the extruder is used in the slice for preheating, nesting and other operations, like:
```
{if is_extruder_used[0]}M104 S{temperature[0]} T0 ;preheat T0{endif}
{if is_extruder_used[1]}M104 S{temperature[1]} T1 ;preheat T1{endif}
```