### PR TITLE
GUI: Fix calls to PrintingTaskPanel::show_profile_info

### DIFF
--- a/src/slic3r/GUI/CalibrationWizardCaliPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardCaliPage.cpp
@@ -349,7 +349,7 @@ void CalibrationCaliPage::update_subtask(MachineObject* obj)
         m_printing_panel->update_subtask_name(wxString::Format("%s", GUI::from_u8(obj->subtask_name)));
 
         if (obj->get_modeltask() && obj->get_modeltask()->design_id > 0) {
-            m_printing_panel->show_profile_info(wxString::FromUTF8(obj->get_modeltask()->profile_name));
+            m_printing_panel->show_profile_info(true, wxString::FromUTF8(obj->get_modeltask()->profile_name));
         }
         else {
             m_printing_panel->show_profile_info(false);

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -2626,7 +2626,7 @@ void StatusPanel::update_subtask(MachineObject *obj)
         m_project_task_panel->update_subtask_name(wxString::Format("%s", GUI::from_u8(obj->subtask_name)));
 
         if (obj->get_modeltask() && obj->get_modeltask()->design_id > 0) {
-            m_project_task_panel->show_profile_info(wxString::FromUTF8(obj->get_modeltask()->profile_name));
+            m_project_task_panel->show_profile_info(true, wxString::FromUTF8(obj->get_modeltask()->profile_name));
         }
         else {
             m_project_task_panel->show_profile_info(false);


### PR DESCRIPTION
These will not compile on STL builds of wxWidgets. I assume that on the non-STL variants, the first argument is cast to a boolean, which might be a bug…