### PR TITLE
Respect retraction length when using firmware retraction

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -600,6 +600,10 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
             gcode += gcodegen.writer().set_pressure_advance(gcodegen.config().pressure_advance.get_at(new_extruder_id));
         }
 
+        if (gcodegen.config().use_firmware_retraction.getBool()) {
+            gcode += gcodegen.writer().set_firmware_retraction(gcodegen.config().retraction_length.get_at(new_extruder_id));
+        }
+
         // A phony move to the end position at the wipe tower.
         gcodegen.writer().travel_to_xy((end_pos + plate_origin_2d).cast<double>());
         gcodegen.set_last_pos(wipe_tower_point_to_object_point(gcodegen, end_pos + plate_origin_2d));
@@ -4750,6 +4754,10 @@ std::string GCode::set_extruder(unsigned int extruder_id, double print_z)
             gcode += m_writer.set_pressure_advance(m_config.pressure_advance.get_at(extruder_id));
         }
 
+        if (m_config.use_firmware_retraction.getBool()) {
+            gcode += m_writer.set_firmware_retraction(m_config.retraction_length.get_at(extruder_id));
+        }
+
         gcode += m_writer.toolchange(extruder_id);
         return gcode;
     }
@@ -4931,6 +4939,10 @@ std::string GCode::set_extruder(unsigned int extruder_id, double print_z)
 
     if (m_config.enable_pressure_advance.get_at(extruder_id)) {
         gcode += m_writer.set_pressure_advance(m_config.pressure_advance.get_at(extruder_id));
+    }
+    
+    if (m_config.use_firmware_retraction.getBool()) {
+        gcode += m_writer.set_firmware_retraction(m_config.retraction_length.get_at(extruder_id));
     }
 
     return gcode;

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -241,6 +241,19 @@ std::string GCodeWriter::set_pressure_advance(double pa) const
 }
 
 
+std::string GCodeWriter::set_firmware_retraction(double retract_length) const
+{
+    std::ostringstream gcode;
+    if (retract_length < 0)
+        return gcode.str();
+    
+    if (FLAVOR_IS(gcfKlipper))
+        gcode << "SET_RETRACTION RETRACT_LENGTH" << std::setprecision(4) << retract_length << "; Override firmware retract length\n";
+    
+    return gcode.str()
+}
+
+
 
 std::string GCodeWriter::reset_e(bool force)
 {

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -47,6 +47,7 @@ public:
     std::string set_bed_temperature(int temperature, bool wait = false);
     std::string set_acceleration(unsigned int acceleration);
     std::string set_jerk_xy(double jerk);
+    std::string set_firmware_retraction(double retract_length) const;
     std::string set_pressure_advance(double pa) const;
     std::string reset_e(bool force = false);
     std::string update_progress(unsigned int num, unsigned int tot, bool allow_100 = false) const;


### PR DESCRIPTION
Currently doesn't respect any other values other than retraction length, TODO add this.

Fixes #1849 