### PR TITLE
Updated tool tip and removed min print speed disabling when slowdown for layer cooling is de-selected

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2680,7 +2680,7 @@ def = this->add("filament_loading_speed", coFloats);
 
     def = this->add("slow_down_min_speed", coFloats);
     def->label = L("Min print speed");
-    def->tooltip = L("The minimum printing speed for the filament.");
+    def->tooltip = L("The minimum printing speed for the filament when slow down for better layer cooling is enabled, when printing overhangs and when feature speeds are not specified explicitly.");
     def->sidetext = L("mm/s");
     def->min = 0;
     def->mode = comAdvanced;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2680,7 +2680,7 @@ def = this->add("filament_loading_speed", coFloats);
 
     def = this->add("slow_down_min_speed", coFloats);
     def->label = L("Min print speed");
-    def->tooltip = L("The minimum printing speed when slow down for cooling");
+    def->tooltip = L("The minimum printing speed for the filament.");
     def->sidetext = L("mm/s");
     def->min = 0;
     def->mode = comAdvanced;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2988,9 +2988,6 @@ void TabFilament::toggle_options()
     }
 
     if (m_active_page->title() == L("Cooling")) {
-      bool cooling = m_config->opt_bool("slow_down_for_layer_cooling", 0);
-      toggle_option("slow_down_min_speed", cooling);
-
       bool has_enable_overhang_bridge_fan = m_config->opt_bool("enable_overhang_bridge_fan", 0);
       for (auto el : {"overhang_fan_speed", "overhang_fan_threshold"})
             toggle_option(el, has_enable_overhang_bridge_fan);


### PR DESCRIPTION
As per discord chat - updated tool tip and removed min print speed disabling feature when slow printing down for better layer cooling is de-selected as the min print speed serves as a print speed floor for the filament.