### PR TITLE
Improve Windows crash log

### DIFF
--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -224,6 +224,13 @@ jobs:
         with:
           name: OrcaSlicer_Windows_V${{ env.ver }}
           path: ${{ github.workspace }}/build/OrcaSlicer*.exe
+
+      - name: Upload artifacts Win PDB
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: OrcaSlicer_Windows_V${{ env.ver }}_pdb
+          path: ${{ github.workspace }}/build/src/Release/*.pdb
 # Ubuntu
 
       - name: Install dependencies

--- a/src/BaseException.cpp
+++ b/src/BaseException.cpp
@@ -91,8 +91,26 @@ void CBaseException::ShowLoadModules()
 
 void CBaseException::ShowCallstack(HANDLE hThread, const CONTEXT* context)
 {
-	OutputString(_T("Show CallStack:\r\n"));
-	LPSTACKINFO phead = StackWalker(hThread, context);
+	OutputString(_T("Show CallStack:\n"));
+    LPSTACKINFO phead = StackWalker(hThread, context);
+
+	// Show RVA of each call stack, so we can locate the symbol using pdb file
+	// To show the symbol, load the <szFaultingModule> in WinDBG with pdb file, then type the following commands:
+	// > lm                                                                   which gives you the start address of each module, as well as module names
+	// > !dh <module name>                                                    list all module headers. Find the <virtual address> of the section given by
+	//                                                                        the <section> output in the crash log
+	// > ln <module start address> + <section virtual address> + <offset>     reveals the debug symbol
+    OutputString(_T("\nLogical Address:\n"));
+    TCHAR szFaultingModule[MAX_PATH];
+    DWORD section, offset;
+    for (LPSTACKINFO ps = phead; ps != nullptr; ps = ps->pNext) {
+        if (GetLogicalAddress((PVOID) ps->szFncAddr, szFaultingModule, sizeof(szFaultingModule), section, offset)) {
+            OutputString(_T("0x%X 0x%X:0x%X %s\n"), ps->szFncAddr, section, offset, szFaultingModule);
+        } else {
+            OutputString(_T("0x%X Unknown\n"), ps->szFncAddr);
+        }
+    }
+
 	FreeStackInformations(phead);
 }
 

--- a/src/StackWalker.cpp
+++ b/src/StackWalker.cpp
@@ -491,7 +491,7 @@ LPSTACKINFO CStackWalker::StackWalker(HANDLE hThread, const CONTEXT* context)
 			}else
 			{
 				//调用错误一般是487(地址无效或者没有访问的权限、在符号表中未找到指定地址的相关信息)
-				this->OutputString(_T("Call SymGetSymFromAddr64 ,Address %08x Error:%08x\r\n"), sf.AddrPC.Offset, GetLastError());
+				//this->OutputString(_T("Call SymGetSymFromAddr64 ,Address %08x Error:%08x\n"), sf.AddrPC.Offset, GetLastError());
 
                 StringCchCopy(pCallStack->undFullName, STACKWALK_MAX_NAMELEN, textconv_helper::A2T_("Unknown"));
 			}
@@ -502,14 +502,14 @@ LPSTACKINFO CStackWalker::StackWalker(HANDLE hThread, const CONTEXT* context)
 				pCallStack->uFileNum = pLine->LineNumber;
 			}else
 			{
-				this->OutputString(_T("Call SymGetLineFromAddr64 ,Address %08x Error:%08x\r\n"), sf.AddrPC.Offset, GetLastError());
+				//this->OutputString(_T("Call SymGetLineFromAddr64 ,Address %08x Error:%08x\n"), sf.AddrPC.Offset, GetLastError());
 
                 StringCchCopy(pCallStack->szFileName, MAX_PATH, textconv_helper::A2T_("Unknown file"));
                 pCallStack->uFileNum = -1;
 			}
 			
 			//这里为了将获取函数信息失败的情况与正常的情况一起输出，防止用户在查看时出现误解
-			this->OutputString(_T("%08llx:%s [%s][%ld]\r\n"), pCallStack->szFncAddr, pCallStack->undFullName, pCallStack->szFileName, pCallStack->uFileNum);
+			this->OutputString(_T("%08llx:%s [%s][%ld]\n"), pCallStack->szFncAddr, pCallStack->undFullName, pCallStack->szFileName, pCallStack->uFileNum);
 			if (NULL == pHead)
 			{
 				pHead = pCallStack;


### PR DESCRIPTION
When we distribute the app to users, it won't come with the PBD file bundled due to the size, which means we will not be able to show the debug symbols (such as function name, source file location, line number etc.) in the crash log. And given the fact that current crash log only shows the virtual address of each function call, it's hard to calculate the RVA of the function which will then be used to locate the function using the PBD file.

This PR shows the section id and the offset within that section for the function address of each stack frame, which then can be used to calculate the function's RVA and also locate the debug symbol in PBD with the help of WinDBG.

The format of the output will be:
`<function virtual address> <section number>:<section offset> <module path>`, and the function's RVA will be the section's virtual address (which we will find out with the help of WinDBG) + section offset.

Given the following line from the crash log:
```
0x8224D5DC 0x1:0x8DC5DC D:\projects\OrcaSlicer\build\src\RelWithDebInfo\OrcaSlicer.dll
```
Once we load the `OrcaSlicer.dll` file in WinDBG with the correct PDB file, we can follow these steps to get the debug symbol:
1. `lm`, which gives you the name of the module:
```
start             end                 module name
00000001`80000000 00000001`856f2000   OrcaSlicer C (private pdb symbols)  C:\ProgramData\Dbg\sym\OrcaSlicer.pdb\1CE5DACBDA6C4A85B8D7EBD6C21635B010\OrcaSlicer.pdb
```
in which `OrcaSlicer` is the module name, which will be used in the following steps.
2. `!dh OrcaSlicer`, which list the sections of this module. What we need to find is the section `0x1`, as indicated in the crash log:
```
SECTION HEADER #1
   .text name
 3BAE26C virtual size
    1000 virtual address
 3BAE400 size of raw data
     400 file pointer to raw data
       0 file pointer to relocation table
       0 file pointer to line numbers
       0 number of relocations
       0 number of line numbers
60000020 flags
         Code
         (no align specified)
         Execute Read
```
what important to us is the value of `virtual address`, which is `0x1000` in our case
3. `ln OrcaSlicer + 1000 + 0x8DC5DC`, which reveals the final symbol:
```
[D:\projects\OrcaSlicer\src\libslic3r\ExtrusionEntity.cpp @ 147] (00000001`808dd580)   OrcaSlicer!Slic3r::ExtrusionLoop::polygon+0x5c   |  (00000001`808dd7c0)   OrcaSlicer!Slic3r::ExtrusionLoop::length
```

Note: the CI process will need to be updated to upload the PBD file as well.