### PR TITLE
Fix object's list text color on Linux (GH-2086)

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -91,6 +91,13 @@ ObjectList::ObjectList(wxWindow* parent) :
     wxDataViewCtrl(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxDV_MULTIPLE)
 {
     wxGetApp().UpdateDVCDarkUI(this, true);
+
+#ifdef __linux__
+    // Temporary fix for incorrect dark mode application regarding list item's text color.
+    // See: https://github.com/SoftFever/OrcaSlicer/issues/2086
+    this->SetForegroundColour(*wxBLACK);
+#endif
+
     SetFont(Label::sysFont(13));
 #ifdef __WXMSW__
     GenericGetHeader()->SetFont(Label::sysFont(13));


### PR DESCRIPTION
Partial solution for #2086 (do not close - this PR does not fully fix the issue, it just makes one place better)

This PR focuses on fixing the Object's list text rendering on linux-based OSes. As some people reported, for Linux users with Dark mode enabled, the Object's list renders its text in black-ish color, making it impossible to read. I'm not sure about that in general, but for me at least, switching temporarily to light mode also didn't fix the problem (comparing to other places where that trick does fix the problem, temporarily), as it was rendered all white.

The proposed fix for that is quite simple - for linux platforms, apply the base text color, which then seems to be handled by dark mode color changing as expected.

### Comparison

#### Before

![obraz](https://github.com/SoftFever/OrcaSlicer/assets/4425221/dae0b0ed-2259-4faa-aea9-bf1cb9092c32)
![obraz](https://github.com/SoftFever/OrcaSlicer/assets/4425221/c8e164bf-6752-4e59-8899-bda4470bdfd3)

#### After

![obraz](https://github.com/SoftFever/OrcaSlicer/assets/4425221/a2e000e9-1221-4eb1-89e4-b89c14ee5d91)
![obraz](https://github.com/SoftFever/OrcaSlicer/assets/4425221/c00cca6f-8258-4d4a-a751-f6a91c616471)
