### PR TITLE
Update BuildLinux.sh

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-set -e # exit on first error
 
 export ROOT=`pwd`
 export NCORES=`nproc --all`
 export CMAKE_BUILD_PARALLEL_LEVEL=${NCORES}
 FOUND_GTK2=$(dpkg -l libgtk* | grep gtk2)
 FOUND_GTK3=$(dpkg -l libgtk* | grep gtk-3)
+
+set -e # exit on first error
 
 function check_available_memory_and_disk() {
     FREE_MEM_GB=$(free -g -t | grep 'Mem:' | rev | cut -d" " -f1 | rev)


### PR DESCRIPTION
getting the value for FOUND_GTK* variables seems to cause an error which prevents using the -u option to install the needed packages. This is fixed by moving the "exit on first error" flag to after setting these vars.