### PR TITLE
Improve arc fitting when new overhang slowdown is used

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4691,68 +4691,68 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
 
     if (m_config.enable_overhang_speed && !m_config.overhang_speed_classic && !this->on_first_layer() &&
         (is_bridge(path.role()) || is_perimeter(path.role()))) {
-               
-        	double out_wall_ref_speed = m_config.get_abs_value("outer_wall_speed");
-        	ConfigOptionPercents         overhang_overlap_levels({75, 50, 25, 13, 12.99, 0});
+            bool is_external = is_external_perimeter(path.role());
+            double ref_speed   = is_external ? m_config.get_abs_value("outer_wall_speed") : m_config.get_abs_value("inner_wall_speed");
+            ConfigOptionPercents         overhang_overlap_levels({75, 50, 25, 13, 12.99, 0});
 
         	if (m_config.slowdown_for_curled_perimeters){
         	 	ConfigOptionFloatsOrPercents dynamic_overhang_speeds(
-            		{(m_config.get_abs_value("overhang_1_4_speed") < 0.5) ?
+            		{(m_config.get_abs_value("overhang_1_4_speed", ref_speed) < 0.5) ?
                  		FloatOrPercent{100, true} :
-                 		FloatOrPercent{m_config.get_abs_value("overhang_1_4_speed") * 100 / out_wall_ref_speed, true},
-            	 	(m_config.get_abs_value("overhang_2_4_speed") < 0.5) ?
+                 		FloatOrPercent{m_config.get_abs_value("overhang_1_4_speed", ref_speed) * 100 / ref_speed, true},
+            	 	(m_config.get_abs_value("overhang_2_4_speed", ref_speed) < 0.5) ?
                  		FloatOrPercent{100, true} :
-                 		FloatOrPercent{m_config.get_abs_value("overhang_2_4_speed") * 100 / out_wall_ref_speed, true},
-             		(m_config.get_abs_value("overhang_3_4_speed") < 0.5) ?
+                 		FloatOrPercent{m_config.get_abs_value("overhang_2_4_speed", ref_speed) * 100 / ref_speed, true},
+             		(m_config.get_abs_value("overhang_3_4_speed", ref_speed) < 0.5) ?
                  		FloatOrPercent{100, true} :
-                 		FloatOrPercent{m_config.get_abs_value("overhang_3_4_speed") * 100 / out_wall_ref_speed, true},
-             		(m_config.get_abs_value("overhang_4_4_speed") < 0.5) ?
+                 		FloatOrPercent{m_config.get_abs_value("overhang_3_4_speed", ref_speed) * 100 / ref_speed, true},
+             		(m_config.get_abs_value("overhang_4_4_speed", ref_speed) < 0.5) ?
                  		FloatOrPercent{100, true} :
-                 		FloatOrPercent{m_config.get_abs_value("overhang_4_4_speed") * 100 / out_wall_ref_speed, true},
-                	(m_config.get_abs_value("overhang_4_4_speed") < 0.5) ?
+                 		FloatOrPercent{m_config.get_abs_value("overhang_4_4_speed", ref_speed) * 100 / ref_speed, true},
+                	(m_config.get_abs_value("overhang_4_4_speed", ref_speed) < 0.5) ?
                  		FloatOrPercent{100, true} :
-                 		FloatOrPercent{m_config.get_abs_value("overhang_4_4_speed") * 100 / out_wall_ref_speed, true},
-                	(m_config.get_abs_value("overhang_4_4_speed") < 0.5) ?
+                 		FloatOrPercent{m_config.get_abs_value("overhang_4_4_speed", ref_speed) * 100 / ref_speed, true},
+                	(m_config.get_abs_value("overhang_4_4_speed", ref_speed) < 0.5) ?
                 		FloatOrPercent{100, true} :
-                 		FloatOrPercent{m_config.get_abs_value("overhang_4_4_speed") * 100 / out_wall_ref_speed, true}});
-            	if (out_wall_ref_speed == 0)
-            		out_wall_ref_speed = EXTRUDER_CONFIG(filament_max_volumetric_speed) / _mm3_per_mm;
+                 		FloatOrPercent{m_config.get_abs_value("overhang_4_4_speed", ref_speed) * 100 / ref_speed, true}});
+            	if (ref_speed == 0)
+            		ref_speed = EXTRUDER_CONFIG(filament_max_volumetric_speed) / _mm3_per_mm;
 
         		if (EXTRUDER_CONFIG(filament_max_volumetric_speed) > 0) {
-            		out_wall_ref_speed = std::min(out_wall_ref_speed, EXTRUDER_CONFIG(filament_max_volumetric_speed) / path.mm3_per_mm);
+            		ref_speed = std::min(ref_speed, EXTRUDER_CONFIG(filament_max_volumetric_speed) / path.mm3_per_mm);
         		}
 
         		new_points = m_extrusion_quality_estimator.estimate_extrusion_quality(path, overhang_overlap_levels, dynamic_overhang_speeds,
-                                                                              out_wall_ref_speed, speed, m_config.slowdown_for_curled_perimeters);
+                                                                              ref_speed, speed, m_config.slowdown_for_curled_perimeters);
         	}else{
             	ConfigOptionFloatsOrPercents dynamic_overhang_speeds(
-            	{(m_config.get_abs_value("overhang_1_4_speed") < 0.5) ?
+            	{(m_config.get_abs_value("overhang_1_4_speed", ref_speed) < 0.5) ?
                  	FloatOrPercent{100, true} :
-                 	FloatOrPercent{m_config.get_abs_value("overhang_1_4_speed") * 100 / out_wall_ref_speed, true},
-             	(m_config.get_abs_value("overhang_2_4_speed") < 0.5) ?
+                 	FloatOrPercent{m_config.get_abs_value("overhang_1_4_speed", ref_speed) * 100 / ref_speed, true},
+             	(m_config.get_abs_value("overhang_2_4_speed", ref_speed) < 0.5) ?
                  	FloatOrPercent{100, true} :
-                 	FloatOrPercent{m_config.get_abs_value("overhang_2_4_speed") * 100 / out_wall_ref_speed, true},
-             	(m_config.get_abs_value("overhang_3_4_speed") < 0.5) ?
+                 	FloatOrPercent{m_config.get_abs_value("overhang_2_4_speed", ref_speed) * 100 / ref_speed, true},
+             	(m_config.get_abs_value("overhang_3_4_speed", ref_speed) < 0.5) ?
                  	FloatOrPercent{100, true} :
-                 	FloatOrPercent{m_config.get_abs_value("overhang_3_4_speed") * 100 / out_wall_ref_speed, true},
-             	(m_config.get_abs_value("overhang_4_4_speed") < 0.5) ?
+                 	FloatOrPercent{m_config.get_abs_value("overhang_3_4_speed", ref_speed) * 100 / ref_speed, true},
+             	(m_config.get_abs_value("overhang_4_4_speed", ref_speed) < 0.5) ?
                  	FloatOrPercent{100, true} :
-                 	FloatOrPercent{m_config.get_abs_value("overhang_4_4_speed") * 100 / out_wall_ref_speed, true},
-             	FloatOrPercent{m_config.get_abs_value("bridge_speed") * 100 / out_wall_ref_speed, true},
-             	FloatOrPercent{m_config.get_abs_value("bridge_speed") * 100 / out_wall_ref_speed, true}});
+                 	FloatOrPercent{m_config.get_abs_value("overhang_4_4_speed", ref_speed) * 100 / ref_speed, true},
+             	FloatOrPercent{m_config.get_abs_value("bridge_speed") * 100 / ref_speed, true},
+             	FloatOrPercent{m_config.get_abs_value("bridge_speed") * 100 / ref_speed, true}});
              
-        		if (out_wall_ref_speed == 0)
-            		out_wall_ref_speed = EXTRUDER_CONFIG(filament_max_volumetric_speed) / _mm3_per_mm;
+        		if (ref_speed == 0)
+            		ref_speed = EXTRUDER_CONFIG(filament_max_volumetric_speed) / _mm3_per_mm;
 
         		if (EXTRUDER_CONFIG(filament_max_volumetric_speed) > 0) {
-            		out_wall_ref_speed = std::min(out_wall_ref_speed, EXTRUDER_CONFIG(filament_max_volumetric_speed) / path.mm3_per_mm);
+            		ref_speed = std::min(ref_speed, EXTRUDER_CONFIG(filament_max_volumetric_speed) / path.mm3_per_mm);
         		}
 
         		new_points = m_extrusion_quality_estimator.estimate_extrusion_quality(path, overhang_overlap_levels, dynamic_overhang_speeds,
-                                                                              out_wall_ref_speed, speed, m_config.slowdown_for_curled_perimeters);
+                                                                              ref_speed, speed, m_config.slowdown_for_curled_perimeters);
         	}
-        	variable_speed = std::any_of(new_points.begin(), new_points.end(), [speed](const ProcessedPoint &p) { return p.speed != speed; });
-
+            variable_speed = std::any_of(new_points.begin(), new_points.end(),
+                                         [speed](const ProcessedPoint &p) { return fabs(double(p.speed) - speed) > EPSILON; });
     }
 
     double F = speed * 60;  // convert mm/sec to mm/min


### PR DESCRIPTION
Now arc fitting should work properly for internal walls.
Also max volumetric speed won't affect arc fitting results anymore.
![image](https://github.com/SoftFever/OrcaSlicer/assets/103989404/b1ba3910-7ad6-4770-b126-dfc2c3c4522f)

Fixed #1257 #1256 #1329 #1257 #1257