### PR TITLE
Fix typo "Fliament" -> "Filament" across codebase

### DIFF
--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -4501,7 +4501,7 @@ msgstr "Automatické obnovení po ztrátě kroku"
 msgid "Allow Prompt Sound"
 msgstr "Povolit zvuky upozornění"
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -4592,7 +4592,7 @@ msgstr "Automatische Wiederherstellung bei Positionsverlust (Schrittverlust)"
 msgid "Allow Prompt Sound"
 msgstr "Erlaube akustische Signale"
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr "Filamentverwicklung erkannt"
 
 msgid "Global"

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -4410,7 +4410,7 @@ msgstr "Auto-recover from step loss"
 msgid "Allow Prompt Sound"
 msgstr ""
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -4549,7 +4549,7 @@ msgstr "Autorecuperar desde pérdida de paso"
 msgid "Allow Prompt Sound"
 msgstr "Permitir Sonido de Aviso"
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -4518,7 +4518,7 @@ msgstr "Restauration automatique en cas de perte de pas"
 msgid "Allow Prompt Sound"
 msgstr "Autoriser le son de l'invite"
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -4437,7 +4437,7 @@ msgstr "Automatikus helyreállítás lépésvesztésből"
 msgid "Allow Prompt Sound"
 msgstr ""
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -4505,7 +4505,7 @@ msgstr "Recupero automatico perdita passi"
 msgid "Allow Prompt Sound"
 msgstr "Consenti suono di richiesta"
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr "Rilevamento del groviglio del filamento"
 
 msgid "Global"

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -4335,7 +4335,7 @@ msgstr "自動回復"
 msgid "Allow Prompt Sound"
 msgstr ""
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -4433,7 +4433,7 @@ msgstr "손실 단계부터 자동 복구"
 msgid "Allow Prompt Sound"
 msgstr "프롬프트 소리 허용"
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr "필라멘트 엉킴 감지"
 
 msgid "Global"

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -4474,7 +4474,7 @@ msgstr "Automatisch herstel na stapverlies"
 msgid "Allow Prompt Sound"
 msgstr ""
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -4560,7 +4560,7 @@ msgstr "Автовосстановление после потери шагов"
 msgid "Allow Prompt Sound"
 msgstr "Разрешить звуковые уведомления"
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -4422,7 +4422,7 @@ msgstr "Automatisk återhämtning vid stegförlust"
 msgid "Allow Prompt Sound"
 msgstr ""
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -4498,7 +4498,7 @@ msgstr "Adım kaybından otomatik kurtarma"
 msgid "Allow Prompt Sound"
 msgstr "Uyarı Sesine İzin Ver"
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr "Filament Dolaşma Tespiti"
 
 msgid "Global"

--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -4468,7 +4468,7 @@ msgstr "Автоматичне відновлення після втрати к
 msgid "Allow Prompt Sound"
 msgstr ""
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -4323,7 +4323,7 @@ msgstr "自动从丢步中恢复"
 msgid "Allow Prompt Sound"
 msgstr "允许提示音"
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -4553,7 +4553,7 @@ msgstr "自動從丟步中恢復"
 msgid "Allow Prompt Sound"
 msgstr "允許提示音效"
 
-msgid "Fliament Tangle Detect"
+msgid "Filament Tangle Detect"
 msgstr ""
 
 msgid "Global"

--- a/src/slic3r/GUI/AmsMappingPopup.cpp
+++ b/src/slic3r/GUI/AmsMappingPopup.cpp
@@ -596,13 +596,13 @@ void AmsMapingPopup::paintEvent(wxPaintEvent &evt)
 }
 
 
-void MappingItem::send_event(int fliament_id) 
+void MappingItem::send_event(int filament_id) 
 {
     auto number = wxGetApp().transition_tridid(m_tray_data.id);
     wxCommandEvent event(EVT_SET_FINISH_MAPPING);
     event.SetInt(m_tray_data.id);
 
-    wxString param = wxString::Format("%d|%d|%d|%d|%s|%d", m_coloul.Red(), m_coloul.Green(), m_coloul.Blue(), m_coloul.Alpha(), number, fliament_id);
+    wxString param = wxString::Format("%d|%d|%d|%d|%s|%d", m_coloul.Red(), m_coloul.Green(), m_coloul.Blue(), m_coloul.Alpha(), number, filament_id);
     event.SetString(param);
     event.SetEventObject(this->GetParent()->GetParent());
     wxPostEvent(this->GetParent()->GetParent()->GetParent(), event);

--- a/src/slic3r/GUI/AmsMappingPopup.hpp
+++ b/src/slic3r/GUI/AmsMappingPopup.hpp
@@ -102,7 +102,7 @@ public:
     ~MappingItem();
 
 	void update_data(TrayData data);
-    void send_event(int fliament_id);
+    void send_event(int filament_id);
     void set_tray_index(wxString t_index) {m_tray_index = t_index;};
 
     wxString m_tray_index;

--- a/src/slic3r/GUI/DeviceManager.hpp
+++ b/src/slic3r/GUI/DeviceManager.hpp
@@ -846,8 +846,8 @@ public:
     //set prompt sound
     int command_set_prompt_sound(bool prompt_sound);
 
-    //set fliament tangle detect
-    int command_set_filament_tangle_detect(bool fliament_tangle_detect);
+    //set filament tangle detect
+    int command_set_filament_tangle_detect(bool filament_tangle_detect);
 
 
     // set print option

--- a/src/slic3r/GUI/PrintOptionsDialog.cpp
+++ b/src/slic3r/GUI/PrintOptionsDialog.cpp
@@ -313,7 +313,7 @@ wxBoxSizer* PrintOptionsDialog::create_settings_group(wxWindow* parent)
     //filament tangle detect
     line_sizer = new wxBoxSizer(wxHORIZONTAL);
     m_cb_filament_tangle = new CheckBox(parent);
-    text_filament_tangle = new wxStaticText(parent, wxID_ANY, _L("Fliament Tangle Detect"));
+    text_filament_tangle = new wxStaticText(parent, wxID_ANY, _L("Filament Tangle Detect"));
     text_filament_tangle->SetFont(Label::Body_14);
     line_sizer->Add(FromDIP(5), 0, 0, 0);
     line_sizer->Add(m_cb_filament_tangle, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(5));


### PR DESCRIPTION
Fix typo "Fliament" -> "Filament"

Backported:
https://github.com/bambulab/BambuStudio/pull/3043