### PR TITLE
Fix tutk logs location (#3209)

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2107,6 +2107,9 @@ void GUI_App::init_app_config()
         if (!boost::filesystem::exists(data_dir_path)){
             boost::filesystem::create_directory(data_dir_path);
         }
+
+        // Change current dirtory of application
+        chdir(encode_path((Slic3r::data_dir() + "/log").c_str()).c_str());
     } else {
         m_datadir_redefined = true;
     }


### PR DESCRIPTION
Now the logs are generated under the log folder, just like what BBS does:
![7bd36a040108d5fd0ee1b2cea10587d2](https://github.com/SoftFever/OrcaSlicer/assets/1537155/ba043e09-a849-4f09-bb79-15b937348f9d)

Fixes #3209