### PR TITLE
Update fdm_filament_common.json

### DIFF
--- a/resources/profiles/Sovol/filament/fdm_filament_common.json
+++ b/resources/profiles/Sovol/filament/fdm_filament_common.json
@@ -61,7 +61,7 @@
         "nil"
     ],
     "filament_diameter": [
-        "2.85"
+        "1.75"
     ],
     "filament_max_volumetric_speed": [
         "0"


### PR DESCRIPTION
Set default filament diameter to 1.75mm for Sovol printers.