### PR TITLE
Fix compatibility with STL builds of wxWidgets

### DIFF
--- a/src/slic3r/GUI/ImageGrid.cpp
+++ b/src/slic3r/GUI/ImageGrid.cpp
@@ -623,11 +623,15 @@ void Slic3r::GUI::ImageGrid::renderContent1(wxDC &dc, wxPoint const &pt, int ind
         }
         // Draw buttons on hovered item
         wxRect rect{pt.x, pt.y + m_content_rect.GetBottom() - m_buttons_background.GetHeight(), m_content_rect.GetWidth(), m_buttons_background.GetHeight()};
+        wxArrayString texts;
         if (hit) {
-            renderButtons(dc, {_L("Delete"), (wxChar const *) secondAction, thirdAction.IsEmpty() ? nullptr : (wxChar const *) thirdAction, nullptr}, rect,
-                          m_hit_type == HIT_ACTION ? m_hit_item & 3 : -1, states);
+            texts.Add(_L("Delete"));
+            texts.Add(secondAction);
+            texts.Add(thirdAction);
+            renderButtons(dc, texts, rect, m_hit_type == HIT_ACTION ? m_hit_item & 3 : -1, states);
         } else if (!nonHoverText.IsEmpty()) {
-            renderButtons(dc, {(wxChar const *) nonHoverText, nullptr}, rect, -1, states);
+            texts.Add(nonHoverText);
+            renderButtons(dc, texts, rect, -1, states);
         }
     } else {
         dc.SetTextForeground(*wxWHITE); // time text color
@@ -673,7 +677,7 @@ void Slic3r::GUI::ImageGrid::renderContent2(wxDC &dc, wxPoint const &pt, int ind
     renderIconText(dc, m_model_weight_icon, file.Metadata("Weight", "0g"), rect);
 }
 
-void Slic3r::GUI::ImageGrid::renderButtons(wxDC &dc, wxStringList const &texts, wxRect const &rect2, size_t hit, int states)
+void Slic3r::GUI::ImageGrid::renderButtons(wxDC &dc, wxArrayString const &texts, wxRect const &rect2, size_t hit, int states)
 {
     // Draw background
     {

--- a/src/slic3r/GUI/ImageGrid.h
+++ b/src/slic3r/GUI/ImageGrid.h
@@ -9,6 +9,7 @@
 #define ImageGrid_h
 
 #include <wx/window.h>
+#include <wx/arrstr.h>
 #include <boost/shared_ptr.hpp>
 
 #include "Widgets/StateColor.hpp"
@@ -84,7 +85,7 @@ protected:
 
     void renderContent2(wxDC &dc, wxPoint const &pt, int index, bool hit);
 
-    void renderButtons(wxDC &dc, wxStringList const &texts, wxRect const &rect, size_t hit, int states);
+    void renderButtons(wxDC &dc, wxArrayString const &texts, wxRect const &rect, size_t hit, int states);
 
     void renderText(wxDC &dc, wxString const &text, wxRect const &rect, int states);
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9240,49 +9240,49 @@ wxBoxSizer *ProjectDropDialog::create_item_checkbox(wxString title, wxWindow *pa
 void ProjectDropDialog::select_radio(int index)
 {
     m_action                         = index;
-    RadioSelectorList::Node *node    = m_radio_group.GetFirst();
+    RadioSelectorList::compatibility_iterator it = m_radio_group.GetFirst();
     auto                     groupid = 0;
 
-    while (node) {
-        RadioSelector *rs = node->GetData();
+    while (it) {
+        RadioSelector *rs = it->GetData();
         if (rs->m_select_id == index) groupid = rs->m_groupid;
-        node = node->GetNext();
+        it = it->GetNext();
     }
 
-    node = m_radio_group.GetFirst();
-    while (node) {
-        RadioSelector *rs = node->GetData();
+    it = m_radio_group.GetFirst();
+    while (it) {
+        RadioSelector *rs = it->GetData();
         if (rs->m_groupid == groupid && rs->m_select_id == index) rs->m_radiobox->SetValue(true);
         if (rs->m_groupid == groupid && rs->m_select_id != index) rs->m_radiobox->SetValue(false);
-        node = node->GetNext();
+        it = it->GetNext();
     }
 }
 
 int ProjectDropDialog::get_select_radio(int groupid)
 {
-    RadioSelectorList::Node *node = m_radio_group.GetFirst();
-    while (node) {
-        RadioSelector *rs = node->GetData();
+    RadioSelectorList::compatibility_iterator it = m_radio_group.GetFirst();
+    while (it) {
+        RadioSelector *rs = it->GetData();
         if (rs->m_groupid == groupid && rs->m_radiobox->GetValue()) { return rs->m_select_id; }
-        node = node->GetNext();
+        it = it->GetNext();
     }
 
     return 0;
 }
 void ProjectDropDialog::on_select_radio(wxMouseEvent &event)
 {
-    RadioSelectorList::Node *node    = m_radio_group.GetFirst();
+    RadioSelectorList::compatibility_iterator it = m_radio_group.GetFirst();
     auto                     groupid = 0;
 
-    while (node) {
-        RadioSelector *rs = node->GetData();
+    while (it) {
+        RadioSelector *rs = it->GetData();
         if (rs->m_radiobox->GetId() == event.GetId()) groupid = rs->m_groupid;
-        node = node->GetNext();
+        it = it->GetNext();
     }
 
-    node = m_radio_group.GetFirst();
-    while (node) {
-        RadioSelector *rs = node->GetData();
+    it = m_radio_group.GetFirst();
+    while (it) {
+        RadioSelector *rs = it->GetData();
         if (rs->m_groupid == groupid && rs->m_radiobox->GetId() == event.GetId()) {
             set_action(rs->m_select_id);
             rs->m_radiobox->SetValue(true);
@@ -9290,7 +9290,7 @@ void ProjectDropDialog::on_select_radio(wxMouseEvent &event)
 
 
         if (rs->m_groupid == groupid && rs->m_radiobox->GetId() != event.GetId()) rs->m_radiobox->SetValue(false);
-        node = node->GetNext();
+        it = it->GetNext();
     }
 }
 

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1307,31 +1307,31 @@ wxWindow* PreferencesDialog::create_debug_page()
 
 void PreferencesDialog::on_select_radio(std::string param)
 {
-    RadioSelectorList::Node *node    = m_radio_group.GetFirst();
+    RadioSelectorList::compatibility_iterator it = m_radio_group.GetFirst();
     auto                     groupid = 0;
 
-    while (node) {
-        RadioSelector *rs = node->GetData();
+    while (it) {
+        RadioSelector *rs = it->GetData();
         if (rs->m_param_name == param) groupid = rs->m_groupid;
-        node = node->GetNext();
+        it = it->GetNext();
     }
 
-    node = m_radio_group.GetFirst();
-    while (node) {
-        RadioSelector *rs = node->GetData();
+    it = m_radio_group.GetFirst();
+    while (it) {
+        RadioSelector *rs = it->GetData();
         if (rs->m_groupid == groupid && rs->m_param_name == param) rs->m_radiobox->SetValue(true);
         if (rs->m_groupid == groupid && rs->m_param_name != param) rs->m_radiobox->SetValue(false);
-        node = node->GetNext();
+        it = it->GetNext();
     }
 }
 
 wxString PreferencesDialog::get_select_radio(int groupid)
 {
-    RadioSelectorList::Node *node = m_radio_group.GetFirst();
-    while (node) {
-        RadioSelector *rs = node->GetData();
+    RadioSelectorList::compatibility_iterator it = m_radio_group.GetFirst();
+    while (it) {
+        RadioSelector *rs = it->GetData();
         if (rs->m_groupid == groupid && rs->m_radiobox->GetValue()) { return rs->m_param_name; }
-        node = node->GetNext();
+        it = it->GetNext();
     }
 
     return wxEmptyString;
@@ -1339,21 +1339,21 @@ wxString PreferencesDialog::get_select_radio(int groupid)
 
 void PreferencesDialog::OnSelectRadio(wxMouseEvent &event)
 {
-    RadioSelectorList::Node *node    = m_radio_group.GetFirst();
+    RadioSelectorList::compatibility_iterator it = m_radio_group.GetFirst();
     auto                     groupid = 0;
 
-    while (node) {
-        RadioSelector *rs = node->GetData();
+    while (it) {
+        RadioSelector *rs = it->GetData();
         if (rs->m_radiobox->GetId() == event.GetId()) groupid = rs->m_groupid;
-        node = node->GetNext();
+        it = it->GetNext();
     }
 
-    node = m_radio_group.GetFirst();
-    while (node) {
-        RadioSelector *rs = node->GetData();
+    it = m_radio_group.GetFirst();
+    while (it) {
+        RadioSelector *rs = it->GetData();
         if (rs->m_groupid == groupid && rs->m_radiobox->GetId() == event.GetId()) rs->m_radiobox->SetValue(true);
         if (rs->m_groupid == groupid && rs->m_radiobox->GetId() != event.GetId()) rs->m_radiobox->SetValue(false);
-        node = node->GetNext();
+        it = it->GetNext();
     }
 }
 

--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -745,8 +745,8 @@ bool PrusaLink::get_storage(wxArrayString& storage_path, wxArrayString& storage_
                 const auto available = section.second.get_optional<bool>("available");
                 if (path && (!available || *available)) {
                     StorageInfo si;
-                    si.path = boost::nowide::widen(*path);
-                    si.name = name ? boost::nowide::widen(*name) : wxString();
+                    si.path = wxString(*path);
+                    si.name = name ? wxString(*name) : wxString();
                     // If read_only is missing, assume it is NOT read only.
                     // si.read_only = read_only ? *read_only : false; // version without "ro"
                     si.read_only = (read_only ? *read_only : (ro ? *ro : false));


### PR DESCRIPTION
This removes the dependency on legacy wxWidgets configurations, and makes OrcaSlicer compile on STL builds.

Also, the wxStringList class has been obsolete for at least 20 years, and disappeared from the documentation.
Replace with wxArrayString.