### PR TITLE
Update AnkerMake printers to make use of Marlin 2 gcode

### DIFF
--- a/resources/profiles/Anker/machine/fdm_machine_common.json
+++ b/resources/profiles/Anker/machine/fdm_machine_common.json
@@ -3,7 +3,7 @@
     "name": "fdm_machine_common",
     "from": "system",
     "instantiation": "false",
-    "gcode_flavor": "marlin",
+    "gcode_flavor": "marlin2",
    	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\nG92 E0.0\n;[layer_z]\n\n",
     "machine_start_gcode": "M4899 T3 ; Enable v3 jerk and S-curve acceleration \nM104 Sfirst_layer_temperature[0] ; Set hotend temp\nM190 S{first_layer_bed_temperature[0]} ; set and wait for bed temp to stabilize\nM109 S{first_layer_temperature[0]} ; set final nozzle temp to stabilize\nG28 ;Home",
     "machine_end_gcode": "M104 S0\nM140 S0\n;Retract the filament\nG92 E1\nG1 E-1 F300\nG28 X0 Y0\nM84",


### PR DESCRIPTION
AnkerMake printers use and perform (slightly) better when using Marlin 2 gocde rather then Marlin Legacy gcode.