### PR TITLE
Fix color blending of preview shells

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1242,8 +1242,8 @@ void GCodeViewer::render(int canvas_width, int canvas_height, int right_margin)
         return;
 
     glsafe(::glEnable(GL_DEPTH_TEST));
-    render_toolpaths();
     render_shells();
+    render_toolpaths();
     float legend_height = 0.0f;
     render_legend(legend_height, canvas_width, canvas_height, right_margin);
 
@@ -4033,7 +4033,7 @@ void GCodeViewer::render_shells()
     if (shader == nullptr)
         return;
 
-//    glsafe(::glDepthMask(GL_FALSE));
+    glsafe(::glDepthMask(GL_FALSE));
 
     shader->start_using();
     shader->set_uniform("emission_factor", 0.1f);
@@ -4042,7 +4042,7 @@ void GCodeViewer::render_shells()
     shader->set_uniform("emission_factor", 0.0f);
     shader->stop_using();
 
-//    glsafe(::glDepthMask(GL_TRUE));
+    glsafe(::glDepthMask(GL_TRUE));
 }
 
 //BBS


### PR DESCRIPTION
Some changes in the recent measuring gizmo port makes the model semi-transparent shell overlapping the gcode paths and make the lines less clear:
![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/31a7ff27-06e8-4f26-aa02-8b5e0395d4f8)
More examples at: https://github.com/SoftFever/OrcaSlicer/pull/2603#issuecomment-1817501192

This pr fixes this issue:
![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/84d2c835-1106-4228-90cf-690131aec1d8)
