### PR TITLE
Disable the cooling moves for snapmaker printers

### DIFF
--- a/resources/profiles/Snapmaker/filament/fdm_filament_common.json
+++ b/resources/profiles/Snapmaker/filament/fdm_filament_common.json
@@ -124,7 +124,7 @@
     "0"
   ],
   "filament_cooling_moves": [
-    "4"
+    "0"
   ],
   "filament_cooling_initial_speed": [
     "2.2"

--- a/resources/profiles/Snapmaker/machine/fdm_common.json
+++ b/resources/profiles/Snapmaker/machine/fdm_common.json
@@ -16,7 +16,7 @@
   "enable_filament_ramming": "0",
   "nozzle_volume": "0",
   "cooling_tube_retraction": "0",
-  "cooling_tube_length": "8",
+  "cooling_tube_length": "0",
   "parking_pos_retraction": "0",
   "extra_loading_move": "-2",
   "high_current_on_filament_swap": "0",


### PR DESCRIPTION
The multi-extruder system does not need cooling features. It generates a lot of unnecessary retractions and slow moves  when switching tool heads, which increases the overall printing time.
