### PR TITLE
Fix build warnings, update deprecated boost headers

### DIFF
--- a/src/libslic3r/PlaceholderParser.cpp
+++ b/src/libslic3r/PlaceholderParser.cpp
@@ -40,11 +40,19 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/qi_lit.hpp>
+#if BOOST_VERSION >= 107800
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/fusion.hpp>
+#include <boost/phoenix/stl.hpp>
+#include <boost/phoenix/object.hpp>
+#else
 #include <boost/spirit/include/phoenix_core.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix_fusion.hpp>
 #include <boost/spirit/include/phoenix_stl.hpp>
 #include <boost/spirit/include/phoenix_object.hpp>
+#endif
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/spirit/repository/include/qi_distinct.hpp>
 #include <boost/spirit/repository/include/qi_iter_pos.hpp>

--- a/src/slic3r/GUI/3DBed.cpp
+++ b/src/slic3r/GUI/3DBed.cpp
@@ -18,7 +18,12 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/log/trivial.hpp>
+
+#if BOOST_VERSION >= 107800
+#include <boost/timer/timer.hpp>
+#else
 #include <boost/timer.hpp>
+#endif
 
 static const float GROUND_Z = -0.04f;
 static const std::array<float, 4> DEFAULT_MODEL_COLOR = { 0.3255f, 0.337f, 0.337f, 1.0f };

--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -3627,7 +3627,7 @@ int MachineObject::parse_json(std::string payload)
             if (j.contains("upgrade")) {
                 if (j["upgrade"].contains("command")) {
                     if (j["upgrade"]["command"].get<std::string>() == "upgrade_confirm") {
-                        this->upgrade_display_state == UpgradingInProgress;
+                        this->upgrade_display_state = (int)UpgradingDisplayState::UpgradingInProgress;
                         upgrade_display_hold_count = HOLD_COUNT_MAX;
                         BOOST_LOG_TRIVIAL(info) << "ack of upgrade_confirm";
                     }

--- a/src/slic3r/Utils/TCPConsole.cpp
+++ b/src/slic3r/Utils/TCPConsole.cpp
@@ -4,7 +4,7 @@
 #include <boost/asio/read_until.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/write.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/algorithm/string.hpp>
@@ -41,7 +41,7 @@ void TCPConsole::transmit_next_command()
     boost::asio::async_write(
         m_socket,
         boost::asio::buffer(m_send_buffer),
-        boost::bind(&TCPConsole::handle_write, this, _1, _2)
+        boost::bind(&TCPConsole::handle_write, this, boost::placeholders::_1, boost::placeholders::_2)
     );
 }
 
@@ -52,7 +52,7 @@ void TCPConsole::wait_next_line()
         m_socket,
         m_recv_buffer,
         m_newline,
-        boost::bind(&TCPConsole::handle_read, this, _1, _2)
+        boost::bind(&TCPConsole::handle_read, this, boost::placeholders::_1, boost::placeholders::_2)
     );
 }
 
@@ -157,7 +157,7 @@ bool TCPConsole::run_queue()
         auto endpoints = m_resolver.resolve(m_host_name, m_port_name);
 
         m_socket.async_connect(endpoints->endpoint(),
-            boost::bind(&TCPConsole::handle_connect, this, _1)
+            boost::bind(&TCPConsole::handle_connect, this, boost::placeholders::_1)
         );
 
         // Loop until we get any reasonable result. Negative result is also result.


### PR DESCRIPTION
Fixed some build warnings on deprecated boost headers, unified using correct boost/bind headers, and fixed logical error in `src/slic3r/GUI/DeviceManager.cpp`:

```
this->upgrade_display_state == UpgradingInProgress;
```

should actually be:

```
this->upgrade_display_state = (int)UpgradingDisplayState::UpgradingInProgress;
```
