### PR TITLE
Update the retraction defaults to account for the M5c

### DIFF
--- a/resources/profiles/Anker/machine/Anker M5.json
+++ b/resources/profiles/Anker/machine/Anker M5.json
@@ -8,5 +8,8 @@
     "bed_model": "M5-CE-bed.stl",
     "bed_texture": "M5-CE-texture.svg",
     "hotend_model": "",
-    "default_materials": "Anker Generic ABS;Anker Generic PLA;Anker Generic PLA-CF;Anker Generic PETG;Anker Generic TPU;Anker Generic ASA;Anker Generic PVA"
+    "default_materials": "Anker Generic ABS;Anker Generic PLA;Anker Generic PLA-CF;Anker Generic PETG;Anker Generic TPU;Anker Generic ASA;Anker Generic PVA",
+    "retraction_length": [
+        "1.5"
+    ]
 }

--- a/resources/profiles/Anker/machine/Anker M5C.json
+++ b/resources/profiles/Anker/machine/Anker M5C.json
@@ -8,5 +8,8 @@
     "bed_model": "M5C-CE-bed.stl",
     "bed_texture": "M5-CE-texture.svg",
     "hotend_model": "",
-    "default_materials": "Anker Generic ABS;Anker Generic PLA;Anker Generic PLA-CF;Anker Generic PETG;Anker Generic TPU;Anker Generic ASA;Anker Generic PVA;Anker Generic PC;Anker Generic PA;Anker Generic PA-CF"
+    "default_materials": "Anker Generic ABS;Anker Generic PLA;Anker Generic PLA-CF;Anker Generic PETG;Anker Generic TPU;Anker Generic ASA;Anker Generic PVA;Anker Generic PC;Anker Generic PA;Anker Generic PA-CF",
+    "retraction_length": [
+        "0.8"
+    ]
 }

--- a/resources/profiles/Anker/machine/fdm_machine_common.json
+++ b/resources/profiles/Anker/machine/fdm_machine_common.json
@@ -88,9 +88,6 @@
     "retract_when_changing_layer": [
         "0"
     ],
-    "retraction_length": [
-        "1.5"
-    ],
     "retract_length_toolchange": [
         "2"
     ],


### PR DESCRIPTION
The previous defaults were only meant for the M5, not the M5c