### PR TITLE
Removed erroneous assert statements carried over from code merges

### DIFF
--- a/src/libslic3r/GCode/PressureEqualizer.cpp
+++ b/src/libslic3r/GCode/PressureEqualizer.cpp
@@ -154,8 +154,6 @@ void PressureEqualizer::process_layer(const std::string &gcode)
 
 long PressureEqualizer::advance_segment_beyond_small_gap(const long idx_orig)
 {
-    // this should only be run on the last extruding line before a gap
-    assert(m_gcode_lines[idx_cur_pos].extruding());
     double distance_traveled = 0.0;
     // start at beginning of gap, advance till extrusion found or gap too big
     for (auto idx_cur_pos = idx_orig + 1; idx_cur_pos < m_gcode_lines.size(); idx_cur_pos++) {

--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -141,9 +141,6 @@ static std::vector<std::pair<TreeSupportSettings, std::vector<size_t>>> group_me
 #ifndef NDEBUG
         const PrintObjectConfig &object_config = print_object.config();
 #endif // NDEBUG
-        // Support must be enabled and set to Tree style.
-        assert(object_config.support_material || object_config.support_material_enforce_layers > 0);
-        assert(object_config.support_material_style == smsTree || object_config.support_material_style == smsOrganic);
 
         bool found_existing_group = false;
         TreeSupportSettings next_settings{ TreeSupportMeshGroupSettings{ print_object }, print_object.slicing_parameters() };
@@ -3537,7 +3534,6 @@ static void generate_support_areas(Print &print, const BuildVolume &build_volume
                 draw_areas(*print.get_object(processing.second.front()), volumes, config, overhangs, move_bounds, 
                     bottom_contacts, top_contacts, intermediate_layers, layer_storage, throw_on_cancel);
             else {
-                assert(print_object.config().support_material_style == smsOrganic);
                 organic_draw_branches(
                     *print.get_object(processing.second.front()), volumes, config, move_bounds, 
                     bottom_contacts, top_contacts, interface_placer, intermediate_layers, layer_storage, 

--- a/src/libslic3r/Support/TreeSupportCommon.cpp
+++ b/src/libslic3r/Support/TreeSupportCommon.cpp
@@ -21,10 +21,6 @@ TreeSupportMeshGroupSettings::TreeSupportMeshGroupSettings(const PrintObject &pr
     const SlicingParameters &slicing_params     = print_object.slicing_parameters();
 //    const std::vector<unsigned int>  printing_extruders = print_object.object_extruders();
 
-    // Support must be enabled and set to Tree style.
-    assert(config.support_material || config.support_material_enforce_layers > 0);
-    assert(config.support_material_style == smsTree || config.support_material_style == smsOrganic);
-
     // Calculate maximum external perimeter width over all printing regions, taking into account the default layer height.
     coordf_t external_perimeter_width = 0.;
     for (size_t region_id = 0; region_id < print_object.num_printing_regions(); ++ region_id) {


### PR DESCRIPTION
Xcode build errors out with the below assert statements. 

Removing them as they have been incorrectly carried over from the organic tree support and pressure equalizer ports from Prusa slicer.