### PR TITLE
Fix crash on BBL's calibration tab

### DIFF
--- a/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
@@ -1535,8 +1535,6 @@ void CalibrationPresetPage::set_cali_method(CalibrationMethod method)
                 m_custom_range_panel->set_titles(titles);
 
                 wxArrayString values;
-                Preset* printer_preset = get_printer_preset(curr_obj, get_nozzle_value());
-                int           extruder_type  = printer_preset->config.opt_enum("extruder_type", 0);
                 values.push_back(_L("0"));
                 values.push_back(_L("0.5"));
                 values.push_back(_L("0.005"));


### PR DESCRIPTION
Reproduce:

1. Connect to a BambuLab printer.
2. Switch to the calibration tab.
3. Crash

Orca does not have `extruder_type` field in printer profile.