### PR TITLE
Fix scaling of `min_width_top_surface` when using abs value

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -899,7 +899,7 @@ void PerimeterGenerator::split_top_surfaces(const ExPolygons &orig_polygons, ExP
         offset_top_surface = 0;
     // don't takes into account too thin areas
     // skip if the exposed area is smaller than "min_width_top_surface"
-    double min_width_top_surface = std::max(double(ext_perimeter_spacing / 2 + 10), config->min_width_top_surface.get_abs_value(perimeter_width));
+    double min_width_top_surface = std::max(double(ext_perimeter_spacing / 2 + 10), scale_(config->min_width_top_surface.get_abs_value(unscale_(perimeter_width))));
 
     Polygons grown_upper_slices = offset(*this->upper_slices, min_width_top_surface);
 


### PR DESCRIPTION
Before:
![0fe104cb13341870e552932925b659e5](https://github.com/SoftFever/OrcaSlicer/assets/1537155/de0de831-9810-4aa6-9c1b-23aa2940bd5a)
![7a4f5be49a135e59a3bfc12cda91005f](https://github.com/SoftFever/OrcaSlicer/assets/1537155/1ef56fc7-181d-49f8-9bf1-9f647385a9ee)


After:
![04e521cdd988f71171c6c11d8152d84c](https://github.com/SoftFever/OrcaSlicer/assets/1537155/d34fb593-7f07-43fb-b3b8-efae0aeba6cc)
