### PR TITLE
Set PointerAlignment to Left

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -95,7 +95,7 @@ PenaltyBreakString: 600
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 50
 PenaltyReturnTypeOnItsOwnLine: 300
-PointerAlignment: Right
+PointerAlignment: Left
 ReflowComments:  true
 SortIncludes:    false
 SortUsingDeclarations: false


### PR DESCRIPTION
A lot of the codebase that I have seen typically uses a left justified pointer character. This would update the formatter to also follow that.

I also want to open a discussion about possibly running a formatter over the entire codebase to try and clean up the look of it. My only concern would be possibly making it harder to apply patches. Curious about your thoughts @SoftFever @Noisyfox @igiannakas