### PR TITLE
Fix crash when switching between different infill patterns

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -913,21 +913,13 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "bottom_surface_pattern"
             || opt_key == "internal_solid_infill_pattern"
             || opt_key == "external_fill_link_max_length"
-            || opt_key == "sparse_infill_pattern"
             || opt_key == "infill_anchor"
             || opt_key == "infill_anchor_max"
             || opt_key == "top_surface_line_width"
             || opt_key == "initial_layer_line_width") {
             steps.emplace_back(posInfill);
         } else if (opt_key == "sparse_infill_pattern") {
-            steps.emplace_back(posInfill);
-            const auto *old_fill_pattern = old_config.option<ConfigOptionEnum<InfillPattern>>(opt_key);
-            const auto *new_fill_pattern = new_config.option<ConfigOptionEnum<InfillPattern>>(opt_key);
-            assert(old_fill_pattern && new_fill_pattern);
-            // We need to recalculate infill surfaces when infill_only_where_needed is enabled, and we are switching from
-            // the Lightning infill to another infill or vice versa.
-            if (PrintObject::infill_only_where_needed && (new_fill_pattern->value == ipLightning || old_fill_pattern->value == ipLightning))
-                steps.emplace_back(posPrepareInfill);
+            steps.emplace_back(posPrepareInfill);
         } else if (opt_key == "sparse_infill_density") {
             // One likely wants to reslice only when switching between zero infill to simulate boolean difference (subtracting volumes),
             // normal infill and 100% (solid) infill.


### PR DESCRIPTION
The error was introduced as part of the "Extend sparse infill" porting.

Reproduce:
1. Add a cube
2. Set infill pattern to cubic
3. Slice
4. Then change the pattern to adaptive cubic
5. Slice
6. Crash

This PR fixes this issue.

https://github.com/prusa3d/PrusaSlicer/commit/1a0d8f5130559aa57ca7f5a83da7e1e2e3629481#diff-3ec83cd4f72e61c92f69178305a0298e90e2d8b43a3d88ca2f8edccde4e02c7aL709-R736

Not sure why I missed this part during the initial port :P