### PR TITLE
Fix filament diameter for Voxelab Aquila to match Creality Ender 3

### DIFF
--- a/resources/profiles/Voxelab/filament/fdm_filament_common.json
+++ b/resources/profiles/Voxelab/filament/fdm_filament_common.json
@@ -61,7 +61,7 @@
         "nil"
     ],
     "filament_diameter": [
-        "2.85"
+        "1.75"
     ],
     "filament_max_volumetric_speed": [
         "0"


### PR DESCRIPTION
The Aquila is an Ender 3 Clone should use the same filament diameter.  

https://github.com/SoftFever/OrcaSlicer/blob/ec90d7f3e4a534157706a263e847ad8ca924809b/resources/profiles/Creality/filament/fdm_filament_common.json#L64

This incorrect size causes cryptic under-extrusion errors for new users.