### PR TITLE
Flashforge: Machine G-code Fix

### DIFF
--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.4 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.4 Nozzle.json
@@ -46,7 +46,7 @@
 	"change_filament_gcode": "",
 	"machine_pause_gcode": "M25",
 	"default_filament_profile": [ "Flashforge Generic PLA" ],
-	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.25 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
+	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F800\nG1 X110 Y-110 F6000\nG1 E2 F800\nG1 Y-110 X55 Z0.25 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG1 Y-110 X55 Z0.45 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG92 E0",
 	"machine_end_gcode": "G1 E-3 F3600\nG0 X50 Y50 F30000\nG28\nM104 S0 ; turn off temperature\nM84    ; disable motors",
 	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]",
 	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.6 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.6 Nozzle.json
@@ -46,7 +46,7 @@
 	"change_filament_gcode": "",
 	"machine_pause_gcode": "M25",
 	"default_filament_profile": [ "Flashforge Generic PLA" ],
-	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.25 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
+	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F800\nG1 X110 Y-110 F6000\nG1 E2 F800\nG1 Y-110 X55 Z0.25 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG1 Y-110 X55 Z0.45 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG92 E0",
 	"machine_end_gcode": "G1 E-3 F3600\nG0 X50 Y50 F30000\nG28\nM104 S0 ; turn off temperature\nM84    ; disable motors",
 	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]",
 	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.4 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.4 Nozzle.json
@@ -46,7 +46,7 @@
 	"change_filament_gcode": "",
 	"machine_pause_gcode": "M25",
 	"default_filament_profile": [ "Flashforge Generic PLA" ],
-	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.25 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
+	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F800\nG1 X110 Y-110 F6000\nG1 E2 F800\nG1 Y-110 X55 Z0.25 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG1 Y-110 X55 Z0.45 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG92 E0",
 	"machine_end_gcode": "G1 E-3 F3600\nG0 X50 Y50 F30000\nG28\nM104 S0 ; turn off temperature\nM84    ; disable motors",
 	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]",
 	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.6 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.6 Nozzle.json
@@ -46,7 +46,7 @@
 	"change_filament_gcode": "",
 	"machine_pause_gcode": "M25",
 	"default_filament_profile": [ "Flashforge Generic PLA" ],
-	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.25 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
+	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F800\nG1 X110 Y-110 F6000\nG1 E2 F800\nG1 Y-110 X55 Z0.25 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG1 Y-110 X55 Z0.45 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG92 E0",
 	"machine_end_gcode": "G1 E-3 F3600\nG0 X50 Y50 F30000\nG28\nM104 S0 ; turn off temperature\nM84    ; disable motors",
 	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]",
 	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",


### PR DESCRIPTION
Hi! @SoftFever @mariuske 
Lately we encountered some issues in using Flashforge printers with the Orca1.8.0 version. And some adjustments need to be made to the machine G-code part.

These are the two issues/recommendations while using the Orca 1.8.0 version:

1. The first print after shutting down the system has a problem of not extruding filament. However, the issue does not occur on subsequent prints. Upon investigation, it was found that this version of the software lacks two lines of code in the initial G-code. This issue dates back to the previous commit #2632 .  @mariuske  FYI: These two lines have to be kept as before to solve this issue.

2. Another feedback concerns the pre-extrusion of printers, which occurs on the left and back sides, making it difficult to remove the skirt.  3D Printing farmers suggest adjusting the pre-extrusion to the front and increasing it to two layers, making it easier to remove. The following G-code is provided for reference. Below is an example of using the changed G-code in this commit:
![skirt_gcode](https://github.com/SoftFever/OrcaSlicer/assets/144670305/302c7170-9cda-46ed-91ad-4acb9698fbbd)


