### PR TITLE
Updated PA test to address crash when default line width was zero

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -8873,7 +8873,7 @@ void Plater::_calib_pa_pattern(const Calib_Params& params)
     print_config.set_key_value(
         "outer_wall_speed",
         new ConfigOptionFloat(CalibPressureAdvance::find_optimal_PA_speed(
-            wxGetApp().preset_bundle->full_config(), print_config.get_abs_value("line_width", nozzle_diameter),
+            wxGetApp().preset_bundle->full_config(), (fabs(print_config.get_abs_value("line_width", nozzle_diameter)) <= DBL_EPSILON)? (nozzle_diameter*1.125) : print_config.get_abs_value("line_width", nozzle_diameter),
             print_config.get_abs_value("layer_height"), 0)));
 
     for (const auto opt : SuggestedConfigCalibPAPattern().nozzle_ratio_pairs) {


### PR DESCRIPTION
Edge case scenario as default line width should always be set but updating the code nonetheless to set some sensible default values when they are missing.

Addresses bug https://github.com/SoftFever/OrcaSlicer/issues/3043