### PR TITLE
Fix value passed to SPEED in air-filteration.md macro.

### DIFF
--- a/doc/air-filtration.md
+++ b/doc/air-filtration.md
@@ -29,7 +29,7 @@ hardware_pwm: false
 [gcode_macro M106]
 gcode:
     {% set fan = 'fan' + (params.P|int if params.P is defined else 0)|string %}
-    {% set speed = (params.S|int if params.S is defined else 255) %}
+    {% set speed = (params.S|float / 255 if params.S is defined else 1.0) %}
     SET_FAN_SPEED FAN={fan} SPEED={speed}
 
 ```


### PR DESCRIPTION
The SPEED parameter of SET_FAN_SPEED needs to be between 0.0  and 1.0. Since the S param, which is between 0 and 255, was being passed as is to SPEED, it effectively resulted in the target fan running at 100% if any value > 0 was passed to M106.