### PR TITLE
Fixed Ender 3 V3's default materials

### DIFF
--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 KE.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 KE.json
@@ -8,5 +8,5 @@
     "bed_model": "creality_ender3v3ke_buildplate_model.stl",
     "bed_texture": "creality_ender3v3ke_buildplate_texture.png",
     "hotend_model": "",
-    "default_materials": "Creality Generic PLA;Creality Generic PETG;Creality Generic ABS"
+    "default_materials": "Creality Generic ABS @Ender-3V3-all;Creality Generic ASA @Ender-3V3-all;Creality Generic PETG @Ender-3V3-all;Creality Generic PLA @Ender-3V3-all;Creality Generic PLA High Speed @Ender-3V3-all;Creality Generic PLA Matte @Ender-3V3-all;Creality Generic PLA Silk @Ender-3V3-all;Creality Generic TPU @Ender-3V3-all"
 }

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE.json
@@ -8,5 +8,5 @@
     "bed_model": "creality_ender3v3se_buildplate_model.stl",
     "bed_texture": "creality_ender3v3se_buildplate_texture.png",
     "hotend_model": "",
-    "default_materials": "Creality Generic PLA;Creality Generic PETG;Creality Generic ABS"
+    "default_materials": "Creality Generic ABS @Ender-3V3-all;Creality Generic ASA @Ender-3V3-all;Creality Generic PETG @Ender-3V3-all;Creality Generic PLA @Ender-3V3-all;Creality Generic PLA High Speed @Ender-3V3-all;Creality Generic PLA Matte @Ender-3V3-all;Creality Generic PLA Silk @Ender-3V3-all;Creality Generic TPU @Ender-3V3-all"
 }


### PR DESCRIPTION
As requested, here is the fix for default materials listing of Ender 3 V3 printers.