### PR TITLE
Bug fix: VFA Test fix

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9289,6 +9289,7 @@ void Plater::calib_VFA(const Calib_Params& params)
     print_config->set_key_value("bottom_shell_layers", new ConfigOptionInt(1));
     print_config->set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config->set_key_value("overhang_reverse", new ConfigOptionBool(false));
+    print_config->set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
     model().objects[0]->config.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterOnly));
     model().objects[0]->config.set_key_value("brim_width", new ConfigOptionFloat(3.0));

--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -807,6 +807,7 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
     print_config.set_key_value("enable_overhang_speed", new ConfigOptionBool{false});
     print_config.set_key_value("timelapse_type", new ConfigOptionEnum<TimelapseType>(tlTraditional));
     print_config.set_key_value("wall_loops", new ConfigOptionInt(1));
+    print_config.set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config.set_key_value("top_shell_layers", new ConfigOptionInt(0));
     print_config.set_key_value("bottom_shell_layers", new ConfigOptionInt(1));
     print_config.set_key_value("sparse_infill_density", new ConfigOptionPercent(0));


### PR DESCRIPTION
VFA Test has a bug where it would not run the vase mode algorithm if the user had the detect thin walls parameter selected.

![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/a280cf5d-3b0a-4239-8ea6-68caf21b110b)

This PR fixes this by deselecting the parameter in the calibration methods.

![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/b0420b98-e72f-4b4d-aa25-79dcb3e7e775)

Softfever, I promise that's all from me this week :D 
