### PR TITLE
Fix overly persistent pressure advance pattern

### DIFF
--- a/src/libslic3r/Model.cpp
+++ b/src/libslic3r/Model.cpp
@@ -71,6 +71,7 @@ Model& Model::assign_copy(const Model &rhs)
     // BBS
     this->plates_custom_gcodes = rhs.plates_custom_gcodes;
     this->curr_plate_index = rhs.curr_plate_index;
+    this->calib_pa_pattern.reset();
 
     if (rhs.calib_pa_pattern) {
         this->calib_pa_pattern = std::make_unique<CalibPressureAdvancePattern>(
@@ -106,7 +107,8 @@ Model& Model::assign_copy(Model &&rhs)
     // BBS
     this->plates_custom_gcodes = std::move(rhs.plates_custom_gcodes);
     this->curr_plate_index = rhs.curr_plate_index;
-    this->calib_pa_pattern = std::move(rhs.calib_pa_pattern);
+    this->calib_pa_pattern.reset();
+    this->calib_pa_pattern.swap(rhs.calib_pa_pattern);
 
     //BBS: add auxiliary path logic
     // BBS: backup, all in one temp dir

--- a/src/libslic3r/calib.hpp
+++ b/src/libslic3r/calib.hpp
@@ -116,7 +116,7 @@ private:
     bool m_draw_numbers {true};
 };
 
-struct SuggestedCalibPressureAdvancePatternConfig {
+struct SuggestedConfigCalibPAPattern {
     const std::vector<std::pair<std::string, double>> float_pairs {
         {"initial_layer_print_height", 0.25},
         {"layer_height", 0.2},
@@ -130,8 +130,11 @@ struct SuggestedCalibPressureAdvancePatternConfig {
     };
 
     const std::vector<std::pair<std::string, int>> int_pairs {
+        {"skirt_loops", 0},
         {"wall_loops", 3}
     };
+
+    const std::pair<std::string, BrimType> brim_pair {"brim_type", BrimType::btNoBrim};
 };
 
 class CalibPressureAdvancePattern : public CalibPressureAdvance {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8144,14 +8144,14 @@ void Plater::_calib_pa_pattern(const Calib_Params& params)
     const DynamicPrintConfig& printer_config = wxGetApp().preset_bundle->printers.get_edited_preset().config;
     DynamicPrintConfig& print_config = wxGetApp().preset_bundle->prints.get_edited_preset().config;
 
-    for (const auto opt : SuggestedCalibPressureAdvancePatternConfig().float_pairs) {
+    for (const auto opt : SuggestedConfigCalibPAPattern().float_pairs) {
         print_config.set_key_value(
             opt.first,
             new ConfigOptionFloat(opt.second)
         );
     }
 
-    for (const auto opt : SuggestedCalibPressureAdvancePatternConfig().nozzle_ratio_pairs) {
+    for (const auto opt : SuggestedConfigCalibPAPattern().nozzle_ratio_pairs) {
         double nozzle_diameter = printer_config.option<ConfigOptionFloats>("nozzle_diameter")->get_at(0);
         print_config.set_key_value(
             opt.first,
@@ -8159,12 +8159,17 @@ void Plater::_calib_pa_pattern(const Calib_Params& params)
         );
     }
 
-    for (const auto opt : SuggestedCalibPressureAdvancePatternConfig().int_pairs) {
+    for (const auto opt : SuggestedConfigCalibPAPattern().int_pairs) {
         print_config.set_key_value(
             opt.first,
             new ConfigOptionInt(opt.second)
         );
     }
+
+    print_config.set_key_value(
+        SuggestedConfigCalibPAPattern().brim_pair.first,
+        new ConfigOptionEnum<BrimType>(SuggestedConfigCalibPAPattern().brim_pair.second)
+    );
 
     wxGetApp().get_tab(Preset::TYPE_PRINT)->update_dirty();
     wxGetApp().get_tab(Preset::TYPE_PRINT)->reload_config();

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -4144,6 +4144,7 @@ void Plater::priv::delete_all_objects_from_model()
     object_list_changed();
 
     //BBS
+    model.calib_pa_pattern.reset();
     model.plates_custom_gcodes.clear();
 }
 
@@ -4195,6 +4196,7 @@ void Plater::priv::reset(bool apply_presets_change)
         wxGetApp().load_current_presets(false, false);
 
     //BBS
+    model.calib_pa_pattern.reset();
     model.plates_custom_gcodes.clear();
 
     // BBS


### PR DESCRIPTION
As first reported by @FillPavS in #1547:

> I've found a bug. When I create a temperature test, a PA test is added to it
> [...]
> I found out that the error appears after some actions. Here's what you need to do to reproduce-
> 
>     1. Create a PA test and click the slice button.
> 
>     2. Without closing the program, create a new project and do not save anything.
> 
>     3. Create any test - temperature, flow, retract and others.
> 
> 
> Now the PA test will appear with them until you restart the program.

They reported that this happened on Windows 10. This bug doesn't appear on MacOS, though I was able to confirm that the `Model.calib_pa_pattern` was still hanging around in the background there, too.

This PR should fix the bug.
