### PR TITLE
Update OrcaSlicer_nl.po

### DIFF
--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -26,7 +26,7 @@ msgid "Ctrl + Mouse wheel"
 msgstr "Ctrl + muiswiel"
 
 msgid "Pen size"
-msgstr "Pen grootte"
+msgstr "Pengrootte"
 
 msgid "Left mouse button"
 msgstr "Linker muisknop"
@@ -41,7 +41,7 @@ msgid "Block supports"
 msgstr "Support blokkeren"
 
 msgid "Shift + Left mouse button"
-msgstr "Shit + linker muisknop"
+msgstr "Shift + linker muisknop"
 
 msgid "Erase"
 msgstr "Wissen"
@@ -77,7 +77,7 @@ msgid "Circle"
 msgstr "Cirkel"
 
 msgid "Sphere"
-msgstr "Gebied"
+msgstr "Bol"
 
 msgid "Fill"
 msgstr "Vullen"
@@ -3101,7 +3101,7 @@ msgid "Explosion Ratio"
 msgstr "Vergrotings ratio"
 
 msgid "Section View"
-msgstr "Sectieweergave"
+msgstr "Sectie weergave"
 
 msgid "Assemble Control"
 msgstr "Assemblage controle"


### PR DESCRIPTION
Fixes/Updates:

1. Shift typo fixed
2. "Pengrootte" is supposed to be one word.
3. "Gebied" doesn't sound right for a shape, "Bol" is better.
4. "Sectie weergave" is two words