### PR TITLE
fix deadlock condition varaible use in netfabb wrapper

### DIFF
--- a/src/slic3r/Utils/FixModelByWin10.cpp
+++ b/src/slic3r/Utils/FixModelByWin10.cpp
@@ -1,3 +1,7 @@
+///|/ Copyright (c) Prusa Research 2018 - 2023 Oleksandra Iushchenko @YuSanka, Lukáš Matěna @lukasmatena, Pavel Mikuš @Godrak, Enrico Turri @enricoturri1966, Vojtěch Bubník @bubnikv
+///|/
+///|/ PrusaSlicer is released under the terms of the AGPLv3 or higher
+///|/
 #ifdef HAS_WIN10SDK
 
 #ifndef NOMINMAX
@@ -323,9 +327,8 @@ public:
 // fix_result containes a message if fixing failed
 bool fix_model_by_win10_sdk_gui(ModelObject &model_object, int volume_idx, GUI::ProgressDialog& progress_dialog, const wxString& msg_header, std::string& fix_result)
 {
-	std::mutex 						mutex;
-	std::condition_variable			condition;
-	std::unique_lock<std::mutex>	lock(mutex);
+    std::mutex mtx;
+    std::condition_variable condition;
 	struct Progress {
 		std::string 				message;
 		int 						percent  = 0;
@@ -344,8 +347,8 @@ bool fix_model_by_win10_sdk_gui(ModelObject &model_object, int volume_idx, GUI::
 	// (It seems like wxWidgets initialize the COM contex as single threaded and we need a multi-threaded context).
 	bool   success = false;
 	size_t ivolume = 0;
-	auto on_progress = [&mutex, &condition, &ivolume, &volumes, &progress](const char *msg, unsigned prcnt) {
-        std::lock_guard<std::mutex> lk(mutex);
+	auto on_progress = [&mtx, &condition, &ivolume, &volumes, &progress](const char *msg, unsigned prcnt) {
+	    std::unique_lock<std::mutex> lock(mtx);
 		progress.message = msg;
 		progress.percent = (int)floor((float(prcnt) + float(ivolume) * 100.f) / float(volumes.size()));
 		progress.updated = true;
@@ -422,6 +425,7 @@ bool fix_model_by_win10_sdk_gui(ModelObject &model_object, int volume_idx, GUI::
 		}
 	});
     while (! finished) {
+		std::unique_lock<std::mutex> lock(mtx);
 		condition.wait_for(lock, std::chrono::milliseconds(250), [&progress]{ return progress.updated; });
 		// decrease progress.percent value to avoid closing of the progress dialog
 		if (!progress_dialog.Update(progress.percent-1, msg_header + _(progress.message)))


### PR DESCRIPTION
(cherry picked from commit prusa3d/PrusaSlicer@04ac99a54e9bc3500dbd32d94d5996798cb894f3)

Currently the slicer freezes if any model part failed to repair. This pr fixes this issue.