### PR TITLE
Show estimated print time in the ruler

### DIFF
--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -768,7 +768,22 @@ void IMSlider::draw_tick_on_mouse_position(const ImRect& slideable_region) {
     ImGuiContext& context = *GImGui;
     
     int tick = get_tick_near_point(v_min, v_max, context.IO.MousePos, slideable_region);
-    printf("hover tick: %d\n", tick);
+
+    if (tick == v_min || tick == v_max) {
+        return;
+    }
+    
+    //draw tick
+    ImVec2 tick_offset   = ImVec2(22.0f, 14.0f) * m_scale;
+    float  tick_width    = 1.0f * m_scale;
+
+    const ImU32 tick_clr = IM_COL32(144, 144, 144, 255);
+
+    float tick_pos = get_pos_from_value(v_min, v_max, tick, slideable_region);
+    ImRect tick_left  = ImRect(slideable_region.GetCenter().x - tick_offset.x, tick_pos - tick_width, slideable_region.GetCenter().x - tick_offset.y, tick_pos);
+    ImRect tick_right = ImRect(slideable_region.GetCenter().x + tick_offset.y, tick_pos - tick_width, slideable_region.GetCenter().x + tick_offset.x, tick_pos);
+    ImGui::RenderFrame(tick_left.Min, tick_left.Max, tick_clr, false);
+    ImGui::RenderFrame(tick_right.Min, tick_right.Max, tick_clr, false);
 }
 
 bool IMSlider::vertical_slider(const char* str_id, int* higher_value, int* lower_value, std::string& higher_label, std::string& lower_label,int v_min, int v_max, const ImVec2& size, SelectedSlider& selection, bool one_layer_flag, float scale)

--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -6,6 +6,7 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 #endif
 #include <imgui/imgui_internal.h>
+#include <boost/algorithm/string/replace.hpp>
 
 namespace Slic3r {
 
@@ -769,9 +770,9 @@ void IMSlider::draw_tick_on_mouse_position(const ImRect& slideable_region) {
     
     int tick = get_tick_near_point(v_min, v_max, context.IO.MousePos, slideable_region);
 
-    if (tick == v_min || tick == v_max) {
-        return;
-    }
+//    if (tick == v_min || tick == v_max) {
+//        return;
+//    }
     
     //draw tick
     ImVec2 tick_offset   = ImVec2(22.0f, 14.0f) * m_scale;
@@ -784,6 +785,11 @@ void IMSlider::draw_tick_on_mouse_position(const ImRect& slideable_region) {
     ImRect tick_right = ImRect(slideable_region.GetCenter().x + tick_offset.y, tick_pos - tick_width, slideable_region.GetCenter().x + tick_offset.x, tick_pos);
     ImGui::RenderFrame(tick_left.Min, tick_left.Max, tick_clr, false);
     ImGui::RenderFrame(tick_right.Min, tick_right.Max, tick_clr, false);
+    
+    // draw layer time
+    std::string label = get_label(tick, ltEstimatedTime);
+    boost::ireplace_all(label, "\n", "");
+    show_tooltip(label);
 }
 
 bool IMSlider::vertical_slider(const char* str_id, int* higher_value, int* lower_value, std::string& higher_label, std::string& lower_label,int v_min, int v_max, const ImVec2& size, SelectedSlider& selection, bool one_layer_flag, float scale)

--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -663,10 +663,8 @@ void IMSlider::draw_ticks(const ImRect& slideable_region) {
             ImGui::RenderFrame(right_hover_box.Min, right_hover_box.Max, tick_hover_box_clr, false);
 
             show_tooltip(*tick_it);
-            if (context.IO.MouseClicked[0]) {
-                m_tick_value = tick_it->tick;
-                m_tick_rect = ImVec4(tick_hover_box.Min.x, tick_hover_box.Min.y, tick_hover_box.Max.x, tick_hover_box.Max.y);
-            }
+            m_tick_value = tick_it->tick;
+            m_tick_rect = ImVec4(tick_hover_box.Min.x, tick_hover_box.Min.y, tick_hover_box.Max.x, tick_hover_box.Max.y);
         }
         ++tick_it;
     }

--- a/src/slic3r/GUI/IMSlider.hpp
+++ b/src/slic3r/GUI/IMSlider.hpp
@@ -146,6 +146,7 @@ protected:
     void draw_background_and_groove(const ImRect& bg_rect, const ImRect& groove);
     void draw_colored_band(const ImRect& groove, const ImRect& slideable_region);
     void draw_ticks(const ImRect& slideable_region);
+    void draw_tick_on_mouse_position(const ImRect& slideable_region);
     void show_tooltip(const TickCode& tick); //menu
     void show_tooltip(const std::string tooltip); //menu
     bool vertical_slider(const char* str_id, int* higher_value, int* lower_value,
@@ -159,6 +160,7 @@ private:
     double get_double_value(const SelectedSlider& selection);
     int    get_tick_from_value(double value, bool force_lower_bound = false);
     float get_pos_from_value(int v_min, int v_max, int value, const ImRect& rect);
+    int    get_tick_near_point(int v_min, int v_max, const ImVec2& pt, const ImRect& rect);
 
     std::string get_color_for_tool_change_tick(std::set<TickCode>::const_iterator it) const;
     // Get active extruders for tick.


### PR DESCRIPTION
#2045

<img width="512" alt="image" src="https://github.com/SoftFever/OrcaSlicer/assets/1537155/4df8f9df-2e6d-4e10-9d6b-6f1fa746cddc">

This shows the estimated print time to the hovered layer.