### PR TITLE
Bugfix for zero-width tree supports

### DIFF
--- a/src/libslic3r/TreeSupport.cpp
+++ b/src/libslic3r/TreeSupport.cpp
@@ -1378,6 +1378,10 @@ void TreeSupport::generate_toolpaths()
     coordf_t layer_height = object_config.layer_height.value;
     const size_t wall_count = object_config.tree_support_wall_count.value;
 
+    // Check if set to zero, use default if so.
+    if (support_extrusion_width <= 0.0)
+        support_extrusion_width = Flow::auto_extrusion_width(FlowRole::frSupportMaterial, (float)nozzle_diameter);
+
     // coconut: use same intensity settings as SupportMaterial.cpp
     auto m_support_material_interface_flow = support_material_interface_flow(m_object, float(m_slicing_params.layer_height));
     coordf_t interface_spacing = object_config.support_interface_spacing.value + m_support_material_interface_flow.spacing();


### PR DESCRIPTION
When support line width is set to 0 (automatic), tree supports do not automatically pull the default line width, leaving it at 0.

This causing an exception to be thrown and the application to crash.

This change fixes that.