### PR TITLE
Fix check multi filament valid

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -911,10 +911,30 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     if (extruders.empty())
         return { L("No extrusions under current settings.") };
 
-    if (extruders.size() > 1 && m_config.single_extruder_multi_material && m_config.print_sequence != PrintSequence::ByObject) {
-        auto ret = check_multi_filament_valid(*this);
-        if (!ret.string.empty())
-            return ret;
+    if (extruders.size() > 1 && m_config.print_sequence != PrintSequence::ByObject) {
+        if (m_config.single_extruder_multi_material) {
+            auto ret = check_multi_filament_valid(*this);
+            if (!ret.string.empty())
+                return ret;
+        }
+
+        if (warning) {
+            for (unsigned int extruder_a: extruders) {
+                const ConfigOptionInts* bed_temp_opt = m_config.option<ConfigOptionInts>(get_bed_temp_key(m_config.curr_bed_type));
+                const ConfigOptionInts* bed_temp_1st_opt = m_config.option<ConfigOptionInts>(get_bed_temp_1st_layer_key(m_config.curr_bed_type));
+                int bed_temp_a = bed_temp_opt->get_at(extruder_a);
+                int bed_temp_1st_a = bed_temp_1st_opt->get_at(extruder_a);
+                for (unsigned int extruder_b: extruders) {
+                    int bed_temp_b = bed_temp_opt->get_at(extruder_b);
+                    int bed_temp_1st_b = bed_temp_1st_opt->get_at(extruder_b);
+                    if (std::abs(bed_temp_a - bed_temp_b) > 15 || std::abs(bed_temp_1st_a - bed_temp_1st_b) > 15) {
+                        warning->string = L("Bed temperatures for the used filaments differ significantly.");
+                        goto DONE;
+                    }
+                }
+            }
+        DONE:;
+        }
     }
 
     if (m_config.print_sequence == PrintSequence::ByObject) {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -911,7 +911,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
     if (extruders.empty())
         return { L("No extrusions under current settings.") };
 
-    if (extruders.size() > 1 && m_config.print_sequence != PrintSequence::ByObject) {
+    if (extruders.size() > 1 && m_config.single_extruder_multi_material && m_config.print_sequence != PrintSequence::ByObject) {
         auto ret = check_multi_filament_valid(*this);
         if (!ret.string.empty())
             return ret;


### PR DESCRIPTION
In a multi-head printer, there is no need to check for temperature differneces in the filaments.
However, it is necessary to check if there is a significant difference in bed temperature. Following the prusaslicer, i have provided a warning message for this.