### PR TITLE
Fix GCode viewer first layer height in vase mode

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -3093,7 +3093,7 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line)
     }
 
     if (m_spiral_vase_active && !m_result.spiral_vase_layers.empty()) {
-        if (m_result.spiral_vase_layers.back().first == FLT_MAX && delta_pos[Z] > 0.0)
+        if (m_result.spiral_vase_layers.back().first == FLT_MAX && delta_pos[Z] >= 0.0)
             // replace layer height placeholder with correct value
             m_result.spiral_vase_layers.back().first = static_cast<float>(m_end_position[Z]);
         if (!m_result.moves.empty())


### PR DESCRIPTION
Cherrypicked from https://github.com/prusa3d/PrusaSlicer/commit/abbc99924ef27a3fe5c703c23bd15ec353848d5f

Before:
![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/646486b0-dae9-42a7-809e-0f64fa5c793f)

After:
![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/7920840c-6736-4eed-9a53-27f6d50c4c63)
