### PR TITLE
Fix sidebar not shown when open 3mf file from command line arg

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -7167,6 +7167,10 @@ void GLCanvas3D::_render_selection_center()
 
 void GLCanvas3D::_check_and_update_toolbar_icon_scale()
 {
+    // Update collapse toolbar
+    GLToolbar& collapse_toolbar = wxGetApp().plater()->get_collapse_toolbar();
+    collapse_toolbar.set_enabled(wxGetApp().plater()->get_sidebar_docking_state() != Sidebar::None);
+
     // Don't update a toolbar scale, when we are on a Preview
     if (wxGetApp().plater()->is_preview_shown()) {
         IMSlider   *m_layers_slider = get_gcode_viewer().get_layers_slider();
@@ -7194,7 +7198,6 @@ void GLCanvas3D::_check_and_update_toolbar_icon_scale()
     //float main_size = GLGizmosManager::Default_Icons_Size * scale;
 
     // Set current size for all top toolbars. It will be used for next calculations
-    GLToolbar& collapse_toolbar = wxGetApp().plater()->get_collapse_toolbar();
 #if ENABLE_RETINA_GL
     const float sc = m_retina_helper->get_scale_factor() * scale;
     //BBS: GUI refactor: GLToolbar
@@ -7215,9 +7218,6 @@ void GLCanvas3D::_check_and_update_toolbar_icon_scale()
     collapse_toolbar.set_icons_size(size / 2.0);
     m_gizmos.set_overlay_icon_size(size);
 #endif // ENABLE_RETINA_GL
-
-    // Update collapse toolbar
-    collapse_toolbar.set_enabled(wxGetApp().plater()->get_sidebar_docking_state() != Sidebar::None);
 
     //BBS: GUI refactor: GLToolbar
 #if BBS_TOOLBAR_ON_TOP

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -5828,8 +5828,10 @@ void Plater::priv::set_current_panel(wxPanel* panel, bool no_slice)
         };
 
     //BBS: add the collapse logic
+    if (panel == preview) {
+        this->enable_sidebar(!q->only_gcode_mode());
+    }
     if (panel == preview && q->only_gcode_mode()) {
-        this->enable_sidebar(false);
         preview->get_canvas3d()->enable_select_plate_toolbar(false);
     }
     else if (panel == preview && q->using_exported_file() && (q->m_valid_plates_count <= 1)) {


### PR DESCRIPTION
This fixes issue that the sidebar is missing if slicer is opened with command line arg, includes:

- Open 3mf file with file association
- Drag & drop 3mf file to slicer executable
- Run slicer from terminal with file path parameter
- Other similar situation that will pass a file path in main function parameter