### PR TITLE
[BUGFIX] Fix emitting Klipper SET_VELOCITY_LIMIT commands

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -176,11 +176,13 @@ std::string GCodeWriter::set_acceleration(unsigned int acceleration)
         // This is new MarlinFirmware with separated print/retraction/travel acceleration.
         // Use M204 P, we don't want to override travel acc by M204 S (which is deprecated anyway).
         gcode << "M204 P" << acceleration;
-    } else if (FLAVOR_IS(gcfKlipper) && this->config.accel_to_decel_enable) {
-        gcode << "SET_VELOCITY_LIMIT ACCEL=" << acceleration
-              << " ACCEL_TO_DECEL=" << acceleration * this->config.accel_to_decel_factor / 100;
-        if (GCodeWriter::full_gcode_comment)
-            gcode << " ; adjust ACCEL_TO_DECEL";
+    } else if (FLAVOR_IS(gcfKlipper)) {
+        gcode << "SET_VELOCITY_LIMIT ACCEL=" << acceleration;
+        if (this->config.accel_to_decel_enable) {
+            gcode << " ACCEL_TO_DECEL=" << acceleration * this->config.accel_to_decel_factor / 100;
+            if (GCodeWriter::full_gcode_comment)
+                gcode << " ; adjust ACCEL_TO_DECEL";
+        }
     } else
         gcode << "M204 S" << acceleration;
 


### PR DESCRIPTION
- Always emit the SET_VELOCITY_LIMIT ACCEL=<acceleration> command when the Klipper firmware flavor is selected
- Only append the ACCEL_TO_DECEL parameter if enabled in config

