### PR TITLE
GUI/Field: Fix crash in color picker init

### DIFF
--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -1539,6 +1539,8 @@ void ColourPicker::set_undef_value(wxColourPickerCtrl* field)
     field->SetColour(wxTransparentColour);
 
     wxButton* btn = dynamic_cast<wxButton*>(field->GetPickerCtrl());
+    if (!btn->GetBitmap().IsOk()) return;
+
     wxImage image(btn->GetBitmap().GetSize());
     image.InitAlpha();
     memset(image.GetAlpha(), 0, image.GetWidth() * image.GetHeight());


### PR DESCRIPTION
wxButton->GetBitmap() may return an invalid wxBitmap. Guard against this.