### PR TITLE
Add option to enforce first layer min wall width

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1784,8 +1784,13 @@ void PerimeterGenerator::process_arachne()
             if (const auto& min_feature_size_opt = object_config->min_feature_size)
                 input_params.min_feature_size = min_feature_size_opt.value * 0.01 * min_nozzle_diameter;
 
-            if (const auto& min_bead_width_opt = object_config->min_bead_width)
-                input_params.min_bead_width = min_bead_width_opt.value * 0.01 * min_nozzle_diameter;
+            if (this->layer_id == 0) {
+                if (const auto& initial_layer_min_bead_width_opt = object_config->initial_layer_min_bead_width)
+                    input_params.min_bead_width = initial_layer_min_bead_width_opt.value * 0.01 * min_nozzle_diameter;
+            } else {
+                if (const auto& min_bead_width_opt = object_config->min_bead_width)
+				    input_params.min_bead_width = min_bead_width_opt.value * 0.01 * min_nozzle_diameter;
+            }
 
             if (const auto& wall_transition_filter_deviation_opt = object_config->wall_transition_filter_deviation)
                 input_params.wall_transition_filter_deviation = wall_transition_filter_deviation_opt.value * 0.01 * min_nozzle_diameter;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -765,7 +765,7 @@ static std::vector<std::string> s_Preset_print_options {
      "sparse_infill_acceleration", "internal_solid_infill_acceleration", "tree_support_adaptive_layer_height", "tree_support_auto_brim", 
      "tree_support_brim_width", "gcode_comments", "gcode_label_objects",
      "initial_layer_travel_speed", "exclude_object", "slow_down_layers", "infill_anchor", "infill_anchor_max",
-     "make_overhang_printable", "make_overhang_printable_angle", "make_overhang_printable_hole_size" ,"notes"
+     "make_overhang_printable", "make_overhang_printable_angle", "make_overhang_printable_hole_size" ,"notes" ,"initial_layer_min_bead_width"
 
 };
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3872,6 +3872,16 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->set_default_value(new ConfigOptionPercent(25));
 
+    def = this->add("initial_layer_min_bead_width", coPercent);
+    def->label = L("First layer minimum wall width");
+    def->category = L("Quality");
+    def->tooltip = L("The minimum wall width that should be used for the first layer is recommended to be set "
+                     "to the same size as the nozzle. This adjustment is expected to enhance adhesion.");
+    def->sidetext = L("%");
+    def->mode = comAdvanced;
+    def->min = 0;
+    def->set_default_value(new ConfigOptionPercent(85));
+
     def = this->add("min_bead_width", coPercent);
     def->label = L("Minimum wall width");
     def->category = L("Quality");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -721,6 +721,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,              wall_transition_angle))
     ((ConfigOptionInt,                wall_distribution_count))
     ((ConfigOptionPercent,            min_feature_size))
+    ((ConfigOptionPercent,            initial_layer_min_bead_width))
     ((ConfigOptionPercent,            min_bead_width))
 
     // Orca

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -672,7 +672,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
 
     bool have_arachne = config->opt_enum<PerimeterGeneratorType>("wall_generator") == PerimeterGeneratorType::Arachne;
     for (auto el : { "wall_transition_length", "wall_transition_filter_deviation", "wall_transition_angle",
-        "min_feature_size", "min_bead_width", "wall_distribution_count" })
+                    "min_feature_size", "min_bead_width", "wall_distribution_count", "initial_layer_min_bead_width"})
         toggle_line(el, have_arachne);
     toggle_field("detect_thin_wall", !have_arachne);
     

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1881,6 +1881,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("wall_transition_filter_deviation");
         optgroup->append_single_option_line("wall_transition_length");
         optgroup->append_single_option_line("wall_distribution_count");
+        optgroup->append_single_option_line("initial_layer_min_bead_width");
         optgroup->append_single_option_line("min_bead_width");
         optgroup->append_single_option_line("min_feature_size");
 


### PR DESCRIPTION
Regarding #1343, I trying to add the option to enforce min wall width to nozel size on first layer. It should be improve the adhesion in some cases.
Here is an example:
<img width="1100" alt="image" src="https://github.com/SoftFever/OrcaSlicer/assets/18913791/e0f177b0-c844-40a5-b25c-8ac7e16375fa">
It really hard for these tiny lines attach to bed if you print with infill first.
<img width="1240" alt="image" src="https://github.com/SoftFever/OrcaSlicer/assets/18913791/a1e5be4a-a2d1-4bee-b17e-0e1bdb7f3486">
After it's enabled, it's more like the classical wall generator.