### PR TITLE
Add a simple subtle outline effect by drawing back faces using wireframe mode

### DIFF
--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -476,6 +476,7 @@ void GLVolume::simple_render(GLShaderProgram* shader, ModelObjectPtrs& model_obj
         glFrontFace(GL_CW);
     glsafe(::glCullFace(GL_BACK));
 
+    glsafe(::glPolygonMode(GL_BACK, GL_LINE));
     bool color_volume = false;
     ModelObject* model_object = nullptr;
     ModelVolume* model_volume = nullptr;
@@ -547,6 +548,7 @@ void GLVolume::simple_render(GLShaderProgram* shader, ModelObjectPtrs& model_obj
     }
     if (this->is_left_handed())
         glFrontFace(GL_CCW);
+    glsafe(::glPolygonMode(GL_BACK, GL_FILL));
 }
 
 bool GLVolume::is_sla_support() const { return this->composite_id.volume_id == -int(slaposSupportTree); }


### PR DESCRIPTION
This should improve the contrast of the edges and make features more visible.

Some comparisons:
![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/3059b3a4-272b-43a7-9848-8289b577f7d9)
![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/a07ab211-a134-4353-8494-d2366c725b54)

![image](https://github.com/SoftFever/OrcaSlicer/assets/1537155/f94eacd7-b6ed-4899-90ef-f1b773a27a84)
