### PR TITLE
Fix duplicate entry of Only Lift Z above and below in the extruder tab

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3562,8 +3562,6 @@ if (is_marlin_flavor)
             optgroup->append_single_option_line("retraction_length", "", extruder_idx);
             optgroup->append_single_option_line("retract_restart_extra", "", extruder_idx);
             optgroup->append_single_option_line("z_hop", "", extruder_idx);
-            optgroup->append_single_option_line("retract_lift_above", "", extruder_idx);
-            optgroup->append_single_option_line("retract_lift_below", "", extruder_idx);
             optgroup->append_single_option_line("z_hop_types", "", extruder_idx);
             optgroup->append_single_option_line("retraction_speed", "", extruder_idx);
             optgroup->append_single_option_line("deretraction_speed", "", extruder_idx);


### PR DESCRIPTION
Just a quick small bug - only lift above and below settings duplicated in the retraction and lift z enforcement section of the extruder settings. This removes the duplicate entry in the retraction section. 

![Screenshot 2023-10-31 at 16 25 36](https://github.com/SoftFever/OrcaSlicer/assets/59056762/5321572e-da01-4e3d-aded-a2febfbc0d96)
