### PR TITLE
enable ironing on a modifier named "ironing_modifier"

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8529,6 +8529,12 @@ void Plater::calib_flowrate(int pass) {
         _obj->config.set_key_value("top_surface_pattern", new ConfigOptionEnum<InfillPattern>(ipMonotonic));
         _obj->config.set_key_value("infill_direction", new ConfigOptionFloat(45));
         _obj->config.set_key_value("ironing_type", new ConfigOptionEnum<IroningType>(IroningType::NoIroning));
+        for (auto _vol : _obj->volumes) {
+            if (_vol->name != "ironing_modifier")
+                _vol->config.set_key_value("ironing_type", new ConfigOptionEnum<IroningType>(IroningType::NoIroning));
+            else
+                _vol->config.set_key_value("ironing_type", new ConfigOptionEnum<IroningType>(IroningType::AllSolid));
+        }
         _obj->config.set_key_value("internal_solid_infill_speed", new ConfigOptionFloat(internal_solid_speed));
         _obj->config.set_key_value("top_surface_speed", new ConfigOptionFloat(top_surface_speed));
 


### PR DESCRIPTION
This allows for the replacement of the flow test project with ones similar to the one in SuperSlicer. More information on why this type of test is a good idea is outlined in issue #2256. I will also include a model I created while implementing this. It uses some of the original models from SuperSlicer and custom nameplates (so that the test can include the extra tests found in the original flow test file). This is not the final form, just a quick and dirty test.