### PR TITLE
Add P1S to config.json, copied from BambuStudio.  

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -26,7 +26,33 @@
             "ftp_folder" : "sdcard/",
             "printer_thumbnail_image": "printer_thumbnail_p1p"
         },
-	      {
+	{
+            "display_name": "Bambu Lab P1S",
+            "func": {
+              "FUNC_CHAMBER_TEMP": false,
+              "FUNC_FIRSTLAYER_INSPECT": false,
+              "FUNC_AI_MONITORING": true,
+              "FUNC_LIDAR_CALIBRATION": false,
+              "FUNC_BUILDPLATE_MARKER_DETECT": false,
+              "FUNC_FLOW_CALIBRATION": false,
+              "FUNC_MONITORING": false,
+              "FUNC_MEDIA_FILE": false,
+              "FUNC_VIRTUAL_CAMERA": false,
+              "FUNC_PRINT_WITHOUT_SD": false,
+              "FUNC_ALTER_RESOLUTION": false,
+              "FUNC_PRINT_ALL": false,
+              "FUNC_VIRTUAL_TYAY": true,
+              "FUNC_EXTRUSION_CALI": true
+            },
+            "camera_resolution": [ "720p" ],
+            "bed_temperature_limit": 100,
+            "model_id": "C12",
+            "compatible_machine":["BL-P001", "BL-P002", "C11"],
+            "printer_type": "C12",
+            "ftp_folder" : "sdcard/",
+            "printer_thumbnail_image": "printer_thumbnail_p1p"
+        },
+	{
             "display_name": "Bambu Lab X1",
             "func": {
                 "FUNC_VIRTUAL_TYAY" : true,


### PR DESCRIPTION
Added P1S to config.json, copied from BambuStudio (https://github.com/bambulab/BambuStudio/blob/master/resources/config.json).  

Fixes #1712, as the printer type can now be identified and the filament type select list is populated correctly.  

