### PR TITLE
Fix #2662 - "Extra length on restart" setting is ignored when wipe is enabled

### DIFF
--- a/src/libslic3r/Extruder.cpp
+++ b/src/libslic3r/Extruder.cpp
@@ -54,11 +54,11 @@ double Extruder::retract(double length, double restart_extra)
         if (m_config->use_relative_e_distances)
             m_share_E = 0.;
         double to_retract = std::max(0., length - m_share_retracted);
+        m_restart_extra = restart_extra;
         if (to_retract > 0.) {
             m_share_E             -= to_retract;
             m_absolute_E          -= to_retract;
             m_share_retracted     += to_retract;
-            m_restart_extra = restart_extra;
         }
         return to_retract;
     } else {
@@ -66,11 +66,11 @@ double Extruder::retract(double length, double restart_extra)
         if (m_config->use_relative_e_distances)
             m_E = 0.;
         double to_retract = std::max(0., length - m_retracted);
+        m_restart_extra = restart_extra;
         if (to_retract > 0.) {
             m_E             -= to_retract;
             m_absolute_E    -= to_retract;
             m_retracted     += to_retract;
-            m_restart_extra = restart_extra;
         }
         return to_retract;
     }


### PR DESCRIPTION
When wipe was enabled it results in a zero length retract after the wipe is performed. This results in a no-op in the Extruder::retract and also means that the m_restart_extra was not set after the wipe command. That resulted in the next de-retraction having a 0 restart extra length.

Bambu is working around this issue by wiping 95% of the retraction and then doing a small retraction, which sets the restart extra length value as seen here:
![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/3df5a5df-31fc-49d1-b562-999e5c2b0f0b)

I am 50-50 whether this change will introduce any regressions, so would appreciate a code review if possible?