### PR TITLE
Fixed double-label for fan speed-up time, fixed label to include hyphen

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1784,7 +1784,8 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("fan_speedup_time", coFloat);
-    def->label = L("Fan Speedup Time");
+	// Label is set in Tab.cpp in the Line object.
+    //def->label = L("Fan speed-up time");
     def->tooltip = L("Start the fan this number of seconds earlier than its target start time (you can use fractional seconds)."
         " It assumes infinite acceleration for this time estimation, and will only take into account G1 and G0 moves (arc fitting"
         " is unsupported)."

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3096,7 +3096,7 @@ void TabPrinter::build_fff()
         optgroup->append_single_option_line("machine_unload_filament_time");
 
         optgroup = page->new_optgroup(L("Cooling Fan"));
-        Line line = Line{ L("Fan speedup time"), optgroup->get_option("fan_speedup_time").opt.tooltip };
+        Line line = Line{ L("Fan speed-up time"), optgroup->get_option("fan_speedup_time").opt.tooltip };
         line.append_option(optgroup->get_option("fan_speedup_time"));
         line.append_option(optgroup->get_option("fan_speedup_overhangs"));
         optgroup->append_line(line);


### PR DESCRIPTION
Minor change to correct double "Fan speedup time" label (now only included in the `Line` object), and add hyphen to "speed-up", which should be the correct spelling.