### PR TITLE
Fix raft size when non-organic tree support is enabled

### DIFF
--- a/src/libslic3r/TreeSupport.cpp
+++ b/src/libslic3r/TreeSupport.cpp
@@ -1441,7 +1441,7 @@ void TreeSupport::generate_toolpaths()
             raft_areas.push_back(expoly);
     }
 
-    raft_areas = std::move(offset_ex(raft_areas, scale_(3.)));
+    raft_areas = std::move(offset_ex(raft_areas, scale_(object_config.raft_first_layer_expansion)));
 
     // generate raft tool path
     if (m_raft_layers > 0)

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -632,7 +632,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
 
     // Orca: Raft, grid, snug and organic supports use these two parameters to control the size & density of the "brim"/flange
     for (auto el : { "raft_first_layer_expansion", "raft_first_layer_density"})
-        toggle_field(el, have_support_material && !support_is_normal_tree);
+        toggle_field(el, have_support_material && !(support_is_normal_tree && !have_raft));
 
     bool has_ironing = (config->opt_enum<IroningType>("ironing_type") != IroningType::NoIroning);
     for (auto el : { "ironing_flow", "ironing_spacing", "ironing_speed" })


### PR DESCRIPTION
This fixes the raft width when normal tree support is enabled
![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/659b7f0f-eb3b-4c4d-bef4-49116d9d4382)
