### PR TITLE
Fix wxWidgets debugging macros

### DIFF
--- a/src/slic3r/GUI/Widgets/StateColor.cpp
+++ b/src/slic3r/GUI/Widgets/StateColor.cpp
@@ -53,7 +53,7 @@ inline wxColour darkModeColorFor2(wxColour const &color)
     if (!gDarkMode)
         return color;
     auto iter = gDarkColors.find(color);
-    wxFAIL(iter != gDarkColors.end());
+    wxASSERT(iter != gDarkColors.end());
     if (iter != gDarkColors.end()) return iter->second;
     return color;
 }
@@ -69,7 +69,7 @@ wxColour StateColor::lightModeColorFor(wxColour const &color)
 {
     static std::map<wxColour, wxColour> gLightColors = revert(gDarkColors);
     auto iter = gLightColors.find(color);
-    wxFAIL(iter != gLightColors.end());
+    wxASSERT(iter != gLightColors.end());
     if (iter != gLightColors.end()) return iter->second;
     return color;
 }


### PR DESCRIPTION
wxFAIL will always generate an assert error and does not expect a condition.