### PR TITLE
Fix toolbar rendering on Windows

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -7032,9 +7032,6 @@ void GLCanvas3D::_check_and_update_toolbar_icon_scale()
     float noitems_width = top_tb_width - size * items_cnt; // width of separators and borders in top toolbars
 
     // calculate scale needed for items in all top toolbars
-#ifdef __WINDOWS__
-    cnv_size.set_width(cnv_size.get_width() + m_separator_toolbar.get_width() + collapse_toolbar_width);
-#endif
     float new_h_scale = (cnv_size.get_width() - noitems_width) / (items_cnt * GLToolbar::Default_Icons_Size);
 
     //for protect


### PR DESCRIPTION
Currently on windows, when you resize the window relatively small, the end of the toolbar will be clipped like so:
![d95d24afdc47eef04df4a2c755d13494](https://github.com/SoftFever/OrcaSlicer/assets/1537155/5f060966-3613-4bd7-8036-e9b27c12ffd3)

This is what it look like on Linux/macOS:
![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/167ab075-1c48-4531-a2ef-3f225874cfbd)

This PR fixes this issue so it behaves like on Linux/macOS:
![60cb540f198c5d680fceaa387302c475](https://github.com/SoftFever/OrcaSlicer/assets/1537155/7e1b404b-bdf7-4c3b-bee7-5d2f0a11f91e)
