### PR TITLE
Fix issue that the slice button is still disabled after a tick is deleted

### DIFF
--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -404,8 +404,9 @@ void IMSlider::add_code_as_tick(Type type, int selected_extruder)
 }
 
 void IMSlider::delete_tick(const TickCode& tick) {
+    Type t = tick.type; // Avoid Use-After-Free issue, which resets the tick.type to 0
     m_ticks.ticks.erase(tick);
-    post_ticks_changed_event(tick.type);
+    post_ticks_changed_event(t);
 }
 
 bool IMSlider::check_ticks_changed_event(Type type)


### PR DESCRIPTION
To reproduce:

1. Slice the model.
2. Add a pause in preview.
3. Slice again.
4. Then delete the pause.
5. Notice that the print button is disabled, but the slice button is not enabled.

This PR fixes this issue.
