### PR TITLE
Parallelise slicer build to take advantage of all CPU cores on OSX

### DIFF
--- a/build_release_macos.sh
+++ b/build_release_macos.sh
@@ -77,7 +77,7 @@ mkdir -p build_$ARCH
 cd build_$ARCH
 echo "building slicer..."
 cmake .. -GXcode -DBBL_RELEASE_TO_PUBLIC=1 -DCMAKE_PREFIX_PATH="$DEPS/usr/local" -DCMAKE_INSTALL_PREFIX="$PWD/OrcaSlicer" -DCMAKE_BUILD_TYPE=Release -DCMAKE_MACOSX_RPATH=ON -DCMAKE_INSTALL_RPATH="$DEPS/usr/local" -DCMAKE_MACOSX_BUNDLE=ON -DCMAKE_OSX_ARCHITECTURES=${ARCH}
-cmake --build . --config Release --target ALL_BUILD 
+cmake --build . --config Release --target ALL_BUILD -j$(sysctl hw.physicalcpu | awk '/^hw.physicalcpu: /{print $2}')
 mkdir -p OrcaSlicer
 cd OrcaSlicer
 rm -r ./OrcaSlicer.app


### PR DESCRIPTION
Parallelize slicer build to take advantage of all CPU cores. 

The current Mac cmake --build syntax is not taking advantage of multicore build. Updated the build command for the slicer to read the number of cores available from hw.physicalcpu and push to the cmake build command using the -j option.

I have tried doing the same with the dependency build but it fails when parallelising them - probably a dependency between build tasks somewhere is missing.