### PR TITLE
Support/Object Base Additional XY Distance

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -735,7 +735,7 @@ static std::vector<std::string> s_Preset_print_options {
     "fuzzy_skin", "fuzzy_skin_thickness", "fuzzy_skin_point_distance",
     "max_volumetric_extrusion_rate_slope", "max_volumetric_extrusion_rate_slope_segment_length",
     "inner_wall_speed", "outer_wall_speed", "sparse_infill_speed", "internal_solid_infill_speed",
-    "top_surface_speed", "support_speed", "support_object_xy_distance", "support_interface_speed",
+    "top_surface_speed", "support_speed", "support_object_xy_distance", "support_object_base_additional_xy_distance", "support_interface_speed",
     "bridge_speed", "internal_bridge_speed", "gap_infill_speed", "travel_speed", "travel_speed_z", "initial_layer_speed",
     "outer_wall_acceleration", "initial_layer_acceleration", "top_surface_acceleration", "default_acceleration", "skirt_loops", "skirt_speed", "skirt_distance", "skirt_height", "draft_shield",
     "brim_width", "brim_object_gap", "brim_type", "brim_ears_max_angle", "brim_ears_detection_length", "enable_support", "support_type", "support_threshold_angle", "enforce_support_layers",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3456,6 +3456,16 @@ def = this->add("filament_loading_speed", coFloats);
     //Support with too small spacing may touch the object and difficult to remove.
     def->set_default_value(new ConfigOptionFloat(0.35));
 
+    def = this->add("support_object_base_additional_xy_distance", coFloat);
+    def->label = L("Support/object base additional xy distance");
+    def->category = L("Support");
+    def->tooltip = L("Additional XY separation between an object and its base support material");
+    def->sidetext = L("mm");
+    def->min = 0;
+    def->max = 10;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(0.0));
+
     def = this->add("support_angle", coFloat);
     def->label = L("Pattern angle");
     def->category = L("Support");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -729,6 +729,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     // Overhang angle threshold.
     ((ConfigOptionInt,                 support_threshold_angle))
     ((ConfigOptionFloat,               support_object_xy_distance))
+    ((ConfigOptionFloat,               support_object_base_additional_xy_distance))
     ((ConfigOptionFloat,               xy_hole_compensation))
     ((ConfigOptionFloat,               xy_contour_compensation))
     ((ConfigOptionBool,                flush_into_objects))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1000,6 +1000,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "support_base_pattern"
             || opt_key == "support_style"
             || opt_key == "support_object_xy_distance"
+            || opt_key == "support_object_base_additional_xy_distance"
             || opt_key == "support_base_pattern_spacing"
             || opt_key == "support_expansion"
             //|| opt_key == "independent_support_layer_height" // BBS

--- a/src/libslic3r/SupportMaterial.cpp
+++ b/src/libslic3r/SupportMaterial.cpp
@@ -378,6 +378,7 @@ PrintObjectSupportMaterial::PrintObjectSupportMaterial(const PrintObject *object
         bridge_flow += region.config().bridge_flow;
     }
     m_support_params.gap_xy = m_object_config->support_object_xy_distance.value;
+    m_support_params.base_additional_gap_xy = m_object_config->support_object_base_additional_xy_distance;
     bridge_flow /= object->num_printing_regions();
 
     m_support_params.support_material_bottom_interface_flow = m_slicing_params.soluble_interface || ! m_object_config->thick_bridges ?
@@ -3274,7 +3275,8 @@ void PrintObjectSupportMaterial::generate_base_layers(
     ++ iRun;
 #endif /* SLIC3R_DEBUG */
 
-    this->trim_support_layers_by_object(object, intermediate_layers, m_slicing_params.gap_support_object, m_slicing_params.gap_object_support, m_support_params.gap_xy);
+    this->trim_support_layers_by_object(object, intermediate_layers, m_slicing_params.gap_support_object, m_slicing_params.gap_object_support, m_support_params.gap_xy + m_support_params.base_additional_gap_xy);
+
 }
 
 void PrintObjectSupportMaterial::trim_support_layers_by_object(

--- a/src/libslic3r/SupportMaterial.hpp
+++ b/src/libslic3r/SupportMaterial.hpp
@@ -132,6 +132,7 @@ public:
 	//	coordf_t	support_layer_height_max;
 
 		coordf_t	gap_xy;
+		coordf_t	base_additional_gap_xy;
 
 	    float    				base_angle;
 	    float    				interface_angle;

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -608,7 +608,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
                     "bridge_no_support", "max_bridge_length", "support_top_z_distance", "support_bottom_z_distance",
                      //BBS: add more support params to dependent of enable_support
                     "support_type", "support_on_build_plate_only", "support_critical_regions_only",
-                    "support_object_xy_distance"/*, "independent_support_layer_height"*/})
+                    "support_object_xy_distance", "support_object_base_additional_xy_distance" /*, "independent_support_layer_height"*/})
         toggle_field(el, have_support_material);
     toggle_field("support_threshold_angle", have_support_material && is_auto(support_type));
     //toggle_field("support_closing_radius", have_support_material && support_style == smsSnug);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2044,6 +2044,7 @@ void TabPrint::build()
         //optgroup->append_single_option_line("support_interface_loop_pattern");
 
         optgroup->append_single_option_line("support_object_xy_distance", "support");
+        optgroup->append_single_option_line("support_object_base_additional_xy_distance", "support");
         optgroup->append_single_option_line("bridge_no_support", "support#base-pattern");
         optgroup->append_single_option_line("max_bridge_length", "support#base-pattern");
         optgroup->append_single_option_line("independent_support_layer_height", "support");


### PR DESCRIPTION
This pr, adds a new support option that allows for the base material between interface layers to have a greater xy offset than the xy offset used for interface layers.

This solves a problem I have with printing sloped overhangs that have low gradients. In this case the support/object xy distance pushes the support interface layer away futher than the top z distance.

Ideally in this case i want a small support/object xy distance, however this causes problems with the base support material getting too close the object.

So i've added a simple fix that allows you to specify an additional base support material offset.

Interface layers are printed with "support/object xy distance".
Base support layers are printed with "support/object xy distance" + "support/object base additional xy distance".

I think this implementation is far from ideal, and is more of quick hack.

Additional this will allow zero/small support/object xy distances when using a support filament for interface only, and preventing the base from getting too close (this might be handled differently already as i haven't tested support filaments but i have seen others request the following Cura option, so i assume it's a problem).

Cura has a support distance priority option, that would probably be better but i have zero clue how to implement that.

Any feed back is greately appreciated. 
