### PR TITLE
Organic: Fix support blocker

### DIFF
--- a/src/libslic3r/Support/TreeSupport.cpp
+++ b/src/libslic3r/Support/TreeSupport.cpp
@@ -249,8 +249,12 @@ static std::vector<std::pair<TreeSupportSettings, std::vector<size_t>>> group_me
                     raw_overhangs = overhangs;
                     raw_overhangs_calculated = true;
                 }
-                if (! (enforced_layer || blockers_layers.empty() || blockers_layers[layer_id].empty()))
-                    overhangs = diff(overhangs, blockers_layers[layer_id], ApplySafetyOffset::Yes);
+                if (! (enforced_layer || blockers_layers.empty() || blockers_layers[layer_id].empty())) {
+                    Polygons &blocker = blockers_layers[layer_id];
+                    // Arthur: union_ is a must because after mirroring, the blocker polygons are in left-hand coordinates, ie clockwise,
+                    // which are not valid polygons, and will be removed by offset. union_ can make these polygons right.
+                    overhangs = diff(overhangs, offset(union_(blocker), scale_(g_config_tree_support_collision_resolution)), ApplySafetyOffset::Yes);
+                }
                 if (config.bridge_no_support) {
                     for (const LayerRegion *layerm : current_layer.regions())
                         remove_bridges_from_contacts(print_config, lower_layer, *layerm, 


### PR DESCRIPTION
This fixes issue that support blocker produces different results when switching between organic/non-organic tree supports.


![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/76b75a5e-8b49-4e10-b4b4-7b05db45f6ac)

Before:
![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/edc53db9-d6bd-4d5f-a612-eaef433dba7c)

After:
![1b2f962b86b08848e4aba543bc9890ba](https://github.com/SoftFever/OrcaSlicer/assets/1537155/8d107ffd-ded7-43eb-a8cd-5a638c503a7f)


[呼呼呼碳纤维1.zip](https://github.com/SoftFever/OrcaSlicer/files/13248410/1.zip)
