### PR TITLE
Revert to WxWidgets 3.1.5

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -236,7 +236,6 @@ endif ()
 
 include(JPEG/JPEG.cmake)
 include(TIFF/TIFF.cmake)
-include(NanoSVG/NanoSVG.cmake)
 include(wxWidgets/wxWidgets.cmake)
 include(OCCT/OCCT.cmake)
 include(FREETYPE/FREETYPE.cmake)

--- a/deps/wxWidgets/0001-wxWidget-fix.patch
+++ b/deps/wxWidgets/0001-wxWidget-fix.patch
@@ -1,0 +1,667 @@
+diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
+index 0bc4f934b9..479431a69c 100644
+--- a/build/cmake/init.cmake
++++ b/build/cmake/init.cmake
+@@ -413,7 +413,11 @@ if(wxUSE_GUI)
+         else()
+             find_package(OpenGL)
+             if(WXGTK3 AND OpenGL_EGL_FOUND AND wxUSE_GLCANVAS_EGL)
++                if(UNIX AND NOT APPLE)
++                set(OPENGL_LIBRARIES OpenGL EGL)
++                else()
+                 set(OPENGL_LIBRARIES OpenGL::OpenGL OpenGL::EGL)
++                endif()
+                 find_package(WAYLANDEGL)
+                 if(WAYLANDEGL_FOUND AND wxHAVE_GDK_WAYLAND)
+                     list(APPEND OPENGL_LIBRARIES ${WAYLANDEGL_LIBRARIES})
+diff --git a/build/cmake/lib/webview/CMakeLists.txt b/build/cmake/lib/webview/CMakeLists.txt
+index cc3298ff33..8adbeaea4f 100644
+--- a/build/cmake/lib/webview/CMakeLists.txt
++++ b/build/cmake/lib/webview/CMakeLists.txt
+@@ -56,7 +56,7 @@ if(APPLE)
+ elseif(WXMSW)
+     if(wxUSE_WEBVIEW_EDGE)
+         # Update the following variables if updating WebView2 SDK
+-        set(WEBVIEW2_VERSION "1.0.705.50")
++        set(WEBVIEW2_VERSION "1.0.1418.22")
+         set(WEBVIEW2_URL "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${WEBVIEW2_VERSION}")
+-        set(WEBVIEW2_SHA256 "6a34bb553e18cfac7297b4031f3eac2558e439f8d16a45945c22945ac404105d")
++        set(WEBVIEW2_SHA256 "51d2ef56196e2a9d768a6843385bcb9c6baf9ed34b2603ddb074fb4995543a99")
+ 
+diff --git a/include/wx/fontutil.h b/include/wx/fontutil.h
+index 09ad8c8ef3..3c0c2d8f7e 100644
+--- a/include/wx/fontutil.h
++++ b/include/wx/fontutil.h
+@@ -294,7 +294,11 @@ public:
+     wxFontEncoding GetEncoding() const;
+ 
+     void SetPointSize(int pointsize);
+-    void SetFractionalPointSize(double pointsize);
++    void SetFractionalPointSize(double pointsize
++#if defined(__WXMSW__)
++    	, const wxWindow *window = nullptr
++#endif
++    	);
+     void SetPixelSize(const wxSize& pixelSize);
+     void SetStyle(wxFontStyle style);
+     void SetNumericWeight(int weight);
+@@ -307,12 +311,19 @@ public:
+ 
+     // Helper used in many ports: use the normal font size if the input is
+     // negative, as we handle -1 as meaning this for compatibility.
+-    void SetSizeOrDefault(double size)
++    void SetSizeOrDefault(double size
++#if defined(__WXMSW__)
++    	, const wxWindow *window = nullptr
++#endif
++    	)
+     {
+         SetFractionalPointSize
+         (
+             size < 0 ? wxNORMAL_FONT->GetFractionalPointSize()
+                      : size
++#if defined(__WXMSW__)
++            ,window
++#endif
+         );
+     }
+ 
+diff --git a/include/wx/gdicmn.h b/include/wx/gdicmn.h
+index e29a77627c..dc48cf9451 100644
+--- a/include/wx/gdicmn.h
++++ b/include/wx/gdicmn.h
+@@ -38,6 +38,7 @@ class WXDLLIMPEXP_FWD_CORE wxRegion;
+ class WXDLLIMPEXP_FWD_BASE wxString;
+ class WXDLLIMPEXP_FWD_CORE wxIconBundle;
+ class WXDLLIMPEXP_FWD_CORE wxPoint;
++class WXDLLIMPEXP_FWD_CORE wxWindow;
+ 
+ // ---------------------------------------------------------------------------
+ // constants
+@@ -1092,7 +1093,9 @@ extern int WXDLLIMPEXP_CORE wxDisplayDepth();
+ 
+ // get the display size
+ extern void WXDLLIMPEXP_CORE wxDisplaySize(int *width, int *height);
++extern void WXDLLIMPEXP_CORE wxDisplaySize(const wxWindow *window, int *width, int *height);
+ extern wxSize WXDLLIMPEXP_CORE wxGetDisplaySize();
++extern wxSize WXDLLIMPEXP_CORE wxGetDisplaySize(const wxWindow *window);
+ extern void WXDLLIMPEXP_CORE wxDisplaySizeMM(int *width, int *height);
+ extern wxSize WXDLLIMPEXP_CORE wxGetDisplaySizeMM();
+ extern wxSize WXDLLIMPEXP_CORE wxGetDisplayPPI();
+diff --git a/include/wx/generic/grid.h b/include/wx/generic/grid.h
+index d7a3890764..e4dee51d5a 100644
+--- a/include/wx/generic/grid.h
++++ b/include/wx/generic/grid.h
+@@ -2951,9 +2951,11 @@ private:
+                          wxGridWindow* gridWindow);
+ 
+     // Update the width/height of the column/row being drag-resized.
++    //BBS: add cursor mode for DoGridDragResize's paremeters
+     void DoGridDragResize(const wxPoint& position,
+                           const wxGridOperations& oper,
+-                          wxGridWindow* gridWindow);
++                          wxGridWindow* gridWindow,
++                          CursorMode mode);
+ 
+     // process different clicks on grid cells
+     void DoGridCellLeftDown(wxMouseEvent& event,
+diff --git a/include/wx/msw/font.h b/include/wx/msw/font.h
+index 0f9768b44e..094d774918 100644
+--- a/include/wx/msw/font.h
++++ b/include/wx/msw/font.h
+@@ -23,7 +23,7 @@ public:
+     // ctors and such
+     wxFont() { }
+ 
+-    wxFont(const wxFontInfo& info);
++    wxFont(const wxFontInfo& info, const wxWindow *window = nullptr);
+ 
+     wxFont(int size,
+            wxFontFamily family,
+diff --git a/include/wx/msw/tooltip.h b/include/wx/msw/tooltip.h
+index 4c3be08cec..96fb378d01 100644
+--- a/include/wx/msw/tooltip.h
++++ b/include/wx/msw/tooltip.h
+@@ -91,10 +91,10 @@ private:
+     // the one and only one tooltip control we use - never access it directly
+     // but use GetToolTipCtrl() which will create it when needed
+     static WXHWND ms_hwndTT;
+-
++public:
+     // create the tooltip ctrl if it doesn't exist yet and return its HWND
+     static WXHWND GetToolTipCtrl();
+-
++private:
+     // to be used in wxModule for deleting tooltip ctrl window when exiting mainloop
+     static void DeleteToolTipCtrl();
+ 
+diff --git a/include/wx/osx/app.h b/include/wx/osx/app.h
+index 317a0ca96f..58014ec1d4 100644
+--- a/include/wx/osx/app.h
++++ b/include/wx/osx/app.h
+@@ -161,7 +161,7 @@ private:
+ 
+ public:
+     bool                OSXInitWasCalled() { return m_inited; }
+-    void                OSXStoreOpenFiles(const wxArrayString &files ) { m_openFiles = files ; }
++    virtual void        OSXStoreOpenFiles(const wxArrayString &files ) { m_openFiles = files ; }
+     void                OSXStorePrintFiles(const wxArrayString &files ) { m_printFiles = files ; }
+     void                OSXStoreOpenURL(const wxString &url ) { m_getURL = url ; }
+ #endif
+diff --git a/src/common/combocmn.cpp b/src/common/combocmn.cpp
+index b61aac35bf..d12b745e8c 100644
+--- a/src/common/combocmn.cpp
++++ b/src/common/combocmn.cpp
+@@ -2141,7 +2141,7 @@ void wxComboCtrlBase::CreatePopup()
+         #if !USES_GENERICTLW
+             m_winPopup = new wxComboPopupWindowBase2( this, wxNO_BORDER );
+         #else
+-            int tlwFlags = wxNO_BORDER;
++            int tlwFlags = wxNO_BORDER | wxSTAY_ON_TOP;
+           #ifdef wxCC_GENERIC_TLW_IS_FRAME
+             tlwFlags |= wxFRAME_NO_TASKBAR;
+           #endif
+@@ -2285,6 +2285,9 @@ void wxComboCtrlBase::ShowPopup()
+ 
+     SetFocus();
+ 
++    //int displayIdx = wxDisplay::GetFromWindow(this);
++    //wxRect displayRect = wxDisplay(displayIdx != wxNOT_FOUND ? displayIdx : 0u).GetGeometry();
++
+     // Space above and below
+     int screenHeight;
+     wxPoint scrPos;
+@@ -2407,9 +2410,13 @@ void wxComboCtrlBase::ShowPopup()
+ 
+     int showFlags = CanDeferShow;
+ 
+-    if ( spaceBelow < szp.y )
++    int anchorSideVertical = m_anchorSide & (wxUP | wxDOWN);
++    if (// Pop up as asked for by the library user.
++        (anchorSideVertical & wxUP) || 
++        // Automatic: Pop up if it does not fit down.
++        (anchorSideVertical == 0 && spaceBelow < szp.y ))
+     {
+-        popupY = scrPos.y - szp.y;
++        popupY = scrPos.y - szp.y + displayRect.GetTop();
+         showFlags |= ShowAbove;
+     }
+ 
+diff --git a/src/common/datavcmn.cpp b/src/common/datavcmn.cpp
+index 1f5fd4d66b..14ea2f8ef1 100644
+--- a/src/common/datavcmn.cpp
++++ b/src/common/datavcmn.cpp
+@@ -1322,7 +1322,11 @@ wxDataViewItem wxDataViewCtrlBase::GetSelection() const
+ 
+     wxDataViewItemArray selections;
+     GetSelections(selections);
+-    return selections[0];
++    // BBS
++    if (!selections.empty())
++        return selections[0];
++    else
++        return wxDataViewItem(0);
+ }
+ 
+ namespace
+diff --git a/src/common/dcbufcmn.cpp b/src/common/dcbufcmn.cpp
+index 74958fce10..59844f4526 100644
+--- a/src/common/dcbufcmn.cpp
++++ b/src/common/dcbufcmn.cpp
+@@ -82,9 +82,15 @@ private:
+         const double scale = dc ? dc->GetContentScaleFactor() : 1.0;
+         wxBitmap* const buffer = new wxBitmap;
+ 
++#if __WXMSW__
+         // we must always return a valid bitmap but creating a bitmap of
+         // size 0 would fail, so create a 1*1 bitmap in this case
+-        buffer->CreateScaled(wxMax(w, 1), wxMax(h, 1), -1, scale);
++        buffer->Create(wxMax(w, 1), wxMax(h, 1), 24);
++#else
++		// we must always return a valid bitmap but creating a bitmap of
++		// size 0 would fail, so create a 1*1 bitmap in this case
++		buffer->CreateScaled(wxMax(w, 1), wxMax(h, 1), -1, scale);
++#endif
+ 
+         return buffer;
+     }
+diff --git a/src/common/gdicmn.cpp b/src/common/gdicmn.cpp
+index 20442bbc73..9a24951ec7 100644
+--- a/src/common/gdicmn.cpp
++++ b/src/common/gdicmn.cpp
+@@ -863,11 +863,25 @@ void wxDisplaySize(int *width, int *height)
+         *height = size.y;
+ }
+ 
++void wxDisplaySize(const wxWindow *window, int *width, int *height)
++{
++    const wxSize size = wxGetDisplaySize(window);
++    if ( width )
++        *width = size.x;
++    if ( height )
++        *height = size.y;    
++}
++
+ wxSize wxGetDisplaySize()
+ {
+     return wxDisplay().GetGeometry().GetSize();
+ }
+ 
++wxSize wxGetDisplaySize(const wxWindow *window)
++{
++    return window ? wxDisplay(window).GetGeometry().GetSize() : wxDisplay().GetGeometry().GetSize();
++}
++
+ void wxClientDisplayRect(int *x, int *y, int *width, int *height)
+ {
+     const wxRect rect = wxGetClientDisplayRect();
+diff --git a/src/common/intl.cpp b/src/common/intl.cpp
+index 0b0d8798f4..7072fab18a 100644
+--- a/src/common/intl.cpp
++++ b/src/common/intl.cpp
+@@ -1628,6 +1628,12 @@ GetInfoFromLCID(LCID lcid,
+             {
+                 str = buf;
+ 
++//FIXME Vojtech: We forcefully set the locales for a decimal point to "C", but this
++// is not possible for the Win32 locales, therefore there is a discrepancy. 
++// It looks like we live with the discrepancy for at least half a year, so we will
++// suppress the assert until we fix Slic3r to properly switch to "C" locales just
++// for file import / export.
++#if 0
+                 // As we get our decimal point separator from Win32 and not the
+                 // CRT there is a possibility of mismatch between them and this
+                 // can easily happen if the user code called setlocale()
+@@ -1641,6 +1647,7 @@ GetInfoFromLCID(LCID lcid,
+                     "Decimal separator mismatch -- did you use setlocale()?"
+                     "If so, use wxLocale to change the locale instead."
+                 );
++#endif
+             }
+             break;
+ 
+diff --git a/src/generic/grid.cpp b/src/generic/grid.cpp
+index 41fd4524cf..f4a15cb839 100644
+--- a/src/generic/grid.cpp
++++ b/src/generic/grid.cpp
+@@ -3824,7 +3824,8 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
+             {
+                 case WXGRID_CURSOR_RESIZE_ROW:
+                 {
+-                    DoGridDragResize(event.GetPosition(), wxGridRowOperations(), gridWindow);
++                    //BBS: add cursor mode for DoGridDragResize's paremeters
++                    DoGridDragResize(event.GetPosition(), wxGridRowOperations(), gridWindow, WXGRID_CURSOR_RESIZE_ROW);
+                 }
+                 break;
+ 
+@@ -4166,7 +4167,8 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
+             switch ( m_cursorMode )
+             {
+                 case WXGRID_CURSOR_RESIZE_COL:
+-                    DoGridDragResize(event.GetPosition(), wxGridColumnOperations(), gridWindow);
++                    //BBS: add cursor mode for DoGridDragResize's paremeters
++                    DoGridDragResize(event.GetPosition(), wxGridColumnOperations(), gridWindow, WXGRID_CURSOR_RESIZE_COL);
+                 break;
+ 
+                 case WXGRID_CURSOR_SELECT_COL:
+@@ -4708,11 +4710,13 @@ bool wxGrid::DoGridDragEvent(wxMouseEvent& event,
+             return DoGridCellDrag(event, coords, isFirstDrag);
+ 
+         case WXGRID_CURSOR_RESIZE_ROW:
+-            DoGridDragResize(event.GetPosition(), wxGridRowOperations(), gridWindow);
++            //BBS: add cursor mode for DoGridDragResize's paremeters
++            DoGridDragResize(event.GetPosition(), wxGridRowOperations(), gridWindow, WXGRID_CURSOR_RESIZE_ROW);
+             break;
+ 
+         case WXGRID_CURSOR_RESIZE_COL:
+-            DoGridDragResize(event.GetPosition(), wxGridColumnOperations(), gridWindow);
++            //BBS: add cursor mode for DoGridDragResize's paremeters
++            DoGridDragResize(event.GetPosition(), wxGridColumnOperations(), gridWindow, WXGRID_CURSOR_RESIZE_COL);
+             break;
+ 
+         default:
+@@ -4803,6 +4807,8 @@ wxGrid::DoGridCellLeftDown(wxMouseEvent& event,
+                             case wxGridSelectCells:
+                             case wxGridSelectRowsOrColumns:
+                                 // nothing to do in these cases
++                                //BBS: select this cell when first click
++                                m_selection->SelectBlock(coords.GetRow(), coords.GetCol(), coords.GetRow(), coords.GetCol(), event);
+                                 break;
+ 
+                             case wxGridSelectRows:
+@@ -5044,9 +5050,11 @@ void wxGrid::ProcessGridCellMouseEvent(wxMouseEvent& event, wxGridWindow *eventG
+     }
+ }
+ 
++//BBS: add cursor mode for DoGridDragResize's paremeters
+ void wxGrid::DoGridDragResize(const wxPoint& position,
+                               const wxGridOperations& oper,
+-                              wxGridWindow* gridWindow)
++                              wxGridWindow* gridWindow,
++                              CursorMode mode)
+ {
+     // Get the logical position from the physical one we're passed.
+     const wxPoint
+@@ -5056,10 +5064,28 @@ void wxGrid::DoGridDragResize(const wxPoint& position,
+     // orthogonal direction.
+     const int linePos = oper.Dual().Select(logicalPos);
+ 
+-    const int lineStart = oper.GetLineStartPos(this, m_dragRowOrCol);
+-    oper.SetLineSize(this, m_dragRowOrCol,
++    //BBS: add logic for resize multiplexed cols
++    if (mode == WXGRID_CURSOR_RESIZE_COL) {
++        int col_to_resize = m_dragRowOrCol;
++        int num_rows, num_cols;
++        this->GetCellSize(0, m_dragRowOrCol, &num_rows, &num_cols);
++        if (num_cols < 1)
++            col_to_resize = m_dragRowOrCol - 1;
++
++        const int lineEnd = oper.GetLineEndPos(this, m_dragRowOrCol);
++        const int lineSize = oper.GetLineSize(this, col_to_resize);
++        int size = linePos - lineEnd + lineSize;
++        oper.SetLineSize(this, col_to_resize,
++                     wxMax(size,
++                           oper.GetMinimalLineSize(this, col_to_resize)));
++    }
++    else {
++        const int lineStart = oper.GetLineStartPos(this, m_dragRowOrCol);
++
++        oper.SetLineSize(this, m_dragRowOrCol,
+                      wxMax(linePos - lineStart,
+                            oper.GetMinimalLineSize(this, m_dragRowOrCol)));
++    }
+ 
+     // TODO: generate RESIZING event, see #10754, if the size has changed.
+ }
+@@ -5082,7 +5108,8 @@ wxPoint wxGrid::GetPositionForResizeEvent(int width) const
+ 
+ void wxGrid::DoEndDragResizeRow(const wxMouseEvent& event, wxGridWindow* gridWindow)
+ {
+-    DoGridDragResize(event.GetPosition(), wxGridRowOperations(), gridWindow);
++    //BBS: add cursor mode for DoGridDragResize's paremeters
++    DoGridDragResize(event.GetPosition(), wxGridRowOperations(), gridWindow, WXGRID_CURSOR_RESIZE_ROW);
+ 
+     SendGridSizeEvent(wxEVT_GRID_ROW_SIZE, m_dragRowOrCol, -1, event);
+ 
+@@ -5091,7 +5118,8 @@ void wxGrid::DoEndDragResizeRow(const wxMouseEvent& event, wxGridWindow* gridWin
+ 
+ void wxGrid::DoEndDragResizeCol(const wxMouseEvent& event, wxGridWindow* gridWindow)
+ {
+-    DoGridDragResize(event.GetPosition(), wxGridColumnOperations(), gridWindow);
++    //BBS: add cursor mode for DoGridDragResize's paremeters
++    DoGridDragResize(event.GetPosition(), wxGridColumnOperations(), gridWindow, WXGRID_CURSOR_RESIZE_COL);
+ 
+     SendGridSizeEvent(wxEVT_GRID_COL_SIZE, -1, m_dragRowOrCol, event);
+ 
+@@ -5105,9 +5133,10 @@ void wxGrid::DoHeaderStartDragResizeCol(int col)
+ 
+ void wxGrid::DoHeaderDragResizeCol(int width)
+ {
++    //BBS: add cursor mode for DoGridDragResize's paremeters
+     DoGridDragResize(GetPositionForResizeEvent(width),
+                      wxGridColumnOperations(),
+-                     m_gridWin);
++                     m_gridWin, WXGRID_CURSOR_RESIZE_COL);
+ }
+ 
+ void wxGrid::DoHeaderEndDragResizeCol(int width)
+@@ -5891,6 +5920,10 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
+                     DisableCellEditControl();
+ 
+                     MoveCursorDown( event.ShiftDown() );
++                    //BBS: select this cell when first click
++                    m_selection->SelectBlock(m_currentCellCoords.GetRow(), m_currentCellCoords.GetCol(),
++                                             m_currentCellCoords.GetRow(), m_currentCellCoords.GetCol(),
++                                             event);
+                 }
+                 break;
+ 
+diff --git a/src/msw/bmpcbox.cpp b/src/msw/bmpcbox.cpp
+index 0a2d167ad7..0aeba45ea9 100644
+--- a/src/msw/bmpcbox.cpp
++++ b/src/msw/bmpcbox.cpp
+@@ -156,13 +156,20 @@ void wxBitmapComboBox::RecreateControl()
+ 
+     wxComboBox::DoClear();
+ 
+-    HWND hwnd = GetHwnd();
++    WNDPROC wndproc_edit = nullptr;
++	WinStruct<COMBOBOXINFO> combobox_info;
++	HWND hwnd = GetHwnd();
++if (::GetComboBoxInfo(hwnd, &combobox_info))
++		wndproc_edit = (WNDPROC)wxGetWindowProc(combobox_info.hwndItem);
+     DissociateHandle();
+     ::DestroyWindow(hwnd);
+ 
+     if ( !MSWCreateControl(wxT("COMBOBOX"), wxEmptyString, pos, size) )
+         return;
+ 
++if (::GetComboBoxInfo(GetHwnd(), &combobox_info))
++    wxSetWindowProc(combobox_info.hwndItem, wndproc_edit);
++
+     // initialize the controls contents
+     for ( i = 0; i < numItems; i++ )
+     {
+diff --git a/src/msw/font.cpp b/src/msw/font.cpp
+index 0bd240d79f..d38b1b00f5 100644
+--- a/src/msw/font.cpp
++++ b/src/msw/font.cpp
+@@ -54,7 +54,7 @@ static const int PITCH_MASK = FIXED_PITCH | VARIABLE_PITCH;
+ class WXDLLEXPORT wxFontRefData: public wxGDIRefData
+ {
+ public:
+-    wxFontRefData(const wxFontInfo& info = wxFontInfo());
++    wxFontRefData(const wxFontInfo& info = wxFontInfo(), const wxWindow* window = nullptr);
+ 
+     wxFontRefData(const wxNativeFontInfo& info, WXHFONT hFont = 0)
+     {
+@@ -324,7 +324,7 @@ protected:
+ // wxFontRefData
+ // ----------------------------------------------------------------------------
+ 
+-wxFontRefData::wxFontRefData(const wxFontInfo& info)
++wxFontRefData::wxFontRefData(const wxFontInfo& info, const wxWindow *window)
+ {
+     m_hFont = NULL;
+ 
+@@ -335,7 +335,7 @@ wxFontRefData::wxFontRefData(const wxFontInfo& info)
+     }
+     else
+     {
+-        m_nativeFontInfo.SetSizeOrDefault(info.GetFractionalPointSize());
++        m_nativeFontInfo.SetSizeOrDefault(info.GetFractionalPointSize(), window);
+     }
+ 
+     SetStyle(info.GetStyle());
+@@ -518,12 +518,12 @@ wxFontEncoding wxNativeFontInfo::GetEncoding() const
+     return wxGetFontEncFromCharSet(lf.lfCharSet);
+ }
+ 
+-void wxNativeFontInfo::SetFractionalPointSize(double pointSizeNew)
++void wxNativeFontInfo::SetFractionalPointSize(double pointSizeNew, const wxWindow *window)
+ {
+     // We don't have the correct DPI to use here, so use that of the
+     // primary screen and rely on WXAdjustToPPI() changing it later if
+     // necessary.
+-    const int ppi = ::GetDeviceCaps(ScreenHDC(), LOGPIXELSY);
++    const int ppi = window ? window->GetDPI().GetY() : ::GetDeviceCaps(ScreenHDC(), LOGPIXELSY);
+     lf.lfHeight = GetLogFontHeightAtPPI(pointSizeNew, ppi);
+ 
+     pointSize = pointSizeNew;
+@@ -812,9 +812,9 @@ wxFont::wxFont(const wxString& fontdesc)
+         (void)Create(info);
+ }
+ 
+-wxFont::wxFont(const wxFontInfo& info)
++wxFont::wxFont(const wxFontInfo& info, const wxWindow *window)
+ {
+-    m_refData = new wxFontRefData(info);
++    m_refData = new wxFontRefData(info, window);
+ }
+ 
+ bool wxFont::Create(const wxNativeFontInfo& info, WXHFONT hFont)
+diff --git a/src/msw/menuitem.cpp b/src/msw/menuitem.cpp
+index 9bb397d472..30af7154a7 100644
+--- a/src/msw/menuitem.cpp
++++ b/src/msw/menuitem.cpp
+@@ -368,6 +368,8 @@ void MenuDrawData::Init(wxWindow const* window)
+         // native menu uses small top margin for separator
+         if ( SeparatorMargin.cyTopHeight >= 2 )
+             SeparatorMargin.cyTopHeight -= 2;
++
++        SeparatorSize.cy = 0;
+     }
+     else
+ #endif // wxUSE_UXTHEME
+diff --git a/src/msw/window.cpp b/src/msw/window.cpp
+index eadc2f5700..f64fea4446 100644
+--- a/src/msw/window.cpp
++++ b/src/msw/window.cpp
+@@ -4773,33 +4773,49 @@ static wxSize GetWindowDPI(HWND hwnd)
+ }
+ 
+ /*extern*/
+-int wxGetSystemMetrics(int nIndex, const wxWindow* window)
++int wxGetSystemMetrics(int nIndex, const wxWindow* win)
+ {
+ #if wxUSE_DYNLIB_CLASS
+-    if ( !window )
+-        window = wxApp::GetMainTopWindow();
++    const wxWindow* window = (!win && wxTheApp) ? wxTheApp->GetTopWindow() : win;
+ 
+-    if ( window )
++    if (window)
+     {
+-        typedef int (WINAPI * GetSystemMetricsForDpi_t)(int nIndex, UINT dpi);
+-        static GetSystemMetricsForDpi_t s_pfnGetSystemMetricsForDpi = NULL;
+-        static bool s_initDone = false;
+-
+-        if ( !s_initDone )
+-        {
+-            wxLoadedDLL dllUser32("user32.dll");
+-            wxDL_INIT_FUNC(s_pfn, GetSystemMetricsForDpi, dllUser32);
+-            s_initDone = true;
++#if 1
++        if (window->GetHWND() && (nIndex == SM_CXSCREEN || nIndex == SM_CYSCREEN)) {
++            HDC hdc = GetDC(window->GetHWND());
++#if 0
++            double dim = GetDeviceCaps(hdc, nIndex == SM_CXSCREEN ? HORZRES : VERTRES);
++            ReleaseDC(window->GetHWND(), hdc);
++            wxSize dpi = window->GetDPI();
++            dim *= 96.0 / (nIndex == SM_CXSCREEN ? dpi.x : dpi.y);
++            return int(dim + 0.5);
++#else
++            return int(GetDeviceCaps(hdc, nIndex == SM_CXSCREEN ? HORZRES : VERTRES));
++#endif
+         }
+-
+-        if ( s_pfnGetSystemMetricsForDpi )
++        else
++#endif
+         {
+-            const int dpi = window->GetDPI().y;
+-            return s_pfnGetSystemMetricsForDpi(nIndex, (UINT)dpi);
++            typedef int (WINAPI * GetSystemMetricsForDpi_t)(int nIndex, UINT dpi);
++            static GetSystemMetricsForDpi_t s_pfnGetSystemMetricsForDpi = NULL;
++            static bool s_initDone = false;
++
++            if ( !s_initDone )
++            {
++                wxLoadedDLL dllUser32("user32.dll");
++                wxDL_INIT_FUNC(s_pfn, GetSystemMetricsForDpi, dllUser32);
++                s_initDone = true;
++            }
++
++            if ( s_pfnGetSystemMetricsForDpi )
++            {
++                const int dpi = window->GetDPI().y;
++                return s_pfnGetSystemMetricsForDpi(nIndex, (UINT)dpi);
++            }
+         }
+     }
+ #else
+-    wxUnusedVar(window);
++    wxUnusedVar(win);
+ #endif // wxUSE_DYNLIB_CLASS
+ 
+     return ::GetSystemMetrics(nIndex);
+diff --git a/src/osx/cocoa/dataview.mm b/src/osx/cocoa/dataview.mm
+index 6ff0cc3088..4943f3ea38 100644
+--- a/src/osx/cocoa/dataview.mm
++++ b/src/osx/cocoa/dataview.mm
+@@ -1734,12 +1734,22 @@ outlineView:(NSOutlineView*)outlineView
+         if ( !dvc->GetEventHandler()->ProcessEvent(eventDV) )
+             [super keyDown:event];
+     }
+-    else
++    //FIXME Vojtech's hack to get the accelerators assigned to the wxDataViewControl working.
++    else if (! implementation->DoHandleKeyEvent(event))
+     {
+         [super keyDown:event];  // all other keys
+     }
+ }
+ 
++//FIXME Vojtech: This is a workaround to get at least the "mouse move" events at the wxDataViewControl,
++// so we can show the tooltips. The "mouse move" events are being send only if the wxDataViewControl
++// has focus, which is a limitation of wxWidgets. We may grab focus on "mouse entry" though.
++- (void)mouseMoved:(NSEvent *)event
++{
++if (! implementation->DoHandleMouseEvent(event))
++        [super mouseMoved:event];
++}
++
+ //
+ // contextual menus
+ //
+@@ -2672,12 +2682,22 @@ void wxCocoaDataViewControl::DoSetIndent(int indent)
+ 
+ void wxCocoaDataViewControl::HitTest(const wxPoint& point, wxDataViewItem& item, wxDataViewColumn*& columnPtr) const
+ {
+-    NSPoint const nativePoint = wxToNSPoint((NSScrollView*) GetWXWidget(),point);
++    NSTableHeaderView *headerView = [m_OutlineView headerView];
++    if (headerView && point.y < headerView.visibleRect.size.height) {
++    // The point is inside the header area.
++            columnPtr = NULL;
++            item      = wxDataViewItem();
++    return;
++        }
++    // Convert from the window coordinates to the virtual scrolled view coordinates.
++    NSScrollView *scrollView = [m_OutlineView enclosingScrollView];
++    const NSRect &visibleRect = scrollView.contentView.visibleRect;
++    NSPoint const nativePoint = wxToNSPoint((NSScrollView*) GetWXWidget(),
++    wxPoint(point.x + visibleRect.origin.x, point.y + visibleRect.origin.y));
+ 
+     int indexColumn;
+     int indexRow;
+ 
+-
+     indexColumn = [m_OutlineView columnAtPoint:nativePoint];
+     indexRow    = [m_OutlineView rowAtPoint:   nativePoint];
+     if ((indexColumn >= 0) && (indexRow >= 0))
+diff --git a/src/osx/cocoa/settings.mm b/src/osx/cocoa/settings.mm
+index de5f52860c..a9581174a4 100644
+--- a/src/osx/cocoa/settings.mm
++++ b/src/osx/cocoa/settings.mm
+@@ -224,7 +224,7 @@ wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
+ // ----------------------------------------------------------------------------
+ 
+ // Get a system metric, e.g. scrollbar size
+-int wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* WXUNUSED(win))
++int wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* win)
+ {
+     int value;
+ 
+@@ -259,11 +259,11 @@ int wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* WXUN
+         // TODO case wxSYS_WINDOWMIN_Y:
+ 
+         case wxSYS_SCREEN_X:
+-            wxDisplaySize(&value, NULL);
++            wxDisplaySize(win, &value, NULL);
+             return value;
+ 
+         case wxSYS_SCREEN_Y:
+-            wxDisplaySize(NULL, &value);
++            wxDisplaySize(win, NULL, &value);
+             return value;
+ 
+         // TODO case wxSYS_FRAMESIZE_X:

--- a/deps/wxWidgets/wxWidgets.cmake
+++ b/deps/wxWidgets/wxWidgets.cmake
@@ -1,5 +1,4 @@
-set(_wx_git_tag v3.2.1)
-set(_wx_patch_name 0001-patch-v3.2.1-for-OrcaSlicer.patch)
+set(_wx_git_tag v3.1.5)
 
 set(_wx_toolkit "")
     set(_wx_private_font "-DwxUSE_PRIVATE_FONTS=1")
@@ -18,13 +17,13 @@ else ()
 endif ()
 
 if (MSVC)
-    set(_patch_cmd if not exist WXWIDGETS_PATCHED ( "${GIT_EXECUTABLE}" apply --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/${_wx_patch_name} && type nul > WXWIDGETS_PATCHED ) )
+    set(_patch_cmd if not exist WXWIDGETS_PATCHED ( "${GIT_EXECUTABLE}" apply --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-wxWidget-fix.patch && type nul > WXWIDGETS_PATCHED ) )
 else ()
-    set(_patch_cmd test -f WXWIDGETS_PATCHED || ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/${_wx_patch_name} && touch WXWIDGETS_PATCHED)
+    set(_patch_cmd test -f WXWIDGETS_PATCHED || ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/0001-wxWidget-fix.patch && touch WXWIDGETS_PATCHED)
 endif ()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(_patch_cmd ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/${_wx_patch_name})
+    set(_patch_cmd ${PATCH_CMD} ${CMAKE_CURRENT_LIST_DIR}/0001-wxWidget-fix.patch)
 endif ()
 
 orcaslicer_add_cmake_project(
@@ -32,7 +31,7 @@ orcaslicer_add_cmake_project(
     GIT_REPOSITORY "https://github.com/wxWidgets/wxWidgets"
     GIT_TAG ${_wx_git_tag}
     PATCH_COMMAND ${_patch_cmd}
-    DEPENDS ${PNG_PKG} ${ZLIB_PKG} ${EXPAT_PKG} dep_TIFF dep_JPEG dep_NanoSVG
+    DEPENDS ${PNG_PKG} ${ZLIB_PKG} ${EXPAT_PKG} dep_TIFF dep_JPEG
     CMAKE_ARGS
         -DwxBUILD_PRECOMP=ON
         ${_wx_toolkit}
@@ -48,9 +47,7 @@ orcaslicer_add_cmake_project(
         -DwxUSE_WEBVIEW=ON
         ${_wx_edge}
         -DwxUSE_WEBVIEW_IE=OFF
-        -DwxUSE_NANOSVG=sys
-        -DwxUSE_NANOSVG_EXTERNAL=ON
-        -DwxUSE_REGEX=OFF
+        -DwxUSE_REGEX=builtin
         -DwxUSE_LIBXPM=builtin
         -DwxUSE_LIBSDL=OFF
         -DwxUSE_XTEST=OFF

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,10 +94,7 @@ if (SLIC3R_GUI)
     # wrong libs for opengl in the link line and it does not link to it by himself.
     # libslic3r_gui will link to opengl anyway, so lets override wx
     list(FILTER wxWidgets_LIBRARIES EXCLUDE REGEX OpenGL)
-    
-    if (UNIX AND NOT APPLE)
-        list(APPEND wxWidgets_LIBRARIES X11 wayland-client wayland-egl EGL)
-    endif ()
+
 #    list(REMOVE_ITEM wxWidgets_LIBRARIES oleacc)
     message(STATUS "wx libs: ${wxWidgets_LIBRARIES}")
 

--- a/src/nanosvg/README.txt
+++ b/src/nanosvg/README.txt
@@ -1,0 +1,1 @@
+Upstream source: https://github.com/fltk/nanosvg/archive/abcd277ea45e9098bed752cf9c6875b533c0892f.zip

--- a/src/nanosvg/README.txt
+++ b/src/nanosvg/README.txt
@@ -1,1 +1,1 @@
-Upstream source: https://github.com/fltk/nanosvg/archive/abcd277ea45e9098bed752cf9c6875b533c0892f.zip
+Upstream source: https://github.com/SoftFever/nanosvg

--- a/src/nanosvg/nanosvg.h
+++ b/src/nanosvg/nanosvg.h
@@ -1,0 +1,3106 @@
+/*
+ * Copyright (c) 2013-14 Mikko Mononen memon@inside.org
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * The SVG parser is based on Anti-Grain Geometry 2.4 SVG example
+ * Copyright (C) 2002-2004 Maxim Shemanarev (McSeem) (http://www.antigrain.com/)
+ *
+ * Arc calculation code based on canvg (https://code.google.com/p/canvg/)
+ *
+ * Bounding box calculation based on http://blog.hackers-cafe.net/2009/06/how-to-calculate-bezier-curves-bounding.html
+ *
+ */
+
+#ifndef NANOSVG_H
+#define NANOSVG_H
+
+#ifndef NANOSVG_CPLUSPLUS
+#ifdef __cplusplus
+extern "C" {
+#endif
+#endif
+
+// NanoSVG is a simple stupid single-header-file SVG parse. The output of the parser is a list of cubic bezier shapes.
+//
+// The library suits well for anything from rendering scalable icons in your editor application to prototyping a game.
+//
+// NanoSVG supports a wide range of SVG features, but something may be missing, feel free to create a pull request!
+//
+// The shapes in the SVG images are transformed by the viewBox and converted to specified units.
+// That is, you should get the same looking data as your designed in your favorite app.
+//
+// NanoSVG can return the paths in few different units. For example if you want to render an image, you may choose
+// to get the paths in pixels, or if you are feeding the data into a CNC-cutter, you may want to use millimeters.
+//
+// The units passed to NanoSVG should be one of: 'px', 'pt', 'pc' 'mm', 'cm', or 'in'.
+// DPI (dots-per-inch) controls how the unit conversion is done.
+//
+// If you don't know or care about the units stuff, "px" and 96 should get you going.
+
+
+/* Example Usage:
+	// Load SVG
+	NSVGimage* image;
+	image = nsvgParseFromFile("test.svg", "px", 96);
+	printf("size: %f x %f\n", image->width, image->height);
+	// Use...
+	for (NSVGshape *shape = image->shapes; shape != NULL; shape = shape->next) {
+		for (NSVGpath *path = shape->paths; path != NULL; path = path->next) {
+			for (int i = 0; i < path->npts-1; i += 3) {
+				float* p = &path->pts[i*2];
+				drawCubicBez(p[0],p[1], p[2],p[3], p[4],p[5], p[6],p[7]);
+			}
+		}
+	}
+	// Delete
+	nsvgDelete(image);
+*/
+
+enum NSVGpaintType {
+	NSVG_PAINT_UNDEF = -1,
+	NSVG_PAINT_NONE = 0,
+	NSVG_PAINT_COLOR = 1,
+	NSVG_PAINT_LINEAR_GRADIENT = 2,
+	NSVG_PAINT_RADIAL_GRADIENT = 3
+};
+
+enum NSVGspreadType {
+	NSVG_SPREAD_PAD = 0,
+	NSVG_SPREAD_REFLECT = 1,
+	NSVG_SPREAD_REPEAT = 2
+};
+
+enum NSVGlineJoin {
+	NSVG_JOIN_MITER = 0,
+	NSVG_JOIN_ROUND = 1,
+	NSVG_JOIN_BEVEL = 2
+};
+
+enum NSVGlineCap {
+	NSVG_CAP_BUTT = 0,
+	NSVG_CAP_ROUND = 1,
+	NSVG_CAP_SQUARE = 2
+};
+
+enum NSVGfillRule {
+	NSVG_FILLRULE_NONZERO = 0,
+	NSVG_FILLRULE_EVENODD = 1
+};
+
+enum NSVGflags {
+	NSVG_FLAGS_VISIBLE = 0x01
+};
+
+typedef struct NSVGgradientStop {
+	unsigned int color;
+	float offset;
+} NSVGgradientStop;
+
+typedef struct NSVGgradient {
+	float xform[6];
+	char spread;
+	float fx, fy;
+	int nstops;
+	NSVGgradientStop stops[1];
+} NSVGgradient;
+
+typedef struct NSVGpaint {
+	signed char type;
+	union {
+		unsigned int color;
+		NSVGgradient* gradient;
+	};
+} NSVGpaint;
+
+typedef struct NSVGpath
+{
+	float* pts;					// Cubic bezier points: x0,y0, [cpx1,cpx1,cpx2,cpy2,x1,y1], ...
+	int npts;					// Total number of bezier points.
+	char closed;				// Flag indicating if shapes should be treated as closed.
+	float bounds[4];			// Tight bounding box of the shape [minx,miny,maxx,maxy].
+	struct NSVGpath* next;		// Pointer to next path, or NULL if last element.
+} NSVGpath;
+
+typedef struct NSVGshape
+{
+	char id[64];				// Optional 'id' attr of the shape or its group
+	NSVGpaint fill;				// Fill paint
+	NSVGpaint stroke;			// Stroke paint
+	float opacity;				// Opacity of the shape.
+	float strokeWidth;			// Stroke width (scaled).
+	float strokeDashOffset;		// Stroke dash offset (scaled).
+	float strokeDashArray[8];	// Stroke dash array (scaled).
+	char strokeDashCount;		// Number of dash values in dash array.
+	char strokeLineJoin;		// Stroke join type.
+	char strokeLineCap;			// Stroke cap type.
+	float miterLimit;			// Miter limit
+	char fillRule;				// Fill rule, see NSVGfillRule.
+	unsigned char flags;		// Logical or of NSVG_FLAGS_* flags
+	float bounds[4];			// Tight bounding box of the shape [minx,miny,maxx,maxy].
+	char fillGradient[64];		// Optional 'id' of fill gradient
+	char strokeGradient[64];	// Optional 'id' of stroke gradient
+	float xform[6];				// Root transformation for fill/stroke gradient
+	NSVGpath* paths;			// Linked list of paths in the image.
+	struct NSVGshape* next;		// Pointer to next shape, or NULL if last element.
+} NSVGshape;
+
+typedef struct NSVGimage
+{
+	float width;				// Width of the image.
+	float height;				// Height of the image.
+	NSVGshape* shapes;			// Linked list of shapes in the image.
+} NSVGimage;
+
+// Parses SVG file from a file, returns SVG image as paths.
+NSVGimage* nsvgParseFromFile(const char* filename, const char* units, float dpi);
+
+// Parses SVG file from a null terminated string, returns SVG image as paths.
+// Important note: changes the string.
+NSVGimage* nsvgParse(char* input, const char* units, float dpi);
+
+// Duplicates a path.
+NSVGpath* nsvgDuplicatePath(NSVGpath* p);
+
+// Deletes an image.
+void nsvgDelete(NSVGimage* image);
+
+#ifndef NANOSVG_CPLUSPLUS
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+#ifdef NANOSVG_IMPLEMENTATION
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+
+#define NSVG_PI (3.14159265358979323846264338327f)
+#define NSVG_KAPPA90 (0.5522847493f)	// Length proportional to radius of a cubic bezier handle for 90deg arcs.
+
+#define NSVG_ALIGN_MIN 0
+#define NSVG_ALIGN_MID 1
+#define NSVG_ALIGN_MAX 2
+#define NSVG_ALIGN_NONE 0
+#define NSVG_ALIGN_MEET 1
+#define NSVG_ALIGN_SLICE 2
+
+#define NSVG_NOTUSED(v) do { (void)(1 ? (void)0 : ( (void)(v) ) ); } while(0)
+#define NSVG_RGB(r, g, b) (((unsigned int)r) | ((unsigned int)g << 8) | ((unsigned int)b << 16))
+
+#ifdef _MSC_VER
+	#pragma warning (disable: 4996) // Switch off security warnings
+	#pragma warning (disable: 4100) // Switch off unreferenced formal parameter warnings
+	#ifdef __cplusplus
+	#define NSVG_INLINE inline
+	#else
+	#define NSVG_INLINE
+	#endif
+#else
+	#define NSVG_INLINE inline
+#endif
+
+
+static int nsvg__isspace(char c)
+{
+	return strchr(" \t\n\v\f\r", c) != 0;
+}
+
+static int nsvg__isdigit(char c)
+{
+	return c >= '0' && c <= '9';
+}
+
+static NSVG_INLINE float nsvg__minf(float a, float b) { return a < b ? a : b; }
+static NSVG_INLINE float nsvg__maxf(float a, float b) { return a > b ? a : b; }
+
+
+// Simple XML parser
+
+#define NSVG_XML_TAG 1
+#define NSVG_XML_CONTENT 2
+#define NSVG_XML_MAX_ATTRIBS 256
+
+static void nsvg__parseContent(char* s,
+							   void (*contentCb)(void* ud, const char* s),
+							   void* ud)
+{
+	// Trim start white spaces
+	while (*s && nsvg__isspace(*s)) s++;
+	if (!*s) return;
+
+	if (contentCb)
+		(*contentCb)(ud, s);
+}
+
+static void nsvg__parseElement(char* s,
+							   void (*startelCb)(void* ud, const char* el, const char** attr),
+							   void (*endelCb)(void* ud, const char* el),
+							   void* ud)
+{
+	const char* attr[NSVG_XML_MAX_ATTRIBS];
+	int nattr = 0;
+	char* name;
+	int start = 0;
+	int end = 0;
+	char quote;
+
+	// Skip white space after the '<'
+	while (*s && nsvg__isspace(*s)) s++;
+
+	// Check if the tag is end tag
+	if (*s == '/') {
+		s++;
+		end = 1;
+	} else {
+		start = 1;
+	}
+
+	// Skip comments, data and preprocessor stuff.
+	if (!*s || *s == '?' || *s == '!')
+		return;
+
+	// Get tag name
+	name = s;
+	while (*s && !nsvg__isspace(*s)) s++;
+	if (*s) { *s++ = '\0'; }
+
+	// Get attribs
+	while (!end && *s && nattr < NSVG_XML_MAX_ATTRIBS-3) {
+		char* name = NULL;
+		char* value = NULL;
+
+		// Skip white space before the attrib name
+		while (*s && nsvg__isspace(*s)) s++;
+		if (!*s) break;
+		if (*s == '/') {
+			end = 1;
+			break;
+		}
+		name = s;
+		// Find end of the attrib name.
+		while (*s && !nsvg__isspace(*s) && *s != '=') s++;
+		if (*s) { *s++ = '\0'; }
+		// Skip until the beginning of the value.
+		while (*s && *s != '\"' && *s != '\'') s++;
+		if (!*s) break;
+		quote = *s;
+		s++;
+		// Store value and find the end of it.
+		value = s;
+		while (*s && *s != quote) s++;
+		if (*s) { *s++ = '\0'; }
+
+		// Store only well formed attributes
+		if (name && value) {
+			attr[nattr++] = name;
+			attr[nattr++] = value;
+		}
+	}
+
+	// List terminator
+	attr[nattr++] = 0;
+	attr[nattr++] = 0;
+
+	// Call callbacks.
+	if (start && startelCb)
+		(*startelCb)(ud, name, attr);
+	if (end && endelCb)
+		(*endelCb)(ud, name);
+}
+
+int nsvg__parseXML(char* input,
+				   void (*startelCb)(void* ud, const char* el, const char** attr),
+				   void (*endelCb)(void* ud, const char* el),
+				   void (*contentCb)(void* ud, const char* s),
+				   void* ud)
+{
+	char* s = input;
+	char* mark = s;
+	int state = NSVG_XML_CONTENT;
+	while (*s) {
+		if (*s == '<' && state == NSVG_XML_CONTENT) {
+			// Start of a tag
+			*s++ = '\0';
+			nsvg__parseContent(mark, contentCb, ud);
+			mark = s;
+			state = NSVG_XML_TAG;
+		} else if (*s == '>' && state == NSVG_XML_TAG) {
+			// Start of a content or new tag.
+			*s++ = '\0';
+			nsvg__parseElement(mark, startelCb, endelCb, ud);
+			mark = s;
+			state = NSVG_XML_CONTENT;
+		} else {
+			s++;
+		}
+	}
+
+	return 1;
+}
+
+
+/* Simple SVG parser. */
+
+#define NSVG_MAX_ATTR 128
+
+enum NSVGgradientUnits {
+	NSVG_USER_SPACE = 0,
+	NSVG_OBJECT_SPACE = 1
+};
+
+#define NSVG_MAX_DASHES 8
+
+enum NSVGunits {
+	NSVG_UNITS_USER,
+	NSVG_UNITS_PX,
+	NSVG_UNITS_PT,
+	NSVG_UNITS_PC,
+	NSVG_UNITS_MM,
+	NSVG_UNITS_CM,
+	NSVG_UNITS_IN,
+	NSVG_UNITS_PERCENT,
+	NSVG_UNITS_EM,
+	NSVG_UNITS_EX
+};
+
+typedef struct NSVGcoordinate {
+	float value;
+	int units;
+} NSVGcoordinate;
+
+typedef struct NSVGlinearData {
+	NSVGcoordinate x1, y1, x2, y2;
+} NSVGlinearData;
+
+typedef struct NSVGradialData {
+	NSVGcoordinate cx, cy, r, fx, fy;
+} NSVGradialData;
+
+typedef struct NSVGgradientData
+{
+	char id[64];
+	char ref[64];
+	signed char type;
+	union {
+		NSVGlinearData linear;
+		NSVGradialData radial;
+	};
+	char spread;
+	char units;
+	float xform[6];
+	int nstops;
+	NSVGgradientStop* stops;
+	struct NSVGgradientData* next;
+} NSVGgradientData;
+
+typedef struct NSVGattrib
+{
+	char id[64];
+	float xform[6];
+	unsigned int fillColor;
+	unsigned int strokeColor;
+	float opacity;
+	float fillOpacity;
+	float strokeOpacity;
+	char fillGradient[64];
+	char strokeGradient[64];
+	float strokeWidth;
+	float strokeDashOffset;
+	float strokeDashArray[NSVG_MAX_DASHES];
+	int strokeDashCount;
+	char strokeLineJoin;
+	char strokeLineCap;
+	float miterLimit;
+	char fillRule;
+	float fontSize;
+	unsigned int stopColor;
+	float stopOpacity;
+	float stopOffset;
+	char hasFill;
+	char hasStroke;
+	char visible;
+} NSVGattrib;
+
+typedef struct NSVGparser
+{
+	NSVGattrib attr[NSVG_MAX_ATTR];
+	int attrHead;
+	float* pts;
+	int npts;
+	int cpts;
+	NSVGpath* plist;
+	NSVGimage* image;
+	NSVGgradientData* gradients;
+	NSVGshape* shapesTail;
+	float viewMinx, viewMiny, viewWidth, viewHeight;
+	int alignX, alignY, alignType;
+	float dpi;
+	char pathFlag;
+	char defsFlag;
+} NSVGparser;
+
+static void nsvg__xformIdentity(float* t)
+{
+	t[0] = 1.0f; t[1] = 0.0f;
+	t[2] = 0.0f; t[3] = 1.0f;
+	t[4] = 0.0f; t[5] = 0.0f;
+}
+
+static void nsvg__xformSetTranslation(float* t, float tx, float ty)
+{
+	t[0] = 1.0f; t[1] = 0.0f;
+	t[2] = 0.0f; t[3] = 1.0f;
+	t[4] = tx; t[5] = ty;
+}
+
+static void nsvg__xformSetScale(float* t, float sx, float sy)
+{
+	t[0] = sx; t[1] = 0.0f;
+	t[2] = 0.0f; t[3] = sy;
+	t[4] = 0.0f; t[5] = 0.0f;
+}
+
+static void nsvg__xformSetSkewX(float* t, float a)
+{
+	t[0] = 1.0f; t[1] = 0.0f;
+	t[2] = tanf(a); t[3] = 1.0f;
+	t[4] = 0.0f; t[5] = 0.0f;
+}
+
+static void nsvg__xformSetSkewY(float* t, float a)
+{
+	t[0] = 1.0f; t[1] = tanf(a);
+	t[2] = 0.0f; t[3] = 1.0f;
+	t[4] = 0.0f; t[5] = 0.0f;
+}
+
+static void nsvg__xformSetRotation(float* t, float a)
+{
+	float cs = cosf(a), sn = sinf(a);
+	t[0] = cs; t[1] = sn;
+	t[2] = -sn; t[3] = cs;
+	t[4] = 0.0f; t[5] = 0.0f;
+}
+
+static void nsvg__xformMultiply(float* t, float* s)
+{
+	float t0 = t[0] * s[0] + t[1] * s[2];
+	float t2 = t[2] * s[0] + t[3] * s[2];
+	float t4 = t[4] * s[0] + t[5] * s[2] + s[4];
+	t[1] = t[0] * s[1] + t[1] * s[3];
+	t[3] = t[2] * s[1] + t[3] * s[3];
+	t[5] = t[4] * s[1] + t[5] * s[3] + s[5];
+	t[0] = t0;
+	t[2] = t2;
+	t[4] = t4;
+}
+
+static void nsvg__xformInverse(float* inv, float* t)
+{
+	double invdet, det = (double)t[0] * t[3] - (double)t[2] * t[1];
+	if (det > -1e-6 && det < 1e-6) {
+		nsvg__xformIdentity(t);
+		return;
+	}
+	invdet = 1.0 / det;
+	inv[0] = (float)(t[3] * invdet);
+	inv[2] = (float)(-t[2] * invdet);
+	inv[4] = (float)(((double)t[2] * t[5] - (double)t[3] * t[4]) * invdet);
+	inv[1] = (float)(-t[1] * invdet);
+	inv[3] = (float)(t[0] * invdet);
+	inv[5] = (float)(((double)t[1] * t[4] - (double)t[0] * t[5]) * invdet);
+}
+
+static void nsvg__xformPremultiply(float* t, float* s)
+{
+	float s2[6];
+	memcpy(s2, s, sizeof(float)*6);
+	nsvg__xformMultiply(s2, t);
+	memcpy(t, s2, sizeof(float)*6);
+}
+
+static void nsvg__xformPoint(float* dx, float* dy, float x, float y, float* t)
+{
+	*dx = x*t[0] + y*t[2] + t[4];
+	*dy = x*t[1] + y*t[3] + t[5];
+}
+
+static void nsvg__xformVec(float* dx, float* dy, float x, float y, float* t)
+{
+	*dx = x*t[0] + y*t[2];
+	*dy = x*t[1] + y*t[3];
+}
+
+#define NSVG_EPSILON (1e-12)
+
+static int nsvg__ptInBounds(float* pt, float* bounds)
+{
+	return pt[0] >= bounds[0] && pt[0] <= bounds[2] && pt[1] >= bounds[1] && pt[1] <= bounds[3];
+}
+
+
+static double nsvg__evalBezier(double t, double p0, double p1, double p2, double p3)
+{
+	double it = 1.0-t;
+	return it*it*it*p0 + 3.0*it*it*t*p1 + 3.0*it*t*t*p2 + t*t*t*p3;
+}
+
+static void nsvg__curveBounds(float* bounds, float* curve)
+{
+	int i, j, count;
+	double roots[2], a, b, c, b2ac, t, v;
+	float* v0 = &curve[0];
+	float* v1 = &curve[2];
+	float* v2 = &curve[4];
+	float* v3 = &curve[6];
+
+	// Start the bounding box by end points
+	bounds[0] = nsvg__minf(v0[0], v3[0]);
+	bounds[1] = nsvg__minf(v0[1], v3[1]);
+	bounds[2] = nsvg__maxf(v0[0], v3[0]);
+	bounds[3] = nsvg__maxf(v0[1], v3[1]);
+
+	// Bezier curve fits inside the convex hull of it's control points.
+	// If control points are inside the bounds, we're done.
+	if (nsvg__ptInBounds(v1, bounds) && nsvg__ptInBounds(v2, bounds))
+		return;
+
+	// Add bezier curve inflection points in X and Y.
+	for (i = 0; i < 2; i++) {
+		a = -3.0 * v0[i] + 9.0 * v1[i] - 9.0 * v2[i] + 3.0 * v3[i];
+		b = 6.0 * v0[i] - 12.0 * v1[i] + 6.0 * v2[i];
+		c = 3.0 * v1[i] - 3.0 * v0[i];
+		count = 0;
+		if (fabs(a) < NSVG_EPSILON) {
+			if (fabs(b) > NSVG_EPSILON) {
+				t = -c / b;
+				if (t > NSVG_EPSILON && t < 1.0-NSVG_EPSILON)
+					roots[count++] = t;
+			}
+		} else {
+			b2ac = b*b - 4.0*c*a;
+			if (b2ac > NSVG_EPSILON) {
+				t = (-b + sqrt(b2ac)) / (2.0 * a);
+				if (t > NSVG_EPSILON && t < 1.0-NSVG_EPSILON)
+					roots[count++] = t;
+				t = (-b - sqrt(b2ac)) / (2.0 * a);
+				if (t > NSVG_EPSILON && t < 1.0-NSVG_EPSILON)
+					roots[count++] = t;
+			}
+		}
+		for (j = 0; j < count; j++) {
+			v = nsvg__evalBezier(roots[j], v0[i], v1[i], v2[i], v3[i]);
+			bounds[0+i] = nsvg__minf(bounds[0+i], (float)v);
+			bounds[2+i] = nsvg__maxf(bounds[2+i], (float)v);
+		}
+	}
+}
+
+static NSVGparser* nsvg__createParser(void)
+{
+	NSVGparser* p;
+	p = (NSVGparser*)malloc(sizeof(NSVGparser));
+	if (p == NULL) goto error;
+	memset(p, 0, sizeof(NSVGparser));
+
+	p->image = (NSVGimage*)malloc(sizeof(NSVGimage));
+	if (p->image == NULL) goto error;
+	memset(p->image, 0, sizeof(NSVGimage));
+
+	// Init style
+	nsvg__xformIdentity(p->attr[0].xform);
+	memset(p->attr[0].id, 0, sizeof p->attr[0].id);
+	p->attr[0].fillColor = NSVG_RGB(0,0,0);
+	p->attr[0].strokeColor = NSVG_RGB(0,0,0);
+	p->attr[0].opacity = 1;
+	p->attr[0].fillOpacity = 1;
+	p->attr[0].strokeOpacity = 1;
+	p->attr[0].stopOpacity = 1;
+	p->attr[0].strokeWidth = 1;
+	p->attr[0].strokeLineJoin = NSVG_JOIN_MITER;
+	p->attr[0].strokeLineCap = NSVG_CAP_BUTT;
+	p->attr[0].miterLimit = 4;
+	p->attr[0].fillRule = NSVG_FILLRULE_NONZERO;
+	p->attr[0].hasFill = 1;
+	p->attr[0].visible = 1;
+
+	return p;
+
+error:
+	if (p) {
+		if (p->image) free(p->image);
+		free(p);
+	}
+	return NULL;
+}
+
+static void nsvg__deletePaths(NSVGpath* path)
+{
+	while (path) {
+		NSVGpath *next = path->next;
+		if (path->pts != NULL)
+			free(path->pts);
+		free(path);
+		path = next;
+	}
+}
+
+static void nsvg__deletePaint(NSVGpaint* paint)
+{
+	if (paint->type == NSVG_PAINT_LINEAR_GRADIENT || paint->type == NSVG_PAINT_RADIAL_GRADIENT)
+		free(paint->gradient);
+}
+
+static void nsvg__deleteGradientData(NSVGgradientData* grad)
+{
+	NSVGgradientData* next;
+	while (grad != NULL) {
+		next = grad->next;
+		free(grad->stops);
+		free(grad);
+		grad = next;
+	}
+}
+
+static void nsvg__deleteParser(NSVGparser* p)
+{
+	if (p != NULL) {
+		nsvg__deletePaths(p->plist);
+		nsvg__deleteGradientData(p->gradients);
+		nsvgDelete(p->image);
+		free(p->pts);
+		free(p);
+	}
+}
+
+static void nsvg__resetPath(NSVGparser* p)
+{
+	p->npts = 0;
+}
+
+static void nsvg__addPoint(NSVGparser* p, float x, float y)
+{
+	if (p->npts+1 > p->cpts) {
+		p->cpts = p->cpts ? p->cpts*2 : 8;
+		p->pts = (float*)realloc(p->pts, p->cpts*2*sizeof(float));
+		if (!p->pts) return;
+	}
+	p->pts[p->npts*2+0] = x;
+	p->pts[p->npts*2+1] = y;
+	p->npts++;
+}
+
+static void nsvg__moveTo(NSVGparser* p, float x, float y)
+{
+	if (p->npts > 0) {
+		p->pts[(p->npts-1)*2+0] = x;
+		p->pts[(p->npts-1)*2+1] = y;
+	} else {
+		nsvg__addPoint(p, x, y);
+	}
+}
+
+static void nsvg__lineTo(NSVGparser* p, float x, float y)
+{
+	float px,py, dx,dy;
+	if (p->npts > 0) {
+		px = p->pts[(p->npts-1)*2+0];
+		py = p->pts[(p->npts-1)*2+1];
+		dx = x - px;
+		dy = y - py;
+		nsvg__addPoint(p, px + dx/3.0f, py + dy/3.0f);
+		nsvg__addPoint(p, x - dx/3.0f, y - dy/3.0f);
+		nsvg__addPoint(p, x, y);
+	}
+}
+
+static void nsvg__cubicBezTo(NSVGparser* p, float cpx1, float cpy1, float cpx2, float cpy2, float x, float y)
+{
+	if (p->npts > 0) {
+		nsvg__addPoint(p, cpx1, cpy1);
+		nsvg__addPoint(p, cpx2, cpy2);
+		nsvg__addPoint(p, x, y);
+	}
+}
+
+static NSVGattrib* nsvg__getAttr(NSVGparser* p)
+{
+	return &p->attr[p->attrHead];
+}
+
+static void nsvg__pushAttr(NSVGparser* p)
+{
+	if (p->attrHead < NSVG_MAX_ATTR-1) {
+		p->attrHead++;
+		memcpy(&p->attr[p->attrHead], &p->attr[p->attrHead-1], sizeof(NSVGattrib));
+	}
+}
+
+static void nsvg__popAttr(NSVGparser* p)
+{
+	if (p->attrHead > 0)
+		p->attrHead--;
+}
+
+static float nsvg__actualOrigX(NSVGparser* p)
+{
+	return p->viewMinx;
+}
+
+static float nsvg__actualOrigY(NSVGparser* p)
+{
+	return p->viewMiny;
+}
+
+static float nsvg__actualWidth(NSVGparser* p)
+{
+	return p->viewWidth;
+}
+
+static float nsvg__actualHeight(NSVGparser* p)
+{
+	return p->viewHeight;
+}
+
+static float nsvg__actualLength(NSVGparser* p)
+{
+	float w = nsvg__actualWidth(p), h = nsvg__actualHeight(p);
+	return sqrtf(w*w + h*h) / sqrtf(2.0f);
+}
+
+static float nsvg__convertToPixels(NSVGparser* p, NSVGcoordinate c, float orig, float length)
+{
+	NSVGattrib* attr = nsvg__getAttr(p);
+	switch (c.units) {
+		case NSVG_UNITS_USER:		return c.value;
+		case NSVG_UNITS_PX:			return c.value;
+		case NSVG_UNITS_PT:			return c.value / 72.0f * p->dpi;
+		case NSVG_UNITS_PC:			return c.value / 6.0f * p->dpi;
+		case NSVG_UNITS_MM:			return c.value / 25.4f * p->dpi;
+		case NSVG_UNITS_CM:			return c.value / 2.54f * p->dpi;
+		case NSVG_UNITS_IN:			return c.value * p->dpi;
+		case NSVG_UNITS_EM:			return c.value * attr->fontSize;
+		case NSVG_UNITS_EX:			return c.value * attr->fontSize * 0.52f; // x-height of Helvetica.
+		case NSVG_UNITS_PERCENT:	return orig + c.value / 100.0f * length;
+		default:					return c.value;
+	}
+	return c.value;
+}
+
+static NSVGgradientData* nsvg__findGradientData(NSVGparser* p, const char* id)
+{
+	NSVGgradientData* grad = p->gradients;
+	if (id == NULL || *id == '\0')
+		return NULL;
+	while (grad != NULL) {
+		if (strcmp(grad->id, id) == 0)
+			return grad;
+		grad = grad->next;
+	}
+	return NULL;
+}
+
+static NSVGgradient* nsvg__createGradient(NSVGparser* p, const char* id, const float* localBounds, float *xform, signed char* paintType)
+{
+	NSVGgradientData* data = NULL;
+	NSVGgradientData* ref = NULL;
+	NSVGgradientStop* stops = NULL;
+	NSVGgradient* grad;
+	float ox, oy, sw, sh, sl;
+	int nstops = 0;
+	int refIter;
+
+	data = nsvg__findGradientData(p, id);
+	if (data == NULL) return NULL;
+
+	// TODO: use ref to fill in all unset values too.
+	ref = data;
+	refIter = 0;
+	while (ref != NULL) {
+		NSVGgradientData* nextRef = NULL;
+		if (stops == NULL && ref->stops != NULL) {
+			stops = ref->stops;
+			nstops = ref->nstops;
+			break;
+		}
+		nextRef = nsvg__findGradientData(p, ref->ref);
+		if (nextRef == ref) break; // prevent infite loops on malformed data
+		ref = nextRef;
+		refIter++;
+		if (refIter > 32) break; // prevent infite loops on malformed data
+	}
+	if (stops == NULL) return NULL;
+
+	grad = (NSVGgradient*)malloc(sizeof(NSVGgradient) + sizeof(NSVGgradientStop)*(nstops-1));
+	if (grad == NULL) return NULL;
+
+	// The shape width and height.
+	if (data->units == NSVG_OBJECT_SPACE) {
+		ox = localBounds[0];
+		oy = localBounds[1];
+		sw = localBounds[2] - localBounds[0];
+		sh = localBounds[3] - localBounds[1];
+	} else {
+		ox = nsvg__actualOrigX(p);
+		oy = nsvg__actualOrigY(p);
+		sw = nsvg__actualWidth(p);
+		sh = nsvg__actualHeight(p);
+	}
+	sl = sqrtf(sw*sw + sh*sh) / sqrtf(2.0f);
+
+	if (data->type == NSVG_PAINT_LINEAR_GRADIENT) {
+		float x1, y1, x2, y2, dx, dy;
+		x1 = nsvg__convertToPixels(p, data->linear.x1, ox, sw);
+		y1 = nsvg__convertToPixels(p, data->linear.y1, oy, sh);
+		x2 = nsvg__convertToPixels(p, data->linear.x2, ox, sw);
+		y2 = nsvg__convertToPixels(p, data->linear.y2, oy, sh);
+		// Calculate transform aligned to the line
+		dx = x2 - x1;
+		dy = y2 - y1;
+		grad->xform[0] = dy; grad->xform[1] = -dx;
+		grad->xform[2] = dx; grad->xform[3] = dy;
+		grad->xform[4] = x1; grad->xform[5] = y1;
+	} else {
+		float cx, cy, fx, fy, r;
+		cx = nsvg__convertToPixels(p, data->radial.cx, ox, sw);
+		cy = nsvg__convertToPixels(p, data->radial.cy, oy, sh);
+		fx = nsvg__convertToPixels(p, data->radial.fx, ox, sw);
+		fy = nsvg__convertToPixels(p, data->radial.fy, oy, sh);
+		r = nsvg__convertToPixels(p, data->radial.r, 0, sl);
+		// Calculate transform aligned to the circle
+		grad->xform[0] = r; grad->xform[1] = 0;
+		grad->xform[2] = 0; grad->xform[3] = r;
+		grad->xform[4] = cx; grad->xform[5] = cy;
+		grad->fx = fx / r;
+		grad->fy = fy / r;
+	}
+
+	nsvg__xformMultiply(grad->xform, data->xform);
+	nsvg__xformMultiply(grad->xform, xform);
+
+	grad->spread = data->spread;
+	memcpy(grad->stops, stops, nstops*sizeof(NSVGgradientStop));
+	grad->nstops = nstops;
+
+	*paintType = data->type;
+
+	return grad;
+}
+
+static float nsvg__getAverageScale(float* t)
+{
+	float sx = sqrtf(t[0]*t[0] + t[2]*t[2]);
+	float sy = sqrtf(t[1]*t[1] + t[3]*t[3]);
+	return (sx + sy) * 0.5f;
+}
+
+static void nsvg__getLocalBounds(float* bounds, NSVGshape *shape, float* xform)
+{
+	NSVGpath* path;
+	float curve[4*2], curveBounds[4];
+	int i, first = 1;
+	for (path = shape->paths; path != NULL; path = path->next) {
+		nsvg__xformPoint(&curve[0], &curve[1], path->pts[0], path->pts[1], xform);
+		for (i = 0; i < path->npts-1; i += 3) {
+			nsvg__xformPoint(&curve[2], &curve[3], path->pts[(i+1)*2], path->pts[(i+1)*2+1], xform);
+			nsvg__xformPoint(&curve[4], &curve[5], path->pts[(i+2)*2], path->pts[(i+2)*2+1], xform);
+			nsvg__xformPoint(&curve[6], &curve[7], path->pts[(i+3)*2], path->pts[(i+3)*2+1], xform);
+			nsvg__curveBounds(curveBounds, curve);
+			if (first) {
+				bounds[0] = curveBounds[0];
+				bounds[1] = curveBounds[1];
+				bounds[2] = curveBounds[2];
+				bounds[3] = curveBounds[3];
+				first = 0;
+			} else {
+				bounds[0] = nsvg__minf(bounds[0], curveBounds[0]);
+				bounds[1] = nsvg__minf(bounds[1], curveBounds[1]);
+				bounds[2] = nsvg__maxf(bounds[2], curveBounds[2]);
+				bounds[3] = nsvg__maxf(bounds[3], curveBounds[3]);
+			}
+			curve[0] = curve[6];
+			curve[1] = curve[7];
+		}
+	}
+}
+
+static void nsvg__addShape(NSVGparser* p)
+{
+	NSVGattrib* attr = nsvg__getAttr(p);
+	float scale = 1.0f;
+	NSVGshape* shape;
+	NSVGpath* path;
+	int i;
+
+	if (p->plist == NULL)
+		return;
+
+	shape = (NSVGshape*)malloc(sizeof(NSVGshape));
+	if (shape == NULL) goto error;
+	memset(shape, 0, sizeof(NSVGshape));
+
+	memcpy(shape->id, attr->id, sizeof shape->id);
+	memcpy(shape->fillGradient, attr->fillGradient, sizeof shape->fillGradient);
+	memcpy(shape->strokeGradient, attr->strokeGradient, sizeof shape->strokeGradient);
+	memcpy(shape->xform, attr->xform, sizeof shape->xform);
+	scale = nsvg__getAverageScale(attr->xform);
+	shape->strokeWidth = attr->strokeWidth * scale;
+	shape->strokeDashOffset = attr->strokeDashOffset * scale;
+	shape->strokeDashCount = (char)attr->strokeDashCount;
+	for (i = 0; i < attr->strokeDashCount; i++)
+		shape->strokeDashArray[i] = attr->strokeDashArray[i] * scale;
+	shape->strokeLineJoin = attr->strokeLineJoin;
+	shape->strokeLineCap = attr->strokeLineCap;
+	shape->miterLimit = attr->miterLimit;
+	shape->fillRule = attr->fillRule;
+	shape->opacity = attr->opacity;
+
+	shape->paths = p->plist;
+	p->plist = NULL;
+
+	// Calculate shape bounds
+	shape->bounds[0] = shape->paths->bounds[0];
+	shape->bounds[1] = shape->paths->bounds[1];
+	shape->bounds[2] = shape->paths->bounds[2];
+	shape->bounds[3] = shape->paths->bounds[3];
+	for (path = shape->paths->next; path != NULL; path = path->next) {
+		shape->bounds[0] = nsvg__minf(shape->bounds[0], path->bounds[0]);
+		shape->bounds[1] = nsvg__minf(shape->bounds[1], path->bounds[1]);
+		shape->bounds[2] = nsvg__maxf(shape->bounds[2], path->bounds[2]);
+		shape->bounds[3] = nsvg__maxf(shape->bounds[3], path->bounds[3]);
+	}
+
+	// Set fill
+	if (attr->hasFill == 0) {
+		shape->fill.type = NSVG_PAINT_NONE;
+	} else if (attr->hasFill == 1) {
+		shape->fill.type = NSVG_PAINT_COLOR;
+		shape->fill.color = attr->fillColor;
+		shape->fill.color |= (unsigned int)(attr->fillOpacity*255) << 24;
+	} else if (attr->hasFill == 2) {
+		shape->fill.type = NSVG_PAINT_UNDEF;
+	}
+
+	// Set stroke
+	if (attr->hasStroke == 0) {
+		shape->stroke.type = NSVG_PAINT_NONE;
+	} else if (attr->hasStroke == 1) {
+		shape->stroke.type = NSVG_PAINT_COLOR;
+		shape->stroke.color = attr->strokeColor;
+		shape->stroke.color |= (unsigned int)(attr->strokeOpacity*255) << 24;
+	} else if (attr->hasStroke == 2) {
+		shape->stroke.type = NSVG_PAINT_UNDEF;
+	}
+
+	// Set flags
+	shape->flags = (attr->visible ? NSVG_FLAGS_VISIBLE : 0x00);
+
+	// Add to tail
+	if (p->image->shapes == NULL)
+		p->image->shapes = shape;
+	else
+		p->shapesTail->next = shape;
+	p->shapesTail = shape;
+
+	return;
+
+error:
+	if (shape) free(shape);
+}
+
+static void nsvg__addPath(NSVGparser* p, char closed)
+{
+	NSVGattrib* attr = nsvg__getAttr(p);
+	NSVGpath* path = NULL;
+	float bounds[4];
+	float* curve;
+	int i;
+
+	if (p->npts < 4)
+		return;
+
+	if (closed)
+		nsvg__lineTo(p, p->pts[0], p->pts[1]);
+
+	// Expect 1 + N*3 points (N = number of cubic bezier segments).
+	if ((p->npts % 3) != 1)
+		return;
+
+	path = (NSVGpath*)malloc(sizeof(NSVGpath));
+	if (path == NULL) goto error;
+	memset(path, 0, sizeof(NSVGpath));
+
+	path->pts = (float*)malloc(p->npts*2*sizeof(float));
+	if (path->pts == NULL) goto error;
+	path->closed = closed;
+	path->npts = p->npts;
+
+	// Transform path.
+	for (i = 0; i < p->npts; ++i)
+		nsvg__xformPoint(&path->pts[i*2], &path->pts[i*2+1], p->pts[i*2], p->pts[i*2+1], attr->xform);
+
+	// Find bounds
+	for (i = 0; i < path->npts-1; i += 3) {
+		curve = &path->pts[i*2];
+		nsvg__curveBounds(bounds, curve);
+		if (i == 0) {
+			path->bounds[0] = bounds[0];
+			path->bounds[1] = bounds[1];
+			path->bounds[2] = bounds[2];
+			path->bounds[3] = bounds[3];
+		} else {
+			path->bounds[0] = nsvg__minf(path->bounds[0], bounds[0]);
+			path->bounds[1] = nsvg__minf(path->bounds[1], bounds[1]);
+			path->bounds[2] = nsvg__maxf(path->bounds[2], bounds[2]);
+			path->bounds[3] = nsvg__maxf(path->bounds[3], bounds[3]);
+		}
+	}
+
+	path->next = p->plist;
+	p->plist = path;
+
+	return;
+
+error:
+	if (path != NULL) {
+		if (path->pts != NULL) free(path->pts);
+		free(path);
+	}
+}
+
+// We roll our own string to float because the std library one uses locale and messes things up.
+static double nsvg__atof(const char* s)
+{
+	char* cur = (char*)s;
+	char* end = NULL;
+	double res = 0.0, sign = 1.0;
+	double intPart = 0.0, fracPart = 0.0;
+	char hasIntPart = 0, hasFracPart = 0;
+
+	// Parse optional sign
+	if (*cur == '+') {
+		cur++;
+	} else if (*cur == '-') {
+		sign = -1;
+		cur++;
+	}
+
+	// Parse integer part
+	if (nsvg__isdigit(*cur)) {
+		// Parse digit sequence
+#ifdef _MSC_VER
+		intPart = (double)_strtoi64(cur, &end, 10);
+#else
+		intPart = (double)strtoll(cur, &end, 10);
+#endif
+		if (cur != end) {
+			res = intPart;
+			hasIntPart = 1;
+			cur = end;
+		}
+	}
+
+	// Parse fractional part.
+	if (*cur == '.') {
+		cur++; // Skip '.'
+		if (nsvg__isdigit(*cur)) {
+			// Parse digit sequence
+#ifdef _MSC_VER
+			fracPart = (double)_strtoi64(cur, &end, 10);
+#else
+			fracPart = (double)strtoll(cur, &end, 10);
+#endif
+			if (cur != end) {
+				res += fracPart / pow(10.0, (double)(end - cur));
+				hasFracPart = 1;
+				cur = end;
+			}
+		}
+	}
+
+	// A valid number should have integer or fractional part.
+	if (!hasIntPart && !hasFracPart)
+		return 0.0;
+
+	// Parse optional exponent
+	if (*cur == 'e' || *cur == 'E') {
+		double expPart = 0.0;
+		cur++; // skip 'E'
+		expPart = (double)strtol(cur, &end, 10); // Parse digit sequence with sign
+		if (cur != end) {
+			res *= pow(10.0, expPart);
+		}
+	}
+
+	return res * sign;
+}
+
+
+static const char* nsvg__parseNumber(const char* s, char* it, const int size)
+{
+	const int last = size-1;
+	int i = 0;
+
+	// sign
+	if (*s == '-' || *s == '+') {
+		if (i < last) it[i++] = *s;
+		s++;
+	}
+	// integer part
+	while (*s && nsvg__isdigit(*s)) {
+		if (i < last) it[i++] = *s;
+		s++;
+	}
+	if (*s == '.') {
+		// decimal point
+		if (i < last) it[i++] = *s;
+		s++;
+		// fraction part
+		while (*s && nsvg__isdigit(*s)) {
+			if (i < last) it[i++] = *s;
+			s++;
+		}
+	}
+	// exponent
+	if ((*s == 'e' || *s == 'E') && (s[1] != 'm' && s[1] != 'x')) {
+		if (i < last) it[i++] = *s;
+		s++;
+		if (*s == '-' || *s == '+') {
+			if (i < last) it[i++] = *s;
+			s++;
+		}
+		while (*s && nsvg__isdigit(*s)) {
+			if (i < last) it[i++] = *s;
+			s++;
+		}
+	}
+	it[i] = '\0';
+
+	return s;
+}
+
+static const char* nsvg__getNextPathItemWhenArcFlag(const char* s, char* it)
+{
+	it[0] = '\0';
+	while (*s && (nsvg__isspace(*s) || *s == ',')) s++;
+	if (!*s) return s;
+	if (*s == '0' || *s == '1') {
+		it[0] = *s++;
+		it[1] = '\0';
+		return s;
+	}
+	return s;
+}
+
+static const char* nsvg__getNextPathItem(const char* s, char* it)
+{
+	it[0] = '\0';
+	// Skip white spaces and commas
+	while (*s && (nsvg__isspace(*s) || *s == ',')) s++;
+	if (!*s) return s;
+	if (*s == '-' || *s == '+' || *s == '.' || nsvg__isdigit(*s)) {
+		s = nsvg__parseNumber(s, it, 64);
+	} else {
+		// Parse command
+		it[0] = *s++;
+		it[1] = '\0';
+		return s;
+	}
+
+	return s;
+}
+
+static unsigned int nsvg__parseColorHex(const char* str)
+{
+	unsigned int r=0, g=0, b=0;
+	if (sscanf(str, "#%2x%2x%2x", &r, &g, &b) == 3 )		// 2 digit hex
+		return NSVG_RGB(r, g, b);
+	if (sscanf(str, "#%1x%1x%1x", &r, &g, &b) == 3 )		// 1 digit hex, e.g. #abc -> 0xccbbaa
+		return NSVG_RGB(r*17, g*17, b*17);			// same effect as (r<<4|r), (g<<4|g), ..
+	return NSVG_RGB(128, 128, 128);
+}
+
+// Parse rgb color. The pointer 'str' must point at "rgb(" (4+ characters).
+// This function returns gray (rgb(128, 128, 128) == '#808080') on parse errors
+// for backwards compatibility. Note: other image viewers return black instead.
+
+static unsigned int nsvg__parseColorRGB(const char* str)
+{
+	int i;
+	unsigned int rgbi[3];
+	float rgbf[3];
+	// try decimal integers first
+	if (sscanf(str, "rgb(%u, %u, %u)", &rgbi[0], &rgbi[1], &rgbi[2]) != 3) {
+		// integers failed, try percent values (float, locale independent)
+		const char delimiter[3] = {',', ',', ')'};
+		str += 4; // skip "rgb("
+		for (i = 0; i < 3; i++) {
+			while (*str && (nsvg__isspace(*str))) str++; 	// skip leading spaces
+			if (*str == '+') str++;				// skip '+' (don't allow '-')
+			if (!*str) break;
+			rgbf[i] = nsvg__atof(str);
+
+			// Note 1: it would be great if nsvg__atof() returned how many
+			// bytes it consumed but it doesn't. We need to skip the number,
+			// the '%' character, spaces, and the delimiter ',' or ')'.
+
+			// Note 2: The following code does not allow values like "33.%",
+			// i.e. a decimal point w/o fractional part, but this is consistent
+			// with other image viewers, e.g. firefox, chrome, eog, gimp.
+
+			while (*str && nsvg__isdigit(*str)) str++;		// skip integer part
+			if (*str == '.') {
+				str++;
+				if (!nsvg__isdigit(*str)) break;		// error: no digit after '.'
+				while (*str && nsvg__isdigit(*str)) str++;	// skip fractional part
+			}
+			if (*str == '%') str++; else break;
+			while (nsvg__isspace(*str)) str++;
+			if (*str == delimiter[i]) str++;
+			else break;
+		}
+		if (i == 3) {
+			rgbi[0] = roundf(rgbf[0] * 2.55f);
+			rgbi[1] = roundf(rgbf[1] * 2.55f);
+			rgbi[2] = roundf(rgbf[2] * 2.55f);
+		} else {
+			rgbi[0] = rgbi[1] = rgbi[2] = 128;
+		}
+	}
+	// clip values as the CSS spec requires
+	for (i = 0; i < 3; i++) {
+		if (rgbi[i] > 255) rgbi[i] = 255;
+	}
+	return NSVG_RGB(rgbi[0], rgbi[1], rgbi[2]);
+}
+
+typedef struct NSVGNamedColor {
+	const char* name;
+	unsigned int color;
+} NSVGNamedColor;
+
+NSVGNamedColor nsvg__colors[] = {
+
+	{ "red", NSVG_RGB(255, 0, 0) },
+	{ "green", NSVG_RGB( 0, 128, 0) },
+	{ "blue", NSVG_RGB( 0, 0, 255) },
+	{ "yellow", NSVG_RGB(255, 255, 0) },
+	{ "cyan", NSVG_RGB( 0, 255, 255) },
+	{ "magenta", NSVG_RGB(255, 0, 255) },
+	{ "black", NSVG_RGB( 0, 0, 0) },
+	{ "grey", NSVG_RGB(128, 128, 128) },
+	{ "gray", NSVG_RGB(128, 128, 128) },
+	{ "white", NSVG_RGB(255, 255, 255) },
+
+#ifdef NANOSVG_ALL_COLOR_KEYWORDS
+	{ "aliceblue", NSVG_RGB(240, 248, 255) },
+	{ "antiquewhite", NSVG_RGB(250, 235, 215) },
+	{ "aqua", NSVG_RGB( 0, 255, 255) },
+	{ "aquamarine", NSVG_RGB(127, 255, 212) },
+	{ "azure", NSVG_RGB(240, 255, 255) },
+	{ "beige", NSVG_RGB(245, 245, 220) },
+	{ "bisque", NSVG_RGB(255, 228, 196) },
+	{ "blanchedalmond", NSVG_RGB(255, 235, 205) },
+	{ "blueviolet", NSVG_RGB(138, 43, 226) },
+	{ "brown", NSVG_RGB(165, 42, 42) },
+	{ "burlywood", NSVG_RGB(222, 184, 135) },
+	{ "cadetblue", NSVG_RGB( 95, 158, 160) },
+	{ "chartreuse", NSVG_RGB(127, 255, 0) },
+	{ "chocolate", NSVG_RGB(210, 105, 30) },
+	{ "coral", NSVG_RGB(255, 127, 80) },
+	{ "cornflowerblue", NSVG_RGB(100, 149, 237) },
+	{ "cornsilk", NSVG_RGB(255, 248, 220) },
+	{ "crimson", NSVG_RGB(220, 20, 60) },
+	{ "darkblue", NSVG_RGB( 0, 0, 139) },
+	{ "darkcyan", NSVG_RGB( 0, 139, 139) },
+	{ "darkgoldenrod", NSVG_RGB(184, 134, 11) },
+	{ "darkgray", NSVG_RGB(169, 169, 169) },
+	{ "darkgreen", NSVG_RGB( 0, 100, 0) },
+	{ "darkgrey", NSVG_RGB(169, 169, 169) },
+	{ "darkkhaki", NSVG_RGB(189, 183, 107) },
+	{ "darkmagenta", NSVG_RGB(139, 0, 139) },
+	{ "darkolivegreen", NSVG_RGB( 85, 107, 47) },
+	{ "darkorange", NSVG_RGB(255, 140, 0) },
+	{ "darkorchid", NSVG_RGB(153, 50, 204) },
+	{ "darkred", NSVG_RGB(139, 0, 0) },
+	{ "darksalmon", NSVG_RGB(233, 150, 122) },
+	{ "darkseagreen", NSVG_RGB(143, 188, 143) },
+	{ "darkslateblue", NSVG_RGB( 72, 61, 139) },
+	{ "darkslategray", NSVG_RGB( 47, 79, 79) },
+	{ "darkslategrey", NSVG_RGB( 47, 79, 79) },
+	{ "darkturquoise", NSVG_RGB( 0, 206, 209) },
+	{ "darkviolet", NSVG_RGB(148, 0, 211) },
+	{ "deeppink", NSVG_RGB(255, 20, 147) },
+	{ "deepskyblue", NSVG_RGB( 0, 191, 255) },
+	{ "dimgray", NSVG_RGB(105, 105, 105) },
+	{ "dimgrey", NSVG_RGB(105, 105, 105) },
+	{ "dodgerblue", NSVG_RGB( 30, 144, 255) },
+	{ "firebrick", NSVG_RGB(178, 34, 34) },
+	{ "floralwhite", NSVG_RGB(255, 250, 240) },
+	{ "forestgreen", NSVG_RGB( 34, 139, 34) },
+	{ "fuchsia", NSVG_RGB(255, 0, 255) },
+	{ "gainsboro", NSVG_RGB(220, 220, 220) },
+	{ "ghostwhite", NSVG_RGB(248, 248, 255) },
+	{ "gold", NSVG_RGB(255, 215, 0) },
+	{ "goldenrod", NSVG_RGB(218, 165, 32) },
+	{ "greenyellow", NSVG_RGB(173, 255, 47) },
+	{ "honeydew", NSVG_RGB(240, 255, 240) },
+	{ "hotpink", NSVG_RGB(255, 105, 180) },
+	{ "indianred", NSVG_RGB(205, 92, 92) },
+	{ "indigo", NSVG_RGB( 75, 0, 130) },
+	{ "ivory", NSVG_RGB(255, 255, 240) },
+	{ "khaki", NSVG_RGB(240, 230, 140) },
+	{ "lavender", NSVG_RGB(230, 230, 250) },
+	{ "lavenderblush", NSVG_RGB(255, 240, 245) },
+	{ "lawngreen", NSVG_RGB(124, 252, 0) },
+	{ "lemonchiffon", NSVG_RGB(255, 250, 205) },
+	{ "lightblue", NSVG_RGB(173, 216, 230) },
+	{ "lightcoral", NSVG_RGB(240, 128, 128) },
+	{ "lightcyan", NSVG_RGB(224, 255, 255) },
+	{ "lightgoldenrodyellow", NSVG_RGB(250, 250, 210) },
+	{ "lightgray", NSVG_RGB(211, 211, 211) },
+	{ "lightgreen", NSVG_RGB(144, 238, 144) },
+	{ "lightgrey", NSVG_RGB(211, 211, 211) },
+	{ "lightpink", NSVG_RGB(255, 182, 193) },
+	{ "lightsalmon", NSVG_RGB(255, 160, 122) },
+	{ "lightseagreen", NSVG_RGB( 32, 178, 170) },
+	{ "lightskyblue", NSVG_RGB(135, 206, 250) },
+	{ "lightslategray", NSVG_RGB(119, 136, 153) },
+	{ "lightslategrey", NSVG_RGB(119, 136, 153) },
+	{ "lightsteelblue", NSVG_RGB(176, 196, 222) },
+	{ "lightyellow", NSVG_RGB(255, 255, 224) },
+	{ "lime", NSVG_RGB( 0, 255, 0) },
+	{ "limegreen", NSVG_RGB( 50, 205, 50) },
+	{ "linen", NSVG_RGB(250, 240, 230) },
+	{ "maroon", NSVG_RGB(128, 0, 0) },
+	{ "mediumaquamarine", NSVG_RGB(102, 205, 170) },
+	{ "mediumblue", NSVG_RGB( 0, 0, 205) },
+	{ "mediumorchid", NSVG_RGB(186, 85, 211) },
+	{ "mediumpurple", NSVG_RGB(147, 112, 219) },
+	{ "mediumseagreen", NSVG_RGB( 60, 179, 113) },
+	{ "mediumslateblue", NSVG_RGB(123, 104, 238) },
+	{ "mediumspringgreen", NSVG_RGB( 0, 250, 154) },
+	{ "mediumturquoise", NSVG_RGB( 72, 209, 204) },
+	{ "mediumvioletred", NSVG_RGB(199, 21, 133) },
+	{ "midnightblue", NSVG_RGB( 25, 25, 112) },
+	{ "mintcream", NSVG_RGB(245, 255, 250) },
+	{ "mistyrose", NSVG_RGB(255, 228, 225) },
+	{ "moccasin", NSVG_RGB(255, 228, 181) },
+	{ "navajowhite", NSVG_RGB(255, 222, 173) },
+	{ "navy", NSVG_RGB( 0, 0, 128) },
+	{ "oldlace", NSVG_RGB(253, 245, 230) },
+	{ "olive", NSVG_RGB(128, 128, 0) },
+	{ "olivedrab", NSVG_RGB(107, 142, 35) },
+	{ "orange", NSVG_RGB(255, 165, 0) },
+	{ "orangered", NSVG_RGB(255, 69, 0) },
+	{ "orchid", NSVG_RGB(218, 112, 214) },
+	{ "palegoldenrod", NSVG_RGB(238, 232, 170) },
+	{ "palegreen", NSVG_RGB(152, 251, 152) },
+	{ "paleturquoise", NSVG_RGB(175, 238, 238) },
+	{ "palevioletred", NSVG_RGB(219, 112, 147) },
+	{ "papayawhip", NSVG_RGB(255, 239, 213) },
+	{ "peachpuff", NSVG_RGB(255, 218, 185) },
+	{ "peru", NSVG_RGB(205, 133, 63) },
+	{ "pink", NSVG_RGB(255, 192, 203) },
+	{ "plum", NSVG_RGB(221, 160, 221) },
+	{ "powderblue", NSVG_RGB(176, 224, 230) },
+	{ "purple", NSVG_RGB(128, 0, 128) },
+	{ "rosybrown", NSVG_RGB(188, 143, 143) },
+	{ "royalblue", NSVG_RGB( 65, 105, 225) },
+	{ "saddlebrown", NSVG_RGB(139, 69, 19) },
+	{ "salmon", NSVG_RGB(250, 128, 114) },
+	{ "sandybrown", NSVG_RGB(244, 164, 96) },
+	{ "seagreen", NSVG_RGB( 46, 139, 87) },
+	{ "seashell", NSVG_RGB(255, 245, 238) },
+	{ "sienna", NSVG_RGB(160, 82, 45) },
+	{ "silver", NSVG_RGB(192, 192, 192) },
+	{ "skyblue", NSVG_RGB(135, 206, 235) },
+	{ "slateblue", NSVG_RGB(106, 90, 205) },
+	{ "slategray", NSVG_RGB(112, 128, 144) },
+	{ "slategrey", NSVG_RGB(112, 128, 144) },
+	{ "snow", NSVG_RGB(255, 250, 250) },
+	{ "springgreen", NSVG_RGB( 0, 255, 127) },
+	{ "steelblue", NSVG_RGB( 70, 130, 180) },
+	{ "tan", NSVG_RGB(210, 180, 140) },
+	{ "teal", NSVG_RGB( 0, 128, 128) },
+	{ "thistle", NSVG_RGB(216, 191, 216) },
+	{ "tomato", NSVG_RGB(255, 99, 71) },
+	{ "turquoise", NSVG_RGB( 64, 224, 208) },
+	{ "violet", NSVG_RGB(238, 130, 238) },
+	{ "wheat", NSVG_RGB(245, 222, 179) },
+	{ "whitesmoke", NSVG_RGB(245, 245, 245) },
+	{ "yellowgreen", NSVG_RGB(154, 205, 50) },
+#endif
+};
+
+static unsigned int nsvg__parseColorName(const char* str)
+{
+	int i, ncolors = sizeof(nsvg__colors) / sizeof(NSVGNamedColor);
+
+	for (i = 0; i < ncolors; i++) {
+		if (strcmp(nsvg__colors[i].name, str) == 0) {
+			return nsvg__colors[i].color;
+		}
+	}
+
+	return NSVG_RGB(128, 128, 128);
+}
+
+static unsigned int nsvg__parseColor(const char* str)
+{
+	size_t len = 0;
+	while(*str == ' ') ++str;
+	len = strlen(str);
+	if (len >= 1 && *str == '#')
+		return nsvg__parseColorHex(str);
+	else if (len >= 4 && str[0] == 'r' && str[1] == 'g' && str[2] == 'b' && str[3] == '(')
+		return nsvg__parseColorRGB(str);
+	return nsvg__parseColorName(str);
+}
+
+static float nsvg__parseOpacity(const char* str)
+{
+	float val = nsvg__atof(str);
+	if (val < 0.0f) val = 0.0f;
+	if (val > 1.0f) val = 1.0f;
+	return val;
+}
+
+static float nsvg__parseMiterLimit(const char* str)
+{
+	float val = nsvg__atof(str);
+	if (val < 0.0f) val = 0.0f;
+	return val;
+}
+
+static int nsvg__parseUnits(const char* units)
+{
+	if (units[0] == 'p' && units[1] == 'x')
+		return NSVG_UNITS_PX;
+	else if (units[0] == 'p' && units[1] == 't')
+		return NSVG_UNITS_PT;
+	else if (units[0] == 'p' && units[1] == 'c')
+		return NSVG_UNITS_PC;
+	else if (units[0] == 'm' && units[1] == 'm')
+		return NSVG_UNITS_MM;
+	else if (units[0] == 'c' && units[1] == 'm')
+		return NSVG_UNITS_CM;
+	else if (units[0] == 'i' && units[1] == 'n')
+		return NSVG_UNITS_IN;
+	else if (units[0] == '%')
+		return NSVG_UNITS_PERCENT;
+	else if (units[0] == 'e' && units[1] == 'm')
+		return NSVG_UNITS_EM;
+	else if (units[0] == 'e' && units[1] == 'x')
+		return NSVG_UNITS_EX;
+	return NSVG_UNITS_USER;
+}
+
+static int nsvg__isCoordinate(const char* s)
+{
+	// optional sign
+	if (*s == '-' || *s == '+')
+		s++;
+	// must have at least one digit, or start by a dot
+	return (nsvg__isdigit(*s) || *s == '.');
+}
+
+static NSVGcoordinate nsvg__parseCoordinateRaw(const char* str)
+{
+	NSVGcoordinate coord = {0, NSVG_UNITS_USER};
+	char buf[64];
+	coord.units = nsvg__parseUnits(nsvg__parseNumber(str, buf, 64));
+	coord.value = nsvg__atof(buf);
+	return coord;
+}
+
+static NSVGcoordinate nsvg__coord(float v, int units)
+{
+	NSVGcoordinate coord = {v, units};
+	return coord;
+}
+
+static float nsvg__parseCoordinate(NSVGparser* p, const char* str, float orig, float length)
+{
+	NSVGcoordinate coord = nsvg__parseCoordinateRaw(str);
+	return nsvg__convertToPixels(p, coord, orig, length);
+}
+
+static int nsvg__parseTransformArgs(const char* str, float* args, int maxNa, int* na)
+{
+	const char* end;
+	const char* ptr;
+	char it[64];
+
+	*na = 0;
+	ptr = str;
+	while (*ptr && *ptr != '(') ++ptr;
+	if (*ptr == 0)
+		return 1;
+	end = ptr;
+	while (*end && *end != ')') ++end;
+	if (*end == 0)
+		return 1;
+
+	while (ptr < end) {
+		if (*ptr == '-' || *ptr == '+' || *ptr == '.' || nsvg__isdigit(*ptr)) {
+			if (*na >= maxNa) return 0;
+			ptr = nsvg__parseNumber(ptr, it, 64);
+			args[(*na)++] = (float)nsvg__atof(it);
+		} else {
+			++ptr;
+		}
+	}
+	return (int)(end - str);
+}
+
+
+static int nsvg__parseMatrix(float* xform, const char* str)
+{
+	float t[6];
+	int na = 0;
+	int len = nsvg__parseTransformArgs(str, t, 6, &na);
+	if (na != 6) return len;
+	memcpy(xform, t, sizeof(float)*6);
+	return len;
+}
+
+static int nsvg__parseTranslate(float* xform, const char* str)
+{
+	float args[2];
+	float t[6];
+	int na = 0;
+	int len = nsvg__parseTransformArgs(str, args, 2, &na);
+	if (na == 1) args[1] = 0.0;
+
+	nsvg__xformSetTranslation(t, args[0], args[1]);
+	memcpy(xform, t, sizeof(float)*6);
+	return len;
+}
+
+static int nsvg__parseScale(float* xform, const char* str)
+{
+	float args[2];
+	int na = 0;
+	float t[6];
+	int len = nsvg__parseTransformArgs(str, args, 2, &na);
+	if (na == 1) args[1] = args[0];
+	nsvg__xformSetScale(t, args[0], args[1]);
+	memcpy(xform, t, sizeof(float)*6);
+	return len;
+}
+
+static int nsvg__parseSkewX(float* xform, const char* str)
+{
+	float args[1];
+	int na = 0;
+	float t[6];
+	int len = nsvg__parseTransformArgs(str, args, 1, &na);
+	nsvg__xformSetSkewX(t, args[0]/180.0f*NSVG_PI);
+	memcpy(xform, t, sizeof(float)*6);
+	return len;
+}
+
+static int nsvg__parseSkewY(float* xform, const char* str)
+{
+	float args[1];
+	int na = 0;
+	float t[6];
+	int len = nsvg__parseTransformArgs(str, args, 1, &na);
+	nsvg__xformSetSkewY(t, args[0]/180.0f*NSVG_PI);
+	memcpy(xform, t, sizeof(float)*6);
+	return len;
+}
+
+static int nsvg__parseRotate(float* xform, const char* str)
+{
+	float args[3];
+	int na = 0;
+	float m[6];
+	float t[6];
+	int len = nsvg__parseTransformArgs(str, args, 3, &na);
+	if (na == 1)
+		args[1] = args[2] = 0.0f;
+	nsvg__xformIdentity(m);
+
+	if (na > 1) {
+		nsvg__xformSetTranslation(t, -args[1], -args[2]);
+		nsvg__xformMultiply(m, t);
+	}
+
+	nsvg__xformSetRotation(t, args[0]/180.0f*NSVG_PI);
+	nsvg__xformMultiply(m, t);
+
+	if (na > 1) {
+		nsvg__xformSetTranslation(t, args[1], args[2]);
+		nsvg__xformMultiply(m, t);
+	}
+
+	memcpy(xform, m, sizeof(float)*6);
+
+	return len;
+}
+
+static void nsvg__parseTransform(float* xform, const char* str)
+{
+	float t[6];
+	int len;
+	nsvg__xformIdentity(xform);
+	while (*str)
+	{
+		if (strncmp(str, "matrix", 6) == 0)
+			len = nsvg__parseMatrix(t, str);
+		else if (strncmp(str, "translate", 9) == 0)
+			len = nsvg__parseTranslate(t, str);
+		else if (strncmp(str, "scale", 5) == 0)
+			len = nsvg__parseScale(t, str);
+		else if (strncmp(str, "rotate", 6) == 0)
+			len = nsvg__parseRotate(t, str);
+		else if (strncmp(str, "skewX", 5) == 0)
+			len = nsvg__parseSkewX(t, str);
+		else if (strncmp(str, "skewY", 5) == 0)
+			len = nsvg__parseSkewY(t, str);
+		else{
+			++str;
+			continue;
+		}
+		if (len != 0) {
+			str += len;
+		} else {
+			++str;
+			continue;
+		}
+
+		nsvg__xformPremultiply(xform, t);
+	}
+}
+
+static void nsvg__parseUrl(char* id, const char* str)
+{
+	int i = 0;
+	str += 4; // "url(";
+	if (*str && *str == '#')
+		str++;
+	while (i < 63 && *str && *str != ')') {
+		id[i] = *str++;
+		i++;
+	}
+	id[i] = '\0';
+}
+
+static char nsvg__parseLineCap(const char* str)
+{
+	if (strcmp(str, "butt") == 0)
+		return NSVG_CAP_BUTT;
+	else if (strcmp(str, "round") == 0)
+		return NSVG_CAP_ROUND;
+	else if (strcmp(str, "square") == 0)
+		return NSVG_CAP_SQUARE;
+	// TODO: handle inherit.
+	return NSVG_CAP_BUTT;
+}
+
+static char nsvg__parseLineJoin(const char* str)
+{
+	if (strcmp(str, "miter") == 0)
+		return NSVG_JOIN_MITER;
+	else if (strcmp(str, "round") == 0)
+		return NSVG_JOIN_ROUND;
+	else if (strcmp(str, "bevel") == 0)
+		return NSVG_JOIN_BEVEL;
+	// TODO: handle inherit.
+	return NSVG_JOIN_MITER;
+}
+
+static char nsvg__parseFillRule(const char* str)
+{
+	if (strcmp(str, "nonzero") == 0)
+		return NSVG_FILLRULE_NONZERO;
+	else if (strcmp(str, "evenodd") == 0)
+		return NSVG_FILLRULE_EVENODD;
+	// TODO: handle inherit.
+	return NSVG_FILLRULE_NONZERO;
+}
+
+static const char* nsvg__getNextDashItem(const char* s, char* it)
+{
+	int n = 0;
+	it[0] = '\0';
+	// Skip white spaces and commas
+	while (*s && (nsvg__isspace(*s) || *s == ',')) s++;
+	// Advance until whitespace, comma or end.
+	while (*s && (!nsvg__isspace(*s) && *s != ',')) {
+		if (n < 63)
+			it[n++] = *s;
+		s++;
+	}
+	it[n++] = '\0';
+	return s;
+}
+
+static int nsvg__parseStrokeDashArray(NSVGparser* p, const char* str, float* strokeDashArray)
+{
+	char item[64];
+	int count = 0, i;
+	float sum = 0.0f;
+
+	// Handle "none"
+	if (str[0] == 'n')
+		return 0;
+
+	// Parse dashes
+	while (*str) {
+		str = nsvg__getNextDashItem(str, item);
+		if (!*item) break;
+		if (count < NSVG_MAX_DASHES)
+			strokeDashArray[count++] = fabsf(nsvg__parseCoordinate(p, item, 0.0f, nsvg__actualLength(p)));
+	}
+
+	for (i = 0; i < count; i++)
+		sum += strokeDashArray[i];
+	if (sum <= 1e-6f)
+		count = 0;
+
+	return count;
+}
+
+static void nsvg__parseStyle(NSVGparser* p, const char* str);
+
+static int nsvg__parseAttr(NSVGparser* p, const char* name, const char* value)
+{
+	float xform[6];
+	NSVGattrib* attr = nsvg__getAttr(p);
+	if (!attr) return 0;
+
+	if (strcmp(name, "style") == 0) {
+		nsvg__parseStyle(p, value);
+	} else if (strcmp(name, "display") == 0) {
+		if (strcmp(value, "none") == 0)
+			attr->visible = 0;
+		// Don't reset ->visible on display:inline, one display:none hides the whole subtree
+
+	} else if (strcmp(name, "fill") == 0) {
+		if (strcmp(value, "none") == 0) {
+			attr->hasFill = 0;
+		} else if (strncmp(value, "url(", 4) == 0) {
+			attr->hasFill = 2;
+			nsvg__parseUrl(attr->fillGradient, value);
+		} else {
+			attr->hasFill = 1;
+			attr->fillColor = nsvg__parseColor(value);
+		}
+	} else if (strcmp(name, "opacity") == 0) {
+		attr->opacity = nsvg__parseOpacity(value);
+	} else if (strcmp(name, "fill-opacity") == 0) {
+		attr->fillOpacity = nsvg__parseOpacity(value);
+	} else if (strcmp(name, "stroke") == 0) {
+		if (strcmp(value, "none") == 0) {
+			attr->hasStroke = 0;
+		} else if (strncmp(value, "url(", 4) == 0) {
+			attr->hasStroke = 2;
+			nsvg__parseUrl(attr->strokeGradient, value);
+		} else {
+			attr->hasStroke = 1;
+			attr->strokeColor = nsvg__parseColor(value);
+		}
+	} else if (strcmp(name, "stroke-width") == 0) {
+		attr->strokeWidth = nsvg__parseCoordinate(p, value, 0.0f, nsvg__actualLength(p));
+	} else if (strcmp(name, "stroke-dasharray") == 0) {
+		attr->strokeDashCount = nsvg__parseStrokeDashArray(p, value, attr->strokeDashArray);
+	} else if (strcmp(name, "stroke-dashoffset") == 0) {
+		attr->strokeDashOffset = nsvg__parseCoordinate(p, value, 0.0f, nsvg__actualLength(p));
+	} else if (strcmp(name, "stroke-opacity") == 0) {
+		attr->strokeOpacity = nsvg__parseOpacity(value);
+	} else if (strcmp(name, "stroke-linecap") == 0) {
+		attr->strokeLineCap = nsvg__parseLineCap(value);
+	} else if (strcmp(name, "stroke-linejoin") == 0) {
+		attr->strokeLineJoin = nsvg__parseLineJoin(value);
+	} else if (strcmp(name, "stroke-miterlimit") == 0) {
+		attr->miterLimit = nsvg__parseMiterLimit(value);
+	} else if (strcmp(name, "fill-rule") == 0) {
+		attr->fillRule = nsvg__parseFillRule(value);
+	} else if (strcmp(name, "font-size") == 0) {
+		attr->fontSize = nsvg__parseCoordinate(p, value, 0.0f, nsvg__actualLength(p));
+	} else if (strcmp(name, "transform") == 0) {
+		nsvg__parseTransform(xform, value);
+		nsvg__xformPremultiply(attr->xform, xform);
+	} else if (strcmp(name, "stop-color") == 0) {
+		attr->stopColor = nsvg__parseColor(value);
+	} else if (strcmp(name, "stop-opacity") == 0) {
+		attr->stopOpacity = nsvg__parseOpacity(value);
+	} else if (strcmp(name, "offset") == 0) {
+		attr->stopOffset = nsvg__parseCoordinate(p, value, 0.0f, 1.0f);
+	} else if (strcmp(name, "id") == 0) {
+		strncpy(attr->id, value, 63);
+		attr->id[63] = '\0';
+	} else {
+		return 0;
+	}
+	return 1;
+}
+
+static int nsvg__parseNameValue(NSVGparser* p, const char* start, const char* end)
+{
+	const char* str;
+	const char* val;
+	char name[512];
+	char value[512];
+	int n;
+
+	str = start;
+	while (str < end && *str != ':') ++str;
+
+	val = str;
+
+	// Right Trim
+	while (str > start &&  (*str == ':' || nsvg__isspace(*str))) --str;
+	++str;
+
+	n = (int)(str - start);
+	if (n > 511) n = 511;
+	if (n) memcpy(name, start, n);
+	name[n] = 0;
+
+	while (val < end && (*val == ':' || nsvg__isspace(*val))) ++val;
+
+	n = (int)(end - val);
+	if (n > 511) n = 511;
+	if (n) memcpy(value, val, n);
+	value[n] = 0;
+
+	return nsvg__parseAttr(p, name, value);
+}
+
+static void nsvg__parseStyle(NSVGparser* p, const char* str)
+{
+	const char* start;
+	const char* end;
+
+	while (*str) {
+		// Left Trim
+		while(*str && nsvg__isspace(*str)) ++str;
+		start = str;
+		while(*str && *str != ';') ++str;
+		end = str;
+
+		// Right Trim
+		while (end > start &&  (*end == ';' || nsvg__isspace(*end))) --end;
+		++end;
+
+		nsvg__parseNameValue(p, start, end);
+		if (*str) ++str;
+	}
+}
+
+static void nsvg__parseAttribs(NSVGparser* p, const char** attr)
+{
+	int i;
+	for (i = 0; attr[i]; i += 2)
+	{
+		if (strcmp(attr[i], "style") == 0)
+			nsvg__parseStyle(p, attr[i + 1]);
+		else
+			nsvg__parseAttr(p, attr[i], attr[i + 1]);
+	}
+}
+
+static int nsvg__getArgsPerElement(char cmd)
+{
+	switch (cmd) {
+		case 'v':
+		case 'V':
+		case 'h':
+		case 'H':
+			return 1;
+		case 'm':
+		case 'M':
+		case 'l':
+		case 'L':
+		case 't':
+		case 'T':
+			return 2;
+		case 'q':
+		case 'Q':
+		case 's':
+		case 'S':
+			return 4;
+		case 'c':
+		case 'C':
+			return 6;
+		case 'a':
+		case 'A':
+			return 7;
+		case 'z':
+		case 'Z':
+			return 0;
+	}
+	return -1;
+}
+
+static void nsvg__pathMoveTo(NSVGparser* p, float* cpx, float* cpy, float* args, int rel)
+{
+	if (rel) {
+		*cpx += args[0];
+		*cpy += args[1];
+	} else {
+		*cpx = args[0];
+		*cpy = args[1];
+	}
+	nsvg__moveTo(p, *cpx, *cpy);
+}
+
+static void nsvg__pathLineTo(NSVGparser* p, float* cpx, float* cpy, float* args, int rel)
+{
+	if (rel) {
+		*cpx += args[0];
+		*cpy += args[1];
+	} else {
+		*cpx = args[0];
+		*cpy = args[1];
+	}
+	nsvg__lineTo(p, *cpx, *cpy);
+}
+
+static void nsvg__pathHLineTo(NSVGparser* p, float* cpx, float* cpy, float* args, int rel)
+{
+	if (rel)
+		*cpx += args[0];
+	else
+		*cpx = args[0];
+	nsvg__lineTo(p, *cpx, *cpy);
+}
+
+static void nsvg__pathVLineTo(NSVGparser* p, float* cpx, float* cpy, float* args, int rel)
+{
+	if (rel)
+		*cpy += args[0];
+	else
+		*cpy = args[0];
+	nsvg__lineTo(p, *cpx, *cpy);
+}
+
+static void nsvg__pathCubicBezTo(NSVGparser* p, float* cpx, float* cpy,
+								 float* cpx2, float* cpy2, float* args, int rel)
+{
+	float x2, y2, cx1, cy1, cx2, cy2;
+
+	if (rel) {
+		cx1 = *cpx + args[0];
+		cy1 = *cpy + args[1];
+		cx2 = *cpx + args[2];
+		cy2 = *cpy + args[3];
+		x2 = *cpx + args[4];
+		y2 = *cpy + args[5];
+	} else {
+		cx1 = args[0];
+		cy1 = args[1];
+		cx2 = args[2];
+		cy2 = args[3];
+		x2 = args[4];
+		y2 = args[5];
+	}
+
+	nsvg__cubicBezTo(p, cx1,cy1, cx2,cy2, x2,y2);
+
+	*cpx2 = cx2;
+	*cpy2 = cy2;
+	*cpx = x2;
+	*cpy = y2;
+}
+
+static void nsvg__pathCubicBezShortTo(NSVGparser* p, float* cpx, float* cpy,
+									  float* cpx2, float* cpy2, float* args, int rel)
+{
+	float x1, y1, x2, y2, cx1, cy1, cx2, cy2;
+
+	x1 = *cpx;
+	y1 = *cpy;
+	if (rel) {
+		cx2 = *cpx + args[0];
+		cy2 = *cpy + args[1];
+		x2 = *cpx + args[2];
+		y2 = *cpy + args[3];
+	} else {
+		cx2 = args[0];
+		cy2 = args[1];
+		x2 = args[2];
+		y2 = args[3];
+	}
+
+	cx1 = 2*x1 - *cpx2;
+	cy1 = 2*y1 - *cpy2;
+
+	nsvg__cubicBezTo(p, cx1,cy1, cx2,cy2, x2,y2);
+
+	*cpx2 = cx2;
+	*cpy2 = cy2;
+	*cpx = x2;
+	*cpy = y2;
+}
+
+static void nsvg__pathQuadBezTo(NSVGparser* p, float* cpx, float* cpy,
+								float* cpx2, float* cpy2, float* args, int rel)
+{
+	float x1, y1, x2, y2, cx, cy;
+	float cx1, cy1, cx2, cy2;
+
+	x1 = *cpx;
+	y1 = *cpy;
+	if (rel) {
+		cx = *cpx + args[0];
+		cy = *cpy + args[1];
+		x2 = *cpx + args[2];
+		y2 = *cpy + args[3];
+	} else {
+		cx = args[0];
+		cy = args[1];
+		x2 = args[2];
+		y2 = args[3];
+	}
+
+	// Convert to cubic bezier
+	cx1 = x1 + 2.0f/3.0f*(cx - x1);
+	cy1 = y1 + 2.0f/3.0f*(cy - y1);
+	cx2 = x2 + 2.0f/3.0f*(cx - x2);
+	cy2 = y2 + 2.0f/3.0f*(cy - y2);
+
+	nsvg__cubicBezTo(p, cx1,cy1, cx2,cy2, x2,y2);
+
+	*cpx2 = cx;
+	*cpy2 = cy;
+	*cpx = x2;
+	*cpy = y2;
+}
+
+static void nsvg__pathQuadBezShortTo(NSVGparser* p, float* cpx, float* cpy,
+									 float* cpx2, float* cpy2, float* args, int rel)
+{
+	float x1, y1, x2, y2, cx, cy;
+	float cx1, cy1, cx2, cy2;
+
+	x1 = *cpx;
+	y1 = *cpy;
+	if (rel) {
+		x2 = *cpx + args[0];
+		y2 = *cpy + args[1];
+	} else {
+		x2 = args[0];
+		y2 = args[1];
+	}
+
+	cx = 2*x1 - *cpx2;
+	cy = 2*y1 - *cpy2;
+
+	// Convert to cubix bezier
+	cx1 = x1 + 2.0f/3.0f*(cx - x1);
+	cy1 = y1 + 2.0f/3.0f*(cy - y1);
+	cx2 = x2 + 2.0f/3.0f*(cx - x2);
+	cy2 = y2 + 2.0f/3.0f*(cy - y2);
+
+	nsvg__cubicBezTo(p, cx1,cy1, cx2,cy2, x2,y2);
+
+	*cpx2 = cx;
+	*cpy2 = cy;
+	*cpx = x2;
+	*cpy = y2;
+}
+
+static float nsvg__sqr(float x) { return x*x; }
+static float nsvg__vmag(float x, float y) { return sqrtf(x*x + y*y); }
+
+static float nsvg__vecrat(float ux, float uy, float vx, float vy)
+{
+	return (ux*vx + uy*vy) / (nsvg__vmag(ux,uy) * nsvg__vmag(vx,vy));
+}
+
+static float nsvg__vecang(float ux, float uy, float vx, float vy)
+{
+	float r = nsvg__vecrat(ux,uy, vx,vy);
+	if (r < -1.0f) r = -1.0f;
+	if (r > 1.0f) r = 1.0f;
+	return ((ux*vy < uy*vx) ? -1.0f : 1.0f) * acosf(r);
+}
+
+static void nsvg__pathArcTo(NSVGparser* p, float* cpx, float* cpy, float* args, int rel)
+{
+	// Ported from canvg (https://code.google.com/p/canvg/)
+	float rx, ry, rotx;
+	float x1, y1, x2, y2, cx, cy, dx, dy, d;
+	float x1p, y1p, cxp, cyp, s, sa, sb;
+	float ux, uy, vx, vy, a1, da;
+	float x, y, tanx, tany, a, px = 0, py = 0, ptanx = 0, ptany = 0, t[6];
+	float sinrx, cosrx;
+	int fa, fs;
+	int i, ndivs;
+	float hda, kappa;
+
+	rx = fabsf(args[0]);				// y radius
+	ry = fabsf(args[1]);				// x radius
+	rotx = args[2] / 180.0f * NSVG_PI;		// x rotation angle
+	fa = fabsf(args[3]) > 1e-6 ? 1 : 0;	// Large arc
+	fs = fabsf(args[4]) > 1e-6 ? 1 : 0;	// Sweep direction
+	x1 = *cpx;							// start point
+	y1 = *cpy;
+	if (rel) {							// end point
+		x2 = *cpx + args[5];
+		y2 = *cpy + args[6];
+	} else {
+		x2 = args[5];
+		y2 = args[6];
+	}
+
+	dx = x1 - x2;
+	dy = y1 - y2;
+	d = sqrtf(dx*dx + dy*dy);
+	if (d < 1e-6f || rx < 1e-6f || ry < 1e-6f) {
+		// The arc degenerates to a line
+		nsvg__lineTo(p, x2, y2);
+		*cpx = x2;
+		*cpy = y2;
+		return;
+	}
+
+	sinrx = sinf(rotx);
+	cosrx = cosf(rotx);
+
+	// Convert to center point parameterization.
+	// http://www.w3.org/TR/SVG11/implnote.html#ArcImplementationNotes
+	// 1) Compute x1', y1'
+	x1p = cosrx * dx / 2.0f + sinrx * dy / 2.0f;
+	y1p = -sinrx * dx / 2.0f + cosrx * dy / 2.0f;
+	d = nsvg__sqr(x1p)/nsvg__sqr(rx) + nsvg__sqr(y1p)/nsvg__sqr(ry);
+	if (d > 1) {
+		d = sqrtf(d);
+		rx *= d;
+		ry *= d;
+	}
+	// 2) Compute cx', cy'
+	s = 0.0f;
+	sa = nsvg__sqr(rx)*nsvg__sqr(ry) - nsvg__sqr(rx)*nsvg__sqr(y1p) - nsvg__sqr(ry)*nsvg__sqr(x1p);
+	sb = nsvg__sqr(rx)*nsvg__sqr(y1p) + nsvg__sqr(ry)*nsvg__sqr(x1p);
+	if (sa < 0.0f) sa = 0.0f;
+	if (sb > 0.0f)
+		s = sqrtf(sa / sb);
+	if (fa == fs)
+		s = -s;
+	cxp = s * rx * y1p / ry;
+	cyp = s * -ry * x1p / rx;
+
+	// 3) Compute cx,cy from cx',cy'
+	cx = (x1 + x2)/2.0f + cosrx*cxp - sinrx*cyp;
+	cy = (y1 + y2)/2.0f + sinrx*cxp + cosrx*cyp;
+
+	// 4) Calculate theta1, and delta theta.
+	ux = (x1p - cxp) / rx;
+	uy = (y1p - cyp) / ry;
+	vx = (-x1p - cxp) / rx;
+	vy = (-y1p - cyp) / ry;
+	a1 = nsvg__vecang(1.0f,0.0f, ux,uy);	// Initial angle
+	da = nsvg__vecang(ux,uy, vx,vy);		// Delta angle
+
+//	if (vecrat(ux,uy,vx,vy) <= -1.0f) da = NSVG_PI;
+//	if (vecrat(ux,uy,vx,vy) >= 1.0f) da = 0;
+
+	if (fs == 0 && da > 0)
+		da -= 2 * NSVG_PI;
+	else if (fs == 1 && da < 0)
+		da += 2 * NSVG_PI;
+
+	// Approximate the arc using cubic spline segments.
+	t[0] = cosrx; t[1] = sinrx;
+	t[2] = -sinrx; t[3] = cosrx;
+	t[4] = cx; t[5] = cy;
+
+	// Split arc into max 90 degree segments.
+	// The loop assumes an iteration per end point (including start and end), this +1.
+	ndivs = (int)(fabsf(da) / (NSVG_PI*0.5f) + 1.0f);
+	hda = (da / (float)ndivs) / 2.0f;
+	// Fix for ticket #179: division by 0: avoid cotangens around 0 (infinite)
+	if ((hda < 1e-3f) && (hda > -1e-3f))
+		hda *= 0.5f;
+	else
+		hda = (1.0f - cosf(hda)) / sinf(hda);
+	kappa = fabsf(4.0f / 3.0f * hda);
+	if (da < 0.0f)
+		kappa = -kappa;
+
+	for (i = 0; i <= ndivs; i++) {
+		a = a1 + da * ((float)i/(float)ndivs);
+		dx = cosf(a);
+		dy = sinf(a);
+		nsvg__xformPoint(&x, &y, dx*rx, dy*ry, t); // position
+		nsvg__xformVec(&tanx, &tany, -dy*rx * kappa, dx*ry * kappa, t); // tangent
+		if (i > 0)
+			nsvg__cubicBezTo(p, px+ptanx,py+ptany, x-tanx, y-tany, x, y);
+		px = x;
+		py = y;
+		ptanx = tanx;
+		ptany = tany;
+	}
+
+	*cpx = x2;
+	*cpy = y2;
+}
+
+static void nsvg__parsePath(NSVGparser* p, const char** attr)
+{
+	const char* s = NULL;
+	char cmd = '\0';
+	float args[10];
+	int nargs;
+	int rargs = 0;
+	char initPoint;
+	float cpx, cpy, cpx2, cpy2;
+	const char* tmp[4];
+	char closedFlag;
+	int i;
+	char item[64];
+
+	for (i = 0; attr[i]; i += 2) {
+		if (strcmp(attr[i], "d") == 0) {
+			s = attr[i + 1];
+		} else {
+			tmp[0] = attr[i];
+			tmp[1] = attr[i + 1];
+			tmp[2] = 0;
+			tmp[3] = 0;
+			nsvg__parseAttribs(p, tmp);
+		}
+	}
+
+	if (s) {
+		nsvg__resetPath(p);
+		cpx = 0; cpy = 0;
+		cpx2 = 0; cpy2 = 0;
+		initPoint = 0;
+		closedFlag = 0;
+		nargs = 0;
+
+		while (*s) {
+			item[0] = '\0';
+			if ((cmd == 'A' || cmd == 'a') && (nargs == 3 || nargs == 4))
+				s = nsvg__getNextPathItemWhenArcFlag(s, item);
+			if (!*item)
+				s = nsvg__getNextPathItem(s, item);
+			if (!*item) break;
+			if (cmd != '\0' && nsvg__isCoordinate(item)) {
+				if (nargs < 10)
+					args[nargs++] = (float)nsvg__atof(item);
+				if (nargs >= rargs) {
+					switch (cmd) {
+						case 'm':
+						case 'M':
+							nsvg__pathMoveTo(p, &cpx, &cpy, args, cmd == 'm' ? 1 : 0);
+							// Moveto can be followed by multiple coordinate pairs,
+							// which should be treated as linetos.
+							cmd = (cmd == 'm') ? 'l' : 'L';
+							rargs = nsvg__getArgsPerElement(cmd);
+							cpx2 = cpx; cpy2 = cpy;
+							initPoint = 1;
+							break;
+						case 'l':
+						case 'L':
+							nsvg__pathLineTo(p, &cpx, &cpy, args, cmd == 'l' ? 1 : 0);
+							cpx2 = cpx; cpy2 = cpy;
+							break;
+						case 'H':
+						case 'h':
+							nsvg__pathHLineTo(p, &cpx, &cpy, args, cmd == 'h' ? 1 : 0);
+							cpx2 = cpx; cpy2 = cpy;
+							break;
+						case 'V':
+						case 'v':
+							nsvg__pathVLineTo(p, &cpx, &cpy, args, cmd == 'v' ? 1 : 0);
+							cpx2 = cpx; cpy2 = cpy;
+							break;
+						case 'C':
+						case 'c':
+							nsvg__pathCubicBezTo(p, &cpx, &cpy, &cpx2, &cpy2, args, cmd == 'c' ? 1 : 0);
+							break;
+						case 'S':
+						case 's':
+							nsvg__pathCubicBezShortTo(p, &cpx, &cpy, &cpx2, &cpy2, args, cmd == 's' ? 1 : 0);
+							break;
+						case 'Q':
+						case 'q':
+							nsvg__pathQuadBezTo(p, &cpx, &cpy, &cpx2, &cpy2, args, cmd == 'q' ? 1 : 0);
+							break;
+						case 'T':
+						case 't':
+							nsvg__pathQuadBezShortTo(p, &cpx, &cpy, &cpx2, &cpy2, args, cmd == 't' ? 1 : 0);
+							break;
+						case 'A':
+						case 'a':
+							nsvg__pathArcTo(p, &cpx, &cpy, args, cmd == 'a' ? 1 : 0);
+							cpx2 = cpx; cpy2 = cpy;
+							break;
+						default:
+							if (nargs >= 2) {
+								cpx = args[nargs-2];
+								cpy = args[nargs-1];
+								cpx2 = cpx; cpy2 = cpy;
+							}
+							break;
+					}
+					nargs = 0;
+				}
+			} else {
+				cmd = item[0];
+				if (cmd == 'M' || cmd == 'm') {
+					// Commit path.
+					if (p->npts > 0)
+						nsvg__addPath(p, closedFlag);
+					// Start new subpath.
+					nsvg__resetPath(p);
+					closedFlag = 0;
+					nargs = 0;
+				} else if (initPoint == 0) {
+					// Do not allow other commands until initial point has been set (moveTo called once).
+					cmd = '\0';
+				}
+				if (cmd == 'Z' || cmd == 'z') {
+					closedFlag = 1;
+					// Commit path.
+					if (p->npts > 0) {
+						// Move current point to first point
+						cpx = p->pts[0];
+						cpy = p->pts[1];
+						cpx2 = cpx; cpy2 = cpy;
+						nsvg__addPath(p, closedFlag);
+					}
+					// Start new subpath.
+					nsvg__resetPath(p);
+					nsvg__moveTo(p, cpx, cpy);
+					closedFlag = 0;
+					nargs = 0;
+				}
+				rargs = nsvg__getArgsPerElement(cmd);
+				if (rargs == -1) {
+					// Command not recognized
+					cmd = '\0';
+					rargs = 0;
+				}
+			}
+		}
+		// Commit path.
+		if (p->npts)
+			nsvg__addPath(p, closedFlag);
+	}
+
+	nsvg__addShape(p);
+}
+
+static void nsvg__parseRect(NSVGparser* p, const char** attr)
+{
+	float x = 0.0f;
+	float y = 0.0f;
+	float w = 0.0f;
+	float h = 0.0f;
+	float rx = -1.0f; // marks not set
+	float ry = -1.0f;
+	int i;
+
+	for (i = 0; attr[i]; i += 2) {
+		if (!nsvg__parseAttr(p, attr[i], attr[i + 1])) {
+			if (strcmp(attr[i], "x") == 0) x = nsvg__parseCoordinate(p, attr[i+1], nsvg__actualOrigX(p), nsvg__actualWidth(p));
+			if (strcmp(attr[i], "y") == 0) y = nsvg__parseCoordinate(p, attr[i+1], nsvg__actualOrigY(p), nsvg__actualHeight(p));
+			if (strcmp(attr[i], "width") == 0) w = nsvg__parseCoordinate(p, attr[i+1], 0.0f, nsvg__actualWidth(p));
+			if (strcmp(attr[i], "height") == 0) h = nsvg__parseCoordinate(p, attr[i+1], 0.0f, nsvg__actualHeight(p));
+			if (strcmp(attr[i], "rx") == 0) rx = fabsf(nsvg__parseCoordinate(p, attr[i+1], 0.0f, nsvg__actualWidth(p)));
+			if (strcmp(attr[i], "ry") == 0) ry = fabsf(nsvg__parseCoordinate(p, attr[i+1], 0.0f, nsvg__actualHeight(p)));
+		}
+	}
+
+	if (rx < 0.0f && ry > 0.0f) rx = ry;
+	if (ry < 0.0f && rx > 0.0f) ry = rx;
+	if (rx < 0.0f) rx = 0.0f;
+	if (ry < 0.0f) ry = 0.0f;
+	if (rx > w/2.0f) rx = w/2.0f;
+	if (ry > h/2.0f) ry = h/2.0f;
+
+	if (w != 0.0f && h != 0.0f) {
+		nsvg__resetPath(p);
+
+		if (rx < 0.00001f || ry < 0.0001f) {
+			nsvg__moveTo(p, x, y);
+			nsvg__lineTo(p, x+w, y);
+			nsvg__lineTo(p, x+w, y+h);
+			nsvg__lineTo(p, x, y+h);
+		} else {
+			// Rounded rectangle
+			nsvg__moveTo(p, x+rx, y);
+			nsvg__lineTo(p, x+w-rx, y);
+			nsvg__cubicBezTo(p, x+w-rx*(1-NSVG_KAPPA90), y, x+w, y+ry*(1-NSVG_KAPPA90), x+w, y+ry);
+			nsvg__lineTo(p, x+w, y+h-ry);
+			nsvg__cubicBezTo(p, x+w, y+h-ry*(1-NSVG_KAPPA90), x+w-rx*(1-NSVG_KAPPA90), y+h, x+w-rx, y+h);
+			nsvg__lineTo(p, x+rx, y+h);
+			nsvg__cubicBezTo(p, x+rx*(1-NSVG_KAPPA90), y+h, x, y+h-ry*(1-NSVG_KAPPA90), x, y+h-ry);
+			nsvg__lineTo(p, x, y+ry);
+			nsvg__cubicBezTo(p, x, y+ry*(1-NSVG_KAPPA90), x+rx*(1-NSVG_KAPPA90), y, x+rx, y);
+		}
+
+		nsvg__addPath(p, 1);
+
+		nsvg__addShape(p);
+	}
+}
+
+static void nsvg__parseCircle(NSVGparser* p, const char** attr)
+{
+	float cx = 0.0f;
+	float cy = 0.0f;
+	float r = 0.0f;
+	int i;
+
+	for (i = 0; attr[i]; i += 2) {
+		if (!nsvg__parseAttr(p, attr[i], attr[i + 1])) {
+			if (strcmp(attr[i], "cx") == 0) cx = nsvg__parseCoordinate(p, attr[i+1], nsvg__actualOrigX(p), nsvg__actualWidth(p));
+			if (strcmp(attr[i], "cy") == 0) cy = nsvg__parseCoordinate(p, attr[i+1], nsvg__actualOrigY(p), nsvg__actualHeight(p));
+			if (strcmp(attr[i], "r") == 0) r = fabsf(nsvg__parseCoordinate(p, attr[i+1], 0.0f, nsvg__actualLength(p)));
+		}
+	}
+
+	if (r > 0.0f) {
+		nsvg__resetPath(p);
+
+		nsvg__moveTo(p, cx+r, cy);
+		nsvg__cubicBezTo(p, cx+r, cy+r*NSVG_KAPPA90, cx+r*NSVG_KAPPA90, cy+r, cx, cy+r);
+		nsvg__cubicBezTo(p, cx-r*NSVG_KAPPA90, cy+r, cx-r, cy+r*NSVG_KAPPA90, cx-r, cy);
+		nsvg__cubicBezTo(p, cx-r, cy-r*NSVG_KAPPA90, cx-r*NSVG_KAPPA90, cy-r, cx, cy-r);
+		nsvg__cubicBezTo(p, cx+r*NSVG_KAPPA90, cy-r, cx+r, cy-r*NSVG_KAPPA90, cx+r, cy);
+
+		nsvg__addPath(p, 1);
+
+		nsvg__addShape(p);
+	}
+}
+
+static void nsvg__parseEllipse(NSVGparser* p, const char** attr)
+{
+	float cx = 0.0f;
+	float cy = 0.0f;
+	float rx = 0.0f;
+	float ry = 0.0f;
+	int i;
+
+	for (i = 0; attr[i]; i += 2) {
+		if (!nsvg__parseAttr(p, attr[i], attr[i + 1])) {
+			if (strcmp(attr[i], "cx") == 0) cx = nsvg__parseCoordinate(p, attr[i+1], nsvg__actualOrigX(p), nsvg__actualWidth(p));
+			if (strcmp(attr[i], "cy") == 0) cy = nsvg__parseCoordinate(p, attr[i+1], nsvg__actualOrigY(p), nsvg__actualHeight(p));
+			if (strcmp(attr[i], "rx") == 0) rx = fabsf(nsvg__parseCoordinate(p, attr[i+1], 0.0f, nsvg__actualWidth(p)));
+			if (strcmp(attr[i], "ry") == 0) ry = fabsf(nsvg__parseCoordinate(p, attr[i+1], 0.0f, nsvg__actualHeight(p)));
+		}
+	}
+
+	if (rx > 0.0f && ry > 0.0f) {
+
+		nsvg__resetPath(p);
+
+		nsvg__moveTo(p, cx+rx, cy);
+		nsvg__cubicBezTo(p, cx+rx, cy+ry*NSVG_KAPPA90, cx+rx*NSVG_KAPPA90, cy+ry, cx, cy+ry);
+		nsvg__cubicBezTo(p, cx-rx*NSVG_KAPPA90, cy+ry, cx-rx, cy+ry*NSVG_KAPPA90, cx-rx, cy);
+		nsvg__cubicBezTo(p, cx-rx, cy-ry*NSVG_KAPPA90, cx-rx*NSVG_KAPPA90, cy-ry, cx, cy-ry);
+		nsvg__cubicBezTo(p, cx+rx*NSVG_KAPPA90, cy-ry, cx+rx, cy-ry*NSVG_KAPPA90, cx+rx, cy);
+
+		nsvg__addPath(p, 1);
+
+		nsvg__addShape(p);
+	}
+}
+
+static void nsvg__parseLine(NSVGparser* p, const char** attr)
+{
+	float x1 = 0.0;
+	float y1 = 0.0;
+	float x2 = 0.0;
+	float y2 = 0.0;
+	int i;
+
+	for (i = 0; attr[i]; i += 2) {
+		if (!nsvg__parseAttr(p, attr[i], attr[i + 1])) {
+			if (strcmp(attr[i], "x1") == 0) x1 = nsvg__parseCoordinate(p, attr[i + 1], nsvg__actualOrigX(p), nsvg__actualWidth(p));
+			if (strcmp(attr[i], "y1") == 0) y1 = nsvg__parseCoordinate(p, attr[i + 1], nsvg__actualOrigY(p), nsvg__actualHeight(p));
+			if (strcmp(attr[i], "x2") == 0) x2 = nsvg__parseCoordinate(p, attr[i + 1], nsvg__actualOrigX(p), nsvg__actualWidth(p));
+			if (strcmp(attr[i], "y2") == 0) y2 = nsvg__parseCoordinate(p, attr[i + 1], nsvg__actualOrigY(p), nsvg__actualHeight(p));
+		}
+	}
+
+	nsvg__resetPath(p);
+
+	nsvg__moveTo(p, x1, y1);
+	nsvg__lineTo(p, x2, y2);
+
+	nsvg__addPath(p, 0);
+
+	nsvg__addShape(p);
+}
+
+static void nsvg__parsePoly(NSVGparser* p, const char** attr, int closeFlag)
+{
+	int i;
+	const char* s;
+	float args[2];
+	int nargs, npts = 0;
+	char item[64];
+
+	nsvg__resetPath(p);
+
+	for (i = 0; attr[i]; i += 2) {
+		if (!nsvg__parseAttr(p, attr[i], attr[i + 1])) {
+			if (strcmp(attr[i], "points") == 0) {
+				s = attr[i + 1];
+				nargs = 0;
+				while (*s) {
+					s = nsvg__getNextPathItem(s, item);
+					args[nargs++] = (float)nsvg__atof(item);
+					if (nargs >= 2) {
+						if (npts == 0)
+							nsvg__moveTo(p, args[0], args[1]);
+						else
+							nsvg__lineTo(p, args[0], args[1]);
+						nargs = 0;
+						npts++;
+					}
+				}
+			}
+		}
+	}
+
+	nsvg__addPath(p, (char)closeFlag);
+
+	nsvg__addShape(p);
+}
+
+static void nsvg__parseSVG(NSVGparser* p, const char** attr)
+{
+	int i;
+	for (i = 0; attr[i]; i += 2) {
+		if (!nsvg__parseAttr(p, attr[i], attr[i + 1])) {
+			if (strcmp(attr[i], "width") == 0) {
+				p->image->width = nsvg__parseCoordinate(p, attr[i + 1], 0.0f, 0.0f);
+			} else if (strcmp(attr[i], "height") == 0) {
+				p->image->height = nsvg__parseCoordinate(p, attr[i + 1], 0.0f, 0.0f);
+			} else if (strcmp(attr[i], "viewBox") == 0) {
+				const char *s = attr[i + 1];
+				char buf[64];
+				s = nsvg__parseNumber(s, buf, 64);
+				p->viewMinx = nsvg__atof(buf);
+				while (*s && (nsvg__isspace(*s) || *s == '%' || *s == ',')) s++;
+				if (!*s) return;
+				s = nsvg__parseNumber(s, buf, 64);
+				p->viewMiny = nsvg__atof(buf);
+				while (*s && (nsvg__isspace(*s) || *s == '%' || *s == ',')) s++;
+				if (!*s) return;
+				s = nsvg__parseNumber(s, buf, 64);
+				p->viewWidth = nsvg__atof(buf);
+				while (*s && (nsvg__isspace(*s) || *s == '%' || *s == ',')) s++;
+				if (!*s) return;
+				s = nsvg__parseNumber(s, buf, 64);
+				p->viewHeight = nsvg__atof(buf);
+			} else if (strcmp(attr[i], "preserveAspectRatio") == 0) {
+				if (strstr(attr[i + 1], "none") != 0) {
+					// No uniform scaling
+					p->alignType = NSVG_ALIGN_NONE;
+				} else {
+					// Parse X align
+					if (strstr(attr[i + 1], "xMin") != 0)
+						p->alignX = NSVG_ALIGN_MIN;
+					else if (strstr(attr[i + 1], "xMid") != 0)
+						p->alignX = NSVG_ALIGN_MID;
+					else if (strstr(attr[i + 1], "xMax") != 0)
+						p->alignX = NSVG_ALIGN_MAX;
+					// Parse X align
+					if (strstr(attr[i + 1], "yMin") != 0)
+						p->alignY = NSVG_ALIGN_MIN;
+					else if (strstr(attr[i + 1], "yMid") != 0)
+						p->alignY = NSVG_ALIGN_MID;
+					else if (strstr(attr[i + 1], "yMax") != 0)
+						p->alignY = NSVG_ALIGN_MAX;
+					// Parse meet/slice
+					p->alignType = NSVG_ALIGN_MEET;
+					if (strstr(attr[i + 1], "slice") != 0)
+						p->alignType = NSVG_ALIGN_SLICE;
+				}
+			}
+		}
+	}
+}
+
+static void nsvg__parseGradient(NSVGparser* p, const char** attr, signed char type)
+{
+	int i;
+	NSVGgradientData* grad = (NSVGgradientData*)malloc(sizeof(NSVGgradientData));
+	if (grad == NULL) return;
+	memset(grad, 0, sizeof(NSVGgradientData));
+	grad->units = NSVG_OBJECT_SPACE;
+	grad->type = type;
+	if (grad->type == NSVG_PAINT_LINEAR_GRADIENT) {
+		grad->linear.x1 = nsvg__coord(0.0f, NSVG_UNITS_PERCENT);
+		grad->linear.y1 = nsvg__coord(0.0f, NSVG_UNITS_PERCENT);
+		grad->linear.x2 = nsvg__coord(100.0f, NSVG_UNITS_PERCENT);
+		grad->linear.y2 = nsvg__coord(0.0f, NSVG_UNITS_PERCENT);
+	} else if (grad->type == NSVG_PAINT_RADIAL_GRADIENT) {
+		grad->radial.cx = nsvg__coord(50.0f, NSVG_UNITS_PERCENT);
+		grad->radial.cy = nsvg__coord(50.0f, NSVG_UNITS_PERCENT);
+		grad->radial.r = nsvg__coord(50.0f, NSVG_UNITS_PERCENT);
+	}
+
+	nsvg__xformIdentity(grad->xform);
+
+	for (i = 0; attr[i]; i += 2) {
+		if (strcmp(attr[i], "id") == 0) {
+			strncpy(grad->id, attr[i+1], 63);
+			grad->id[63] = '\0';
+		} else if (!nsvg__parseAttr(p, attr[i], attr[i + 1])) {
+			if (strcmp(attr[i], "gradientUnits") == 0) {
+				if (strcmp(attr[i+1], "objectBoundingBox") == 0)
+					grad->units = NSVG_OBJECT_SPACE;
+				else
+					grad->units = NSVG_USER_SPACE;
+			} else if (strcmp(attr[i], "gradientTransform") == 0) {
+				nsvg__parseTransform(grad->xform, attr[i + 1]);
+			} else if (strcmp(attr[i], "cx") == 0) {
+				grad->radial.cx = nsvg__parseCoordinateRaw(attr[i + 1]);
+			} else if (strcmp(attr[i], "cy") == 0) {
+				grad->radial.cy = nsvg__parseCoordinateRaw(attr[i + 1]);
+			} else if (strcmp(attr[i], "r") == 0) {
+				grad->radial.r = nsvg__parseCoordinateRaw(attr[i + 1]);
+			} else if (strcmp(attr[i], "fx") == 0) {
+				grad->radial.fx = nsvg__parseCoordinateRaw(attr[i + 1]);
+			} else if (strcmp(attr[i], "fy") == 0) {
+				grad->radial.fy = nsvg__parseCoordinateRaw(attr[i + 1]);
+			} else if (strcmp(attr[i], "x1") == 0) {
+				grad->linear.x1 = nsvg__parseCoordinateRaw(attr[i + 1]);
+			} else if (strcmp(attr[i], "y1") == 0) {
+				grad->linear.y1 = nsvg__parseCoordinateRaw(attr[i + 1]);
+			} else if (strcmp(attr[i], "x2") == 0) {
+				grad->linear.x2 = nsvg__parseCoordinateRaw(attr[i + 1]);
+			} else if (strcmp(attr[i], "y2") == 0) {
+				grad->linear.y2 = nsvg__parseCoordinateRaw(attr[i + 1]);
+			} else if (strcmp(attr[i], "spreadMethod") == 0) {
+				if (strcmp(attr[i+1], "pad") == 0)
+					grad->spread = NSVG_SPREAD_PAD;
+				else if (strcmp(attr[i+1], "reflect") == 0)
+					grad->spread = NSVG_SPREAD_REFLECT;
+				else if (strcmp(attr[i+1], "repeat") == 0)
+					grad->spread = NSVG_SPREAD_REPEAT;
+			} else if (strcmp(attr[i], "xlink:href") == 0) {
+				const char *href = attr[i+1];
+				strncpy(grad->ref, href+1, 62);
+				grad->ref[62] = '\0';
+			}
+		}
+	}
+
+	grad->next = p->gradients;
+	p->gradients = grad;
+}
+
+static void nsvg__parseGradientStop(NSVGparser* p, const char** attr)
+{
+	NSVGattrib* curAttr = nsvg__getAttr(p);
+	NSVGgradientData* grad;
+	NSVGgradientStop* stop;
+	int i, idx;
+
+	curAttr->stopOffset = 0;
+	curAttr->stopColor = 0;
+	curAttr->stopOpacity = 1.0f;
+
+	for (i = 0; attr[i]; i += 2) {
+		nsvg__parseAttr(p, attr[i], attr[i + 1]);
+	}
+
+	// Add stop to the last gradient.
+	grad = p->gradients;
+	if (grad == NULL) return;
+
+	grad->nstops++;
+	grad->stops = (NSVGgradientStop*)realloc(grad->stops, sizeof(NSVGgradientStop)*grad->nstops);
+	if (grad->stops == NULL) return;
+
+	// Insert
+	idx = grad->nstops-1;
+	for (i = 0; i < grad->nstops-1; i++) {
+		if (curAttr->stopOffset < grad->stops[i].offset) {
+			idx = i;
+			break;
+		}
+	}
+	if (idx != grad->nstops-1) {
+		for (i = grad->nstops-1; i > idx; i--)
+			grad->stops[i] = grad->stops[i-1];
+	}
+
+	stop = &grad->stops[idx];
+	stop->color = curAttr->stopColor;
+	stop->color |= (unsigned int)(curAttr->stopOpacity*255) << 24;
+	stop->offset = curAttr->stopOffset;
+}
+
+static void nsvg__startElement(void* ud, const char* el, const char** attr)
+{
+	NSVGparser* p = (NSVGparser*)ud;
+
+	if (p->defsFlag) {
+		// Skip everything but gradients in defs
+		if (strcmp(el, "linearGradient") == 0) {
+			nsvg__parseGradient(p, attr, NSVG_PAINT_LINEAR_GRADIENT);
+		} else if (strcmp(el, "radialGradient") == 0) {
+			nsvg__parseGradient(p, attr, NSVG_PAINT_RADIAL_GRADIENT);
+		} else if (strcmp(el, "stop") == 0) {
+			nsvg__parseGradientStop(p, attr);
+		}
+		return;
+	}
+
+	if (strcmp(el, "g") == 0) {
+		nsvg__pushAttr(p);
+		nsvg__parseAttribs(p, attr);
+	} else if (strcmp(el, "path") == 0) {
+		if (p->pathFlag)	// Do not allow nested paths.
+			return;
+		nsvg__pushAttr(p);
+		nsvg__parsePath(p, attr);
+		nsvg__popAttr(p);
+	} else if (strcmp(el, "rect") == 0) {
+		nsvg__pushAttr(p);
+		nsvg__parseRect(p, attr);
+		nsvg__popAttr(p);
+	} else if (strcmp(el, "circle") == 0) {
+		nsvg__pushAttr(p);
+		nsvg__parseCircle(p, attr);
+		nsvg__popAttr(p);
+	} else if (strcmp(el, "ellipse") == 0) {
+		nsvg__pushAttr(p);
+		nsvg__parseEllipse(p, attr);
+		nsvg__popAttr(p);
+	} else if (strcmp(el, "line") == 0)  {
+		nsvg__pushAttr(p);
+		nsvg__parseLine(p, attr);
+		nsvg__popAttr(p);
+	} else if (strcmp(el, "polyline") == 0)  {
+		nsvg__pushAttr(p);
+		nsvg__parsePoly(p, attr, 0);
+		nsvg__popAttr(p);
+	} else if (strcmp(el, "polygon") == 0)  {
+		nsvg__pushAttr(p);
+		nsvg__parsePoly(p, attr, 1);
+		nsvg__popAttr(p);
+	} else  if (strcmp(el, "linearGradient") == 0) {
+		nsvg__parseGradient(p, attr, NSVG_PAINT_LINEAR_GRADIENT);
+	} else if (strcmp(el, "radialGradient") == 0) {
+		nsvg__parseGradient(p, attr, NSVG_PAINT_RADIAL_GRADIENT);
+	} else if (strcmp(el, "stop") == 0) {
+		nsvg__parseGradientStop(p, attr);
+	} else if (strcmp(el, "defs") == 0) {
+		p->defsFlag = 1;
+	} else if (strcmp(el, "svg") == 0) {
+		nsvg__parseSVG(p, attr);
+	}
+}
+
+static void nsvg__endElement(void* ud, const char* el)
+{
+	NSVGparser* p = (NSVGparser*)ud;
+
+	if (strcmp(el, "g") == 0) {
+		nsvg__popAttr(p);
+	} else if (strcmp(el, "path") == 0) {
+		p->pathFlag = 0;
+	} else if (strcmp(el, "defs") == 0) {
+		p->defsFlag = 0;
+	}
+}
+
+static void nsvg__content(void* ud, const char* s)
+{
+	NSVG_NOTUSED(ud);
+	NSVG_NOTUSED(s);
+	// empty
+}
+
+static void nsvg__imageBounds(NSVGparser* p, float* bounds)
+{
+	NSVGshape* shape;
+	shape = p->image->shapes;
+	if (shape == NULL) {
+		bounds[0] = bounds[1] = bounds[2] = bounds[3] = 0.0;
+		return;
+	}
+	bounds[0] = shape->bounds[0];
+	bounds[1] = shape->bounds[1];
+	bounds[2] = shape->bounds[2];
+	bounds[3] = shape->bounds[3];
+	for (shape = shape->next; shape != NULL; shape = shape->next) {
+		bounds[0] = nsvg__minf(bounds[0], shape->bounds[0]);
+		bounds[1] = nsvg__minf(bounds[1], shape->bounds[1]);
+		bounds[2] = nsvg__maxf(bounds[2], shape->bounds[2]);
+		bounds[3] = nsvg__maxf(bounds[3], shape->bounds[3]);
+	}
+}
+
+static float nsvg__viewAlign(float content, float container, int type)
+{
+	if (type == NSVG_ALIGN_MIN)
+		return 0;
+	else if (type == NSVG_ALIGN_MAX)
+		return container - content;
+	// mid
+	return (container - content) * 0.5f;
+}
+
+static void nsvg__scaleGradient(NSVGgradient* grad, float tx, float ty, float sx, float sy)
+{
+	float t[6];
+	nsvg__xformSetTranslation(t, tx, ty);
+	nsvg__xformMultiply (grad->xform, t);
+
+	nsvg__xformSetScale(t, sx, sy);
+	nsvg__xformMultiply (grad->xform, t);
+}
+
+static void nsvg__scaleToViewbox(NSVGparser* p, const char* units)
+{
+	NSVGshape* shape;
+	NSVGpath* path;
+	float tx, ty, sx, sy, us, bounds[4], t[6], avgs;
+	int i;
+	float* pt;
+
+	// Guess image size if not set completely.
+	nsvg__imageBounds(p, bounds);
+
+	if (p->viewWidth == 0) {
+		if (p->image->width > 0) {
+			p->viewWidth = p->image->width;
+		} else {
+			p->viewMinx = bounds[0];
+			p->viewWidth = bounds[2] - bounds[0];
+		}
+	}
+	if (p->viewHeight == 0) {
+		if (p->image->height > 0) {
+			p->viewHeight = p->image->height;
+		} else {
+			p->viewMiny = bounds[1];
+			p->viewHeight = bounds[3] - bounds[1];
+		}
+	}
+	if (p->image->width == 0)
+		p->image->width = p->viewWidth;
+	if (p->image->height == 0)
+		p->image->height = p->viewHeight;
+
+	tx = -p->viewMinx;
+	ty = -p->viewMiny;
+	sx = p->viewWidth > 0 ? p->image->width / p->viewWidth : 0;
+	sy = p->viewHeight > 0 ? p->image->height / p->viewHeight : 0;
+	// Unit scaling
+	us = 1.0f / nsvg__convertToPixels(p, nsvg__coord(1.0f, nsvg__parseUnits(units)), 0.0f, 1.0f);
+
+	// Fix aspect ratio
+	if (p->alignType == NSVG_ALIGN_MEET) {
+		// fit whole image into viewbox
+		sx = sy = nsvg__minf(sx, sy);
+		tx += nsvg__viewAlign(p->viewWidth*sx, p->image->width, p->alignX) / sx;
+		ty += nsvg__viewAlign(p->viewHeight*sy, p->image->height, p->alignY) / sy;
+	} else if (p->alignType == NSVG_ALIGN_SLICE) {
+		// fill whole viewbox with image
+		sx = sy = nsvg__maxf(sx, sy);
+		tx += nsvg__viewAlign(p->viewWidth*sx, p->image->width, p->alignX) / sx;
+		ty += nsvg__viewAlign(p->viewHeight*sy, p->image->height, p->alignY) / sy;
+	}
+
+	// Transform
+	sx *= us;
+	sy *= us;
+	avgs = (sx+sy) / 2.0f;
+	for (shape = p->image->shapes; shape != NULL; shape = shape->next) {
+		shape->bounds[0] = (shape->bounds[0] + tx) * sx;
+		shape->bounds[1] = (shape->bounds[1] + ty) * sy;
+		shape->bounds[2] = (shape->bounds[2] + tx) * sx;
+		shape->bounds[3] = (shape->bounds[3] + ty) * sy;
+		for (path = shape->paths; path != NULL; path = path->next) {
+			path->bounds[0] = (path->bounds[0] + tx) * sx;
+			path->bounds[1] = (path->bounds[1] + ty) * sy;
+			path->bounds[2] = (path->bounds[2] + tx) * sx;
+			path->bounds[3] = (path->bounds[3] + ty) * sy;
+			for (i =0; i < path->npts; i++) {
+				pt = &path->pts[i*2];
+				pt[0] = (pt[0] + tx) * sx;
+				pt[1] = (pt[1] + ty) * sy;
+			}
+		}
+
+		if (shape->fill.type == NSVG_PAINT_LINEAR_GRADIENT || shape->fill.type == NSVG_PAINT_RADIAL_GRADIENT) {
+			nsvg__scaleGradient(shape->fill.gradient, tx,ty, sx,sy);
+			memcpy(t, shape->fill.gradient->xform, sizeof(float)*6);
+			nsvg__xformInverse(shape->fill.gradient->xform, t);
+		}
+		if (shape->stroke.type == NSVG_PAINT_LINEAR_GRADIENT || shape->stroke.type == NSVG_PAINT_RADIAL_GRADIENT) {
+			nsvg__scaleGradient(shape->stroke.gradient, tx,ty, sx,sy);
+			memcpy(t, shape->stroke.gradient->xform, sizeof(float)*6);
+			nsvg__xformInverse(shape->stroke.gradient->xform, t);
+		}
+
+		shape->strokeWidth *= avgs;
+		shape->strokeDashOffset *= avgs;
+		for (i = 0; i < shape->strokeDashCount; i++)
+			shape->strokeDashArray[i] *= avgs;
+	}
+}
+
+static void nsvg__createGradients(NSVGparser* p)
+{
+	NSVGshape* shape;
+
+	for (shape = p->image->shapes; shape != NULL; shape = shape->next) {
+		if (shape->fill.type == NSVG_PAINT_UNDEF) {
+			if (shape->fillGradient[0] != '\0') {
+				float inv[6], localBounds[4];
+				nsvg__xformInverse(inv, shape->xform);
+				nsvg__getLocalBounds(localBounds, shape, inv);
+				shape->fill.gradient = nsvg__createGradient(p, shape->fillGradient, localBounds, shape->xform, &shape->fill.type);
+			}
+			if (shape->fill.type == NSVG_PAINT_UNDEF) {
+				shape->fill.type = NSVG_PAINT_NONE;
+			}
+		}
+		if (shape->stroke.type == NSVG_PAINT_UNDEF) {
+			if (shape->strokeGradient[0] != '\0') {
+				float inv[6], localBounds[4];
+				nsvg__xformInverse(inv, shape->xform);
+				nsvg__getLocalBounds(localBounds, shape, inv);
+				shape->stroke.gradient = nsvg__createGradient(p, shape->strokeGradient, localBounds, shape->xform, &shape->stroke.type);
+			}
+			if (shape->stroke.type == NSVG_PAINT_UNDEF) {
+				shape->stroke.type = NSVG_PAINT_NONE;
+			}
+		}
+	}
+}
+
+NSVGimage* nsvgParse(char* input, const char* units, float dpi)
+{
+	NSVGparser* p;
+	NSVGimage* ret = 0;
+
+	p = nsvg__createParser();
+	if (p == NULL) {
+		return NULL;
+	}
+	p->dpi = dpi;
+
+	nsvg__parseXML(input, nsvg__startElement, nsvg__endElement, nsvg__content, p);
+
+	// Create gradients after all definitions have been parsed
+	nsvg__createGradients(p);
+
+	// Scale to viewBox
+	nsvg__scaleToViewbox(p, units);
+
+	ret = p->image;
+	p->image = NULL;
+
+	nsvg__deleteParser(p);
+
+	return ret;
+}
+
+NSVGimage* nsvgParseFromFile(const char* filename, const char* units, float dpi)
+{
+	FILE* fp = NULL;
+	size_t size;
+	char* data = NULL;
+	NSVGimage* image = NULL;
+
+	fp = fopen(filename, "rb");
+	if (!fp) goto error;
+	fseek(fp, 0, SEEK_END);
+	size = ftell(fp);
+	fseek(fp, 0, SEEK_SET);
+	data = (char*)malloc(size+1);
+	if (data == NULL) goto error;
+	if (fread(data, 1, size, fp) != size) goto error;
+	data[size] = '\0';	// Must be null terminated.
+	fclose(fp);
+	image = nsvgParse(data, units, dpi);
+	free(data);
+
+	return image;
+
+error:
+	if (fp) fclose(fp);
+	if (data) free(data);
+	if (image) nsvgDelete(image);
+	return NULL;
+}
+
+NSVGpath* nsvgDuplicatePath(NSVGpath* p)
+{
+    NSVGpath* res = NULL;
+
+    if (p == NULL)
+        return NULL;
+
+    res = (NSVGpath*)malloc(sizeof(NSVGpath));
+    if (res == NULL) goto error;
+    memset(res, 0, sizeof(NSVGpath));
+
+    res->pts = (float*)malloc(p->npts*2*sizeof(float));
+    if (res->pts == NULL) goto error;
+    memcpy(res->pts, p->pts, p->npts * sizeof(float) * 2);
+    res->npts = p->npts;
+
+    memcpy(res->bounds, p->bounds, sizeof(p->bounds));
+
+    res->closed = p->closed;
+
+    return res;
+
+error:
+    if (res != NULL) {
+        free(res->pts);
+        free(res);
+    }
+    return NULL;
+}
+
+void nsvgDelete(NSVGimage* image)
+{
+	NSVGshape *snext, *shape;
+	if (image == NULL) return;
+	shape = image->shapes;
+	while (shape != NULL) {
+		snext = shape->next;
+		nsvg__deletePaths(shape->paths);
+		nsvg__deletePaint(&shape->fill);
+		nsvg__deletePaint(&shape->stroke);
+		free(shape);
+		shape = snext;
+	}
+	free(image);
+}
+
+#endif // NANOSVG_IMPLEMENTATION
+
+#endif // NANOSVG_H

--- a/src/nanosvg/nanosvg.h
+++ b/src/nanosvg/nanosvg.h
@@ -3026,6 +3026,11 @@ NSVGimage* nsvgParse(char* input, const char* units, float dpi)
 	return ret;
 }
 
+#if WIN32
+#define WIN32_LEAN_AND_MEAN 
+#include "windows.h"
+#endif
+
 NSVGimage* nsvgParseFromFile(const char* filename, const char* units, float dpi)
 {
 	FILE* fp = NULL;
@@ -3033,7 +3038,16 @@ NSVGimage* nsvgParseFromFile(const char* filename, const char* units, float dpi)
 	char* data = NULL;
 	NSVGimage* image = NULL;
 
+#if WIN32
+    int name_len = MultiByteToWideChar(CP_UTF8, NULL, filename, strlen(filename), NULL, 0);
+    wchar_t w_fname[512];
+    memset(w_fname, 0, sizeof(w_fname));
+    MultiByteToWideChar(CP_UTF8, NULL, filename, strlen(filename), w_fname, name_len);
+    w_fname[name_len] = '\0';
+	fp = _wfopen(w_fname, L"rb");
+#else
 	fp = fopen(filename, "rb");
+#endif
 	if (!fp) goto error;
 	fseek(fp, 0, SEEK_END);
 	size = ftell(fp);

--- a/src/nanosvg/nanosvgrast.h
+++ b/src/nanosvg/nanosvgrast.h
@@ -1,0 +1,1482 @@
+/*
+ * Copyright (c) 2013-14 Mikko Mononen memon@inside.org
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * The polygon rasterization is heavily based on stb_truetype rasterizer
+ * by Sean Barrett - http://nothings.org/
+ *
+ */
+
+/* Modified by FLTK to support non-square X,Y axes scaling.
+ *
+ * Added: nsvgRasterizeXY()
+*/
+
+
+#ifndef NANOSVGRAST_H
+#define NANOSVGRAST_H
+
+#include "nanosvg.h"
+
+#ifndef NANOSVGRAST_CPLUSPLUS
+#ifdef __cplusplus
+extern "C" {
+#endif
+#endif
+
+typedef struct NSVGrasterizer NSVGrasterizer;
+
+/* Example Usage:
+	// Load SVG
+	NSVGimage* image;
+	image = nsvgParseFromFile("test.svg", "px", 96);
+
+	// Create rasterizer (can be used to render multiple images).
+	struct NSVGrasterizer* rast = nsvgCreateRasterizer();
+	// Allocate memory for image
+	unsigned char* img = malloc(w*h*4);
+	// Rasterize
+	nsvgRasterize(rast, image, 0,0,1, img, w, h, w*4);
+
+	// For non-square X,Y scaling, use
+	nsvgRasterizeXY(rast, image, 0,0,1,1, img, w, h, w*4);
+*/
+
+// Allocated rasterizer context.
+NSVGrasterizer* nsvgCreateRasterizer(void);
+
+// Rasterizes SVG image, returns RGBA image (non-premultiplied alpha)
+//   r - pointer to rasterizer context
+//   image - pointer to image to rasterize
+//   tx,ty - image offset (applied after scaling)
+//   scale - image scale (assumes square aspect ratio)
+//   dst - pointer to destination image data, 4 bytes per pixel (RGBA)
+//   w - width of the image to render
+//   h - height of the image to render
+//   stride - number of bytes per scaleline in the destination buffer
+void nsvgRasterize(NSVGrasterizer* r,
+				   NSVGimage* image, float tx, float ty, float scale,
+				   unsigned char* dst, int w, int h, int stride);
+
+// As above, but allow X and Y axes to scale independently for non-square aspects
+void nsvgRasterizeXY(NSVGrasterizer* r,
+				   NSVGimage* image, float tx, float ty,
+				   float sx, float sy,
+				   unsigned char* dst, int w, int h, int stride);
+
+// Deletes rasterizer context.
+void nsvgDeleteRasterizer(NSVGrasterizer*);
+
+
+#ifndef NANOSVGRAST_CPLUSPLUS
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+#ifdef NANOSVGRAST_IMPLEMENTATION
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NSVG__SUBSAMPLES	5
+#define NSVG__FIXSHIFT		10
+#define NSVG__FIX			(1 << NSVG__FIXSHIFT)
+#define NSVG__FIXMASK		(NSVG__FIX-1)
+#define NSVG__MEMPAGE_SIZE	1024
+
+typedef struct NSVGedge {
+	float x0,y0, x1,y1;
+	int dir;
+	struct NSVGedge* next;
+} NSVGedge;
+
+typedef struct NSVGpoint {
+	float x, y;
+	float dx, dy;
+	float len;
+	float dmx, dmy;
+	unsigned char flags;
+} NSVGpoint;
+
+typedef struct NSVGactiveEdge {
+	int x,dx;
+	float ey;
+	int dir;
+	struct NSVGactiveEdge *next;
+} NSVGactiveEdge;
+
+typedef struct NSVGmemPage {
+	unsigned char mem[NSVG__MEMPAGE_SIZE];
+	int size;
+	struct NSVGmemPage* next;
+} NSVGmemPage;
+
+typedef struct NSVGcachedPaint {
+	signed char type;
+	char spread;
+	float xform[6];
+	unsigned int colors[256];
+} NSVGcachedPaint;
+
+struct NSVGrasterizer
+{
+	float px, py;
+
+	float tessTol;
+	float distTol;
+
+	NSVGedge* edges;
+	int nedges;
+	int cedges;
+
+	NSVGpoint* points;
+	int npoints;
+	int cpoints;
+
+	NSVGpoint* points2;
+	int npoints2;
+	int cpoints2;
+
+	NSVGactiveEdge* freelist;
+	NSVGmemPage* pages;
+	NSVGmemPage* curpage;
+
+	unsigned char* scanline;
+	int cscanline;
+
+	unsigned char* bitmap;
+	int width, height, stride;
+};
+
+NSVGrasterizer* nsvgCreateRasterizer(void)
+{
+	NSVGrasterizer* r = (NSVGrasterizer*)malloc(sizeof(NSVGrasterizer));
+	if (r == NULL) goto error;
+	memset(r, 0, sizeof(NSVGrasterizer));
+
+	r->tessTol = 0.25f;
+	r->distTol = 0.01f;
+
+	return r;
+
+error:
+	nsvgDeleteRasterizer(r);
+	return NULL;
+}
+
+void nsvgDeleteRasterizer(NSVGrasterizer* r)
+{
+	NSVGmemPage* p;
+
+	if (r == NULL) return;
+
+	p = r->pages;
+	while (p != NULL) {
+		NSVGmemPage* next = p->next;
+		free(p);
+		p = next;
+	}
+
+	if (r->edges) free(r->edges);
+	if (r->points) free(r->points);
+	if (r->points2) free(r->points2);
+	if (r->scanline) free(r->scanline);
+
+	free(r);
+}
+
+static NSVGmemPage* nsvg__nextPage(NSVGrasterizer* r, NSVGmemPage* cur)
+{
+	NSVGmemPage *newp;
+
+	// If using existing chain, return the next page in chain
+	if (cur != NULL && cur->next != NULL) {
+		return cur->next;
+	}
+
+	// Alloc new page
+	newp = (NSVGmemPage*)malloc(sizeof(NSVGmemPage));
+	if (newp == NULL) return NULL;
+	memset(newp, 0, sizeof(NSVGmemPage));
+
+	// Add to linked list
+	if (cur != NULL)
+		cur->next = newp;
+	else
+		r->pages = newp;
+
+	return newp;
+}
+
+static void nsvg__resetPool(NSVGrasterizer* r)
+{
+	NSVGmemPage* p = r->pages;
+	while (p != NULL) {
+		p->size = 0;
+		p = p->next;
+	}
+	r->curpage = r->pages;
+}
+
+static unsigned char* nsvg__alloc(NSVGrasterizer* r, int size)
+{
+	unsigned char* buf;
+	if (size > NSVG__MEMPAGE_SIZE) return NULL;
+	if (r->curpage == NULL || r->curpage->size+size > NSVG__MEMPAGE_SIZE) {
+		r->curpage = nsvg__nextPage(r, r->curpage);
+	}
+	buf = &r->curpage->mem[r->curpage->size];
+	r->curpage->size += size;
+	return buf;
+}
+
+static int nsvg__ptEquals(float x1, float y1, float x2, float y2, float tol)
+{
+	float dx = x2 - x1;
+	float dy = y2 - y1;
+	return dx*dx + dy*dy < tol*tol;
+}
+
+static void nsvg__addPathPoint(NSVGrasterizer* r, float x, float y, int flags)
+{
+	NSVGpoint* pt;
+
+	if (r->npoints > 0) {
+		pt = &r->points[r->npoints-1];
+		if (nsvg__ptEquals(pt->x,pt->y, x,y, r->distTol)) {
+			pt->flags = (unsigned char)(pt->flags | flags);
+			return;
+		}
+	}
+
+	if (r->npoints+1 > r->cpoints) {
+		r->cpoints = r->cpoints > 0 ? r->cpoints * 2 : 64;
+		r->points = (NSVGpoint*)realloc(r->points, sizeof(NSVGpoint) * r->cpoints);
+		if (r->points == NULL) return;
+	}
+
+	pt = &r->points[r->npoints];
+	pt->x = x;
+	pt->y = y;
+	pt->flags = (unsigned char)flags;
+	r->npoints++;
+}
+
+static void nsvg__appendPathPoint(NSVGrasterizer* r, NSVGpoint pt)
+{
+	if (r->npoints+1 > r->cpoints) {
+		r->cpoints = r->cpoints > 0 ? r->cpoints * 2 : 64;
+		r->points = (NSVGpoint*)realloc(r->points, sizeof(NSVGpoint) * r->cpoints);
+		if (r->points == NULL) return;
+	}
+	r->points[r->npoints] = pt;
+	r->npoints++;
+}
+
+static void nsvg__duplicatePoints(NSVGrasterizer* r)
+{
+	if (r->npoints > r->cpoints2) {
+		r->cpoints2 = r->npoints;
+		r->points2 = (NSVGpoint*)realloc(r->points2, sizeof(NSVGpoint) * r->cpoints2);
+		if (r->points2 == NULL) return;
+	}
+
+	memcpy(r->points2, r->points, sizeof(NSVGpoint) * r->npoints);
+	r->npoints2 = r->npoints;
+}
+
+static void nsvg__addEdge(NSVGrasterizer* r, float x0, float y0, float x1, float y1)
+{
+	NSVGedge* e;
+
+	// Skip horizontal edges
+	if (y0 == y1)
+		return;
+
+	if (r->nedges+1 > r->cedges) {
+		r->cedges = r->cedges > 0 ? r->cedges * 2 : 64;
+		r->edges = (NSVGedge*)realloc(r->edges, sizeof(NSVGedge) * r->cedges);
+		if (r->edges == NULL) return;
+	}
+
+	e = &r->edges[r->nedges];
+	r->nedges++;
+
+	if (y0 < y1) {
+		e->x0 = x0;
+		e->y0 = y0;
+		e->x1 = x1;
+		e->y1 = y1;
+		e->dir = 1;
+	} else {
+		e->x0 = x1;
+		e->y0 = y1;
+		e->x1 = x0;
+		e->y1 = y0;
+		e->dir = -1;
+	}
+}
+
+static float nsvg__normalize(float *x, float* y)
+{
+	float d = sqrtf((*x)*(*x) + (*y)*(*y));
+	if (d > 1e-6f) {
+		float id = 1.0f / d;
+		*x *= id;
+		*y *= id;
+	}
+	return d;
+}
+
+static float nsvg__absf(float x) { return x < 0 ? -x : x; }
+
+static void nsvg__flattenCubicBez(NSVGrasterizer* r,
+								  float x1, float y1, float x2, float y2,
+								  float x3, float y3, float x4, float y4,
+								  int level, int type)
+{
+	float x12,y12,x23,y23,x34,y34,x123,y123,x234,y234,x1234,y1234;
+	float dx,dy,d2,d3;
+
+	if (level > 10) return;
+
+	x12 = (x1+x2)*0.5f;
+	y12 = (y1+y2)*0.5f;
+	x23 = (x2+x3)*0.5f;
+	y23 = (y2+y3)*0.5f;
+	x34 = (x3+x4)*0.5f;
+	y34 = (y3+y4)*0.5f;
+	x123 = (x12+x23)*0.5f;
+	y123 = (y12+y23)*0.5f;
+
+	dx = x4 - x1;
+	dy = y4 - y1;
+	d2 = nsvg__absf(((x2 - x4) * dy - (y2 - y4) * dx));
+	d3 = nsvg__absf(((x3 - x4) * dy - (y3 - y4) * dx));
+
+	if ((d2 + d3)*(d2 + d3) < r->tessTol * (dx*dx + dy*dy)) {
+		nsvg__addPathPoint(r, x4, y4, type);
+		return;
+	}
+
+	x234 = (x23+x34)*0.5f;
+	y234 = (y23+y34)*0.5f;
+	x1234 = (x123+x234)*0.5f;
+	y1234 = (y123+y234)*0.5f;
+
+	nsvg__flattenCubicBez(r, x1,y1, x12,y12, x123,y123, x1234,y1234, level+1, 0);
+	nsvg__flattenCubicBez(r, x1234,y1234, x234,y234, x34,y34, x4,y4, level+1, type);
+}
+
+static void nsvg__flattenShape(NSVGrasterizer* r, NSVGshape* shape, float sx, float sy)
+{
+	int i, j;
+	NSVGpath* path;
+
+	for (path = shape->paths; path != NULL; path = path->next) {
+		r->npoints = 0;
+		// Flatten path
+		nsvg__addPathPoint(r, path->pts[0]*sx, path->pts[1]*sy, 0);
+		for (i = 0; i < path->npts-1; i += 3) {
+			float* p = &path->pts[i*2];
+			nsvg__flattenCubicBez(r, p[0]*sx,p[1]*sy, p[2]*sx,p[3]*sy, p[4]*sx,p[5]*sy, p[6]*sx,p[7]*sy, 0, 0);
+		}
+		// Close path
+		nsvg__addPathPoint(r, path->pts[0]*sx, path->pts[1]*sy, 0);
+		// Build edges
+		for (i = 0, j = r->npoints-1; i < r->npoints; j = i++)
+			nsvg__addEdge(r, r->points[j].x, r->points[j].y, r->points[i].x, r->points[i].y);
+	}
+}
+
+enum NSVGpointFlags
+{
+	NSVG_PT_CORNER = 0x01,
+	NSVG_PT_BEVEL = 0x02,
+	NSVG_PT_LEFT = 0x04
+};
+
+static void nsvg__initClosed(NSVGpoint* left, NSVGpoint* right, NSVGpoint* p0, NSVGpoint* p1, float lineWidth)
+{
+	float w = lineWidth * 0.5f;
+	float dx = p1->x - p0->x;
+	float dy = p1->y - p0->y;
+	float len = nsvg__normalize(&dx, &dy);
+	float px = p0->x + dx*len*0.5f, py = p0->y + dy*len*0.5f;
+	float dlx = dy, dly = -dx;
+	float lx = px - dlx*w, ly = py - dly*w;
+	float rx = px + dlx*w, ry = py + dly*w;
+	left->x = lx; left->y = ly;
+	right->x = rx; right->y = ry;
+}
+
+static void nsvg__buttCap(NSVGrasterizer* r, NSVGpoint* left, NSVGpoint* right, NSVGpoint* p, float dx, float dy, float lineWidth, int connect)
+{
+	float w = lineWidth * 0.5f;
+	float px = p->x, py = p->y;
+	float dlx = dy, dly = -dx;
+	float lx = px - dlx*w, ly = py - dly*w;
+	float rx = px + dlx*w, ry = py + dly*w;
+
+	nsvg__addEdge(r, lx, ly, rx, ry);
+
+	if (connect) {
+		nsvg__addEdge(r, left->x, left->y, lx, ly);
+		nsvg__addEdge(r, rx, ry, right->x, right->y);
+	}
+	left->x = lx; left->y = ly;
+	right->x = rx; right->y = ry;
+}
+
+static void nsvg__squareCap(NSVGrasterizer* r, NSVGpoint* left, NSVGpoint* right, NSVGpoint* p, float dx, float dy, float lineWidth, int connect)
+{
+	float w = lineWidth * 0.5f;
+	float px = p->x - dx*w, py = p->y - dy*w;
+	float dlx = dy, dly = -dx;
+	float lx = px - dlx*w, ly = py - dly*w;
+	float rx = px + dlx*w, ry = py + dly*w;
+
+	nsvg__addEdge(r, lx, ly, rx, ry);
+
+	if (connect) {
+		nsvg__addEdge(r, left->x, left->y, lx, ly);
+		nsvg__addEdge(r, rx, ry, right->x, right->y);
+	}
+	left->x = lx; left->y = ly;
+	right->x = rx; right->y = ry;
+}
+
+#ifndef NSVG_PI
+#define NSVG_PI (3.14159265358979323846264338327f)
+#endif
+
+static void nsvg__roundCap(NSVGrasterizer* r, NSVGpoint* left, NSVGpoint* right, NSVGpoint* p, float dx, float dy, float lineWidth, int ncap, int connect)
+{
+	int i;
+	float w = lineWidth * 0.5f;
+	float px = p->x, py = p->y;
+	float dlx = dy, dly = -dx;
+	float lx = 0, ly = 0, rx = 0, ry = 0, prevx = 0, prevy = 0;
+
+	for (i = 0; i < ncap; i++) {
+		float a = (float)i/(float)(ncap-1)*NSVG_PI;
+		float ax = cosf(a) * w, ay = sinf(a) * w;
+		float x = px - dlx*ax - dx*ay;
+		float y = py - dly*ax - dy*ay;
+
+		if (i > 0)
+			nsvg__addEdge(r, prevx, prevy, x, y);
+
+		prevx = x;
+		prevy = y;
+
+		if (i == 0) {
+			lx = x; ly = y;
+		} else if (i == ncap-1) {
+			rx = x; ry = y;
+		}
+	}
+
+	if (connect) {
+		nsvg__addEdge(r, left->x, left->y, lx, ly);
+		nsvg__addEdge(r, rx, ry, right->x, right->y);
+	}
+
+	left->x = lx; left->y = ly;
+	right->x = rx; right->y = ry;
+}
+
+static void nsvg__bevelJoin(NSVGrasterizer* r, NSVGpoint* left, NSVGpoint* right, NSVGpoint* p0, NSVGpoint* p1, float lineWidth)
+{
+	float w = lineWidth * 0.5f;
+	float dlx0 = p0->dy, dly0 = -p0->dx;
+	float dlx1 = p1->dy, dly1 = -p1->dx;
+	float lx0 = p1->x - (dlx0 * w), ly0 = p1->y - (dly0 * w);
+	float rx0 = p1->x + (dlx0 * w), ry0 = p1->y + (dly0 * w);
+	float lx1 = p1->x - (dlx1 * w), ly1 = p1->y - (dly1 * w);
+	float rx1 = p1->x + (dlx1 * w), ry1 = p1->y + (dly1 * w);
+
+	nsvg__addEdge(r, lx0, ly0, left->x, left->y);
+	nsvg__addEdge(r, lx1, ly1, lx0, ly0);
+
+	nsvg__addEdge(r, right->x, right->y, rx0, ry0);
+	nsvg__addEdge(r, rx0, ry0, rx1, ry1);
+
+	left->x = lx1; left->y = ly1;
+	right->x = rx1; right->y = ry1;
+}
+
+static void nsvg__miterJoin(NSVGrasterizer* r, NSVGpoint* left, NSVGpoint* right, NSVGpoint* p0, NSVGpoint* p1, float lineWidth)
+{
+	float w = lineWidth * 0.5f;
+	float dlx0 = p0->dy, dly0 = -p0->dx;
+	float dlx1 = p1->dy, dly1 = -p1->dx;
+	float lx0, rx0, lx1, rx1;
+	float ly0, ry0, ly1, ry1;
+
+	if (p1->flags & NSVG_PT_LEFT) {
+		lx0 = lx1 = p1->x - p1->dmx * w;
+		ly0 = ly1 = p1->y - p1->dmy * w;
+		nsvg__addEdge(r, lx1, ly1, left->x, left->y);
+
+		rx0 = p1->x + (dlx0 * w);
+		ry0 = p1->y + (dly0 * w);
+		rx1 = p1->x + (dlx1 * w);
+		ry1 = p1->y + (dly1 * w);
+		nsvg__addEdge(r, right->x, right->y, rx0, ry0);
+		nsvg__addEdge(r, rx0, ry0, rx1, ry1);
+	} else {
+		lx0 = p1->x - (dlx0 * w);
+		ly0 = p1->y - (dly0 * w);
+		lx1 = p1->x - (dlx1 * w);
+		ly1 = p1->y - (dly1 * w);
+		nsvg__addEdge(r, lx0, ly0, left->x, left->y);
+		nsvg__addEdge(r, lx1, ly1, lx0, ly0);
+
+		rx0 = rx1 = p1->x + p1->dmx * w;
+		ry0 = ry1 = p1->y + p1->dmy * w;
+		nsvg__addEdge(r, right->x, right->y, rx1, ry1);
+	}
+
+	left->x = lx1; left->y = ly1;
+	right->x = rx1; right->y = ry1;
+}
+
+static void nsvg__roundJoin(NSVGrasterizer* r, NSVGpoint* left, NSVGpoint* right, NSVGpoint* p0, NSVGpoint* p1, float lineWidth, int ncap)
+{
+	int i, n;
+	float w = lineWidth * 0.5f;
+	float dlx0 = p0->dy, dly0 = -p0->dx;
+	float dlx1 = p1->dy, dly1 = -p1->dx;
+	float a0 = atan2f(dly0, dlx0);
+	float a1 = atan2f(dly1, dlx1);
+	float da = a1 - a0;
+	float lx, ly, rx, ry;
+
+	if (da < NSVG_PI) da += NSVG_PI*2;
+	if (da > NSVG_PI) da -= NSVG_PI*2;
+
+	n = (int)ceilf((nsvg__absf(da) / NSVG_PI) * (float)ncap);
+	if (n < 2) n = 2;
+	if (n > ncap) n = ncap;
+
+	lx = left->x;
+	ly = left->y;
+	rx = right->x;
+	ry = right->y;
+
+	for (i = 0; i < n; i++) {
+		float u = (float)i/(float)(n-1);
+		float a = a0 + u*da;
+		float ax = cosf(a) * w, ay = sinf(a) * w;
+		float lx1 = p1->x - ax, ly1 = p1->y - ay;
+		float rx1 = p1->x + ax, ry1 = p1->y + ay;
+
+		nsvg__addEdge(r, lx1, ly1, lx, ly);
+		nsvg__addEdge(r, rx, ry, rx1, ry1);
+
+		lx = lx1; ly = ly1;
+		rx = rx1; ry = ry1;
+	}
+
+	left->x = lx; left->y = ly;
+	right->x = rx; right->y = ry;
+}
+
+static void nsvg__straightJoin(NSVGrasterizer* r, NSVGpoint* left, NSVGpoint* right, NSVGpoint* p1, float lineWidth)
+{
+	float w = lineWidth * 0.5f;
+	float lx = p1->x - (p1->dmx * w), ly = p1->y - (p1->dmy * w);
+	float rx = p1->x + (p1->dmx * w), ry = p1->y + (p1->dmy * w);
+
+	nsvg__addEdge(r, lx, ly, left->x, left->y);
+	nsvg__addEdge(r, right->x, right->y, rx, ry);
+
+	left->x = lx; left->y = ly;
+	right->x = rx; right->y = ry;
+}
+
+static int nsvg__curveDivs(float r, float arc, float tol)
+{
+	float da = acosf(r / (r + tol)) * 2.0f;
+	int divs = (int)ceilf(arc / da);
+	if (divs < 2) divs = 2;
+	return divs;
+}
+
+static void nsvg__expandStroke(NSVGrasterizer* r, NSVGpoint* points, int npoints, int closed, int lineJoin, int lineCap, float lineWidth)
+{
+	int ncap = nsvg__curveDivs(lineWidth*0.5f, NSVG_PI, r->tessTol);	// Calculate divisions per half circle.
+	NSVGpoint left = {0,0,0,0,0,0,0,0}, right = {0,0,0,0,0,0,0,0}, firstLeft = {0,0,0,0,0,0,0,0}, firstRight = {0,0,0,0,0,0,0,0};
+	NSVGpoint* p0, *p1;
+	int j, s, e;
+
+	// Build stroke edges
+	if (closed) {
+		// Looping
+		p0 = &points[npoints-1];
+		p1 = &points[0];
+		s = 0;
+		e = npoints;
+	} else {
+		// Add cap
+		p0 = &points[0];
+		p1 = &points[1];
+		s = 1;
+		e = npoints-1;
+	}
+
+	if (closed) {
+		nsvg__initClosed(&left, &right, p0, p1, lineWidth);
+		firstLeft = left;
+		firstRight = right;
+	} else {
+		// Add cap
+		float dx = p1->x - p0->x;
+		float dy = p1->y - p0->y;
+		nsvg__normalize(&dx, &dy);
+		if (lineCap == NSVG_CAP_BUTT)
+			nsvg__buttCap(r, &left, &right, p0, dx, dy, lineWidth, 0);
+		else if (lineCap == NSVG_CAP_SQUARE)
+			nsvg__squareCap(r, &left, &right, p0, dx, dy, lineWidth, 0);
+		else if (lineCap == NSVG_CAP_ROUND)
+			nsvg__roundCap(r, &left, &right, p0, dx, dy, lineWidth, ncap, 0);
+	}
+
+	for (j = s; j < e; ++j) {
+		if (p1->flags & NSVG_PT_CORNER) {
+			if (lineJoin == NSVG_JOIN_ROUND)
+				nsvg__roundJoin(r, &left, &right, p0, p1, lineWidth, ncap);
+			else if (lineJoin == NSVG_JOIN_BEVEL || (p1->flags & NSVG_PT_BEVEL))
+				nsvg__bevelJoin(r, &left, &right, p0, p1, lineWidth);
+			else
+				nsvg__miterJoin(r, &left, &right, p0, p1, lineWidth);
+		} else {
+			nsvg__straightJoin(r, &left, &right, p1, lineWidth);
+		}
+		p0 = p1++;
+	}
+
+	if (closed) {
+		// Loop it
+		nsvg__addEdge(r, firstLeft.x, firstLeft.y, left.x, left.y);
+		nsvg__addEdge(r, right.x, right.y, firstRight.x, firstRight.y);
+	} else {
+		// Add cap
+		float dx = p1->x - p0->x;
+		float dy = p1->y - p0->y;
+		nsvg__normalize(&dx, &dy);
+		if (lineCap == NSVG_CAP_BUTT)
+			nsvg__buttCap(r, &right, &left, p1, -dx, -dy, lineWidth, 1);
+		else if (lineCap == NSVG_CAP_SQUARE)
+			nsvg__squareCap(r, &right, &left, p1, -dx, -dy, lineWidth, 1);
+		else if (lineCap == NSVG_CAP_ROUND)
+			nsvg__roundCap(r, &right, &left, p1, -dx, -dy, lineWidth, ncap, 1);
+	}
+}
+
+static void nsvg__prepareStroke(NSVGrasterizer* r, float miterLimit, int lineJoin)
+{
+	int i, j;
+	NSVGpoint* p0, *p1;
+
+	p0 = &r->points[r->npoints-1];
+	p1 = &r->points[0];
+	for (i = 0; i < r->npoints; i++) {
+		// Calculate segment direction and length
+		p0->dx = p1->x - p0->x;
+		p0->dy = p1->y - p0->y;
+		p0->len = nsvg__normalize(&p0->dx, &p0->dy);
+		// Advance
+		p0 = p1++;
+	}
+
+	// calculate joins
+	p0 = &r->points[r->npoints-1];
+	p1 = &r->points[0];
+	for (j = 0; j < r->npoints; j++) {
+		float dlx0, dly0, dlx1, dly1, dmr2, cross;
+		dlx0 = p0->dy;
+		dly0 = -p0->dx;
+		dlx1 = p1->dy;
+		dly1 = -p1->dx;
+		// Calculate extrusions
+		p1->dmx = (dlx0 + dlx1) * 0.5f;
+		p1->dmy = (dly0 + dly1) * 0.5f;
+		dmr2 = p1->dmx*p1->dmx + p1->dmy*p1->dmy;
+		if (dmr2 > 0.000001f) {
+			float s2 = 1.0f / dmr2;
+			if (s2 > 600.0f) {
+				s2 = 600.0f;
+			}
+			p1->dmx *= s2;
+			p1->dmy *= s2;
+		}
+
+		// Clear flags, but keep the corner.
+		p1->flags = (p1->flags & NSVG_PT_CORNER) ? NSVG_PT_CORNER : 0;
+
+		// Keep track of left turns.
+		cross = p1->dx * p0->dy - p0->dx * p1->dy;
+		if (cross > 0.0f)
+			p1->flags |= NSVG_PT_LEFT;
+
+		// Check to see if the corner needs to be beveled.
+		if (p1->flags & NSVG_PT_CORNER) {
+			if ((dmr2 * miterLimit*miterLimit) < 1.0f || lineJoin == NSVG_JOIN_BEVEL || lineJoin == NSVG_JOIN_ROUND) {
+				p1->flags |= NSVG_PT_BEVEL;
+			}
+		}
+
+		p0 = p1++;
+	}
+}
+
+static void nsvg__flattenShapeStroke(NSVGrasterizer* r, NSVGshape* shape, float sx, float sy)
+{
+	int i, j, closed;
+	NSVGpath* path;
+	NSVGpoint* p0, *p1;
+	float miterLimit = shape->miterLimit;
+	int lineJoin = shape->strokeLineJoin;
+	int lineCap = shape->strokeLineCap;
+	const float sw = (sx + sy) / 2; // average scaling factor
+	const float lineWidth = shape->strokeWidth * sw; // FIXME (?)
+
+	for (path = shape->paths; path != NULL; path = path->next) {
+		// Flatten path
+		r->npoints = 0;
+		nsvg__addPathPoint(r, path->pts[0]*sx, path->pts[1]*sy, NSVG_PT_CORNER);
+		for (i = 0; i < path->npts-1; i += 3) {
+			float* p = &path->pts[i*2];
+			nsvg__flattenCubicBez(r, p[0]*sx,p[1]*sy, p[2]*sx,p[3]*sy, p[4]*sx,p[5]*sy, p[6]*sx,p[7]*sy, 0, NSVG_PT_CORNER);
+		}
+		if (r->npoints < 2)
+			continue;
+
+		closed = path->closed;
+
+		// If the first and last points are the same, remove the last, mark as closed path.
+		p0 = &r->points[r->npoints-1];
+		p1 = &r->points[0];
+		if (nsvg__ptEquals(p0->x,p0->y, p1->x,p1->y, r->distTol)) {
+			r->npoints--;
+			p0 = &r->points[r->npoints-1];
+			closed = 1;
+		}
+
+		if (shape->strokeDashCount > 0) {
+			int idash = 0, dashState = 1;
+			float totalDist = 0, dashLen, allDashLen, dashOffset;
+			NSVGpoint cur;
+
+			if (closed)
+				nsvg__appendPathPoint(r, r->points[0]);
+
+			// Duplicate points -> points2.
+			nsvg__duplicatePoints(r);
+
+			r->npoints = 0;
+ 			cur = r->points2[0];
+			nsvg__appendPathPoint(r, cur);
+
+			// Figure out dash offset.
+			allDashLen = 0;
+			for (j = 0; j < shape->strokeDashCount; j++)
+				allDashLen += shape->strokeDashArray[j];
+			if (shape->strokeDashCount & 1)
+				allDashLen *= 2.0f;
+			// Find location inside pattern
+			dashOffset = fmodf(shape->strokeDashOffset, allDashLen);
+			if (dashOffset < 0.0f)
+				dashOffset += allDashLen;
+
+			while (dashOffset > shape->strokeDashArray[idash]) {
+				dashOffset -= shape->strokeDashArray[idash];
+				idash = (idash + 1) % shape->strokeDashCount;
+			}
+			dashLen = (shape->strokeDashArray[idash] - dashOffset) * sw;
+
+			for (j = 1; j < r->npoints2; ) {
+				float dx = r->points2[j].x - cur.x;
+				float dy = r->points2[j].y - cur.y;
+				float dist = sqrtf(dx*dx + dy*dy);
+
+				if ((totalDist + dist) > dashLen) {
+					// Calculate intermediate point
+					float d = (dashLen - totalDist) / dist;
+					float x = cur.x + dx * d;
+					float y = cur.y + dy * d;
+					nsvg__addPathPoint(r, x, y, NSVG_PT_CORNER);
+
+					// Stroke
+					if (r->npoints > 1 && dashState) {
+						nsvg__prepareStroke(r, miterLimit, lineJoin);
+						nsvg__expandStroke(r, r->points, r->npoints, 0, lineJoin, lineCap, lineWidth);
+					}
+					// Advance dash pattern
+					dashState = !dashState;
+					idash = (idash+1) % shape->strokeDashCount;
+					dashLen = shape->strokeDashArray[idash] * sw;
+					// Restart
+					cur.x = x;
+					cur.y = y;
+					cur.flags = NSVG_PT_CORNER;
+					totalDist = 0.0f;
+					r->npoints = 0;
+					nsvg__appendPathPoint(r, cur);
+				} else {
+					totalDist += dist;
+					cur = r->points2[j];
+					nsvg__appendPathPoint(r, cur);
+					j++;
+				}
+			}
+			// Stroke any leftover path
+			if (r->npoints > 1 && dashState)
+				nsvg__expandStroke(r, r->points, r->npoints, 0, lineJoin, lineCap, lineWidth);
+		} else {
+			nsvg__prepareStroke(r, miterLimit, lineJoin);
+			nsvg__expandStroke(r, r->points, r->npoints, closed, lineJoin, lineCap, lineWidth);
+		}
+	}
+}
+
+static int nsvg__cmpEdge(const void *p, const void *q)
+{
+	const NSVGedge* a = (const NSVGedge*)p;
+	const NSVGedge* b = (const NSVGedge*)q;
+
+	if (a->y0 < b->y0) return -1;
+	if (a->y0 > b->y0) return  1;
+	return 0;
+}
+
+
+static NSVGactiveEdge* nsvg__addActive(NSVGrasterizer* r, NSVGedge* e, float startPoint)
+{
+	 NSVGactiveEdge* z;
+
+	if (r->freelist != NULL) {
+		// Restore from freelist.
+		z = r->freelist;
+		r->freelist = z->next;
+	} else {
+		// Alloc new edge.
+		z = (NSVGactiveEdge*)nsvg__alloc(r, sizeof(NSVGactiveEdge));
+		if (z == NULL) return NULL;
+	}
+
+	float dxdy = (e->x1 - e->x0) / (e->y1 - e->y0);
+//	STBTT_assert(e->y0 <= start_point);
+	// round dx down to avoid going too far
+	if (dxdy < 0)
+		z->dx = (int)(-floorf(NSVG__FIX * -dxdy));
+	else
+		z->dx = (int)floorf(NSVG__FIX * dxdy);
+	z->x = (int)floorf(NSVG__FIX * (e->x0 + dxdy * (startPoint - e->y0)));
+//	z->x -= off_x * FIX;
+	z->ey = e->y1;
+	z->next = 0;
+	z->dir = e->dir;
+
+	return z;
+}
+
+static void nsvg__freeActive(NSVGrasterizer* r, NSVGactiveEdge* z)
+{
+	z->next = r->freelist;
+	r->freelist = z;
+}
+
+static void nsvg__fillScanline(unsigned char* scanline, int len, int x0, int x1, int maxWeight, int* xmin, int* xmax)
+{
+	int i = x0 >> NSVG__FIXSHIFT;
+	int j = x1 >> NSVG__FIXSHIFT;
+	if (i < *xmin) *xmin = i;
+	if (j > *xmax) *xmax = j;
+	if (i < len && j >= 0) {
+		if (i == j) {
+			// x0,x1 are the same pixel, so compute combined coverage
+			scanline[i] = (unsigned char)(scanline[i] + ((x1 - x0) * maxWeight >> NSVG__FIXSHIFT));
+		} else {
+			if (i >= 0) // add antialiasing for x0
+				scanline[i] = (unsigned char)(scanline[i] + (((NSVG__FIX - (x0 & NSVG__FIXMASK)) * maxWeight) >> NSVG__FIXSHIFT));
+			else
+				i = -1; // clip
+
+			if (j < len) // add antialiasing for x1
+				scanline[j] = (unsigned char)(scanline[j] + (((x1 & NSVG__FIXMASK) * maxWeight) >> NSVG__FIXSHIFT));
+			else
+				j = len; // clip
+
+			for (++i; i < j; ++i) // fill pixels between x0 and x1
+				scanline[i] = (unsigned char)(scanline[i] + maxWeight);
+		}
+	}
+}
+
+// note: this routine clips fills that extend off the edges... ideally this
+// wouldn't happen, but it could happen if the truetype glyph bounding boxes
+// are wrong, or if the user supplies a too-small bitmap
+static void nsvg__fillActiveEdges(unsigned char* scanline, int len, NSVGactiveEdge* e, int maxWeight, int* xmin, int* xmax, char fillRule)
+{
+	// non-zero winding fill
+	int x0 = 0, w = 0;
+
+	if (fillRule == NSVG_FILLRULE_NONZERO) {
+		// Non-zero
+		while (e != NULL) {
+			if (w == 0) {
+				// if we're currently at zero, we need to record the edge start point
+				x0 = e->x; w += e->dir;
+			} else {
+				int x1 = e->x; w += e->dir;
+				// if we went to zero, we need to draw
+				if (w == 0)
+					nsvg__fillScanline(scanline, len, x0, x1, maxWeight, xmin, xmax);
+			}
+			e = e->next;
+		}
+	} else if (fillRule == NSVG_FILLRULE_EVENODD) {
+		// Even-odd
+		while (e != NULL) {
+			if (w == 0) {
+				// if we're currently at zero, we need to record the edge start point
+				x0 = e->x; w = 1;
+			} else {
+				int x1 = e->x; w = 0;
+				nsvg__fillScanline(scanline, len, x0, x1, maxWeight, xmin, xmax);
+			}
+			e = e->next;
+		}
+	}
+}
+
+static float nsvg__clampf(float a, float mn, float mx) { return a < mn ? mn : (a > mx ? mx : a); }
+
+static unsigned int nsvg__RGBA(unsigned char r, unsigned char g, unsigned char b, unsigned char a)
+{
+	return ((unsigned int)r) | ((unsigned int)g << 8) | ((unsigned int)b << 16) | ((unsigned int)a << 24);
+}
+
+static unsigned int nsvg__lerpRGBA(unsigned int c0, unsigned int c1, float u)
+{
+	int iu = (int)(nsvg__clampf(u, 0.0f, 1.0f) * 256.0f);
+	int r = (((c0) & 0xff)*(256-iu) + (((c1) & 0xff)*iu)) >> 8;
+	int g = (((c0>>8) & 0xff)*(256-iu) + (((c1>>8) & 0xff)*iu)) >> 8;
+	int b = (((c0>>16) & 0xff)*(256-iu) + (((c1>>16) & 0xff)*iu)) >> 8;
+	int a = (((c0>>24) & 0xff)*(256-iu) + (((c1>>24) & 0xff)*iu)) >> 8;
+	return nsvg__RGBA((unsigned char)r, (unsigned char)g, (unsigned char)b, (unsigned char)a);
+}
+
+static unsigned int nsvg__applyOpacity(unsigned int c, float u)
+{
+	int iu = (int)(nsvg__clampf(u, 0.0f, 1.0f) * 256.0f);
+	int r = (c) & 0xff;
+	int g = (c>>8) & 0xff;
+	int b = (c>>16) & 0xff;
+	int a = (((c>>24) & 0xff)*iu) >> 8;
+	return nsvg__RGBA((unsigned char)r, (unsigned char)g, (unsigned char)b, (unsigned char)a);
+}
+
+static inline int nsvg__div255(int x)
+{
+    return ((x+1) * 257) >> 16;
+}
+
+static void nsvg__scanlineSolid(unsigned char* dst, int count, unsigned char* cover, int x, int y,
+								float tx, float ty, float sx, float sy, NSVGcachedPaint* cache)
+{
+
+	if (cache->type == NSVG_PAINT_COLOR) {
+		int i, cr, cg, cb, ca;
+		cr = cache->colors[0] & 0xff;
+		cg = (cache->colors[0] >> 8) & 0xff;
+		cb = (cache->colors[0] >> 16) & 0xff;
+		ca = (cache->colors[0] >> 24) & 0xff;
+
+		for (i = 0; i < count; i++) {
+			int r,g,b;
+			int a = nsvg__div255((int)cover[0] * ca);
+			int ia = 255 - a;
+			// Premultiply
+			r = nsvg__div255(cr * a);
+			g = nsvg__div255(cg * a);
+			b = nsvg__div255(cb * a);
+
+			// Blend over
+			r += nsvg__div255(ia * (int)dst[0]);
+			g += nsvg__div255(ia * (int)dst[1]);
+			b += nsvg__div255(ia * (int)dst[2]);
+			a += nsvg__div255(ia * (int)dst[3]);
+
+			dst[0] = (unsigned char)r;
+			dst[1] = (unsigned char)g;
+			dst[2] = (unsigned char)b;
+			dst[3] = (unsigned char)a;
+
+			cover++;
+			dst += 4;
+		}
+	} else if (cache->type == NSVG_PAINT_LINEAR_GRADIENT) {
+		// TODO: spread modes.
+		// TODO: plenty of opportunities to optimize.
+		float fx, fy, dx, gy;
+		float* t = cache->xform;
+		int i, cr, cg, cb, ca;
+		unsigned int c;
+
+		fx = ((float)x - tx) / sx;
+		fy = ((float)y - ty) / sy;
+		dx = 1.0f / sx;
+
+		for (i = 0; i < count; i++) {
+			int r,g,b,a,ia;
+			gy = fx*t[1] + fy*t[3] + t[5];
+			c = cache->colors[(int)nsvg__clampf(gy*255.0f, 0, 255.0f)];
+			cr = (c) & 0xff;
+			cg = (c >> 8) & 0xff;
+			cb = (c >> 16) & 0xff;
+			ca = (c >> 24) & 0xff;
+
+			a = nsvg__div255((int)cover[0] * ca);
+			ia = 255 - a;
+
+			// Premultiply
+			r = nsvg__div255(cr * a);
+			g = nsvg__div255(cg * a);
+			b = nsvg__div255(cb * a);
+
+			// Blend over
+			r += nsvg__div255(ia * (int)dst[0]);
+			g += nsvg__div255(ia * (int)dst[1]);
+			b += nsvg__div255(ia * (int)dst[2]);
+			a += nsvg__div255(ia * (int)dst[3]);
+
+			dst[0] = (unsigned char)r;
+			dst[1] = (unsigned char)g;
+			dst[2] = (unsigned char)b;
+			dst[3] = (unsigned char)a;
+
+			cover++;
+			dst += 4;
+			fx += dx;
+		}
+	} else if (cache->type == NSVG_PAINT_RADIAL_GRADIENT) {
+		// TODO: spread modes.
+		// TODO: plenty of opportunities to optimize.
+		// TODO: focus (fx,fy)
+		float fx, fy, dx, gx, gy, gd;
+		float* t = cache->xform;
+		int i, cr, cg, cb, ca;
+		unsigned int c;
+
+		fx = ((float)x - tx) / sx;
+		fy = ((float)y - ty) / sy;
+		dx = 1.0f / sx;
+
+		for (i = 0; i < count; i++) {
+			int r,g,b,a,ia;
+			gx = fx*t[0] + fy*t[2] + t[4];
+			gy = fx*t[1] + fy*t[3] + t[5];
+			gd = sqrtf(gx*gx + gy*gy);
+			c = cache->colors[(int)nsvg__clampf(gd*255.0f, 0, 255.0f)];
+			cr = (c) & 0xff;
+			cg = (c >> 8) & 0xff;
+			cb = (c >> 16) & 0xff;
+			ca = (c >> 24) & 0xff;
+
+			a = nsvg__div255((int)cover[0] * ca);
+			ia = 255 - a;
+
+			// Premultiply
+			r = nsvg__div255(cr * a);
+			g = nsvg__div255(cg * a);
+			b = nsvg__div255(cb * a);
+
+			// Blend over
+			r += nsvg__div255(ia * (int)dst[0]);
+			g += nsvg__div255(ia * (int)dst[1]);
+			b += nsvg__div255(ia * (int)dst[2]);
+			a += nsvg__div255(ia * (int)dst[3]);
+
+			dst[0] = (unsigned char)r;
+			dst[1] = (unsigned char)g;
+			dst[2] = (unsigned char)b;
+			dst[3] = (unsigned char)a;
+
+			cover++;
+			dst += 4;
+			fx += dx;
+		}
+	}
+}
+
+static void nsvg__rasterizeSortedEdges(NSVGrasterizer *r, float tx, float ty, float sx, float sy, NSVGcachedPaint* cache, char fillRule)
+{
+	NSVGactiveEdge *active = NULL;
+	int y, s;
+	int e = 0;
+	int maxWeight = (255 / NSVG__SUBSAMPLES);  // weight per vertical scanline
+	int xmin, xmax;
+
+	for (y = 0; y < r->height; y++) {
+		memset(r->scanline, 0, r->width);
+		xmin = r->width;
+		xmax = 0;
+		for (s = 0; s < NSVG__SUBSAMPLES; ++s) {
+			// find center of pixel for this scanline
+			float scany = (float)(y*NSVG__SUBSAMPLES + s) + 0.5f;
+			NSVGactiveEdge **step = &active;
+
+			// update all active edges;
+			// remove all active edges that terminate before the center of this scanline
+			while (*step) {
+				NSVGactiveEdge *z = *step;
+				if (z->ey <= scany) {
+					*step = z->next; // delete from list
+//					NSVG__assert(z->valid);
+					nsvg__freeActive(r, z);
+				} else {
+					z->x += z->dx; // advance to position for current scanline
+					step = &((*step)->next); // advance through list
+				}
+			}
+
+			// resort the list if needed
+			for (;;) {
+				int changed = 0;
+				step = &active;
+				while (*step && (*step)->next) {
+					if ((*step)->x > (*step)->next->x) {
+						NSVGactiveEdge* t = *step;
+						NSVGactiveEdge* q = t->next;
+						t->next = q->next;
+						q->next = t;
+						*step = q;
+						changed = 1;
+					}
+					step = &(*step)->next;
+				}
+				if (!changed) break;
+			}
+
+			// insert all edges that start before the center of this scanline -- omit ones that also end on this scanline
+			while (e < r->nedges && r->edges[e].y0 <= scany) {
+				if (r->edges[e].y1 > scany) {
+					NSVGactiveEdge* z = nsvg__addActive(r, &r->edges[e], scany);
+					if (z == NULL) break;
+					// find insertion point
+					if (active == NULL) {
+						active = z;
+					} else if (z->x < active->x) {
+						// insert at front
+						z->next = active;
+						active = z;
+					} else {
+						// find thing to insert AFTER
+						NSVGactiveEdge* p = active;
+						while (p->next && p->next->x < z->x)
+							p = p->next;
+						// at this point, p->next->x is NOT < z->x
+						z->next = p->next;
+						p->next = z;
+					}
+				}
+				e++;
+			}
+
+			// now process all active edges in non-zero fashion
+			if (active != NULL)
+				nsvg__fillActiveEdges(r->scanline, r->width, active, maxWeight, &xmin, &xmax, fillRule);
+		}
+		// Blit
+		if (xmin < 0) xmin = 0;
+		if (xmax > r->width-1) xmax = r->width-1;
+		if (xmin <= xmax) {
+			nsvg__scanlineSolid(&r->bitmap[y * r->stride] + xmin*4, xmax-xmin+1, &r->scanline[xmin], xmin, y, tx,ty, sx, sy, cache);
+		}
+	}
+
+}
+
+static void nsvg__unpremultiplyAlpha(unsigned char* image, int w, int h, int stride)
+{
+	int x,y;
+
+	// Unpremultiply
+	for (y = 0; y < h; y++) {
+		unsigned char *row = &image[y*stride];
+		for (x = 0; x < w; x++) {
+			int r = row[0], g = row[1], b = row[2], a = row[3];
+			if (a != 0) {
+				row[0] = (unsigned char)(r*255/a);
+				row[1] = (unsigned char)(g*255/a);
+				row[2] = (unsigned char)(b*255/a);
+			}
+			row += 4;
+		}
+	}
+
+	// Defringe
+	for (y = 0; y < h; y++) {
+		unsigned char *row = &image[y*stride];
+		for (x = 0; x < w; x++) {
+			int r = 0, g = 0, b = 0, a = row[3], n = 0;
+			if (a == 0) {
+				if (x-1 > 0 && row[-1] != 0) {
+					r += row[-4];
+					g += row[-3];
+					b += row[-2];
+					n++;
+				}
+				if (x+1 < w && row[7] != 0) {
+					r += row[4];
+					g += row[5];
+					b += row[6];
+					n++;
+				}
+				if (y-1 > 0 && row[-stride+3] != 0) {
+					r += row[-stride];
+					g += row[-stride+1];
+					b += row[-stride+2];
+					n++;
+				}
+				if (y+1 < h && row[stride+3] != 0) {
+					r += row[stride];
+					g += row[stride+1];
+					b += row[stride+2];
+					n++;
+				}
+				if (n > 0) {
+					row[0] = (unsigned char)(r/n);
+					row[1] = (unsigned char)(g/n);
+					row[2] = (unsigned char)(b/n);
+				}
+			}
+			row += 4;
+		}
+	}
+}
+
+
+static void nsvg__initPaint(NSVGcachedPaint* cache, NSVGpaint* paint, float opacity)
+{
+	int i, j;
+	NSVGgradient* grad;
+
+	cache->type = paint->type;
+
+	if (paint->type == NSVG_PAINT_COLOR) {
+		cache->colors[0] = nsvg__applyOpacity(paint->color, opacity);
+		return;
+	}
+
+	grad = paint->gradient;
+
+	cache->spread = grad->spread;
+	memcpy(cache->xform, grad->xform, sizeof(float)*6);
+
+	if (grad->nstops == 0) {
+		for (i = 0; i < 256; i++)
+			cache->colors[i] = 0;
+	} if (grad->nstops == 1) {
+		for (i = 0; i < 256; i++)
+			cache->colors[i] = nsvg__applyOpacity(grad->stops[i].color, opacity);
+	} else {
+		unsigned int ca, cb = 0;
+		float ua, ub, du, u;
+		int ia, ib, count;
+
+		ca = nsvg__applyOpacity(grad->stops[0].color, opacity);
+		ua = nsvg__clampf(grad->stops[0].offset, 0, 1);
+		ub = nsvg__clampf(grad->stops[grad->nstops-1].offset, ua, 1);
+		ia = (int)(ua * 255.0f);
+		ib = (int)(ub * 255.0f);
+		for (i = 0; i < ia; i++) {
+			cache->colors[i] = ca;
+		}
+
+		for (i = 0; i < grad->nstops-1; i++) {
+			ca = nsvg__applyOpacity(grad->stops[i].color, opacity);
+			cb = nsvg__applyOpacity(grad->stops[i+1].color, opacity);
+			ua = nsvg__clampf(grad->stops[i].offset, 0, 1);
+			ub = nsvg__clampf(grad->stops[i+1].offset, 0, 1);
+			ia = (int)(ua * 255.0f);
+			ib = (int)(ub * 255.0f);
+			count = ib - ia;
+			if (count <= 0) continue;
+			u = 0;
+			du = 1.0f / (float)count;
+			for (j = 0; j < count; j++) {
+				cache->colors[ia+j] = nsvg__lerpRGBA(ca,cb,u);
+				u += du;
+			}
+		}
+
+		for (i = ib; i < 256; i++)
+			cache->colors[i] = cb;
+	}
+
+}
+
+/*
+static void dumpEdges(NSVGrasterizer* r, const char* name)
+{
+	float xmin = 0, xmax = 0, ymin = 0, ymax = 0;
+	NSVGedge *e = NULL;
+	int i;
+	if (r->nedges == 0) return;
+	FILE* fp = fopen(name, "w");
+	if (fp == NULL) return;
+
+	xmin = xmax = r->edges[0].x0;
+	ymin = ymax = r->edges[0].y0;
+	for (i = 0; i < r->nedges; i++) {
+		e = &r->edges[i];
+		xmin = nsvg__minf(xmin, e->x0);
+		xmin = nsvg__minf(xmin, e->x1);
+		xmax = nsvg__maxf(xmax, e->x0);
+		xmax = nsvg__maxf(xmax, e->x1);
+		ymin = nsvg__minf(ymin, e->y0);
+		ymin = nsvg__minf(ymin, e->y1);
+		ymax = nsvg__maxf(ymax, e->y0);
+		ymax = nsvg__maxf(ymax, e->y1);
+	}
+
+	fprintf(fp, "<svg viewBox=\"%f %f %f %f\" xmlns=\"http://www.w3.org/2000/svg\">", xmin, ymin, (xmax - xmin), (ymax - ymin));
+
+	for (i = 0; i < r->nedges; i++) {
+		e = &r->edges[i];
+		fprintf(fp ,"<line x1=\"%f\" y1=\"%f\" x2=\"%f\" y2=\"%f\" style=\"stroke:#000;\" />", e->x0,e->y0, e->x1,e->y1);
+	}
+
+	for (i = 0; i < r->npoints; i++) {
+		if (i+1 < r->npoints)
+			fprintf(fp ,"<line x1=\"%f\" y1=\"%f\" x2=\"%f\" y2=\"%f\" style=\"stroke:#f00;\" />", r->points[i].x, r->points[i].y, r->points[i+1].x, r->points[i+1].y);
+		fprintf(fp ,"<circle cx=\"%f\" cy=\"%f\" r=\"1\" style=\"fill:%s;\" />", r->points[i].x, r->points[i].y, r->points[i].flags == 0 ? "#f00" : "#0f0");
+	}
+
+	fprintf(fp, "</svg>");
+	fclose(fp);
+}
+*/
+
+void nsvgRasterizeXY(NSVGrasterizer* r,
+				   NSVGimage* image, float tx, float ty,
+				   float sx, float sy,
+				   unsigned char* dst, int w, int h, int stride)
+{
+	NSVGshape *shape = NULL;
+	NSVGedge *e = NULL;
+	NSVGcachedPaint cache;
+	int i;
+
+	r->bitmap = dst;
+	r->width = w;
+	r->height = h;
+	r->stride = stride;
+
+	if (w > r->cscanline) {
+		r->cscanline = w;
+		r->scanline = (unsigned char*)realloc(r->scanline, w);
+		if (r->scanline == NULL) return;
+	}
+
+	for (i = 0; i < h; i++)
+		memset(&dst[i*stride], 0, w*4);
+
+	for (shape = image->shapes; shape != NULL; shape = shape->next) {
+		if (!(shape->flags & NSVG_FLAGS_VISIBLE))
+			continue;
+
+		if (shape->fill.type != NSVG_PAINT_NONE) {
+			nsvg__resetPool(r);
+			r->freelist = NULL;
+			r->nedges = 0;
+
+			nsvg__flattenShape(r, shape, sx, sy);
+
+			// Scale and translate edges
+			for (i = 0; i < r->nedges; i++) {
+				e = &r->edges[i];
+				e->x0 = tx + e->x0;
+				e->y0 = (ty + e->y0) * NSVG__SUBSAMPLES;
+				e->x1 = tx + e->x1;
+				e->y1 = (ty + e->y1) * NSVG__SUBSAMPLES;
+			}
+
+			// Rasterize edges
+			if (r->nedges != 0)
+				qsort(r->edges, r->nedges, sizeof(NSVGedge), nsvg__cmpEdge);
+
+			// now, traverse the scanlines and find the intersections on each scanline, use non-zero rule
+			nsvg__initPaint(&cache, &shape->fill, shape->opacity);
+
+			nsvg__rasterizeSortedEdges(r, tx,ty, sx, sy, &cache, shape->fillRule);
+		}
+		if (shape->stroke.type != NSVG_PAINT_NONE && (shape->strokeWidth * sx) > 0.01f) {
+			nsvg__resetPool(r);
+			r->freelist = NULL;
+			r->nedges = 0;
+
+			nsvg__flattenShapeStroke(r, shape, sx, sy);
+
+//			dumpEdges(r, "edge.svg");
+
+			// Scale and translate edges
+			for (i = 0; i < r->nedges; i++) {
+				e = &r->edges[i];
+				e->x0 = tx + e->x0;
+				e->y0 = (ty + e->y0) * NSVG__SUBSAMPLES;
+				e->x1 = tx + e->x1;
+				e->y1 = (ty + e->y1) * NSVG__SUBSAMPLES;
+			}
+
+			// Rasterize edges
+			if (r->nedges != 0)
+				qsort(r->edges, r->nedges, sizeof(NSVGedge), nsvg__cmpEdge);
+
+			// now, traverse the scanlines and find the intersections on each scanline, use non-zero rule
+			nsvg__initPaint(&cache, &shape->stroke, shape->opacity);
+
+			nsvg__rasterizeSortedEdges(r, tx,ty,sx, sy, &cache, NSVG_FILLRULE_NONZERO);
+		}
+	}
+
+	nsvg__unpremultiplyAlpha(dst, w, h, stride);
+
+	r->bitmap = NULL;
+	r->width = 0;
+	r->height = 0;
+	r->stride = 0;
+}
+
+void nsvgRasterize(NSVGrasterizer* r,
+				   NSVGimage* image, float tx, float ty, float scale,
+				   unsigned char* dst, int w, int h, int stride)
+{
+	nsvgRasterizeXY(r,image, tx, ty, scale, scale, dst, w, h, stride);
+}
+
+#endif // NANOSVGRAST_IMPLEMENTATION
+
+#endif // NANOSVGRAST_H

--- a/src/nanosvg/nanosvgrast.h
+++ b/src/nanosvg/nanosvgrast.h
@@ -346,6 +346,7 @@ static float nsvg__normalize(float *x, float* y)
 }
 
 static float nsvg__absf(float x) { return x < 0 ? -x : x; }
+static float nsvg__roundf(float x) { return (x >= 0) ? floorf(x + 0.5) : ceilf(x - 0.5); }
 
 static void nsvg__flattenCubicBez(NSVGrasterizer* r,
 								  float x1, float y1, float x2, float y2,
@@ -888,10 +889,10 @@ static NSVGactiveEdge* nsvg__addActive(NSVGrasterizer* r, NSVGedge* e, float sta
 //	STBTT_assert(e->y0 <= start_point);
 	// round dx down to avoid going too far
 	if (dxdy < 0)
-		z->dx = (int)(-floorf(NSVG__FIX * -dxdy));
+		z->dx = (int)(-nsvg__roundf(NSVG__FIX * -dxdy));
 	else
-		z->dx = (int)floorf(NSVG__FIX * dxdy);
-	z->x = (int)floorf(NSVG__FIX * (e->x0 + dxdy * (startPoint - e->y0)));
+		z->dx = (int)nsvg__roundf(NSVG__FIX * dxdy);
+	z->x = (int)nsvg__roundf(NSVG__FIX * (e->x0 + dxdy * (startPoint - e->y0)));
 //	z->x -= off_x * FIX;
 	z->ey = e->y1;
 	z->next = 0;
@@ -1298,7 +1299,7 @@ static void nsvg__initPaint(NSVGcachedPaint* cache, NSVGpaint* paint, float opac
 	if (grad->nstops == 0) {
 		for (i = 0; i < 256; i++)
 			cache->colors[i] = 0;
-	} if (grad->nstops == 1) {
+	} else if (grad->nstops == 1) {
 		for (i = 0; i < 256; i++)
 			cache->colors[i] = nsvg__applyOpacity(grad->stops[i].color, opacity);
 	} else {

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -524,8 +524,6 @@ set(SLIC3R_GUI_SOURCES
     Utils/CalibUtils.hpp
 )
 
-find_package(NanoSVG REQUIRED)
-
 if (WIN32)
     list(APPEND SLIC3R_GUI_SOURCES
             GUI/dark_mode/dark_mode.hpp
@@ -573,7 +571,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SLIC3R_GUI_SOURCES})
 
 encoding_check(libslic3r_gui)
 
-target_link_libraries(libslic3r_gui libslic3r cereal::cereal imgui minilzo GLEW::GLEW OpenGL::GL hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto NanoSVG::nanosvg NanoSVG::nanosvgrast)
+target_link_libraries(libslic3r_gui libslic3r cereal::cereal imgui minilzo GLEW::GLEW OpenGL::GL hidapi ${wxWidgets_LIBRARIES} glfw libcurl OpenSSL::SSL OpenSSL::Crypto)
 #target_link_libraries(libslic3r_gui libslic3r cereal imgui minilzo GLEW::GLEW OpenGL::GL hidapi libcurl OpenSSL::SSL OpenSSL::Crypto ${wxWidgets_LIBRARIES} glfw)
 
 if (MSVC)

--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -1084,7 +1084,7 @@ void AMSMaterialsSetting::on_dpi_changed(const wxRect &suggested_rect)
     m_input_nozzle_max->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(20)));
     m_input_nozzle_min->GetTextCtrl()->SetSize(wxSize(-1, FromDIP(20)));
     //m_clr_picker->msw_rescale();
-    degree->sys_color_changed();
+    degree->msw_rescale();
     bitmap_max_degree->SetBitmap(degree->bmp());
     bitmap_min_degree->SetBitmap(degree->bmp());
     m_button_reset->SetMinSize(AMS_MATERIALS_SETTING_BUTTON_SIZE);

--- a/src/slic3r/GUI/AboutDialog.cpp
+++ b/src/slic3r/GUI/AboutDialog.cpp
@@ -19,7 +19,7 @@ AboutDialogLogo::AboutDialogLogo(wxWindow* parent)
 {
     this->SetBackgroundColour(*wxWHITE);
     this->logo = ScalableBitmap(this, Slic3r::var("OrcaSlicer_192px.png"), wxBITMAP_TYPE_PNG);
-    this->SetMinSize(this->logo.GetSize());
+    this->SetMinSize(this->logo.GetBmpSize());
 
     this->Bind(wxEVT_PAINT, &AboutDialogLogo::onRepaint, this);
 }
@@ -30,9 +30,9 @@ void AboutDialogLogo::onRepaint(wxEvent &event)
     dc.SetBackgroundMode(wxTRANSPARENT);
 
     wxSize size = this->GetSize();
-    int logo_w = this->logo.GetWidth();
-    int logo_h = this->logo.GetHeight();
-    dc.DrawBitmap(this->logo.get_bitmap(), (size.GetWidth() - logo_w)/2, (size.GetHeight() - logo_h)/2, true);
+    int logo_w = this->logo.GetBmpWidth();
+    int logo_h = this->logo.GetBmpHeight();
+    dc.DrawBitmap(this->logo.bmp(), (size.GetWidth() - logo_w)/2, (size.GetHeight() - logo_h)/2, true);
 
     event.Skip();
 }
@@ -232,7 +232,7 @@ AboutDialog::AboutDialog()
     main_sizer->Add(ver_sizer, 0, wxEXPAND | wxALL, 0);
 
     // logo
-    m_logo_bitmap = ScalableBitmap(this, "OrcaSlicer_about", {562,250});
+    m_logo_bitmap = ScalableBitmap(this, "OrcaSlicer_about", 250);
     m_logo = new wxStaticBitmap(this, wxID_ANY, m_logo_bitmap.bmp(), wxDefaultPosition,wxDefaultSize, 0);
     m_logo->SetSizer(vesizer);
 
@@ -380,7 +380,7 @@ AboutDialog::AboutDialog()
 
 void AboutDialog::on_dpi_changed(const wxRect &suggested_rect)
 {
-    m_logo_bitmap.sys_color_changed();
+    m_logo_bitmap.msw_rescale();
     m_logo->SetBitmap(m_logo_bitmap.bmp());
 
     const wxFont& font = GetFont();

--- a/src/slic3r/GUI/AmsMappingPopup.cpp
+++ b/src/slic3r/GUI/AmsMappingPopup.cpp
@@ -187,7 +187,7 @@ void MaterialItem::doRender(wxDC &dc)
     auto acolor = m_ams_coloul;
 
     if (mcolor.Alpha() == 0 || acolor.Alpha() == 0) {
-        dc.DrawBitmap(m_transparent_mitem.get_bitmap(), FromDIP(1), FromDIP(1));
+        dc.DrawBitmap(m_transparent_mitem.bmp(), FromDIP(1), FromDIP(1));
     }
 
     if (!IsEnabled()) {
@@ -247,10 +247,10 @@ void MaterialItem::doRender(wxDC &dc)
     //arrow
     if ( (acolor.Red() > 160 && acolor.Green() > 160 && acolor.Blue() > 160) &&
         (acolor.Red() < 180 && acolor.Green() < 180 && acolor.Blue() < 180)) {
-        dc.DrawBitmap(m_arraw_bitmap_white.get_bitmap(), GetSize().x - m_arraw_bitmap_white.GetSize().x - FromDIP(7),  GetSize().y - m_arraw_bitmap_white.GetSize().y);
+        dc.DrawBitmap(m_arraw_bitmap_white.bmp(), GetSize().x - m_arraw_bitmap_white.GetBmpSize().x - FromDIP(7),  GetSize().y - m_arraw_bitmap_white.GetBmpSize().y);
     }
     else {
-        dc.DrawBitmap(m_arraw_bitmap_gray.get_bitmap(), GetSize().x - m_arraw_bitmap_gray.GetSize().x - FromDIP(7),  GetSize().y - m_arraw_bitmap_gray.GetSize().y);
+        dc.DrawBitmap(m_arraw_bitmap_gray.bmp(), GetSize().x - m_arraw_bitmap_gray.GetBmpSize().x - FromDIP(7),  GetSize().y - m_arraw_bitmap_gray.GetBmpSize().y);
     }
 
     
@@ -677,7 +677,7 @@ void MappingItem::doRender(wxDC &dc)
     dc.SetBrush(wxBrush(m_coloul));
 
     if (m_coloul.Alpha() == 0) {
-       dc.DrawBitmap( m_transparent_mapping_item.get_bitmap(), 0, (GetSize().y - MAPPING_ITEM_REAL_SIZE.y) / 2);
+       dc.DrawBitmap( m_transparent_mapping_item.bmp(), 0, (GetSize().y - MAPPING_ITEM_REAL_SIZE.y) / 2);
     }
     else {
         dc.DrawRectangle(0, (GetSize().y - MAPPING_ITEM_REAL_SIZE.y) / 2, MAPPING_ITEM_REAL_SIZE.x, MAPPING_ITEM_REAL_SIZE.y);
@@ -1340,7 +1340,7 @@ void AmsReplaceMaterialDialog::update_machine_obj(MachineObject* obj)
         }
         else {
             label_txt->SetLabelText(_L("If there are two identical filaments in AMS, AMS filament backup will be enabled. \n(Currently supporting automatic supply of consumables with the same brand, material type, and color)"));
-        }
+        } 
 
         label_txt->SetMinSize(wxSize(FromDIP(380), -1));
         label_txt->SetMaxSize(wxSize(FromDIP(380), -1));
@@ -1494,7 +1494,7 @@ void AmsRMGroup::doRender(wxDC& dc)
     float startAngle = 0.0;
     float endAngle = 0.0;
 
-    dc.DrawBitmap(bitmap_bg.get_bitmap(), wxPoint((size.x - bitmap_bg.GetSize().x) / 2, (size.y - bitmap_bg.GetSize().y) / 2));
+    dc.DrawBitmap(bitmap_bg.bmp(), wxPoint((size.x - bitmap_bg.GetBmpSize().x) / 2, (size.y - bitmap_bg.GetBmpSize().y) / 2));
 
     for (auto iter = m_group_info.rbegin(); iter != m_group_info.rend(); ++iter) {
         std::string tray_name = iter->first;
@@ -1575,7 +1575,7 @@ void AmsRMGroup::doRender(wxDC& dc)
     dc.DrawEllipticArc(x - center_mask_radius, y - center_mask_radius, center_mask_radius * 2, center_mask_radius * 2, 0, 360);
 
     //draw center icon
-    dc.DrawBitmap(bitmap_backup_tips_0.get_bitmap(), wxPoint((size.x - bitmap_backup_tips_0.GetSize().x) / 2, (size.y - bitmap_backup_tips_0.GetSize().y) / 2));
+    dc.DrawBitmap(bitmap_backup_tips_0.bmp(), wxPoint((size.x - bitmap_backup_tips_0.GetBmpSize().x) / 2, (size.y - bitmap_backup_tips_0.GetBmpSize().y) / 2));
     //dc.DrawBitmap(bitmap_backup_tips_1.bmp(), wxPoint((size.x - bitmap_backup_tips_1.GetBmpSize().x) / 2, (size.y - bitmap_backup_tips_1.GetBmpSize().y) / 2));
 
     //draw material

--- a/src/slic3r/GUI/Auxiliary.cpp
+++ b/src/slic3r/GUI/Auxiliary.cpp
@@ -226,7 +226,7 @@ void AuFile::PaintBackground(wxDC &dc)
         dc.SetPen(AUFILE_GREY200);
         dc.SetBrush(AUFILE_GREY200);
         dc.DrawRoundedRectangle(0, 0, size.x, size.y, AUFILE_ROUNDING);
-        dc.DrawBitmap(m_file_bitmap.get_bitmap(), (size.x - m_file_bitmap.GetWidth()) / 2, (size.y - m_file_bitmap.GetHeight()) / 2);
+        dc.DrawBitmap(m_file_bitmap.bmp(), (size.x - m_file_bitmap.GetBmpWidth()) / 2, (size.y - m_file_bitmap.GetBmpHeight()) / 2);
     }
 }
 
@@ -257,7 +257,7 @@ void AuFile::PaintForeground(wxDC &dc)
         }
 
         if (m_type == MODEL_PICTURE) {
-            dc.DrawBitmap(m_file_edit_mask.get_bitmap(), 0, size.y - m_file_edit_mask.GetSize().y);
+            dc.DrawBitmap(m_file_edit_mask.bmp(), 0, size.y - m_file_edit_mask.GetBmpSize().y); 
         }
 
 
@@ -268,14 +268,14 @@ void AuFile::PaintForeground(wxDC &dc)
             auto sizet = dc.GetTextExtent(cover_text_left);
             auto pos   = wxPoint(0, 0);
             pos.x      = (size.x / 2 - sizet.x) / 2;
-            pos.y      = (size.y - (m_file_edit_mask.GetSize().y + sizet.y) / 2);
+            pos.y      = (size.y - (m_file_edit_mask.GetBmpSize().y + sizet.y) / 2);
             dc.DrawText(cover_text_left, pos);
 
             // right text
             sizet = dc.GetTextExtent(cover_text_right);
             pos   = wxPoint(0, 0);
             pos.x = size.x / 2 + (size.x / 2 - sizet.x) / 2;
-            pos.y = (size.y - (m_file_edit_mask.GetSize().y + sizet.y) / 2);
+            pos.y = (size.y - (m_file_edit_mask.GetBmpSize().y + sizet.y) / 2);
             dc.DrawText(cover_text_right, pos);
 
             // Split
@@ -283,7 +283,7 @@ void AuFile::PaintForeground(wxDC &dc)
             dc.SetBrush(*wxWHITE);
             pos   = wxPoint(0, 0);
             pos.x = size.x / 2 - 1;
-            pos.y = size.y - FromDIP(24) - (m_file_edit_mask.GetSize().y - FromDIP(24)) / 2;
+            pos.y = size.y - FromDIP(24) - (m_file_edit_mask.GetBmpSize().y - FromDIP(24)) / 2;
             dc.DrawRectangle(pos.x, pos.y, 2, FromDIP(24));
         } else {
             // right text
@@ -297,7 +297,7 @@ void AuFile::PaintForeground(wxDC &dc)
 
     if (m_cover) {
         dc.SetTextForeground(*wxWHITE);
-        dc.DrawBitmap(m_file_cover.get_bitmap(), size.x - m_file_cover.GetSize().x, 0);
+        dc.DrawBitmap(m_file_cover.bmp(), size.x - m_file_cover.GetBmpSize().x, 0);
         dc.SetFont(Label::Body_12);
         auto sizet = dc.GetTextExtent(cover_text_cover);
         auto pos   = wxPoint(0, 0);
@@ -306,7 +306,7 @@ void AuFile::PaintForeground(wxDC &dc)
         dc.DrawText(cover_text_cover, pos);
     }
 
-    if (m_hover) { dc.DrawBitmap(m_file_delete.get_bitmap(), size.x - m_file_delete.GetSize().x - FromDIP(10), FromDIP(10)); }
+    if (m_hover) { dc.DrawBitmap(m_file_delete.bmp(), size.x - m_file_delete.GetBmpSize().x - FromDIP(10), FromDIP(10)); }
 }
 
 void AuFile::on_mouse_enter(wxMouseEvent &evt)
@@ -421,7 +421,7 @@ void AuFile::on_mouse_left_up(wxMouseEvent &evt)
 
     auto pos = evt.GetPosition();
     // set cover
-    auto mask_size    = wxSize(GetSize().x, m_file_edit_mask.GetSize().y);
+    auto mask_size    = wxSize(GetSize().x, m_file_edit_mask.GetBmpSize().y);
     auto cover_left   = 0;
     auto cover_top    = size.y - mask_size.y;
     auto cover_right  = mask_size.x / 2;
@@ -443,10 +443,10 @@ void AuFile::on_mouse_left_up(wxMouseEvent &evt)
     if (pos.x > rename_left && pos.x < rename_right && pos.y > rename_top && pos.y < rename_bottom) { on_set_rename(); return; }
 
     // close
-    auto close_left   = size.x - m_file_delete.GetSize().x - FromDIP(10);
+    auto close_left   = size.x - m_file_delete.GetBmpSize().x - FromDIP(10);
     auto close_top    = FromDIP(10);
     auto close_right  = size.x - FromDIP(10);
-    auto close_bottom = m_file_delete.GetSize().y + FromDIP(10);
+    auto close_bottom = m_file_delete.GetBmpSize().y + FromDIP(10);
     if (pos.x > close_left && pos.x < close_right && pos.y > close_top && pos.y < close_bottom) { on_set_delete(); return; }
 
     exit_rename_mode();

--- a/src/slic3r/GUI/BBLTopbar.cpp
+++ b/src/slic3r/GUI/BBLTopbar.cpp
@@ -29,11 +29,6 @@ enum CUSTOM_ID
     ID_AMS_NOTEBOOK,
 };
 
-static bool IsThemeDark()
-{
-    return wxSystemSettings::GetAppearance().IsDark();
-}
-
 class BBLTopbarArt : public wxAuiDefaultToolBarArt
 {
 public:
@@ -98,7 +93,9 @@ void BBLTopbarArt::DrawButton(wxDC& dc, wxWindow* wnd, const wxAuiToolBarItem& i
     int bmpX = 0, bmpY = 0;
     int textX = 0, textY = 0;
 
-    const wxBitmap &bmp = item.GetCurrentBitmapFor(wnd);
+    const wxBitmap& bmp = item.GetState() & wxAUI_BUTTON_STATE_DISABLED
+        ? item.GetDisabledBitmap()
+        : item.GetBitmap();
 
     const wxSize bmpSize = bmp.IsOk() ? bmp.GetScaledSize() : wxSize(0, 0);
 
@@ -135,18 +132,18 @@ void BBLTopbarArt::DrawButton(wxDC& dc, wxWindow* wnd, const wxAuiToolBarItem& i
         if (item.GetState() & wxAUI_BUTTON_STATE_PRESSED)
         {
             dc.SetPen(wxPen(m_highlightColour));
-            dc.SetBrush(wxBrush(m_highlightColour.ChangeLightness(IsThemeDark() ? 20 : 150)));
+            dc.SetBrush(wxBrush(m_highlightColour.ChangeLightness(20)));
             dc.DrawRectangle(rect);
         }
         else if ((item.GetState() & wxAUI_BUTTON_STATE_HOVER) || item.IsSticky())
         {
             dc.SetPen(wxPen(m_highlightColour));
-            dc.SetBrush(wxBrush(m_highlightColour.ChangeLightness(IsThemeDark() ? 40 : 170)));
+            dc.SetBrush(wxBrush(m_highlightColour.ChangeLightness(40)));
 
             // draw an even lighter background for checked item hovers (since
             // the hover background is the same color as the check background)
             if (item.GetState() & wxAUI_BUTTON_STATE_CHECKED)
-                dc.SetBrush(wxBrush(m_highlightColour.ChangeLightness(IsThemeDark() ? 50 : 180)));
+                dc.SetBrush(wxBrush(m_highlightColour.ChangeLightness(50)));
 
             dc.DrawRectangle(rect);
         }
@@ -155,7 +152,7 @@ void BBLTopbarArt::DrawButton(wxDC& dc, wxWindow* wnd, const wxAuiToolBarItem& i
             // it's important to put this code in an else statement after the
             // hover, otherwise hovers won't draw properly for checked items
             dc.SetPen(wxPen(m_highlightColour));
-            dc.SetBrush(wxBrush(m_highlightColour.ChangeLightness(IsThemeDark() ? 40 : 170)));
+            dc.SetBrush(wxBrush(m_highlightColour.ChangeLightness(40)));
             dc.DrawRectangle(rect);
         }
     }
@@ -200,25 +197,23 @@ void BBLTopbar::Init(wxFrame* parent)
     m_skip_popup_dropdown_menu = false;
     m_skip_popup_calib_menu    = false;
 
-    m_font.Scale(parent->GetDPIScaleFactor());
-
     wxInitAllImageHandlers();
 
     this->AddSpacer(5);
 
-    /*wxBitmap logo_bitmap = *get_bmp_bundle("topbar_logo", TOPBAR_ICON_SIZE);
+    /*wxBitmap logo_bitmap = create_scaled_bitmap("topbar_logo", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* logo_item = this->AddTool(ID_LOGO, "", logo_bitmap);
     logo_item->SetHoverBitmap(logo_bitmap);
     logo_item->SetActive(false);*/
 
-    wxBitmapBundle file_bitmap = *get_bmp_bundle("topbar_file", TOPBAR_ICON_SIZE);
+    wxBitmap file_bitmap = create_scaled_bitmap("topbar_file", nullptr, TOPBAR_ICON_SIZE);
     m_file_menu_item = this->AddTool(ID_TOP_FILE_MENU, _L("File"), file_bitmap, wxEmptyString, wxITEM_NORMAL);
 
     this->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 
     this->AddSpacer(FromDIP(5));
 
-    wxBitmapBundle dropdown_bitmap = *get_bmp_bundle("topbar_dropdown", TOPBAR_ICON_SIZE);
+    wxBitmap dropdown_bitmap = create_scaled_bitmap("topbar_dropdown", nullptr, TOPBAR_ICON_SIZE);
     m_dropdown_menu_item = this->AddTool(ID_TOP_DROPDOWN_MENU, "",
         dropdown_bitmap, wxEmptyString);
 
@@ -226,32 +221,32 @@ void BBLTopbar::Init(wxFrame* parent)
     this->AddSeparator();
     this->AddSpacer(FromDIP(5));
 
-    //wxBitmap open_bitmap = *get_bmp_bundle("topbar_open", TOPBAR_ICON_SIZE);
+    //wxBitmap open_bitmap = create_scaled_bitmap("topbar_open", nullptr, TOPBAR_ICON_SIZE);
     //wxAuiToolBarItem* tool_item = this->AddTool(wxID_OPEN, "", open_bitmap);
 
     this->AddSpacer(FromDIP(10));
 
-    wxBitmapBundle save_bitmap = *get_bmp_bundle("topbar_save", TOPBAR_ICON_SIZE);
+    wxBitmap save_bitmap = create_scaled_bitmap("topbar_save", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* save_btn = this->AddTool(wxID_SAVE, "", save_bitmap);
 
     this->AddSpacer(FromDIP(10));
 
-    wxBitmapBundle undo_bitmap = *get_bmp_bundle("topbar_undo", TOPBAR_ICON_SIZE);
+    wxBitmap undo_bitmap = create_scaled_bitmap("topbar_undo", nullptr, TOPBAR_ICON_SIZE);
     m_undo_item = this->AddTool(wxID_UNDO, "", undo_bitmap);
-    wxBitmapBundle undo_inactive_bitmap = *get_bmp_bundle("topbar_undo_inactive", TOPBAR_ICON_SIZE);
+    wxBitmap undo_inactive_bitmap = create_scaled_bitmap("topbar_undo_inactive", nullptr, TOPBAR_ICON_SIZE);
     m_undo_item->SetDisabledBitmap(undo_inactive_bitmap);
 
     this->AddSpacer(FromDIP(10));
 
-    wxBitmapBundle redo_bitmap = *get_bmp_bundle("topbar_redo", TOPBAR_ICON_SIZE);
+    wxBitmap redo_bitmap = create_scaled_bitmap("topbar_redo", nullptr, TOPBAR_ICON_SIZE);
     m_redo_item = this->AddTool(wxID_REDO, "", redo_bitmap);
-    wxBitmapBundle redo_inactive_bitmap = *get_bmp_bundle("topbar_redo_inactive", TOPBAR_ICON_SIZE);
+    wxBitmap redo_inactive_bitmap = create_scaled_bitmap("topbar_redo_inactive", nullptr, TOPBAR_ICON_SIZE);
     m_redo_item->SetDisabledBitmap(redo_inactive_bitmap);
 
     this->AddSpacer(FromDIP(10));
 
-    wxBitmapBundle calib_bitmap          = *get_bmp_bundle("calib_sf", TOPBAR_ICON_SIZE);
-    wxBitmapBundle calib_bitmap_inactive = *get_bmp_bundle("calib_sf_inactive", TOPBAR_ICON_SIZE);
+    wxBitmap calib_bitmap          = create_scaled_bitmap("calib_sf", nullptr, TOPBAR_ICON_SIZE);
+    wxBitmap calib_bitmap_inactive = create_scaled_bitmap("calib_sf_inactive", nullptr, TOPBAR_ICON_SIZE);
     m_calib_item                   = this->AddTool(ID_CALIB, _L("Calibration"), calib_bitmap);
     m_calib_item->SetDisabledBitmap(calib_bitmap_inactive);
 
@@ -264,14 +259,14 @@ void BBLTopbar::Init(wxFrame* parent)
     this->AddSpacer(FromDIP(10));
     this->AddStretchSpacer(1);
 
-    m_publish_bitmap = *get_bmp_bundle("topbar_publish", TOPBAR_ICON_SIZE);
+    m_publish_bitmap = create_scaled_bitmap("topbar_publish", nullptr, TOPBAR_ICON_SIZE);
     m_publish_item = this->AddTool(ID_PUBLISH, "", m_publish_bitmap);
-    m_publish_disable_bitmap = *get_bmp_bundle("topbar_publish_disable", TOPBAR_ICON_SIZE);
+    m_publish_disable_bitmap = create_scaled_bitmap("topbar_publish_disable", nullptr, TOPBAR_ICON_SIZE);
     m_publish_item->SetDisabledBitmap(m_publish_disable_bitmap);
     this->EnableTool(m_publish_item->GetId(), false);
     this->AddSpacer(FromDIP(4));
 
-    /*wxBitmap model_store_bitmap = *get_bmp_bundle("topbar_store", TOPBAR_ICON_SIZE);
+    /*wxBitmap model_store_bitmap = create_scaled_bitmap("topbar_store", nullptr, TOPBAR_ICON_SIZE);
     m_model_store_item = this->AddTool(ID_MODEL_STORE, "", model_store_bitmap);
     this->AddSpacer(12);
     */
@@ -279,13 +274,13 @@ void BBLTopbar::Init(wxFrame* parent)
     //this->AddSeparator();
     this->AddSpacer(FromDIP(4));
 
-    wxBitmapBundle iconize_bitmap = *get_bmp_bundle("topbar_min", TOPBAR_ICON_SIZE);
+    wxBitmap iconize_bitmap = create_scaled_bitmap("topbar_min", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* iconize_btn = this->AddTool(wxID_ICONIZE_FRAME, "", iconize_bitmap);
 
     this->AddSpacer(FromDIP(4));
 
-    maximize_bitmap = *get_bmp_bundle("topbar_max", TOPBAR_ICON_SIZE);
-    window_bitmap = *get_bmp_bundle("topbar_win", TOPBAR_ICON_SIZE);
+    maximize_bitmap = create_scaled_bitmap("topbar_max", nullptr, TOPBAR_ICON_SIZE);
+    window_bitmap = create_scaled_bitmap("topbar_win", nullptr, TOPBAR_ICON_SIZE);
     if (m_frame->IsMaximized()) {
         maximize_btn = this->AddTool(wxID_MAXIMIZE_FRAME, "", window_bitmap);
     }
@@ -295,7 +290,7 @@ void BBLTopbar::Init(wxFrame* parent)
 
     this->AddSpacer(FromDIP(4));
 
-    wxBitmapBundle close_bitmap = *get_bmp_bundle("topbar_close", TOPBAR_ICON_SIZE);
+    wxBitmap close_bitmap = create_scaled_bitmap("topbar_close", nullptr, TOPBAR_ICON_SIZE);
     wxAuiToolBarItem* close_btn = this->AddTool(wxID_CLOSE_FRAME, "", close_bitmap);
 
     Realize();
@@ -471,51 +466,49 @@ void BBLTopbar::Rescale() {
     int em = em_unit(this);
     wxAuiToolBarItem* item;
 
-    m_font.Scale(m_frame->GetDPIScaleFactor());
-
     /*item = this->FindTool(ID_LOGO);
-    item->SetBitmap(*get_bmp_bundle("topbar_logo", TOPBAR_ICON_SIZE));*/
+    item->SetBitmap(create_scaled_bitmap("topbar_logo", nullptr, TOPBAR_ICON_SIZE));*/
 
     item = this->FindTool(ID_TOP_FILE_MENU);
-    item->SetBitmap(*get_bmp_bundle("topbar_file", TOPBAR_ICON_SIZE));
+    item->SetBitmap(create_scaled_bitmap("topbar_file", this, TOPBAR_ICON_SIZE));
 
     item = this->FindTool(ID_TOP_DROPDOWN_MENU);
-    item->SetBitmap(*get_bmp_bundle("topbar_dropdown", TOPBAR_ICON_SIZE));
+    item->SetBitmap(create_scaled_bitmap("topbar_dropdown", this, TOPBAR_ICON_SIZE));
 
     //item = this->FindTool(wxID_OPEN);
-    //item->SetBitmap(*get_bmp_bundle("topbar_open", nullptr, TOPBAR_ICON_SIZE));
+    //item->SetBitmap(create_scaled_bitmap("topbar_open", nullptr, TOPBAR_ICON_SIZE));
 
     item = this->FindTool(wxID_SAVE);
-    item->SetBitmap(*get_bmp_bundle("topbar_save", TOPBAR_ICON_SIZE));
+    item->SetBitmap(create_scaled_bitmap("topbar_save", this, TOPBAR_ICON_SIZE));
 
     item = this->FindTool(wxID_UNDO);
-    item->SetBitmap(*get_bmp_bundle("topbar_undo", TOPBAR_ICON_SIZE));
-    item->SetDisabledBitmap(*get_bmp_bundle("topbar_undo_inactive", TOPBAR_ICON_SIZE));
+    item->SetBitmap(create_scaled_bitmap("topbar_undo", this, TOPBAR_ICON_SIZE));
+    item->SetDisabledBitmap(create_scaled_bitmap("topbar_undo_inactive", nullptr, TOPBAR_ICON_SIZE));
 
     item = this->FindTool(wxID_REDO);
-    item->SetBitmap(*get_bmp_bundle("topbar_redo", TOPBAR_ICON_SIZE));
-    item->SetDisabledBitmap(*get_bmp_bundle("topbar_redo_inactive", TOPBAR_ICON_SIZE));
+    item->SetBitmap(create_scaled_bitmap("topbar_redo", this, TOPBAR_ICON_SIZE));
+    item->SetDisabledBitmap(create_scaled_bitmap("topbar_redo_inactive", nullptr, TOPBAR_ICON_SIZE));
 
     item = this->FindTool(ID_CALIB);
-    item->SetBitmap(*get_bmp_bundle("calib_sf", TOPBAR_ICON_SIZE));
-    item->SetDisabledBitmap(*get_bmp_bundle("calib_sf_inactive", TOPBAR_ICON_SIZE));
+    item->SetBitmap(create_scaled_bitmap("calib_sf", nullptr, TOPBAR_ICON_SIZE));
+    item->SetDisabledBitmap(create_scaled_bitmap("calib_sf_inactive", nullptr, TOPBAR_ICON_SIZE));
 
     item = this->FindTool(ID_TITLE);
 
     /*item = this->FindTool(ID_PUBLISH);
-    item->SetBitmap(*get_bmp_bundle("topbar_publish", TOPBAR_ICON_SIZE));
-    item->SetDisabledBitmap(*get_bmp_bundle("topbar_publish_disable", TOPBAR_ICON_SIZE));*/
+    item->SetBitmap(create_scaled_bitmap("topbar_publish", this, TOPBAR_ICON_SIZE));
+    item->SetDisabledBitmap(create_scaled_bitmap("topbar_publish_disable", nullptr, TOPBAR_ICON_SIZE));*/
 
     /*item = this->FindTool(ID_MODEL_STORE);
-    item->SetBitmap(*get_bmp_bundle("topbar_store", TOPBAR_ICON_SIZE));
+    item->SetBitmap(create_scaled_bitmap("topbar_store", this, TOPBAR_ICON_SIZE));
     */
 
     item = this->FindTool(wxID_ICONIZE_FRAME);
-    item->SetBitmap(*get_bmp_bundle("topbar_min", TOPBAR_ICON_SIZE));
+    item->SetBitmap(create_scaled_bitmap("topbar_min", this, TOPBAR_ICON_SIZE));
 
     item = this->FindTool(wxID_MAXIMIZE_FRAME);
-    maximize_bitmap = *get_bmp_bundle("topbar_max", TOPBAR_ICON_SIZE);
-    window_bitmap   = *get_bmp_bundle("topbar_win", TOPBAR_ICON_SIZE);
+    maximize_bitmap = create_scaled_bitmap("topbar_max", this, TOPBAR_ICON_SIZE);
+    window_bitmap   = create_scaled_bitmap("topbar_win", this, TOPBAR_ICON_SIZE);
     if (m_frame->IsMaximized()) {
         item->SetBitmap(window_bitmap);
     }
@@ -524,7 +517,7 @@ void BBLTopbar::Rescale() {
     }
 
     item = this->FindTool(wxID_CLOSE_FRAME);
-    item->SetBitmap(*get_bmp_bundle("topbar_close", TOPBAR_ICON_SIZE));
+    item->SetBitmap(create_scaled_bitmap("topbar_close", this, TOPBAR_ICON_SIZE));
 
     Realize();
 }

--- a/src/slic3r/GUI/BBLTopbar.hpp
+++ b/src/slic3r/GUI/BBLTopbar.hpp
@@ -75,11 +75,11 @@ private:
     wxAuiToolBarItem* m_calib_item;
     wxAuiToolBarItem* maximize_btn;
 
-    wxBitmapBundle m_publish_bitmap;
-    wxBitmapBundle m_publish_disable_bitmap;
+    wxBitmap m_publish_bitmap;
+    wxBitmap m_publish_disable_bitmap;
 
-    wxBitmapBundle maximize_bitmap;
-    wxBitmapBundle window_bitmap;
+    wxBitmap maximize_bitmap;
+    wxBitmap window_bitmap;
 
     int m_toolbar_h;
     bool m_skip_popup_file_menu;

--- a/src/slic3r/GUI/BitmapCache.cpp
+++ b/src/slic3r/GUI/BitmapCache.cpp
@@ -13,8 +13,10 @@
     #include <wx/rawbmp.h>
 #endif /* __WXGTK2__ */
 
-#include <nanosvg/nanosvg.h>
-#include <nanosvg/nanosvgrast.h>
+#define NANOSVG_IMPLEMENTATION
+#include "nanosvg/nanosvg.h"
+#define NANOSVGRAST_IMPLEMENTATION
+#include "nanosvg/nanosvgrast.h"
 
 namespace Slic3r { namespace GUI {
 
@@ -58,168 +60,7 @@ static wxBitmap wxImage_to_wxBitmap_with_alpha(wxImage &&image, float scale = 1.
 #endif
 }
 
-wxBitmapBundle* BitmapCache::insert_bndl(const std::string& name, const std::vector<wxBitmapBundle*>& bmps)
-{
-    wxVector<wxBitmap> bitmaps;
-
-    std::set<double> scales = {1.0};
-#ifndef __linux__
-
-#ifdef __APPLE__
-    scales.emplace(m_scale);
-#else
-    size_t disp_cnt = wxDisplay::GetCount();
-    for (size_t disp = 0; disp < disp_cnt; ++disp)
-        scales.emplace(wxDisplay(disp).GetScaleFactor());
-#endif
-
-#endif // !__linux__
-
-    for (double scale : scales) {
-        size_t width = 0;
-        size_t height = 0;
-        for (const wxBitmapBundle* bmp_bndl : bmps) {
-#ifdef __APPLE__
-            wxSize size = bmp_bndl->GetDefaultSize();
-#else
-            wxSize size = bmp_bndl->GetPreferredBitmapSizeAtScale(scale);
-#endif
-            width += size.GetWidth();
-            height = std::max<size_t>(height, size.GetHeight());
-        }
-
-        std::string bitmap_key = name + "," +float_to_string_decimal_point(scale);
-
-#ifdef __WXGTK2__
-        // Broken alpha workaround
-        wxImage image(width, height);
-        image.InitAlpha();
-        // Fill in with a white color.
-        memset(image.GetData(), 0x0ff, width * height * 3);
-        // Fill in with full transparency.
-        memset(image.GetAlpha(), 0, width * height);
-        size_t x = 0;
-        for (const wxBitmapBundle* bmp_bndl : bmps) {
-            wxBitmap bmp = bmp_bndl->GetBitmap(bmp_bndl->GetDefaultSize());
-            if (bmp.GetWidth() > 0) {
-                if (bmp.GetDepth() == 32) {
-                    wxAlphaPixelData data(bmp);
-                    //FIXME The following method is missing from wxWidgets 3.1.1.
-                    // It looks like the wxWidgets 3.0.3 called the wrapped bitmap's UseAlpha().
-                    //data.UseAlpha();
-                    if (data) {
-                        for (int r = 0; r < bmp.GetHeight(); ++r) {
-                            wxAlphaPixelData::Iterator src(data);
-                            src.Offset(data, 0, r);
-                            unsigned char* dst_pixels = image.GetData() + (x + r * width) * 3;
-                            unsigned char* dst_alpha = image.GetAlpha() + x + r * width;
-                            for (int c = 0; c < bmp.GetWidth(); ++c, ++src) {
-                                *dst_pixels++ = src.Red();
-                                *dst_pixels++ = src.Green();
-                                *dst_pixels++ = src.Blue();
-                                *dst_alpha++ = src.Alpha();
-                            }
-                        }
-                    }
-                }
-                else if (bmp.GetDepth() == 24) {
-                    wxNativePixelData data(bmp);
-                    if (data) {
-                        for (int r = 0; r < bmp.GetHeight(); ++r) {
-                            wxNativePixelData::Iterator src(data);
-                            src.Offset(data, 0, r);
-                            unsigned char* dst_pixels = image.GetData() + (x + r * width) * 3;
-                            unsigned char* dst_alpha = image.GetAlpha() + x + r * width;
-                            for (int c = 0; c < bmp.GetWidth(); ++c, ++src) {
-                                *dst_pixels++ = src.Red();
-                                *dst_pixels++ = src.Green();
-                                *dst_pixels++ = src.Blue();
-                                *dst_alpha++ = wxALPHA_OPAQUE;
-                            }
-                        }
-                    }
-                }
-            }
-            x += bmp.GetScaledWidth();
-        }
-
-        bitmaps.push_back(* this->insert(bitmap_key, wxImage_to_wxBitmap_with_alpha(std::move(image))));
-
-#else
-
-        wxBitmap* bitmap = this->insert(bitmap_key, width, height, scale);
-        wxMemoryDC memDC;
-        memDC.SelectObject(*bitmap);
-        memDC.SetBackground(*wxTRANSPARENT_BRUSH);
-        memDC.Clear();
-        size_t x = 0;
-        for (const wxBitmapBundle* bmp_bndl : bmps) {
-            wxBitmap bmp = bmp_bndl->GetBitmap(bmp_bndl->GetPreferredBitmapSizeAtScale(scale));
-
-            if (bmp.GetWidth() > 0)
-                memDC.DrawBitmap(bmp, x, 0, true);
-            // we should "move" with step equal to non-scaled width
-#ifdef __APPLE__
-            x += bmp.GetScaledWidth();
-#else
-            x += bmp.GetWidth();
-#endif
-        }
-        memDC.SelectObject(wxNullBitmap);
-        bitmaps.push_back(*bitmap);
-
-#endif
-    }
-
-    return insert_bndl(name, bitmaps);
-}
-
-wxBitmapBundle* BitmapCache::insert_bndl(const std::string &bitmap_key, const char* data, size_t width, size_t height)
-{
-    wxBitmapBundle* bndl = nullptr;
-    auto it = m_bndl_map.find(bitmap_key);
-    if (it == m_bndl_map.end()) {
-        bndl = new wxBitmapBundle(wxBitmapBundle::FromSVG(data, wxSize(width, height)));
-        m_bndl_map[bitmap_key] = bndl;
-    }
-    else {
-        bndl = it->second;
-        *bndl = wxBitmapBundle::FromSVG(data, wxSize(width, height));
-    }
-    return bndl;
-}
-
-wxBitmapBundle* BitmapCache::insert_bndl(const std::string& bitmap_key, const wxBitmapBundle& bmp)
-{
-    wxBitmapBundle* bndl = nullptr;
-    auto it = m_bndl_map.find(bitmap_key);
-    if (it == m_bndl_map.end()) {
-        bndl = new wxBitmapBundle(bmp);
-        m_bndl_map[bitmap_key] = bndl;
-    }
-    else {
-        bndl = it->second;
-        *bndl = wxBitmapBundle(bmp);
-    }
-    return bndl;
-}
-
-wxBitmapBundle* BitmapCache::insert_bndl(const std::string& bitmap_key, const wxVector<wxBitmap>& bmps)
-{
-    wxBitmapBundle* bndl = nullptr;
-    auto it = m_bndl_map.find(bitmap_key);
-    if (it == m_bndl_map.end()) {
-        bndl = new wxBitmapBundle(wxBitmapBundle::FromBitmaps(bmps));
-        m_bndl_map[bitmap_key] = bndl;
-    }
-    else {
-        bndl = it->second;
-        *bndl = wxBitmapBundle::FromBitmaps(bmps);
-    }
-    return bndl;
-}
-
-wxBitmap* BitmapCache::insert(const std::string &bitmap_key, size_t width, size_t height, double scale/* = -1.0*/)
+wxBitmap* BitmapCache::insert(const std::string &bitmap_key, size_t width, size_t height)
 {
     wxBitmap *bitmap = nullptr;
     auto      it     = m_map.find(bitmap_key);
@@ -235,7 +76,7 @@ wxBitmap* BitmapCache::insert(const std::string &bitmap_key, size_t width, size_
         // So, We need to let the Mac OS wxBitmap implementation
         // know that the image may already be scaled appropriately for Retina,
         // and thereby that it's not supposed to upscale it.
-        bitmap->CreateScaled(width, height, -1, scale < 0.0 ? m_scale : scale);
+        bitmap->CreateScaled(width, height, -1, m_scale);
 #endif
         m_map[bitmap_key] = bitmap;
     } else {
@@ -262,6 +103,110 @@ wxBitmap* BitmapCache::insert(const std::string &bitmap_key, const wxBitmap &bmp
         *bitmap = bmp;
     }
     return bitmap;
+}
+
+wxBitmap* BitmapCache::insert(const std::string &bitmap_key, const wxBitmap &bmp, const wxBitmap &bmp2)
+{
+    // Copying the wxBitmaps is cheap as the bitmap's content is reference counted.
+    const wxBitmap bmps[2] = { bmp, bmp2 };
+    return this->insert(bitmap_key, bmps, bmps + 2);
+}
+
+wxBitmap* BitmapCache::insert(const std::string &bitmap_key, const wxBitmap &bmp, const wxBitmap &bmp2, const wxBitmap &bmp3)
+{
+    // Copying the wxBitmaps is cheap as the bitmap's content is reference counted.
+    const wxBitmap bmps[3] = { bmp, bmp2, bmp3 };
+    return this->insert(bitmap_key, bmps, bmps + 3);
+}
+
+wxBitmap* BitmapCache::insert(const std::string &bitmap_key, const wxBitmap *begin, const wxBitmap *end)
+{
+    size_t width  = 0;
+    size_t height = 0;
+    for (const wxBitmap *bmp = begin; bmp != end; ++ bmp) {
+#ifdef __APPLE__
+        width += bmp->GetScaledWidth();
+        height = std::max<size_t>(height, bmp->GetScaledHeight());
+#else
+        width += bmp->GetWidth();
+        height = std::max<size_t>(height, bmp->GetHeight());
+#endif
+    }
+
+#ifdef __WXGTK2__
+    // Broken alpha workaround
+    wxImage image(width, height);
+    image.InitAlpha();
+    // Fill in with a white color.
+    memset(image.GetData(), 0x0ff, width * height * 3);
+    // Fill in with full transparency.
+    memset(image.GetAlpha(),    0, width * height);
+    size_t x = 0;
+    for (const wxBitmap *bmp = begin; bmp != end; ++ bmp) {
+        if (bmp->GetWidth() > 0) {
+            if (bmp->GetDepth() == 32) {
+                wxAlphaPixelData data(*const_cast<wxBitmap*>(bmp));
+                //FIXME The following method is missing from wxWidgets 3.1.1.
+                // It looks like the wxWidgets 3.0.3 called the wrapped bitmap's UseAlpha().
+                //data.UseAlpha();
+                if (data) {
+                    for (int r = 0; r < bmp->GetHeight(); ++ r) {
+                        wxAlphaPixelData::Iterator src(data);
+                        src.Offset(data, 0, r);
+                        unsigned char *dst_pixels = image.GetData()  + (x + r * width) * 3;
+                        unsigned char *dst_alpha  = image.GetAlpha() +  x + r * width;
+                        for (int c = 0; c < bmp->GetWidth(); ++ c, ++ src) {
+                            *dst_pixels ++ = src.Red();
+                            *dst_pixels ++ = src.Green();
+                            *dst_pixels ++ = src.Blue();
+                            *dst_alpha  ++ = src.Alpha();
+                        }
+                    }
+                }
+            } else if (bmp->GetDepth() == 24) {
+                wxNativePixelData data(*const_cast<wxBitmap*>(bmp));
+                if (data) {
+                    for (int r = 0; r < bmp->GetHeight(); ++ r) {
+                        wxNativePixelData::Iterator src(data);
+                        src.Offset(data, 0, r);
+                        unsigned char *dst_pixels = image.GetData()  + (x + r * width) * 3;
+                        unsigned char *dst_alpha  = image.GetAlpha() +  x + r * width;
+                        for (int c = 0; c < bmp->GetWidth(); ++ c, ++ src) {
+                            *dst_pixels ++ = src.Red();
+                            *dst_pixels ++ = src.Green();
+                            *dst_pixels ++ = src.Blue();
+                            *dst_alpha  ++ = wxALPHA_OPAQUE;
+                        }
+                    }
+                }
+            }
+        }
+        x += bmp->GetWidth();
+    }
+    return this->insert(bitmap_key, wxImage_to_wxBitmap_with_alpha(std::move(image)));
+
+#else
+
+    wxBitmap *bitmap = this->insert(bitmap_key, width, height);
+    wxMemoryDC memDC;
+    memDC.SelectObject(*bitmap);
+    memDC.SetBackground(*wxTRANSPARENT_BRUSH);
+    memDC.Clear();
+    size_t x = 0;
+    for (const wxBitmap *bmp = begin; bmp != end; ++ bmp) {
+        if (bmp->GetWidth() > 0)
+            memDC.DrawBitmap(*bmp, x, 0, true);
+#ifdef __APPLE__
+        // we should "move" with step equal to non-scaled width
+        x += bmp->GetScaledWidth();
+#else
+        x += bmp->GetWidth();
+#endif 
+    }
+    memDC.SelectObject(wxNullBitmap);
+    return bitmap;
+
+#endif
 }
 
 wxBitmap* BitmapCache::insert_raw_rgba(const std::string &bitmap_key, unsigned width, unsigned height, const unsigned char *raw_data, const bool grayscale/* = false*/)
@@ -360,102 +305,7 @@ error:
     return NULL;
 }
 
-void BitmapCache::nsvgGetDataFromFileWithReplace(const char* filename, std::string& data_str, const std::map<std::string, std::string>& replaces)
-{
-    FILE* fp = NULL;
-    size_t size;
-    char* data = NULL;
-
-    fp = boost::nowide::fopen(filename, "rb");
-    if (!fp) goto error;
-    fseek(fp, 0, SEEK_END);
-    size = ftell(fp);
-    fseek(fp, 0, SEEK_SET);
-    data = (char*)malloc(size + 1);
-    if (data == NULL) goto error;
-    if (fread(data, 1, size, fp) != size) goto error;
-    data[size] = '\0';	// Must be null terminated.
-    fclose(fp);
-
-    data_str.assign(data);
-    for (auto val : replaces)
-        boost::replace_all(data_str, val.first, val.second);
-
-    free(data);
-    return;
-
-error:
-    if (fp) fclose(fp);
-    if (data) free(data);
-    return;
-}
-
-wxBitmapBundle* BitmapCache::from_svg(const std::string& bitmap_name, unsigned target_width, unsigned target_height,
-                                      const bool dark_mode, const std::string& new_color /*= ""*/)
-{
-    if (target_width == 0)
-        target_width = target_height;
-    std::string bitmap_key = bitmap_name + (target_height != 0 ?
-        "-h" + std::to_string(target_height) :
-        "-w" + std::to_string(target_width))
-        + (dark_mode ? "-dm" : "")
-        + new_color;
-
-    auto it = m_bndl_map.find(bitmap_key);
-    if (it != m_bndl_map.end())
-        return it->second;
-
-    // map of color replaces
-    //Orca: use replaces from load_svg function
-    std::map<std::string, std::string> replaces;
-    replaces["\"#0x00AE42\""] = "\"#009688\"";
-    replaces["\"#00FF00\""] = "\"#52c7b8\"";
-    if (dark_mode) {
-        replaces["\"#262E30\""] = "\"#EFEFF0\"";
-        replaces["\"#323A3D\""] = "\"#B3B3B5\"";
-        replaces["\"#808080\""] = "\"#818183\"";
-        replaces["\"#CECECE\""] = "\"#54545B\"";
-        replaces["\"#6B6B6B\""] = "\"#818182\"";
-        replaces["\"#909090\""] = "\"#FFFFFF\"";
-        replaces["\"#00FF00\""] = "\"#FF0000\"";
-        replaces["\"#009688\""] = "\"#00675b\"";
-    }
-
-    std::string str;
-    nsvgGetDataFromFileWithReplace(Slic3r::var(bitmap_name + ".svg").c_str(), str, replaces);
-    if (str.empty())
-        return nullptr;
-
-    return insert_bndl(bitmap_key, str.data(), target_width, target_height);
-}
-
-wxBitmapBundle* BitmapCache::from_png(const std::string& bitmap_name, unsigned width, unsigned height)
-{
-    std::string bitmap_key = bitmap_name + (height != 0 ?
-        "-h" + std::to_string(height) :
-        "-w" + std::to_string(width));
-
-    auto it = m_bndl_map.find(bitmap_key);
-    if (it != m_bndl_map.end())
-        return it->second;
-
-    wxImage image;
-    if (!image.LoadFile(Slic3r::GUI::from_u8(Slic3r::var(bitmap_name + ".png")), wxBITMAP_TYPE_PNG) ||
-        image.GetWidth() == 0 || image.GetHeight() == 0)
-        return nullptr;
-
-    if (height != 0 && unsigned(image.GetHeight()) != height)
-        width = unsigned(0.5f + float(image.GetWidth()) * height / image.GetHeight());
-    else if (width != 0 && unsigned(image.GetWidth()) != width)
-        height = unsigned(0.5f + float(image.GetHeight()) * width / image.GetWidth());
-
-    if (height != 0 && width != 0)
-        image.Rescale(width, height, wxIMAGE_QUALITY_BILINEAR);
-
-    return this->insert_bndl(bitmap_key, wxImage_to_wxBitmap_with_alpha(std::move(image)));
-}
-
-wxBitmap* BitmapCache::load_svg(const std::string &bitmap_name, unsigned target_width, unsigned target_height,
+wxBitmap* BitmapCache::load_svg(const std::string &bitmap_name, unsigned target_width, unsigned target_height, 
     const bool grayscale/* = false*/, const bool dark_mode/* = false*/, const std::string& new_color /*= ""*/, const float scale_in_center/* = 0*/)
 {
     std::string bitmap_key = bitmap_name + ( target_height !=0 ? 
@@ -472,7 +322,7 @@ wxBitmap* BitmapCache::load_svg(const std::string &bitmap_name, unsigned target_
 
     // map of color replaces
     std::map<std::string, std::string> replaces;
-    replaces["\"#0x00AE42\""] = "\"#009688\"";
+replaces["\"#0x00AE42\""] = "\"#009688\"";
     replaces["\"#00FF00\""] = "\"#52c7b8\"";
     if (dark_mode) {
         replaces["\"#262E30\""] = "\"#EFEFF0\"";
@@ -483,7 +333,7 @@ wxBitmap* BitmapCache::load_svg(const std::string &bitmap_name, unsigned target_
         replaces["\"#6B6B6B\""] = "\"#818182\"";
         replaces["\"#909090\""] = "\"#FFFFFF\"";
         replaces["\"#00FF00\""] = "\"#FF0000\"";
-        replaces["\"#009688\""] = "\"#00675b\"";
+replaces["\"#009688\""] = "\"#00675b\"";
     }
     //if (!new_color.empty())
     //    replaces["\"#ED6B21\""] = "\"" + new_color + "\"";
@@ -536,9 +386,9 @@ wxBitmap* BitmapCache::load_svg(const std::string &bitmap_name, unsigned target_
 
     return this->insert_raw_rgba(bitmap_key, width, height, data.data(), grayscale);
 }
-/*
+
 //we make scaled solid bitmaps only for the cases, when its will be used with scaled SVG icon in one output bitmap
-wxBitmap BitmapCache::mksolid(size_t width, size_t height, unsigned char r, unsigned char g, unsigned char b, unsigned char transparency, bool suppress_scaling/* = false* /, size_t border_width /*= 0* /, bool dark_mode/* = false* /)
+wxBitmap BitmapCache::mksolid(size_t width, size_t height, unsigned char r, unsigned char g, unsigned char b, unsigned char transparency, bool suppress_scaling/* = false*/, size_t border_width /*= 0*/, bool dark_mode/* = false*/)
 {
     double scale = suppress_scaling ? 1.0f : m_scale;
     width  *= scale;
@@ -579,89 +429,6 @@ wxBitmap BitmapCache::mksolid(size_t width, size_t height, unsigned char r, unsi
     }
 
     return wxImage_to_wxBitmap_with_alpha(std::move(image), scale);
-}
-*/
-//we make scaled solid bitmaps only for the cases, when its will be used with scaled SVG icon in one output bitmap
-wxBitmapBundle BitmapCache::mksolid(size_t width_in, size_t height_in, unsigned char r, unsigned char g, unsigned char b, unsigned char transparency, size_t border_width /*= 0*/, bool dark_mode/* = false*/)
-{
-    wxVector<wxBitmap> bitmaps;
-
-    std::set<double> scales = { 1.0 };
-#ifndef __linux__
-
-#ifdef __APPLE__
-    scales.emplace(m_scale);
-#else
-    size_t disp_cnt = wxDisplay::GetCount();
-    for (size_t disp = 0; disp < disp_cnt; ++disp)
-        scales.emplace(wxDisplay(disp).GetScaleFactor());
-#endif
-
-#endif // !__linux__
-
-    for (double scale : scales) {
-        size_t width = width_in * scale;
-        size_t height = height_in * scale;
-
-        wxImage image(width, height);
-        image.InitAlpha();
-        unsigned char* imgdata = image.GetData();
-        unsigned char* imgalpha = image.GetAlpha();
-        for (size_t i = 0; i < width * height; ++i) {
-            *imgdata++ = r;
-            *imgdata++ = g;
-            *imgdata++ = b;
-            *imgalpha++ = transparency;
-        }
-
-        // Add border, make white/light spools easier to see
-        if (border_width > 0) {
-
-            // Restrict to width of image
-            if (border_width > height) border_width = height - 1;
-            if (border_width > width) border_width = width - 1;
-
-            auto px_data = (uint8_t*)image.GetData();
-            auto a_data = (uint8_t*)image.GetAlpha();
-
-            for (size_t x = 0; x < width; ++x) {
-                for (size_t y = 0; y < height; ++y) {
-                    if (x < border_width || y < border_width ||
-                        x >= (width - border_width) || y >= (height - border_width)) {
-                        const size_t idx = (x + y * width);
-                        const size_t idx_rgb = (x + y * width) * 3;
-                        px_data[idx_rgb] = px_data[idx_rgb + 1] = px_data[idx_rgb + 2] = dark_mode ? 245u : 110u;
-                        a_data[idx] = 255u;
-                    }
-                }
-            }
-        }
-
-        bitmaps.push_back(wxImage_to_wxBitmap_with_alpha(std::move(image), scale));
-    }
-    return wxBitmapBundle::FromBitmaps(bitmaps);
-}
-
-wxBitmapBundle* BitmapCache::mksolid_bndl(size_t width, size_t height, const std::string& color, size_t border_width, bool dark_mode)
-{
-    std::string bitmap_key = (color.empty() ? "empty" : color) + "-h" + std::to_string(height) + "-w" + std::to_string(width) + (dark_mode ? "-dm" : "");
-
-    wxBitmapBundle* bndl = nullptr;
-    auto it = m_bndl_map.find(bitmap_key);
-    if (it == m_bndl_map.end()) {
-        if (color.empty())
-            bndl = new wxBitmapBundle(mksolid(width, height, 0, 0, 0, wxALPHA_TRANSPARENT, size_t(0)));
-        else {
-            ColorRGB rgb;// [3]
-            decode_color(color, rgb);
-            bndl = new wxBitmapBundle(mksolid(width, height, rgb.r_uchar(), rgb.g_uchar(), rgb.b_uchar(), wxALPHA_OPAQUE, border_width, dark_mode));
-        }
-        m_bndl_map[bitmap_key] = bndl;
-    }
-    else
-        return it->second;
-
-    return bndl;
 }
 
 bool BitmapCache::parse_color(const std::string& scolor, unsigned char* rgb_out)

--- a/src/slic3r/GUI/BitmapCache.hpp
+++ b/src/slic3r/GUI/BitmapCache.hpp
@@ -12,8 +12,7 @@
 #include "libslic3r/Color.hpp"
 struct NSVGimage;
 
-namespace Slic3r {
-namespace GUI {
+namespace Slic3r { namespace GUI {
 
 class BitmapCache
 {
@@ -23,23 +22,15 @@ public:
 	void 			clear();
 	double			scale() { return m_scale; }
 
-	wxBitmapBundle* 	  find_bndl(const std::string &name)		{ auto it = m_bndl_map.find(name); return (it == m_bndl_map.end()) ? nullptr : it->second; }
-	const wxBitmapBundle* find_bndl(const std::string &name) const	{ return const_cast<BitmapCache*>(this)->find_bndl(name); }
 	wxBitmap* 		find(const std::string &name) 		{ auto it = m_map.find(name); return (it == m_map.end()) ? nullptr : it->second; }
 	const wxBitmap* find(const std::string &name) const { return const_cast<BitmapCache*>(this)->find(name); }
 
-	wxBitmapBundle*			insert_bndl(const std::string& bitmap_key, const char* data, size_t width, size_t height);
-	wxBitmapBundle* 		insert_bndl(const std::string& bitmap_key, const wxBitmapBundle &bmp);
-	wxBitmapBundle*			insert_bndl(const std::string& bitmap_key, const wxVector<wxBitmap>& bmps);
-	wxBitmapBundle*			insert_bndl(const std::string& name, const std::vector<wxBitmapBundle*>& bmps);
-	wxBitmapBundle* 		insert_raw_rgba_bndl(const std::string &bitmap_key, unsigned width, unsigned height, const unsigned char *raw_data, const bool grayscale = false);
-
-	wxBitmap*       insert(const std::string &name, size_t width, size_t height, double scale = -1.0);
+	wxBitmap*       insert(const std::string &name, size_t width, size_t height);
 	wxBitmap* 		insert(const std::string &name, const wxBitmap &bmp);
-//    wxBitmap* 		insert(const std::string &name, const wxBitmap &bmp, const wxBitmap &bmp2);
-//    wxBitmap* 		insert(const std::string &name, const wxBitmap &bmp, const wxBitmap &bmp2, const wxBitmap &bmp3);
-//    wxBitmap* 		insert(const std::string &name, const std::vector<wxBitmap> &bmps) { return this->insert(name, &bmps.front(), &bmps.front() + bmps.size()); }
-//    wxBitmap* 		insert(const std::string &name, const wxBitmap *begin, const wxBitmap *end);
+	wxBitmap* 		insert(const std::string &name, const wxBitmap &bmp, const wxBitmap &bmp2);
+	wxBitmap* 		insert(const std::string &name, const wxBitmap &bmp, const wxBitmap &bmp2, const wxBitmap &bmp3);
+	wxBitmap* 		insert(const std::string &name, const std::vector<wxBitmap> &bmps) { return this->insert(name, &bmps.front(), &bmps.front() + bmps.size()); }
+	wxBitmap* 		insert(const std::string &name, const wxBitmap *begin, const wxBitmap *end);
 	wxBitmap* 		insert_raw_rgba(const std::string &bitmap_key, unsigned width, unsigned height, const unsigned char *raw_data, const bool grayscale = false);
 
 	// BBS: support resize by fill border  (scale_in_center)
@@ -50,28 +41,19 @@ public:
 	// And makes replases befor parsing
 	// replace_map containes old_value->new_value
 	static NSVGimage* nsvgParseFromFileWithReplace(const char* filename, const char* units, float dpi, const std::map<std::string, std::string>& replaces);
-	// Gets a data from SVG file and makes replases
-	// replace_map containes old_value->new_value
-    static void		nsvgGetDataFromFileWithReplace(const char* filename, std::string& data_str, const std::map<std::string, std::string>& replaces);
-	wxBitmapBundle* from_svg(const std::string& bitmap_name, unsigned target_width, unsigned target_height, const bool dark_mode, const std::string& new_color = "");
-	wxBitmapBundle* from_png(const std::string& bitmap_name, unsigned width, unsigned height);
 	// Load svg from resources/icons. bitmap_key is given without the .svg suffix. SVG will be rasterized to provided height/width.
     wxBitmap* 		load_svg(const std::string &bitmap_key, unsigned width = 0, unsigned height = 0, const bool grayscale = false, const bool dark_mode = false, const std::string& new_color = "", const float scale_in_center = 0.f);
 
-//	wxBitmap 		mksolid(size_t width, size_t height, unsigned char r, unsigned char g, unsigned char b, unsigned char transparency, bool suppress_scaling = false, size_t border_width = 0, bool dark_mode = false);
-//	wxBitmap 		mksolid(size_t width, size_t height, const unsigned char rgb[3], bool suppress_scaling = false, size_t border_width = 0, bool dark_mode = false) { return mksolid(width, height, rgb[0], rgb[1], rgb[2], wxALPHA_OPAQUE, suppress_scaling, border_width, dark_mode); }
-//	wxBitmap 		mksolid(size_t width, size_t height, const ColorRGB& rgb, bool suppress_scaling = false, size_t border_width = 0, bool dark_mode = false) { return mksolid(width, height, rgb.r_uchar(), rgb.g_uchar(), rgb.b_uchar(), wxALPHA_OPAQUE, suppress_scaling, border_width, dark_mode); }
-//	wxBitmap 		mkclear(size_t width, size_t height) { return mksolid(width, height, 0, 0, 0, wxALPHA_TRANSPARENT, true, 0); }
-	wxBitmapBundle	mksolid(size_t width, size_t height, unsigned char r, unsigned char g, unsigned char b, unsigned char transparency, size_t border_width = 0, bool dark_mode = false);
-	wxBitmapBundle*	mksolid_bndl(size_t width, size_t height, const std::string& color = std::string(), size_t border_width = 0, bool dark_mode = false);
-	wxBitmapBundle* mkclear_bndl(size_t width, size_t height) { return 	mksolid_bndl(width, height); }
+	wxBitmap 		mksolid(size_t width, size_t height, unsigned char r, unsigned char g, unsigned char b, unsigned char transparency, bool suppress_scaling = false, size_t border_width = 0, bool dark_mode = false);
+	wxBitmap 		mksolid(size_t width, size_t height, const unsigned char rgb[3], bool suppress_scaling = false, size_t border_width = 0, bool dark_mode = false) { return mksolid(width, height, rgb[0], rgb[1], rgb[2], wxALPHA_OPAQUE, suppress_scaling, border_width, dark_mode); }
+	wxBitmap 		mksolid(size_t width, size_t height, const ColorRGB& rgb, bool suppress_scaling = false, size_t border_width = 0, bool dark_mode = false) { return mksolid(width, height, rgb.r_uchar(), rgb.g_uchar(), rgb.b_uchar(), wxALPHA_OPAQUE, suppress_scaling, border_width, dark_mode); }
+	wxBitmap 		mkclear(size_t width, size_t height) { return mksolid(width, height, 0, 0, 0, wxALPHA_TRANSPARENT); }
 
 	static bool     parse_color(const std::string& scolor, unsigned char* rgb_out);
 	static bool     parse_color4(const std::string& scolor, unsigned char* rgba_out);
 
 private:
     std::map<std::string, wxBitmap*>	m_map;
-    std::map<std::string, wxBitmapBundle*>	m_bndl_map;
     double	m_gs	= 0.2;	// value, used for image.ConvertToGreyscale(m_gs, m_gs, m_gs)
 	double	m_scale = 1.0;	// value, used for correct scaling of SVG icons on Retina display
 };

--- a/src/slic3r/GUI/BitmapComboBox.hpp
+++ b/src/slic3r/GUI/BitmapComboBox.hpp
@@ -29,12 +29,27 @@ BitmapComboBox(wxWindow* parent,
 #ifdef _WIN32
     int Append(const wxString& item);
 #endif
-    int Append(const wxString& item, const wxBitmapBundle& bitmap)
+    int Append(const wxString& item, const wxBitmap& bitmap)
     {
         return wxBitmapComboBox::Append(item, bitmap);
     }
 
 protected:
+
+#ifdef __APPLE__
+/* For PresetComboBox we use bitmaps that are created from images that are already scaled appropriately for Retina
+ * (Contrary to the intuition, the `scale` argument for Bitmap's constructor doesn't mean
+ * "please scale this to such and such" but rather
+ * "the wxImage is already sized for backing scale such and such". )
+ * Unfortunately, the constructor changes the size of wxBitmap too.
+ * Thus We need to use unscaled size value for bitmaps that we use
+ * to avoid scaled size of control items.
+ * For this purpose control drawing methods and
+ * control size calculation methods (virtual) are overridden.
+ **/
+bool OnAddBitmap(const wxBitmap& bitmap) override;
+void OnDrawItem(wxDC& dc, const wxRect& rect, int item, int flags) const override;
+#endif
 
 #ifdef _WIN32
 bool MSWOnDraw(WXDRAWITEMSTRUCT* item) override;

--- a/src/slic3r/GUI/CalibrationPanel.cpp
+++ b/src/slic3r/GUI/CalibrationPanel.cpp
@@ -102,9 +102,9 @@ void MObjectPanel::doRender(wxDC& dc)
     if (m_state == PrinterState::IN_LAN) { dwbitmap = m_printer_in_lan; }
 
     // dc.DrawCircle(left, size.y / 2, 3);
-    dc.DrawBitmap(dwbitmap.get_bitmap(), wxPoint(left, (size.y - dwbitmap.GetSize().y) / 2));
+    dc.DrawBitmap(dwbitmap.bmp(), wxPoint(left, (size.y - dwbitmap.GetBmpSize().y) / 2));
 
-    left += dwbitmap.GetSize().x + 8;
+    left += dwbitmap.GetBmpSize().x + 8;
     dc.SetFont(Label::Body_13);
     dc.SetBackgroundMode(wxTRANSPARENT);
     dc.SetTextForeground(StateColor::darkModeColorFor(SELECT_MACHINE_GREY900));

--- a/src/slic3r/GUI/CalibrationWizardPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPage.cpp
@@ -371,7 +371,7 @@ CaliPageCaption::CaliPageCaption(wxWindow* parent, CalibMode cali_mode,
     auto top_sizer = new wxBoxSizer(wxVERTICAL);
     auto caption_sizer = new wxBoxSizer(wxHORIZONTAL);
     m_prev_btn = new ScalableButton(this, wxID_ANY, "cali_page_caption_prev",
-        wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, 30);
+        wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, true, 30);
     m_prev_btn->SetBackgroundColour(*wxWHITE);
     caption_sizer->Add(m_prev_btn, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(10));
 
@@ -382,7 +382,7 @@ CaliPageCaption::CaliPageCaption(wxWindow* parent, CalibMode cali_mode,
     caption_sizer->Add(title_text, 0, wxALIGN_CENTER | wxRIGHT, FromDIP(10));
 
     m_help_btn = new ScalableButton(this, wxID_ANY, "cali_page_caption_help",
-        wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, 30);
+        wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, true, 30);
     m_help_btn->Hide();
     m_help_btn->SetBackgroundColour(*wxWHITE);
     caption_sizer->Add(m_help_btn, 0, wxALIGN_CENTER);
@@ -472,12 +472,12 @@ void CaliPageCaption::show_help_icon(bool show)
 
 void CaliPageCaption::on_sys_color_changed()
 {
-    m_prev_btn->sys_color_changed();
+    m_prev_btn->msw_rescale();
 }
 
 void CaliPageCaption::msw_rescale()
 {
-    m_prev_btn->sys_color_changed();
+    m_prev_btn->msw_rescale();
 }
 
 CaliPageStepGuide::CaliPageStepGuide(wxWindow* parent, wxArrayString steps,
@@ -593,7 +593,7 @@ PAPageHelpPanel::PAPageHelpPanel(wxWindow* parent, bool ground_panel, wxWindowID
     wxBoxSizer* help_text_sizer = new wxBoxSizer(wxHORIZONTAL);
     auto help_text = new Label(this, _L("You could change the Flow Dynamics Calibration Factor in material editing"));
     help_text->SetFont(Label::Body_14);
-    m_help_btn = new ScalableButton(this, wxID_ANY, "cali_page_caption_help", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, 24);
+    m_help_btn = new ScalableButton(this, wxID_ANY, "cali_page_caption_help", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, false, 24);
     m_help_btn->SetBackgroundColour(m_help_btn->GetParent()->GetBackgroundColour());
     help_text_sizer->Add(help_text, 0, wxALIGN_CENTER | wxLEFT, left_align_padding);
     help_text_sizer->Add(m_help_btn, 0, wxALIGN_CENTER | wxLEFT, FromDIP(8));
@@ -611,8 +611,8 @@ PAPageHelpPanel::PAPageHelpPanel(wxWindow* parent, bool ground_panel, wxWindowID
 
 void PAPageHelpPanel::msw_rescale()
 {
-    m_help_btn->sys_color_changed();
-    m_bmp.sys_color_changed();
+    m_help_btn->msw_rescale();
+    m_bmp.msw_rescale();
     m_img->SetBitmap(m_bmp.bmp());
 }
 

--- a/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
@@ -448,7 +448,7 @@ CalibrationPresetPage::CalibrationPresetPage(
 void CalibrationPresetPage::msw_rescale()
 {
     CalibrationWizardPage::msw_rescale();
-    m_ams_sync_button->sys_color_changed();
+    m_ams_sync_button->msw_rescale();
     m_virtual_tray_comboBox->msw_rescale();
     for (auto& comboBox : m_filament_comboBox_list) {
         comboBox->msw_rescale();
@@ -458,7 +458,7 @@ void CalibrationPresetPage::msw_rescale()
 void CalibrationPresetPage::on_sys_color_changed()
 {
     CalibrationWizardPage::on_sys_color_changed();
-    m_ams_sync_button->sys_color_changed();
+    m_ams_sync_button->msw_rescale();
 }
 
 void CalibrationPresetPage::create_selection_panel(wxWindow* parent)
@@ -507,7 +507,7 @@ void CalibrationPresetPage::create_selection_panel(wxWindow* parent)
     filament_for_text->SetFont(Label::Head_14);
     filament_for_title_sizer->Add(filament_for_text, 0, wxALIGN_CENTER);
     filament_for_title_sizer->AddSpacer(FromDIP(25));
-    m_ams_sync_button = new ScalableButton(parent, wxID_ANY, "ams_fila_sync", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, 18);
+    m_ams_sync_button = new ScalableButton(parent, wxID_ANY, "ams_fila_sync", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, false, 18);
     m_ams_sync_button->SetBackgroundColour(*wxWHITE);
     m_ams_sync_button->SetToolTip(_L("Synchronize filament list from AMS"));
     filament_for_title_sizer->Add(m_ams_sync_button, 0, wxALIGN_CENTER);

--- a/src/slic3r/GUI/CameraPopup.cpp
+++ b/src/slic3r/GUI/CameraPopup.cpp
@@ -470,8 +470,8 @@ CameraItem::CameraItem(wxWindow *parent, std::string normal, std::string hover)
 CameraItem::~CameraItem() {}
 
 void CameraItem::msw_rescale() {
-    m_bitmap_normal.sys_color_changed();
-    m_bitmap_hover.sys_color_changed();
+    m_bitmap_normal.msw_rescale();
+    m_bitmap_hover.msw_rescale();
 }
 
 void CameraItem::on_enter_win(wxMouseEvent &evt)
@@ -519,9 +519,9 @@ void CameraItem::render(wxDC &dc)
 void CameraItem::doRender(wxDC &dc)
 {
     if (m_hover) {
-        dc.DrawBitmap(m_bitmap_hover.get_bitmap(), wxPoint((GetSize().x - m_bitmap_hover.GetSize().x) / 2, (GetSize().y - m_bitmap_hover.GetSize().y) / 2));
+        dc.DrawBitmap(m_bitmap_hover.bmp(), wxPoint((GetSize().x - m_bitmap_hover.GetBmpSize().x) / 2, (GetSize().y - m_bitmap_hover.GetBmpSize().y) / 2));
     } else {
-        dc.DrawBitmap(m_bitmap_normal.get_bitmap(), wxPoint((GetSize().x - m_bitmap_normal.GetSize().x) / 2, (GetSize().y - m_bitmap_normal.GetSize().y) / 2));
+        dc.DrawBitmap(m_bitmap_normal.bmp(), wxPoint((GetSize().x - m_bitmap_normal.GetBmpSize().x) / 2, (GetSize().y - m_bitmap_normal.GetBmpSize().y) / 2));
     }
 }
 

--- a/src/slic3r/GUI/ConfigWizard.cpp
+++ b/src/slic3r/GUI/ConfigWizard.cpp
@@ -1499,7 +1499,7 @@ ConfigWizardIndex::ConfigWizardIndex(wxWindow *parent)
 #ifndef __WXOSX__ 
     SetDoubleBuffered(true);// SetDoubleBuffered exists on Win and Linux/GTK, but is missing on OSX
 #endif //__WXOSX__
-    SetMinSize(bg.GetSize());
+    SetMinSize(bg.bmp().GetSize());
 
     const wxSize size = GetTextExtent("m");
     em_w = size.x;
@@ -1626,8 +1626,8 @@ void ConfigWizardIndex::on_paint(wxPaintEvent & evt)
    
     wxPaintDC dc(this);
     
-    const auto bullet_w = bullet_black.GetWidth();
-    const auto bullet_h = bullet_black.GetHeight();
+    const auto bullet_w = bullet_black.bmp().GetSize().GetWidth();
+    const auto bullet_h = bullet_black.bmp().GetSize().GetHeight();
     const int yoff_icon = bullet_h < em_h ? (em_h - bullet_h) / 2 : 0;
     const int yoff_text = bullet_h > em_h ? (bullet_h - em_h) / 2 : 0;
     const int yinc = item_height();
@@ -1640,10 +1640,10 @@ void ConfigWizardIndex::on_paint(wxPaintEvent & evt)
         unsigned x = em_w/2 + item.indent * em_w;
 
         if (i == item_active || (item_hover >= 0 && i == (size_t)item_hover)) {
-            dc.DrawBitmap(bullet_blue.get_bitmap(), x, y + yoff_icon, false);
+            dc.DrawBitmap(bullet_blue.bmp(), x, y + yoff_icon, false);
         }
-        else if (i < item_active)  { dc.DrawBitmap(bullet_black.get_bitmap(), x, y + yoff_icon, false); }
-        else if (i > item_active)  { dc.DrawBitmap(bullet_white.get_bitmap(), x, y + yoff_icon, false); }
+        else if (i < item_active)  { dc.DrawBitmap(bullet_black.bmp(), x, y + yoff_icon, false); }
+        else if (i > item_active)  { dc.DrawBitmap(bullet_white.bmp(), x, y + yoff_icon, false); }
 
         x += + bullet_w + em_w/2;
         const auto text_size = dc.GetTextExtent(item.label);
@@ -1655,9 +1655,9 @@ void ConfigWizardIndex::on_paint(wxPaintEvent & evt)
     }
     
     //draw logo
-    if (int y = size.y - bg.GetHeight(); y>=0) {
-        dc.DrawBitmap(bg.get_bitmap(), 0, y, false);
-        index_width = std::max(index_width, bg.GetWidth() + em_w / 2);
+    if (int y = size.y - bg.GetBmpHeight(); y>=0) {
+        dc.DrawBitmap(bg.bmp(), 0, y, false);
+        index_width = std::max(index_width, bg.GetBmpWidth() + em_w / 2);
     }
 
     if (GetMinSize().x < index_width) {
@@ -1689,12 +1689,12 @@ void ConfigWizardIndex::msw_rescale()
     em_w = size.x;
     em_h = size.y;
 
-    bg.sys_color_changed();
-    SetMinSize(bg.GetSize());
+    bg.msw_rescale();
+    SetMinSize(bg.bmp().GetSize());
 
-    bullet_black.sys_color_changed();
-    bullet_blue.sys_color_changed();
-    bullet_white.sys_color_changed();
+    bullet_black.msw_rescale();
+    bullet_blue.msw_rescale();
+    bullet_white.msw_rescale();
     Refresh();
 }
 

--- a/src/slic3r/GUI/ConfigWizard_private.hpp
+++ b/src/slic3r/GUI/ConfigWizard_private.hpp
@@ -510,7 +510,7 @@ private:
     ssize_t item_hover;
     size_t last_page;
 
-    int item_height() const { return std::max(bullet_black.GetHeight(), em_w) + em_w; }
+    int item_height() const { return std::max(bullet_black.bmp().GetSize().GetHeight(), em_w) + em_w; }
 
     void on_paint(wxPaintEvent &evt);
     void on_mouse_move(wxMouseEvent &evt);

--- a/src/slic3r/GUI/DragCanvas.cpp
+++ b/src/slic3r/GUI/DragCanvas.cpp
@@ -46,8 +46,8 @@ void DragCanvas::set_shape_list(const std::vector<std::string>& colors, const st
     m_dragshape_list.clear();
 
     for (int i = 0; i < order.size(); i++) {
-        wxBitmap bmp = get_extruder_color_icon(colors[order[i] - 1], std::to_string(order[i]), SHAPE_SIZE, SHAPE_SIZE)->GetBitmapFor(m_parent);
-        DragShape* shape = new DragShape(bmp, order[i]);
+        wxBitmap* bmp = get_extruder_color_icon(colors[order[i] - 1], std::to_string(order[i]), SHAPE_SIZE, SHAPE_SIZE);
+        DragShape* shape = new DragShape(*bmp, order[i]);
         m_dragshape_list.push_back(shape);
     }
 

--- a/src/slic3r/GUI/ExtraRenderers.cpp
+++ b/src/slic3r/GUI/ExtraRenderers.cpp
@@ -33,15 +33,6 @@ wxIMPLEMENT_DYNAMIC_CLASS(DataViewBitmapText, wxObject)
 
 IMPLEMENT_VARIANT_OBJECT(DataViewBitmapText)
 
-static wxSize get_size(const wxBitmap& icon)
-{
-#ifdef __WIN32__
-    return icon.GetSize();
-#else
-    return icon.GetScaledSize();
-#endif
-}
-
 // ---------------------------------------------------------
 // BitmapTextRenderer
 // ---------------------------------------------------------
@@ -133,7 +124,11 @@ bool BitmapTextRenderer::Render(wxRect rect, wxDC *dc, int state)
     const wxBitmap& icon = m_value.GetBitmap();
     if (icon.IsOk())
     {
-        wxSize icon_sz = get_size(icon);
+#ifdef __APPLE__
+        wxSize icon_sz = icon.GetScaledSize();
+#else
+        wxSize icon_sz = icon.GetSize();
+#endif
         dc->DrawBitmap(icon, rect.x, rect.y + (rect.height - icon_sz.y) / 2);
         xoffset = icon_sz.x + 4;
     }
@@ -275,12 +270,11 @@ bool BitmapChoiceRenderer::Render(wxRect rect, wxDC* dc, int state)
     const wxBitmap& icon = m_value.GetBitmap();
     if (icon.IsOk())
     {
-        wxSize icon_sz = get_size(icon);
-        dc->DrawBitmap(icon, rect.x, rect.y + (rect.height - icon_sz.GetHeight()) / 2);
-//        xoffset = icon_sz.GetWidth() + 4;
+        dc->DrawBitmap(icon, rect.x, rect.y + (rect.height - icon.GetHeight()) / 2);
+//        xoffset = icon.GetWidth() + 4;
 
         if (rect.height == 0)
-          rect.height = icon_sz.GetHeight();
+          rect.height = icon.GetHeight();
     }
 
 #ifdef _WIN32
@@ -311,7 +305,7 @@ wxWindow* BitmapChoiceRenderer::CreateEditorCtrl(wxWindow* parent, wxRect labelR
     if (can_create_editor_ctrl && !can_create_editor_ctrl())
         return nullptr;
 
-    std::vector<wxBitmapBundle*> icons = get_extruder_color_icons();
+    std::vector<wxBitmap*> icons = get_extruder_color_icons();
     if (icons.empty())
         return nullptr;
 

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -1127,7 +1127,7 @@ void Choice::BUILD()
                 auto icon_name = "param_" + m_opt.enum_values[i];
                 if (boost::filesystem::exists(image_path / (icon_name + ".svg"))) {
                     ScalableBitmap bm(temp, icon_name, 24);
-				    temp->Append(_(el), bm.get_bitmap());
+				    temp->Append(_(el), bm.bmp());
                 } else {
                     temp->Append(_(el));
                 }
@@ -1529,7 +1529,7 @@ void Choice::msw_rescale()
             auto icon_name = "param_" + m_opt.enum_values[i];
             if (boost::filesystem::exists(image_path / (icon_name + ".svg"))) {
                 ScalableBitmap bm(window, icon_name, 24);
-                temp->SetItemBitmap(i, bm.get_bitmap());
+                temp->SetItemBitmap(i, bm.bmp());
             }
             ++i;
         }

--- a/src/slic3r/GUI/GLTexture.cpp
+++ b/src/slic3r/GUI/GLTexture.cpp
@@ -28,8 +28,8 @@
 #define STB_DXT_IMPLEMENTATION
 #include "stb_dxt/stb_dxt.h"
 
-#include <nanosvg/nanosvg.h>
-#include <nanosvg/nanosvgrast.h>
+#include "nanosvg/nanosvg.h"
+#include "nanosvg/nanosvgrast.h"
 
 #include "libslic3r/Utils.hpp"
 #include "GUI_App.hpp"

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -369,7 +369,7 @@ public:
         // See https://github.com/wxWidgets/wxWidgets/blob/master/src/msw/font.cpp
         // void wxNativeFontInfo::SetFractionalPointSize(float pointSizeNew)
         wxNativeFontInfo nfi= *font.GetNativeFontInfo();
-        float pointSizeNew  = wxDisplay(this).GetScaleFactor() * scale * font.GetPointSize();
+        float pointSizeNew  = scale * font.GetPointSize();
         nfi.lf.lfHeight     = nfi.GetLogFontHeightAtPPI(pointSizeNew, get_dpi_for_window(this));
         nfi.pointSize       = pointSizeNew;
         font = wxFont(nfi);

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -267,12 +267,13 @@ std::map<std::string, std::string> SettingsFactory::CATEGORY_ICON =
     // BBS: remove SLA categories
 };
 
-wxBitmapBundle* SettingsFactory::get_category_bitmap(const std::string& category_name)
+wxBitmap SettingsFactory::get_category_bitmap(const std::string& category_name, bool menu_bmp)
 {
     if (CATEGORY_ICON.find(category_name) == CATEGORY_ICON.end())
-        return get_bmp_bundle("empty");
-    return get_bmp_bundle(CATEGORY_ICON.at(category_name));
+        return wxNullBitmap;
+    return create_scaled_bitmap(CATEGORY_ICON.at(category_name));
 }
+
 
 //-------------------------------------
 //            MenuFactory
@@ -434,30 +435,31 @@ static void create_freq_settings_popupmenu(wxMenu* menu, const bool is_object_se
     }
 }
 
-std::vector<wxBitmapBundle*> MenuFactory::get_volume_bitmaps()
+std::vector<wxBitmap> MenuFactory::get_volume_bitmaps()
 {
-    std::vector<wxBitmapBundle*> volume_bmps;
+    std::vector<wxBitmap> volume_bmps;
     volume_bmps.reserve(ADD_VOLUME_MENU_ITEMS.size());
-    for (const auto& item : ADD_VOLUME_MENU_ITEMS)
-        volume_bmps.push_back(get_bmp_bundle(item.second));
+    for (const auto& item : ADD_VOLUME_MENU_ITEMS) {
+        volume_bmps.push_back(create_scaled_bitmap(item.second));
+    }
     return volume_bmps;
 }
 
-std::vector<wxBitmapBundle*> MenuFactory::get_text_volume_bitmaps()
+std::vector<wxBitmap> MenuFactory::get_text_volume_bitmaps()
 {
-    std::vector<wxBitmapBundle*> volume_bmps;
+    std::vector<wxBitmap> volume_bmps;
     volume_bmps.reserve(TEXT_VOLUME_ICONS.size());
     for (const auto& item : TEXT_VOLUME_ICONS)
-        volume_bmps.push_back(get_bmp_bundle(item.second));
+        volume_bmps.push_back(create_scaled_bitmap(item.second));
     return volume_bmps;
 }
 
-std::vector<wxBitmapBundle*> MenuFactory::get_svg_volume_bitmaps()
+std::vector<wxBitmap> MenuFactory::get_svg_volume_bitmaps()
 {
-    std::vector<wxBitmapBundle *> volume_bmps;
+    std::vector<wxBitmap> volume_bmps;
     volume_bmps.reserve(SVG_VOLUME_ICONS.size());
     for (const auto &item : SVG_VOLUME_ICONS)
-        volume_bmps.push_back(get_bmp_bundle(item.second));
+        volume_bmps.push_back(create_scaled_bitmap(item.second));
     return volume_bmps;
 }
 
@@ -698,7 +700,7 @@ wxMenuItem* MenuFactory::append_menu_item_settings(wxMenu* menu_)
 
     // Add full settings list
     auto  menu_item = new wxMenuItem(menu, wxID_ANY, menu_name);
-    menu_item->SetBitmap(*get_bmp_bundle("cog"));
+    menu_item->SetBitmap(create_scaled_bitmap("cog"));
     menu_item->SetSubMenu(create_settings_popupmenu(menu, is_object_settings, item));
 
     return menu->Append(menu_item);
@@ -847,7 +849,7 @@ void MenuFactory::append_menu_item_change_extruder(wxMenu* menu)
     if (sels.IsEmpty())
         return;
 
-    std::vector<wxBitmapBundle*> icons = get_extruder_color_icons(true);
+    std::vector<wxBitmap*> icons = get_extruder_color_icons(true);
     wxMenu* extruder_selection_menu = new wxMenu();
     const wxString& name = sels.Count() == 1 ? names[0] : names[1];
 
@@ -868,7 +870,7 @@ void MenuFactory::append_menu_item_change_extruder(wxMenu* menu)
 
         if (icon_idx >= 0 && icon_idx < icons.size()) {
             append_menu_item(
-                extruder_selection_menu, wxID_ANY, item_name, "", [i](wxCommandEvent &) { obj_list()->set_extruder_for_selected_items(i); }, icons[icon_idx], menu,
+                extruder_selection_menu, wxID_ANY, item_name, "", [i](wxCommandEvent &) { obj_list()->set_extruder_for_selected_items(i); }, *icons[icon_idx], menu,
                 [is_active_extruder]() { return !is_active_extruder; }, m_parent);
         } else {
             append_menu_item(
@@ -1806,7 +1808,7 @@ void MenuFactory::append_menu_item_change_filament(wxMenu* menu)
             return;
     }
 
-    std::vector<wxBitmapBundle*> icons = get_extruder_color_icons(true);
+    std::vector<wxBitmap*> icons = get_extruder_color_icons(true);
     if (icons.size() < filaments_cnt) {
         BOOST_LOG_TRIVIAL(warning) << boost::format("Warning: icons size %1%, filaments_cnt=%2%")%icons.size()%filaments_cnt;
         if (icons.size() <= 1)
@@ -1846,9 +1848,8 @@ void MenuFactory::append_menu_item_change_filament(wxMenu* menu)
         const wxString& item_name = (i == 0 ? _L("Default") : wxString::Format(_L("Filament %d"), i)) +
             (is_active_extruder ? " (" + _L("current") + ")" : "");
 
-        //OcraftyoneTODO: determine if nullptr in place of icon causes issues
         append_menu_item(extruder_selection_menu, wxID_ANY, item_name, "",
-            [i](wxCommandEvent&) { obj_list()->set_extruder_for_selected_items(i); }, i == 0 ? nullptr : icons[i - 1], menu,
+            [i](wxCommandEvent&) { obj_list()->set_extruder_for_selected_items(i); }, i == 0 ? wxNullBitmap : *icons[i - 1], menu,
             [is_active_extruder]() { return !is_active_extruder; }, m_parent);
     }
     menu->Append(wxID_ANY, name, extruder_selection_menu, _L("Change Filament"));
@@ -1966,6 +1967,12 @@ void MenuFactory::update_default_menu()
     create_default_menu();
 }
 
+void MenuFactory::msw_rescale()
+{
+    for (MenuWithSeparators* menu : { &m_object_menu, &m_sla_object_menu, &m_part_menu, &m_default_menu })
+        msw_rescale_menu(dynamic_cast<wxMenu*>(menu));
+}
+
 #ifdef _WIN32
 // For this class is used code from stackoverflow:
 // https://stackoverflow.com/questions/257288/is-it-possible-to-write-a-template-to-check-for-a-functions-existence
@@ -1995,7 +2002,7 @@ static void update_menu_item_def_colors(T* item)
 void MenuFactory::sys_color_changed()
 {
     for (MenuWithSeparators* menu : { &m_object_menu, &m_sla_object_menu, &m_part_menu, &m_default_menu }) {
-        sys_color_changed_menu(dynamic_cast<wxMenu *>(menu));// msw_rescale_menu updates just icons, so use it
+        msw_rescale_menu(dynamic_cast<wxMenu*>(menu));// msw_rescale_menu updates just icons, so use it
 #ifdef _WIN32
         // but under MSW we have to update item's bachground color
         for (wxMenuItem* item : menu->GetMenuItems())
@@ -2010,17 +2017,14 @@ void MenuFactory::sys_color_changed(wxMenuBar* menubar)
 #if 0
     for (size_t id = 0; id < menubar->GetMenuCount(); id++) {
         wxMenu* menu = menubar->GetMenu(id);
-        sys_color_changed_menu(menu);
-#ifndef __linux__
-        menu->SetupBitmaps();
+        msw_rescale_menu(menu);
 #ifdef _WIN32
         // but under MSW we have to update item's bachground color
         for (wxMenuItem* item : menu->GetMenuItems())
             update_menu_item_def_colors(item);
 #endif
     }
-//    menubar->Refresh();
-#endif
+    menubar->Refresh();
 #endif
 }
 

--- a/src/slic3r/GUI/GUI_Factories.hpp
+++ b/src/slic3r/GUI/GUI_Factories.hpp
@@ -40,7 +40,7 @@ struct SettingsFactory
     static std::map<std::string, std::vector<SimpleSettingData>>  OBJECT_CATEGORY_SETTINGS;
     static std::map<std::string, std::vector<SimpleSettingData>>  PART_CATEGORY_SETTINGS;
 
-    static wxBitmapBundle*                      get_category_bitmap(const std::string& category_name);
+    static wxBitmap                             get_category_bitmap(const std::string& category_name, bool menu_bmp = true);
     static Bundle                               get_bundle(const DynamicPrintConfig* config, bool is_object_settings, bool is_layer_settings = false);
     static std::vector<std::string>             get_options(bool is_part);
     //BBS: add api to get options for catogary
@@ -51,9 +51,9 @@ struct SettingsFactory
 class MenuFactory
 {
 public:
-	static std::vector<wxBitmapBundle*> get_volume_bitmaps();
-	static std::vector<wxBitmapBundle*> get_text_volume_bitmaps();
-	static std::vector<wxBitmapBundle*> get_svg_volume_bitmaps();
+	static std::vector<wxBitmap>    get_volume_bitmaps();
+	static std::vector<wxBitmap> get_text_volume_bitmaps();
+	static std::vector<wxBitmap> get_svg_volume_bitmaps();
 
     MenuFactory();
     ~MenuFactory() = default;
@@ -62,6 +62,7 @@ public:
     void    update();
     void    update_object_menu();
     void    update_default_menu();
+    void    msw_rescale();
     void    sys_color_changed();
 
     static void sys_color_changed(wxMenuBar* menu_bar);

--- a/src/slic3r/GUI/GUI_ObjectLayers.cpp
+++ b/src/slic3r/GUI/GUI_ObjectLayers.cpp
@@ -248,14 +248,47 @@ void ObjectLayers::UpdateAndShow(const bool show)
 
 void ObjectLayers::msw_rescale()
 {
-    //Orca: deleted what PS commented out
+    m_bmp_delete.msw_rescale();
+    m_bmp_add.msw_rescale();
+
+    m_grid_sizer->SetHGap(wxGetApp().em_unit());
+
+    // rescale edit-boxes
+    const int cells_cnt = m_grid_sizer->GetCols() * m_grid_sizer->GetEffectiveRowsCount();
+    for (int i = 0; i < cells_cnt; ++i) {
+        const wxSizerItem* item = m_grid_sizer->GetItem(i);
+        if (item->IsWindow()) {
+            LayerRangeEditor* editor = dynamic_cast<LayerRangeEditor*>(item->GetWindow());
+            if (editor != nullptr)
+                editor->msw_rescale();
+        }
+        else if (item->IsSizer()) // case when we have editor with buttons
+        {
+            wxSizerItem* e_item = item->GetSizer()->GetItem(size_t(0)); // editor
+            if (e_item->IsWindow()) {
+                LayerRangeEditor* editor = dynamic_cast<LayerRangeEditor*>(e_item->GetWindow());
+                if (editor != nullptr)
+                    editor->msw_rescale();
+            }
+
+            if (item->GetSizer()->GetItemCount() > 2) // if there are Add/Del buttons
+                for (size_t btn : {2, 3}) { // del_btn, add_btn
+                    wxSizerItem* b_item = item->GetSizer()->GetItem(btn);
+                    if (b_item->IsWindow()) {
+                        auto button = dynamic_cast<PlusMinusButton*>(b_item->GetWindow());
+                        if (button != nullptr)
+                            button->msw_rescale();
+                    }
+                }
+        }
+    }
     m_grid_sizer->Layout();
 }
 
 void ObjectLayers::sys_color_changed()
 {
-    m_bmp_delete.sys_color_changed();
-    m_bmp_add.sys_color_changed();
+    m_bmp_delete.msw_rescale();
+    m_bmp_add.msw_rescale();
 
     // rescale edit-boxes
     const int cells_cnt = m_grid_sizer->GetCols() * m_grid_sizer->GetEffectiveRowsCount();
@@ -267,7 +300,7 @@ void ObjectLayers::sys_color_changed()
                 if (b_item && b_item->IsWindow()) {
                     auto button = dynamic_cast<PlusMinusButton*>(b_item->GetWindow());
                     if (button != nullptr)
-                        button->sys_color_changed();
+                        button->msw_rescale();
                 }
             }
         }

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -1368,11 +1368,12 @@ void ObjectList::extruder_editing()
     if (!item || !(m_objects_model->GetItemType(item) & (itVolume | itObject)))
         return;
 
-    wxRect rect = this->GetItemRect(item, GetColumn(colFilament));
-    wxPoint pos = rect.GetPosition();
-    pos.y -= 4;
-    wxSize size = rect.GetSize();
-    size.SetWidth(size.GetWidth() + 8);
+    const int column_width = GetColumn(colFilament)->GetWidth() + wxSystemSettings::GetMetric(wxSYS_VSCROLL_X) + 5;
+
+    wxPoint pos = this->get_mouse_position_in_control();
+    wxSize size = wxSize(column_width, -1);
+    pos.x = GetColumn(colName)->GetWidth() + GetColumn(colPrint)->GetWidth() + 5;
+    pos.y -= GetTextExtent("m").y;
 
     apply_extruder_selector(&m_extruder_editor, this, "1", pos, size);
 
@@ -3158,21 +3159,6 @@ bool ObjectList::can_merge_to_single_object() const
 
     // selected object should be multipart
     return (*m_objects)[obj_idx]->volumes.size() > 1;
-}
-
-wxPoint ObjectList::get_mouse_position_in_control() const
-{
-    wxPoint pt = wxGetMousePosition() - this->GetScreenPosition();
-
-#ifdef __APPLE__
-    // Workaround for OSX. From wxWidgets 3.1.6 Hittest doesn't respect to the header of wxDataViewCtrl
-    if (wxDataViewItem top_item = this->GetTopItem(); top_item.IsOk()) {
-        auto rect = this->GetItemRect(top_item, this->GetColumn(0));
-        pt.y -= rect.y;
-    }
-#endif // __APPLE__
-
-    return pt;
 }
 
 bool ObjectList::can_mesh_boolean() const
@@ -5486,17 +5472,17 @@ void ObjectList::msw_rescale()
     GetColumn(colSinking)->SetWidth(3 * em);
     GetColumn(colEditing )->SetWidth( 3 * em);
 
+    // rescale/update existing items with bitmaps
+    m_objects_model->Rescale();
+
     Layout();
 }
 
 void ObjectList::sys_color_changed()
 {
     wxGetApp().UpdateDVCDarkUI(this, true);
-
-    // rescale/update existing items with bitmaps
-    m_objects_model->UpdateBitmaps();
-
-    Layout();
+    
+    msw_rescale();
 
     if (m_objects_model) { m_objects_model->sys_color_changed(); }
 }
@@ -5597,15 +5583,6 @@ void ObjectList::OnEditingStarted(wxDataViewEvent &event)
     SetCustomRendererPtr(dynamic_cast<wxDataViewCustomRenderer*>(renderer));
 #endif
 #endif //__WXMSW__
-
-    // Orca: Automatically show drop down on editing start and finish editing when the combobox is closed
-    // Note: this must placed AFTER the above `renderer->StartEditing` call, otherwise `c` will be nullptr on MacOS,
-    //       due to the code in MacDarkMode.mm
-    if (event.GetColumn() == colFilament) {
-        ::ComboBox*c         = static_cast<::ComboBox *>(event.GetDataViewColumn()->GetRenderer()->GetEditorCtrl());
-        c->ToggleDropDown();
-        c->Bind(wxEVT_COMBOBOX_CLOSEUP, [event](wxCommandEvent& evt){ event.GetDataViewColumn()->GetRenderer()->FinishEditing(); });
-    }
 }
 
 void ObjectList::OnEditingDone(wxDataViewEvent &event)

--- a/src/slic3r/GUI/GUI_ObjectList.hpp
+++ b/src/slic3r/GUI/GUI_ObjectList.hpp
@@ -319,7 +319,7 @@ public:
     void                delete_all_connectors_for_selection();
     void                delete_all_connectors_for_object(int obj_idx);
 
-    wxPoint             get_mouse_position_in_control() const;
+    wxPoint             get_mouse_position_in_control() const { return wxGetMousePosition() - this->GetScreenPosition(); }
     int                 get_selected_obj_idx() const;
     ModelConfig&        get_item_config(const wxDataViewItem& item) const;
 

--- a/src/slic3r/GUI/GUI_ObjectSettings.cpp
+++ b/src/slic3r/GUI/GUI_ObjectSettings.cpp
@@ -112,7 +112,7 @@ bool ObjectSettings::update_settings_list()
             btn->SetToolTip(_(L("Remove parameter")));
 
             btn->SetBitmapFocus(m_bmp_delete_focus.bmp());
-            btn->SetBitmapCurrent(m_bmp_delete_focus.bmp());
+            btn->SetBitmapHover(m_bmp_delete_focus.bmp());
 
 			btn->Bind(wxEVT_BUTTON, [opt_key, config, this](wxEvent &event) {
                 wxGetApp().plater()->take_snapshot(from_u8((boost::format("Delete Option %s") % opt_key).str()).ToStdString());
@@ -146,7 +146,7 @@ bool ObjectSettings::update_settings_list()
                     return;
                 ctrl->SetBitmap_(m_bmp_delete);
                 ctrl->SetBitmapFocus(m_bmp_delete_focus.bmp()); 
-                ctrl->SetBitmapCurrent(m_bmp_delete_focus.bmp());
+                ctrl->SetBitmapHover(m_bmp_delete_focus.bmp());
             };
 
             const bool is_extruders_cat = cat.first == "Extruders";
@@ -415,13 +415,21 @@ void ObjectSettings::UpdateAndShow(const bool show)
 #endif
 }
 
+void ObjectSettings::msw_rescale()
+{
+#if !NEW_OBJECT_SETTING
+    m_bmp_delete.msw_rescale();
+    m_bmp_delete_focus.msw_rescale();
+
+    for (auto group : m_og_settings)
+        group->msw_rescale();
+#endif
+}
+
 void ObjectSettings::sys_color_changed()
 {
 #if !NEW_OBJECT_SETTING
-    m_og->sys_color_changed(); // not in old msw_rescale. is it needed?
-    // moved from old msw_rescale
-    m_bmp_delete.sys_color_changed();
-    m_bmp_delete_focus.sys_color_changed();
+    m_og->sys_color_changed();
 
     for (auto group : m_og_settings)
         group->sys_color_changed();

--- a/src/slic3r/GUI/GUI_ObjectSettings.hpp
+++ b/src/slic3r/GUI/GUI_ObjectSettings.hpp
@@ -68,6 +68,7 @@ public:
     bool        add_missed_options(ModelConfig *config_to, const DynamicPrintConfig &config_from);
     void        update_config_values(ModelConfig *config);
     void        UpdateAndShow(const bool show);
+    void        msw_rescale();
     void        sys_color_changed();
 };
 

--- a/src/slic3r/GUI/GUI_ObjectTable.hpp
+++ b/src/slic3r/GUI/GUI_ObjectTable.hpp
@@ -82,10 +82,10 @@ public:
     GridCellFilamentsEditor(size_t count = 0,
                            const wxString choices[] = NULL,
                            bool allowOthers = false,
-                           std::vector<wxBitmapBundle*>* bitmaps = NULL);
+                           std::vector<wxBitmap*>* bitmaps = NULL);
     GridCellFilamentsEditor(const wxArrayString& choices,
                            bool allowOthers = false,
-                           std::vector<wxBitmapBundle*>* bitmaps = NULL);
+                           std::vector<wxBitmap*>* bitmaps = NULL);
 
     virtual void Create(wxWindow* parent,
                         wxWindowID id,
@@ -105,7 +105,7 @@ protected:
     ::ComboBox *Combo() const { return (::ComboBox *)m_control; }
     void OnComboCloseUp(wxCommandEvent& evt);
 
-    std::vector<wxBitmapBundle*>* m_icons;
+    std::vector<wxBitmap*>* m_icons;
 
     wxDECLARE_NO_COPY_CLASS(GridCellFilamentsEditor);
 private:
@@ -498,8 +498,8 @@ public:
     void update_filament_to_config(ModelConfig* config, std::string& key, ConfigOption& new_value,  ConfigOption& ori_value, bool is_object);
     void update_volume_values_from_object(int row, int col);
     void update_value_to_object(Model* model, ObjectGridRow* grid_row, int col);
-    wxBitmapBundle& get_undo_bitmap(bool selected = false);
-    wxBitmapBundle* get_color_bitmap(int color_index);
+    wxBitmap& get_undo_bitmap(bool selected = false);
+    wxBitmap* get_color_bitmap(int color_index);
     bool OnCellLeftClick(int row, int col, ConfigOptionType &type);
     void OnSelectCell(int row, int col);
     void OnRangeSelected(int row, int col, int row_count, int col_count);
@@ -610,10 +610,10 @@ private:
     int init_filaments_and_colors();
 
     wxFloatingPointValidator<float> m_float_validator;
-    wxBitmapBundle           m_undo_bitmap;
-    std::vector<wxBitmapBundle*> m_color_bitmaps;
-    wxBitmapBundle     m_bmp_reset;
-    wxBitmapBundle     m_bmp_reset_disable;
+    wxBitmap           m_undo_bitmap;
+    std::vector<wxBitmap*> m_color_bitmaps;
+    ScalableBitmap     m_bmp_reset;
+    ScalableBitmap     m_bmp_reset_disable;
 private:
     wxDECLARE_ABSTRACT_CLASS(ObjectGrid);
     wxDECLARE_EVENT_TABLE();

--- a/src/slic3r/GUI/GUI_ObjectTableSettings.cpp
+++ b/src/slic3r/GUI/GUI_ObjectTableSettings.cpp
@@ -173,7 +173,7 @@ bool ObjectTableSettings::update_settings_list(bool is_object, bool is_multiple_
 
             
             btn->SetBitmapFocus(m_bmp_reset_focus.bmp());
-            btn->SetBitmapHover(m_bmp_reset_focus.get_bitmap());
+            btn->SetBitmapHover(m_bmp_reset_focus.bmp());
 
             #ifdef __WINDOWS__
             btn->SetBitmapDisabled(m_bmp_reset_disable.bmp());
@@ -236,7 +236,7 @@ bool ObjectTableSettings::update_settings_list(bool is_object, bool is_multiple_
                 return;
             ctrl->SetBitmap_(m_bmp_reset);
             ctrl->SetBitmapFocus(m_bmp_reset_focus.bmp()); 
-            ctrl->SetBitmapHover(m_bmp_reset_focus.get_bitmap());
+            ctrl->SetBitmapHover(m_bmp_reset_focus.bmp());
             #ifdef __WINDOWS__  
             ctrl->SetBitmapDisabled(m_bmp_reset_disable.bmp());
             #endif

--- a/src/slic3r/GUI/ImageGrid.cpp
+++ b/src/slic3r/GUI/ImageGrid.cpp
@@ -508,10 +508,10 @@ void ImageGrid::render(wxDC& dc)
     if (!m_file_sys || m_file_sys->GetCount() == 0) {
         dc.DrawRectangle({ 0, 0, size.x, size.y });
         if (!m_status_msg.IsEmpty()) {
-            auto   si = m_status_icon.GetSize();
+            auto   si = m_status_icon.GetBmpSize();
             auto   st = dc.GetTextExtent(m_status_msg);
             auto   rect = wxRect{0, 0, max(st.x, si.x), si.y + 26 + st.y}.CenterIn(wxRect({0, 0}, size));
-            dc.DrawBitmap(m_status_icon.get_bitmap(), rect.x + (rect.width - si.x) / 2, rect.y);
+            dc.DrawBitmap(m_status_icon.bmp(), rect.x + (rect.width - si.x) / 2, rect.y);
             dc.SetTextForeground(wxColor(0x909090));
             dc.DrawText(m_status_msg, rect.x + (rect.width - st.x) / 2, rect.GetBottom() - st.y);
         }
@@ -602,7 +602,7 @@ void Slic3r::GUI::ImageGrid::renderContent1(wxDC &dc, wxPoint const &pt, int ind
     bool show_download_state_always = true;
     // Draw checked icon
     if (m_selecting && !show_download_state_always)
-        dc.DrawBitmap(selected ? m_checked_icon.get_bitmap() : m_unchecked_icon.get_bitmap(), pt + wxPoint{10, m_content_rect.GetHeight() - m_checked_icon.GetHeight() - 10});
+        dc.DrawBitmap(selected ? m_checked_icon.bmp() : m_unchecked_icon.bmp(), pt + wxPoint{10, 10});
     // can't handle alpha
     // dc.GradientFillLinear({pt.x, pt.y, m_border_size.GetWidth(), 60}, wxColour(0x6F, 0x6F, 0x6F, 0x99), wxColour(0x6F, 0x6F, 0x6F, 0), wxBOTTOM);
     else if (m_file_sys->GetGroupMode() == PrinterFileSystem::G_NONE) {
@@ -653,7 +653,7 @@ void Slic3r::GUI::ImageGrid::renderContent1(wxDC &dc, wxPoint const &pt, int ind
         dc.DrawText(date, pt + wxPoint{24, 16});
     }
     if (m_selecting && show_download_state_always)
-        dc.DrawBitmap(selected ? m_checked_icon.get_bitmap() : m_unchecked_icon.get_bitmap(), pt + wxPoint{10, m_content_rect.GetHeight() - m_checked_icon.GetHeight() - 10});
+        dc.DrawBitmap(selected ? m_checked_icon.bmp() : m_unchecked_icon.bmp(), pt + wxPoint{10, 10});
 }
 
 void Slic3r::GUI::ImageGrid::renderContent2(wxDC &dc, wxPoint const &pt, int index, bool hit)
@@ -745,8 +745,8 @@ void Slic3r::GUI::ImageGrid::renderText2(wxDC &dc, wxString text, wxRect const &
 
 void Slic3r::GUI::ImageGrid::renderIconText(wxDC & dc, ScalableBitmap const & icon, wxString text, wxRect const & rect)
 {
-    dc.DrawBitmap(icon.get_bitmap(), rect.x, rect.y + (rect.height - icon.GetHeight()) / 2);
-    renderText2(dc, text, {rect.x + icon.GetWidth() + 4, rect.y, rect.width - icon.GetWidth() - 4, rect.height});
+    dc.DrawBitmap(icon.bmp(), rect.x, rect.y + (rect.height - icon.GetBmpHeight()) / 2);
+    renderText2(dc, text, {rect.x + icon.GetBmpWidth() + 4, rect.y, rect.width - icon.GetBmpWidth() - 4, rect.height});
 }
 
 }}

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -155,7 +155,7 @@ wxWindow *KBShortcutsDialog::create_button(int id, wxString text)
 
 void KBShortcutsDialog::on_dpi_changed(const wxRect& suggested_rect)
 {
-    m_logo_bmp.sys_color_changed();
+    m_logo_bmp.msw_rescale();
     m_header_bitmap->SetBitmap(m_logo_bmp.bmp());
     msw_buttons_rescale(this, em_unit(), { wxID_OK });
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1970,6 +1970,11 @@ void MainFrame::on_dpi_changed(const wxRect& suggested_rect)
     m_monitor->msw_rescale();
     m_calibration->msw_rescale();
 
+    // BBS
+#if 0
+    for (size_t id = 0; id < m_menubar->GetMenuCount(); id++)
+        msw_rescale_menu(m_menubar->GetMenu(id));
+#endif
 
     // Workarounds for correct Window rendering after rescale
 
@@ -2011,7 +2016,7 @@ void MainFrame::on_sys_color_changed()
 #ifdef _MSW_DARK_MODE
     // update common mode sizer
     if (!wxGetApp().tabs_as_menu())
-        dynamic_cast<Notebook*>(m_tabpanel)->OnColorsChanged();
+        dynamic_cast<Notebook*>(m_tabpanel)->Rescale();
 #endif
 #endif
 

--- a/src/slic3r/GUI/MediaFilePanel.cpp
+++ b/src/slic3r/GUI/MediaFilePanel.cpp
@@ -354,9 +354,9 @@ void MediaFilePanel::SwitchStorage(bool external)
 
 void MediaFilePanel::Rescale()
 {
-    m_bmp_loading.sys_color_changed();
-    m_bmp_failed.sys_color_changed();
-    m_bmp_empty.sys_color_changed();
+    m_bmp_loading.msw_rescale();
+    m_bmp_failed.msw_rescale();
+    m_bmp_empty.msw_rescale();
 
     auto top_sizer = GetSizer()->GetItem((size_t) 0)->GetSizer();
     top_sizer->SetMinSize({-1, 75 * em_unit(this) / 10});

--- a/src/slic3r/GUI/ModelMall.cpp
+++ b/src/slic3r/GUI/ModelMall.cpp
@@ -36,7 +36,7 @@ namespace GUI {
 
         wxBoxSizer* m_sizer_web_control = new wxBoxSizer(wxHORIZONTAL);
 
-        auto m_control_back = new ScalableButton(m_web_control_panel, wxID_ANY, "mall_control_back", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER);
+        auto m_control_back = new ScalableButton(m_web_control_panel, wxID_ANY, "mall_control_back", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, true);
         m_control_back->SetBackgroundColour(*wxWHITE);
         m_control_back->SetSize(wxSize(FromDIP(25), FromDIP(30)));
         m_control_back->SetMinSize(wxSize(FromDIP(25), FromDIP(30)));
@@ -47,7 +47,7 @@ namespace GUI {
         m_control_back->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {SetCursor(wxCursor(wxCURSOR_ARROW));});
 
 
-        auto m_control_forward = new ScalableButton(m_web_control_panel, wxID_ANY, "mall_control_forward", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER);
+        auto m_control_forward = new ScalableButton(m_web_control_panel, wxID_ANY, "mall_control_forward", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, true);
         m_control_forward->SetBackgroundColour(*wxWHITE);
         m_control_forward->SetSize(wxSize(FromDIP(25), FromDIP(30)));
         m_control_forward->SetMinSize(wxSize(FromDIP(25), FromDIP(30)));
@@ -57,7 +57,7 @@ namespace GUI {
         m_control_forward->Bind(wxEVT_ENTER_WINDOW, [this](auto& e) {SetCursor(wxCursor(wxCURSOR_HAND)); });
         m_control_forward->Bind(wxEVT_LEAVE_WINDOW, [this](auto& e) {SetCursor(wxCursor(wxCURSOR_ARROW)); });
 
-        auto m_control_refresh = new ScalableButton(m_web_control_panel, wxID_ANY, "mall_control_refresh", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER);
+        auto m_control_refresh = new ScalableButton(m_web_control_panel, wxID_ANY, "mall_control_refresh", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, true);
         m_control_refresh->SetBackgroundColour(*wxWHITE);
         m_control_refresh->SetSize(wxSize(FromDIP(25), FromDIP(30)));
         m_control_refresh->SetMinSize(wxSize(FromDIP(25), FromDIP(30)));

--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -227,10 +227,10 @@ void MsgDialog::apply_style(long style)
     if (style & wxNO)       add_button(wxID_NO, false,_L("No"));
     if (style & wxCANCEL)   add_button(wxID_CANCEL, false, _L("Cancel"));
 
-    logo->SetBitmap( *get_bmp_bundle(style & wxAPPLY        ? "completed" :
+    logo->SetBitmap( create_scaled_bitmap(style & wxAPPLY        ? "completed" :
                                           style & wxICON_WARNING        ? "obj_warning" :
                                           style & wxICON_INFORMATION    ? "info"        :
-                                          style & wxICON_QUESTION       ? "question"    : "OrcaSlicer", 64));
+                                          style & wxICON_QUESTION       ? "question"    : "OrcaSlicer", this, 64, style & wxICON_ERROR));
 }
 
 void MsgDialog::finalize()
@@ -339,7 +339,7 @@ ErrorDialog::ErrorDialog(wxWindow *parent, const wxString &msg, bool monospaced_
     add_msg_content(this, content_sizer, msg, monospaced_font);
 
 	// Use a small bitmap with monospaced font, as the error text will not be wrapped.
-	logo->SetBitmap(*get_bmp_bundle("OrcaSlicer_192px_grayscale.png", monospaced_font ? 48 : /*1*/84));
+	logo->SetBitmap(create_scaled_bitmap("OrcaSlicer_192px_grayscale.png", this, monospaced_font ? 48 : /*1*/84));
 
     SetMaxSize(wxSize(-1, CONTENT_MAX_HEIGHT*wxGetApp().em_unit()));
 

--- a/src/slic3r/GUI/Notebook.cpp
+++ b/src/slic3r/GUI/Notebook.cpp
@@ -122,8 +122,6 @@ void ButtonsListCtrl::Rescale()
 {
     //m_mode_sizer->msw_rescale();
     int em = em_unit(this);
-    // Orca: following is removed by PS in wx 3.16 refactor.
-    // doesn't seem to be doing anything rn so leaving it alone
     for (Button* btn : m_pageButtons) {
         //BBS
         btn->SetMinSize({(btn->GetLabel().empty() ? 40 : 132) * em / 10, 36 * em / 10});
@@ -135,14 +133,6 @@ void ButtonsListCtrl::Rescale()
     //m_line_margin = std::lround(0.1 * em);
     //m_buttons_sizer->SetVGap(m_btn_margin);
     //m_buttons_sizer->SetHGap(m_btn_margin);
-
-    m_sizer->Layout();
-}
-
-void ButtonsListCtrl::OnColorsChanged()
-{
-    for (Button* btn : m_pageButtons)
-        btn->Rescale();
 
     m_sizer->Layout();
 }

--- a/src/slic3r/GUI/Notebook.hpp
+++ b/src/slic3r/GUI/Notebook.hpp
@@ -23,7 +23,6 @@ public:
     void SetSelection(int sel);
     void UpdateMode();
     void Rescale();
-    void OnColorsChanged();
     bool InsertPage(size_t n, const wxString &text, bool bSelect = false, const std::string &bmp_name = "", const std::string &inactive_bmp_name = "");
     void RemovePage(size_t n);
     bool SetPageImage(size_t n, const std::string& bmp_name) const;
@@ -260,11 +259,6 @@ public:
     void Rescale()
     {
         GetBtnsListCtrl()->Rescale();
-    }
-
-    void OnColorsChanged()
-    {
-        GetBtnsListCtrl()->OnColorsChanged();
     }
 
     void OnNavigationKey(wxNavigationKeyEvent& event)

--- a/src/slic3r/GUI/OG_CustomCtrl.cpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.cpp
@@ -28,12 +28,12 @@ static bool is_point_in_rect(const wxPoint& pt, const wxRect& rect)
             rect.GetTop() <= pt.y && pt.y <= rect.GetBottom();
 }
 
-static wxSize get_bitmap_size(const wxBitmapBundle* bmp, wxWindow* parent)
+static wxSize get_bitmap_size(const wxBitmap& bmp)
 {
-#ifndef __WIN32__
-    return bmp->GetBitmapFor(parent).GetSize();
+#ifdef __APPLE__
+    return bmp.GetScaledSize();
 #else
-    return bmp->GetDefaultSize();
+    return bmp.GetSize();
 #endif
 }
 
@@ -58,8 +58,8 @@ OG_CustomCtrl::OG_CustomCtrl(   wxWindow*            parent,
     m_v_gap2  = lround(0.8 * m_em_unit);
     m_h_gap   = lround(0.2 * m_em_unit);
 
-    //m_bmp_mode_sz       = get_bitmap_size(get_bmp_bundle("mode_simple", wxOSX ? 10 : 12), this);
-    m_bmp_blinking_sz   = get_bitmap_size(get_bmp_bundle("blank_16"), this);
+    //m_bmp_mode_sz       = get_bitmap_size(create_scaled_bitmap("mode_simple", this, wxOSX ? 10 : 12));
+    m_bmp_blinking_sz   = get_bitmap_size(create_scaled_bitmap("blank_16", this));
 
     init_ctrl_lines();// from og.lines()
 
@@ -572,8 +572,8 @@ void OG_CustomCtrl::msw_rescale()
     m_v_gap2     = lround(0.8 * m_em_unit);
     m_h_gap     = lround(0.2 * m_em_unit);
 
-    //m_bmp_mode_sz       = get_bitmap_size(get_bmp_bundle("mode_simple", wxOSX ? 10 : 12), this);
-    m_bmp_blinking_sz = get_bitmap_size(get_bmp_bundle("blank_16"), this);
+    //m_bmp_mode_sz = create_scaled_bitmap("mode_simple", this, wxOSX ? 10 : 12).GetSize();
+    m_bmp_blinking_sz = create_scaled_bitmap("blank_16", this).GetSize();
 
     m_max_win_width = 0;
 
@@ -666,7 +666,7 @@ void OG_CustomCtrl::CtrlLine::msw_rescale()
 {
     // if we have a single option with no label, no sidetext
     if (draw_just_act_buttons)
-        height = get_bitmap_size(get_bmp_bundle("empty"), ctrl).GetHeight();
+        height = get_bitmap_size(create_scaled_bitmap("empty")).GetHeight();
 
     if (ctrl->opt_group->label_width != 0 && !og_line.label.IsEmpty()) {
         wxSize label_sz = ctrl->GetTextExtent(og_line.label);
@@ -748,7 +748,7 @@ void OG_CustomCtrl::CtrlLine::render(wxDC& dc, wxCoord h_pos, wxCoord v_pos)
         if (field && field->undo_bitmap())
         //if (field)
             // BBS: new layout
-            draw_act_bmps(dc, wxPoint(h_pos, v_pos), field->undo_to_sys_bitmap()->get_bitmap(), field->undo_bitmap()->get_bitmap(), field->blink());
+            draw_act_bmps(dc, wxPoint(h_pos, v_pos), field->undo_to_sys_bitmap()->bmp(), field->undo_bitmap()->bmp(), field->blink());
         return;
     }
 
@@ -802,7 +802,7 @@ void OG_CustomCtrl::CtrlLine::render(wxDC& dc, wxCoord h_pos, wxCoord v_pos)
 
     auto draw_buttons = [&h_pos, &dc, &v_pos, this](Field* field, size_t bmp_rect_id = 0) {
         if (field && field->undo_to_sys_bitmap()) {
-            h_pos = draw_act_bmps(dc, wxPoint(h_pos, v_pos), field->undo_to_sys_bitmap()->get_bitmap(), field->undo_bitmap()->get_bitmap(), field->blink(), bmp_rect_id);
+            h_pos = draw_act_bmps(dc, wxPoint(h_pos, v_pos), field->undo_to_sys_bitmap()->bmp(), field->undo_bitmap()->bmp(), field->blink(), bmp_rect_id);
         }
 #ifndef DISABLE_BLINKING
         else if (field && !field->undo_to_sys_bitmap() && field->blink()) 
@@ -933,19 +933,19 @@ wxCoord OG_CustomCtrl::CtrlLine::draw_text(wxDC &dc, wxPoint pos, const wxString
 
 wxPoint OG_CustomCtrl::CtrlLine::draw_blinking_bmp(wxDC& dc, wxPoint pos, bool is_blinking)
 {
-    wxBitmapBundle* bmp_blinking = get_bmp_bundle(is_blinking ? "blank_16" : "empty");
+    wxBitmap bmp_blinking = create_scaled_bitmap(is_blinking ? "blank_16" : "empty", ctrl);
     wxCoord h_pos = pos.x;
-    wxCoord v_pos = pos.y + lround((height - get_bitmap_size(bmp_blinking, ctrl).GetHeight()) / 2);
+    wxCoord v_pos = pos.y + lround((height - get_bitmap_size(bmp_blinking).GetHeight()) / 2);
 
-    dc.DrawBitmap(bmp_blinking->GetBitmapFor(ctrl), h_pos, v_pos);
+    dc.DrawBitmap(bmp_blinking, h_pos, v_pos);
 
-    int bmp_dim = get_bitmap_size(bmp_blinking, ctrl).GetWidth();
+    int bmp_dim = get_bitmap_size(bmp_blinking).GetWidth();
 
     h_pos += bmp_dim + ctrl->m_h_gap;
     return wxPoint(h_pos, v_pos);
 }
 
-wxCoord OG_CustomCtrl::CtrlLine::draw_act_bmps(wxDC& dc, wxPoint pos, const wxBitmapBundle& bmp_undo_to_sys, const wxBitmapBundle& bmp_undo, bool is_blinking, size_t rect_id)
+wxCoord OG_CustomCtrl::CtrlLine::draw_act_bmps(wxDC& dc, wxPoint pos, const wxBitmap& bmp_undo_to_sys, const wxBitmap& bmp_undo, bool is_blinking, size_t rect_id)
 {
 #ifndef DISABLE_BLINKING
     pos = draw_blinking_bmp(dc, pos, is_blinking);
@@ -953,11 +953,11 @@ wxCoord OG_CustomCtrl::CtrlLine::draw_act_bmps(wxDC& dc, wxPoint pos, const wxBi
     if (ctrl->opt_group->split_multi_line) { // BBS
         const std::vector<Option> &option_set = og_line.get_options();
         if (option_set.size() > 1)
-            pos.y += lround(((height - ctrl->m_v_gap + ctrl->m_v_gap2) / option_set.size() - get_bitmap_size(&bmp_undo, ctrl).GetHeight()) / 2);
+            pos.y += lround(((height - ctrl->m_v_gap + ctrl->m_v_gap2) / option_set.size() - get_bitmap_size(bmp_undo).GetHeight()) / 2);
         else
-            pos.y += lround((height - get_bitmap_size(&bmp_undo, ctrl).GetHeight()) / 2);
+            pos.y += lround((height - get_bitmap_size(bmp_undo).GetHeight()) / 2);
     } else {
-        pos.y += lround((height - get_bitmap_size(&bmp_undo, ctrl).GetHeight()) / 2);
+        pos.y += lround((height - get_bitmap_size(bmp_undo).GetHeight()) / 2);
     }
 #endif
     wxCoord h_pos = pos.x;
@@ -965,16 +965,16 @@ wxCoord OG_CustomCtrl::CtrlLine::draw_act_bmps(wxDC& dc, wxPoint pos, const wxBi
 
 #ifndef DISABLE_UNDO_SYS
     //BBS: GUI refactor
-    dc.DrawBitmap(bmp_undo_to_sys.GetBitmapFor(ctrl), h_pos, v_pos);
+    dc.DrawBitmap(bmp_undo_to_sys, h_pos, v_pos);
 
-    int bmp_dim = get_bitmap_size(&bmp_undo_to_sys, ctrl).GetWidth();
+    int bmp_dim = get_bitmap_size(bmp_undo_to_sys).GetWidth();
     rects_undo_to_sys_icon[rect_id] = wxRect(h_pos, v_pos, bmp_dim, bmp_dim);
 
     h_pos += bmp_dim + ctrl->m_h_gap;
 #endif
-    dc.DrawBitmap(og_line.undo_to_sys ? bmp_undo_to_sys.GetBitmapFor(ctrl) : bmp_undo.GetBitmapFor(ctrl), h_pos, v_pos);
+    dc.DrawBitmap(og_line.undo_to_sys ? bmp_undo_to_sys : bmp_undo, h_pos, v_pos);
 
-    int bmp_dim2 = get_bitmap_size(&bmp_undo, ctrl).GetWidth();
+    int bmp_dim2 = get_bitmap_size(bmp_undo).GetWidth();
     (og_line.undo_to_sys ? rects_undo_to_sys_icon[rect_id] : rects_undo_icon[rect_id]) = wxRect(h_pos, v_pos, bmp_dim2, bmp_dim2);
 
     h_pos += bmp_dim2 + ctrl->m_h_gap;

--- a/src/slic3r/GUI/OG_CustomCtrl.hpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.hpp
@@ -64,7 +64,7 @@ class OG_CustomCtrl :public wxPanel
         void    render(wxDC& dc, wxCoord h_pos, wxCoord v_pos);
         wxCoord draw_text      (wxDC& dc, wxPoint pos, const wxString& text, const wxColour* color, int width, bool is_url = false, bool is_main = false);
         wxPoint draw_blinking_bmp(wxDC& dc, wxPoint pos, bool is_blinking);
-        wxCoord draw_act_bmps(wxDC& dc, wxPoint pos, const wxBitmapBundle& bmp_undo_to_sys, const wxBitmapBundle& bmp_undo, bool is_blinking, size_t rect_id = 0);
+        wxCoord draw_act_bmps(wxDC& dc, wxPoint pos, const wxBitmap& bmp_undo_to_sys, const wxBitmap& bmp_undo, bool is_blinking, size_t rect_id = 0);
         bool    launch_browser() const;
         bool    is_separator() const { return og_line.is_separator(); }
 

--- a/src/slic3r/GUI/ObjectDataViewModel.hpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.hpp
@@ -75,27 +75,27 @@ class ObjectDataViewModelNode
 {
     ObjectDataViewModelNode*	    m_parent;
     MyObjectTreeModelNodePtrArray   m_children;
-    wxBitmapBundle                  m_empty_bmp;
+    wxBitmap                        m_empty_bmp;
     size_t                          m_volumes_cnt = 0;
     std::vector< std::string >      m_opt_categories;
     t_layer_height_range            m_layer_range = { 0.0f, 0.0f };
 
     wxString				        m_name;
-    wxBitmapBundle&                 m_bmp = m_empty_bmp;
+    wxBitmap&                       m_bmp = m_empty_bmp;
     ItemType				        m_type;
     int                             m_idx = -1;
     int                             m_plate_idx = -1;
     bool					        m_container = false;
     // BBS
     wxString				        m_extruder = wxEmptyString;
-    wxBitmapBundle                  m_extruder_bmp;
-    wxBitmapBundle  		        m_action_icon;
+    wxBitmap                        m_extruder_bmp;
+    wxBitmap  		                m_action_icon;
     // BBS
-    wxBitmapBundle                        m_support_icon;
-    wxBitmapBundle                        m_color_icon;
-    wxBitmapBundle                        m_sinking_icon;
+    wxBitmap                        m_support_icon;
+    wxBitmap                        m_color_icon;
+    wxBitmap                        m_sinking_icon;
     PrintIndicator                  m_printable {piUndef};
-    wxBitmapBundle                  m_printable_icon;
+    wxBitmap                        m_printable_icon;
     std::string                     m_warning_icon_name{ "" };
     bool                            m_has_lock{false};  // for cut object icon
 
@@ -229,11 +229,11 @@ public:
     void            SetName(const wxString &);
     bool            SetValue(const wxVariant &variant, unsigned int col);
     void            SetVolumeType(ModelVolumeType type) { m_volume_type = type; }
-    void            SetBitmap(const wxBitmapBundle &icon) { m_bmp = icon; }
+    void            SetBitmap(const wxBitmap &icon) { m_bmp = icon; }
     void            SetExtruder(const wxString &extruder) { m_extruder = extruder; }
     void            SetWarningIconName(const std::string& warning_icon_name) { m_warning_icon_name = warning_icon_name; }
     void            SetLock(bool has_lock)                                   { m_has_lock = has_lock; }
-    const wxBitmapBundle& GetBitmap() const         { return m_bmp; }
+    const wxBitmap& GetBitmap() const         { return m_bmp; }
     const wxString& GetName() const                 { return m_name; }
     ItemType        GetType() const                 { return m_type; }
     InfoItemType    GetInfoItemType() const         { return m_info_item_type; }
@@ -302,6 +302,7 @@ public:
     bool        is_text_volume() const { return m_is_text_volume; }
     bool        is_svg_volume() const { return m_is_svg_volume; }
     void        sys_color_changed();
+    void        msw_rescale();
 
 #ifndef NDEBUG
     bool 		valid();
@@ -327,14 +328,14 @@ class ObjectDataViewModel :public wxDataViewModel
 {
     std::vector<ObjectDataViewModelNode*>       m_plates;
     std::vector<ObjectDataViewModelNode*>       m_objects;
-    std::vector<wxBitmapBundle*>                m_volume_bmps;
-    std::vector<wxBitmapBundle*>                m_text_volume_bmps;
-    std::vector<wxBitmapBundle*>                m_svg_volume_bmps;
-    std::map<InfoItemType, wxBitmapBundle*>     m_info_bmps;
-    wxBitmapBundle                              m_empty_bmp;
-    wxBitmapBundle                              m_warning_bmp;
-    wxBitmapBundle                              m_warning_manifold_bmp;
-    wxBitmapBundle                              m_lock_bmp;
+    std::vector<wxBitmap>                m_volume_bmps;
+    std::vector<wxBitmap>                m_text_volume_bmps;
+    std::vector<wxBitmap>                m_svg_volume_bmps;
+    std::map<InfoItemType, wxBitmap>     m_info_bmps;
+    wxBitmap                              m_empty_bmp;
+    wxBitmap                              m_warning_bmp;
+    wxBitmap                              m_warning_manifold_bmp;
+    wxBitmap                              m_lock_bmp;
 
     ObjectDataViewModelNode*                    m_plate_outside;
 
@@ -399,7 +400,7 @@ public:
     // helper method for wxLog
 
     wxString    GetName(const wxDataViewItem &item) const;
-    wxBitmapBundle&   GetBitmap(const wxDataViewItem &item) const;
+    wxBitmap&   GetBitmap(const wxDataViewItem &item) const;
     wxString    GetExtruder(const wxDataViewItem &item) const;
     int         GetExtruderNumber(const wxDataViewItem &item) const;
 
@@ -479,7 +480,7 @@ public:
 
     void    SetAssociatedControl(wxDataViewCtrl* ctrl) { m_ctrl = ctrl; }
     // Rescale bitmaps for existing Items
-    void    UpdateBitmaps();
+    void    Rescale();
 
     void        AddWarningIcon(const wxDataViewItem& item, const std::string& warning_name);
     void        DeleteWarningIcon(const wxDataViewItem& item, const bool unmark_object = false);

--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -836,6 +836,7 @@ void ConfigOptionsGroup::msw_rescale()
                 // check if window is ScalableButton
                 ScalableButton* sc_btn = dynamic_cast<ScalableButton*>(win);
                 if (sc_btn) {
+                    sc_btn->msw_rescale();
                     sc_btn->SetSize(sc_btn->GetBestSize());
                     return;
                 }
@@ -883,7 +884,7 @@ void ConfigOptionsGroup::sys_color_changed()
                 wxWindow* win = item->GetWindow();
                 // check if window is ScalableButton
                 if (ScalableButton* sc_btn = dynamic_cast<ScalableButton*>(win)) {
-                    sc_btn->sys_color_changed();
+                    sc_btn->msw_rescale();
                     return;
                 }
                 wxGetApp().UpdateDarkUI(win, dynamic_cast<wxButton*>(win) != nullptr);

--- a/src/slic3r/GUI/ParamsPanel.cpp
+++ b/src/slic3r/GUI/ParamsPanel.cpp
@@ -233,11 +233,11 @@ ParamsPanel::ParamsPanel( wxWindow* parent, wxWindowID id, const wxPoint& pos, c
         //m_search_btn->SetToolTip(format_wxstr(_L("Search in settings [%1%]"), "Ctrl+F"));
         //m_search_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) { wxGetApp().plater()->search(false); });
 
-        m_compare_btn = new ScalableButton(m_top_panel, wxID_ANY, "compare", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER);
+        m_compare_btn = new ScalableButton(m_top_panel, wxID_ANY, "compare", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, true);
         m_compare_btn->SetToolTip(_L("Compare presets"));
         m_compare_btn->Bind(wxEVT_BUTTON, ([this](wxCommandEvent e) { wxGetApp().mainframe->diff_dialog.show(); }));
 
-        m_setting_btn = new ScalableButton(m_top_panel, wxID_ANY, "table", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER);
+        m_setting_btn = new ScalableButton(m_top_panel, wxID_ANY, "table", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, true);
         m_setting_btn->SetToolTip(_L("View all object's settings"));
         m_setting_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) { wxGetApp().plater()->PopupObjectTable(-1, -1, {0, 0}); });
 
@@ -646,11 +646,11 @@ void ParamsPanel::update_mode()
 
 void ParamsPanel::msw_rescale()
 {
-    if (m_process_icon) m_process_icon->sys_color_changed();
-    if (m_setting_btn) m_setting_btn->sys_color_changed();
-    if (m_search_btn) m_search_btn->sys_color_changed();
-    if (m_compare_btn) m_compare_btn->sys_color_changed();
-    if (m_tips_arrow) m_tips_arrow->sys_color_changed();
+    if (m_process_icon) m_process_icon->msw_rescale();
+    if (m_setting_btn) m_setting_btn->msw_rescale();
+    if (m_search_btn) m_search_btn->msw_rescale();
+    if (m_compare_btn) m_compare_btn->msw_rescale();
+    if (m_tips_arrow) m_tips_arrow->msw_rescale();
     m_left_sizer->SetMinSize(wxSize(40 * em_unit(this), -1));
     if (m_mode_sizer)
         m_mode_sizer->SetMinSize(-1, 3 * em_unit(this));

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -515,6 +515,11 @@ void PhysicalPrinterDialog::on_dpi_changed(const wxRect& suggested_rect)
 {
     const int& em = em_unit();
 
+    m_printhost_browse_btn->msw_rescale();
+    m_printhost_test_btn->msw_rescale();
+    if (m_printhost_cafile_browse_btn)
+        m_printhost_cafile_browse_btn->msw_rescale();
+
     m_optgroup->msw_rescale();
 
     msw_buttons_rescale(this, em, { wxID_OK, wxID_CANCEL });
@@ -525,15 +530,6 @@ void PhysicalPrinterDialog::on_dpi_changed(const wxRect& suggested_rect)
     Fit();
     Refresh();
 }
-
-void PhysicalPrinterDialog::on_sys_color_changed()
-{
-    m_printhost_browse_btn->sys_color_changed();
-    m_printhost_test_btn->sys_color_changed();
-    if (m_printhost_cafile_browse_btn)
-        m_printhost_cafile_browse_btn->sys_color_changed();
-}
-
 
 void PhysicalPrinterDialog::OnOK(wxEvent& event)
 {

--- a/src/slic3r/GUI/PhysicalPrinterDialog.hpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.hpp
@@ -64,7 +64,7 @@ public:
 
 protected:
     void on_dpi_changed(const wxRect& suggested_rect) override;
-    void on_sys_color_changed() override;
+    void on_sys_color_changed() override {};
 };
 
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -494,7 +494,7 @@ void Sidebar::priv::hide_rich_tip(wxButton* btn)
 
 static struct DynamicFilamentList : DynamicList
 {
-    std::vector<std::pair<wxString, wxBitmapBundle *>> items;
+    std::vector<std::pair<wxString, wxBitmap *>> items;
 
     void apply_on(Choice *c) override
     {
@@ -533,8 +533,7 @@ static struct DynamicFilamentList : DynamicList
             std::string type;
             wxGetApp().preset_bundle->filaments.find_preset(presets[i])->get_filament_type(type);
             str << type;
-            wxBitmapBundle* bmp = icons[i];
-            items.push_back({str, bmp});
+            items.push_back({str, icons[i]});
         }
         DynamicList::update();
     }
@@ -818,7 +817,9 @@ Sidebar::Sidebar(Plater *parent)
 
             if (dlg.ShowModal() == wxID_OK) {
                 std::vector<float> matrix = dlg.get_matrix();
+                std::vector<float> extruders = dlg.get_extruders();
                 (project_config.option<ConfigOptionFloats>("flush_volumes_matrix"))->values = std::vector<double>(matrix.begin(), matrix.end());
+                (project_config.option<ConfigOptionFloats>("flush_volumes_vector"))->values = std::vector<double>(extruders.begin(), extruders.end());
                 (project_config.option<ConfigOptionFloat>("flush_multiplier"))->set(new ConfigOptionFloat(dlg.get_flush_multiplier()));
 
                 wxGetApp().preset_bundle->export_selections(*wxGetApp().app_config);
@@ -879,7 +880,7 @@ Sidebar::Sidebar(Plater *parent)
     bSizer39->Add(FromDIP(20), 0, 0, 0, 0);
 
     ams_btn = new ScalableButton(p->m_panel_filament_title, wxID_ANY, "ams_fila_sync", wxEmptyString, wxDefaultSize, wxDefaultPosition,
-                                                 wxBU_EXACTFIT | wxNO_BORDER, 18);
+                                                 wxBU_EXACTFIT | wxNO_BORDER, false, 18);
     ams_btn->SetToolTip(_L("Synchronize filament list from AMS"));
     ams_btn->Bind(wxEVT_BUTTON, [this, scrolled_sizer](wxCommandEvent &e) {
         sync_ams_list();
@@ -1341,20 +1342,20 @@ void Sidebar::msw_rescale()
     p->m_panel_printer_title->GetSizer()->SetMinSize(-1, 3 * wxGetApp().em_unit());
     p->m_panel_filament_title->GetSizer()
         ->SetMinSize(-1, 3 * wxGetApp().em_unit());
-    p->m_printer_icon->sys_color_changed();
-    p->m_printer_setting->sys_color_changed();
-    p->m_filament_icon->sys_color_changed();
-    p->m_bpButton_add_filament->sys_color_changed();
-    p->m_bpButton_del_filament->sys_color_changed();
-    p->m_bpButton_ams_filament->sys_color_changed();
-    p->m_bpButton_set_filament->sys_color_changed();
+    p->m_printer_icon->msw_rescale();
+    p->m_printer_setting->msw_rescale();
+    p->m_filament_icon->msw_rescale();
+    p->m_bpButton_add_filament->msw_rescale();
+    p->m_bpButton_del_filament->msw_rescale();
+    p->m_bpButton_ams_filament->msw_rescale();
+    p->m_bpButton_set_filament->msw_rescale();
     p->m_flushing_volume_btn->Rescale();
     //BBS
     m_bed_type_list->Rescale();
     m_bed_type_list->SetMinSize({-1, 3 * wxGetApp().em_unit()});
 #if 0
     if (p->mode_sizer)
-        p->mode_sizer->sys_color_changed();
+        p->mode_sizer->msw_rescale();
 #endif
 
     //for (PlaterPresetComboBox* combo : std::vector<PlaterPresetComboBox*> { p->combo_print,
@@ -1373,14 +1374,15 @@ void Sidebar::msw_rescale()
     // BBS TODO: add msw_rescale for newly added windows
     // BBS
     //p->object_manipulation->msw_rescale();
+    p->object_settings->msw_rescale();
 
     // BBS
 #if 0
     p->object_info->msw_rescale();
 
-    p->btn_send_gcode->sys_color_changed();
+    p->btn_send_gcode->msw_rescale();
 //    p->btn_eject_device->msw_rescale();
-    p->btn_export_gcode_removable->sys_color_changed();
+    p->btn_export_gcode_removable->msw_rescale();
 #ifdef _WIN32
     const int scaled_height = p->btn_export_gcode_removable->GetBitmapHeight();
 #else
@@ -1401,26 +1403,26 @@ void Sidebar::sys_color_changed()
 #if 0
     for (wxWindow* win : std::vector<wxWindow*>{ this, p->sliced_info->GetStaticBox(), p->object_info->GetStaticBox(), p->btn_reslice, p->btn_export_gcode })
         wxGetApp().UpdateDarkUI(win);
-    p->object_info->sys_color_changed();
+    p->object_info->msw_rescale();
 
     for (wxWindow* win : std::vector<wxWindow*>{ p->scrolled, p->presets_panel })
         wxGetApp().UpdateAllStaticTextDarkUI(win);
 #endif
     //for (wxWindow* btn : std::vector<wxWindow*>{ p->btn_reslice, p->btn_export_gcode })
     //    wxGetApp().UpdateDarkUI(btn, true);
-    p->m_printer_icon->sys_color_changed();
-    p->m_printer_setting->sys_color_changed();
-    p->m_filament_icon->sys_color_changed();
-    p->m_bpButton_add_filament->sys_color_changed();
-    p->m_bpButton_del_filament->sys_color_changed();
-    p->m_bpButton_ams_filament->sys_color_changed();
-    p->m_bpButton_set_filament->sys_color_changed();
+    p->m_printer_icon->msw_rescale();
+    p->m_printer_setting->msw_rescale();
+    p->m_filament_icon->msw_rescale();
+    p->m_bpButton_add_filament->msw_rescale();
+    p->m_bpButton_del_filament->msw_rescale();
+    p->m_bpButton_ams_filament->msw_rescale();
+    p->m_bpButton_set_filament->msw_rescale();
     p->m_flushing_volume_btn->Rescale();
 
     // BBS
 #if 0
     if (p->mode_sizer)
-        p->mode_sizer->sys_color_changed();
+        p->mode_sizer->msw_rescale();
     p->frequently_changed_parameters->sys_color_changed();
 #endif
     p->object_settings->sys_color_changed();
@@ -1448,7 +1450,6 @@ void Sidebar::sys_color_changed()
     //p->btn_export_gcode_removable->msw_rescale();
 
     p->scrolled->Layout();
-    p->scrolled->Refresh();
 
     p->searcher.dlg_sys_color_changed();
 }
@@ -12458,6 +12459,8 @@ void Plater::msw_rescale()
     p->view3D->get_canvas3d()->msw_rescale();
 
     p->sidebar->msw_rescale();
+
+    p->menus.msw_rescale();
 
     Layout();
     GetParent()->Layout();

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -112,8 +112,8 @@ PresetComboBox::PresetComboBox(wxWindow* parent, Preset::Type preset_type, const
     default: break;
     }
 
-    m_bitmapCompatible   = get_bmp_bundle("flag_green");
-    m_bitmapIncompatible = get_bmp_bundle("flag_red");
+    m_bitmapCompatible   = ScalableBitmap(this, "flag_green");
+    m_bitmapIncompatible = ScalableBitmap(this, "flag_red");
 
     // parameters for an icon's drawing
     fill_width_height();
@@ -295,12 +295,12 @@ void PresetComboBox::update(std::string select_preset_name)
 
     const std::deque<Preset>& presets = m_collection->get_presets();
 
-    std::map<wxString, std::pair<wxBitmapBundle*, bool>>  nonsys_presets;
-    std::map<wxString, wxBitmapBundle*>                   incomp_presets;
+    std::map<wxString, std::pair<wxBitmap*, bool>>  nonsys_presets;
+    std::map<wxString, wxBitmap*>                   incomp_presets;
 
     wxString selected = "";
     if (!presets.front().is_visible)
-        set_label_marker(Append(separator(L("System presets")), NullBitmapBndl()));
+        set_label_marker(Append(separator(L("System presets")), wxNullBitmap));
 
     for (size_t i = presets.front().is_visible ? 0 : m_collection->num_default_presets(); i < presets.size(); ++i)
     {
@@ -313,7 +313,7 @@ void PresetComboBox::update(std::string select_preset_name)
         if (select_preset_name.empty() && is_enabled)
             select_preset_name = preset.name;
 
-        wxBitmapBundle* bmp = get_bmp(preset);
+        wxBitmap* bmp = get_bmp(preset);
         assert(bmp);
 
         if (!is_enabled)
@@ -325,17 +325,17 @@ void PresetComboBox::update(std::string select_preset_name)
         }
         else
         {
-            nonsys_presets.emplace(get_preset_name(preset), std::pair<wxBitmapBundle*, bool>(bmp, is_enabled));
+            nonsys_presets.emplace(get_preset_name(preset), std::pair<wxBitmap*, bool>(bmp, is_enabled));
             if (preset.name == select_preset_name || (select_preset_name.empty() && is_enabled))
                 selected = get_preset_name(preset);
         }
         if (i + 1 == m_collection->num_default_presets())
-            set_label_marker(Append(separator(L("System presets")), NullBitmapBndl()));
+            set_label_marker(Append(separator(L("System presets")), wxNullBitmap));
     }
     if (!nonsys_presets.empty())
     {
-        set_label_marker(Append(separator(L("User presets")), NullBitmapBndl()));
-        for (std::map<wxString, std::pair<wxBitmapBundle*, bool>>::iterator it = nonsys_presets.begin(); it != nonsys_presets.end(); ++it) {
+        set_label_marker(Append(separator(L("User presets")), wxNullBitmap));
+        for (std::map<wxString, std::pair<wxBitmap*, bool>>::iterator it = nonsys_presets.begin(); it != nonsys_presets.end(); ++it) {
             int item_id = Append(it->first, *it->second.first);
             bool is_enabled = it->second.second;
             if (!is_enabled)
@@ -345,8 +345,8 @@ void PresetComboBox::update(std::string select_preset_name)
     }
     if (!incomp_presets.empty())
     {
-        set_label_marker(Append(separator(L("Incompatible presets")), NullBitmapBndl()));
-        for (std::map<wxString, wxBitmapBundle*>::iterator it = incomp_presets.begin(); it != incomp_presets.end(); ++it) {
+        set_label_marker(Append(separator(L("Incompatible presets")), wxNullBitmap));
+        for (std::map<wxString, wxBitmap*>::iterator it = incomp_presets.begin(); it != incomp_presets.end(); ++it) {
             set_label_marker(Append(it->first, *it->second), LABEL_ITEM_DISABLED);
         }
     }
@@ -363,8 +363,7 @@ void PresetComboBox::show_all(bool show_all)
 
 void PresetComboBox::update()
 {
-    int n = this->GetSelection();
-    this->update(n < 0 ? "" : into_u8(this->GetString(n)));
+    this->update(into_u8(this->GetString(this->GetSelection())));
 }
 
 void PresetComboBox::update_from_bundle()
@@ -400,7 +399,9 @@ void PresetComboBox::add_ams_filaments(std::string selected, bool alias_name)
             const_cast<Preset&>(*iter).is_visible = true;
             auto color = tray.opt_string("filament_colour", 0u);
             auto name = tray.opt_string("tray_name", 0u);
-            int item_id = Append(get_preset_name(*iter), *get_extruder_color_icon(color, name, 24, 16), &m_first_ams_filament + entry.first);
+            wxBitmap bmp(*get_extruder_color_icon(color, name, 24, 16));
+            int item_id = Append(get_preset_name(*iter), bmp.ConvertToImage(), &m_first_ams_filament + entry.first);
+            //validate_selection(id->value == selected); // can not select
         }
         m_last_ams_filament = GetCount();
     }
@@ -418,24 +419,29 @@ void PresetComboBox::msw_rescale()
 {
     m_em_unit = em_unit(this);
     Rescale();
+
+    m_bitmapIncompatible.msw_rescale();
+    m_bitmapCompatible.msw_rescale();
+
+    // parameters for an icon's drawing
+    fill_width_height();
+
+    // update the control to redraw the icons
+    update();
 }
 
 void PresetComboBox::sys_color_changed()
 {
-    m_bitmapCompatible = get_bmp_bundle("flag_green");
-    m_bitmapIncompatible = get_bmp_bundle("flag_red");
     wxGetApp().UpdateDarkUI(this);
-
-    // update the control to redraw the icons
-    update();
+    msw_rescale();
 }
 
 void PresetComboBox::fill_width_height()
 {
     // To avoid asserts, each added bitmap to wxBitmapCombobox should be the same size, so
     // set a bitmap's height to m_bitmapCompatible->GetHeight() and norm_icon_width to m_bitmapCompatible->GetWidth()
-    icon_height     = 16;
-    norm_icon_width = 16;
+    icon_height     = m_bitmapCompatible.GetBmpHeight();
+    norm_icon_width = m_bitmapCompatible.GetBmpWidth();
 
     /* It's supposed that standard size of an icon is 16px*16px for 100% scaled display.
     * So set sizes for solid_colored icons used for filament preset
@@ -446,11 +452,9 @@ void PresetComboBox::fill_width_height()
     thin_icon_width = lroundf(8 * scale_f);          // analogue to 8px;
     wide_icon_width = norm_icon_width + thin_icon_width;
 
-    null_icon_width = 2 * norm_icon_width;
-
-    space_icon_width      = 2;
-    thin_space_icon_width = 4;
-    wide_space_icon_width = 6;
+    space_icon_width      = lroundf(2 * scale_f);
+    thin_space_icon_width = lroundf(4 * scale_f);
+    wide_space_icon_width = lroundf(6 * scale_f);
 }
 
 wxString PresetComboBox::separator(const std::string& label)
@@ -458,15 +462,15 @@ wxString PresetComboBox::separator(const std::string& label)
     return wxString::FromUTF8(separator_head()) + _(label) + wxString::FromUTF8(separator_tail());
 }
 
-wxBitmapBundle* PresetComboBox::get_bmp(  std::string bitmap_key, bool wide_icons, const std::string& main_icon_name,
+wxBitmap* PresetComboBox::get_bmp(  std::string bitmap_key, bool wide_icons, const std::string& main_icon_name,
                                     bool is_compatible/* = true*/, bool is_system/* = false*/, bool is_single_bar/* = false*/,
                                     const std::string& filament_rgb/* = ""*/, const std::string& extruder_rgb/* = ""*/, const std::string& material_rgb/* = ""*/)
 {
     // BBS: no icon
 #if 1
-    static wxBitmapBundle bmp;
+    static wxBitmap bmp;
     return &bmp;
-#else // if this is updated, refer to PrusaSlicer for updates
+#else
     // If the filament preset is not compatible and there is a "red flag" icon loaded, show it left
     // to the filament color image.
     if (wide_icons)
@@ -479,52 +483,52 @@ wxBitmapBundle* PresetComboBox::get_bmp(  std::string bitmap_key, bool wide_icon
         bitmap_key += ",dark";
     bitmap_key += material_rgb;
 
-    wxBitmapBundle* bmp_bndl = bitmap_cache().find_bndl(bitmap_key);
-    if (bmp_bndl == nullptr) {
+    wxBitmap* bmp = bitmap_cache().find(bitmap_key);
+    if (bmp == nullptr) {
         // Create the bitmap with color bars.
-        std::vector<wxBitmapBundle*> bmps;
+        std::vector<wxBitmap> bmps;
         if (wide_icons)
             // Paint a red flag for incompatible presets.
-            bmps.emplace_back(is_compatible ? get_empty_bmp_bundle(norm_icon_width, icon_height) : m_bitmapIncompatible);
+            bmps.emplace_back(is_compatible ? bitmap_cache().mkclear(norm_icon_width, icon_height) : m_bitmapIncompatible.bmp());
 
         if (m_type == Preset::TYPE_FILAMENT && !filament_rgb.empty())
         {
             // BBS
             // Paint a lock at the system presets.
-            bmps.emplace_back(get_empty_bmp_bundle(space_icon_width, icon_height));
+            bmps.emplace_back(bitmap_cache().mkclear(space_icon_width, icon_height));
         }
         else
         {
             // BBS
 #if 0
             // Paint the color bars.
-            bmps.emplace_back(get_empty_bmp_bundle(thin_space_icon_width, icon_height));
+            bmps.emplace_back(bitmap_cache().mkclear(thin_space_icon_width, icon_height));
             if (m_type == Preset::TYPE_SLA_MATERIAL)
-                bmps.emplace_back(bitmap_cache().from_svg(main_icon_name, 16, 16, dark_mode, material_rgb));
+                bmps.emplace_back(create_scaled_bitmap(main_icon_name, this, 16, false, material_rgb));
             else
-                bmps.emplace_back(get_bmp_bundle(main_icon_name));
+                bmps.emplace_back(create_scaled_bitmap(main_icon_name));
 #endif
             // Paint a lock at the system presets.
-            bmps.emplace_back(get_empty_bmp_bundle(wide_space_icon_width, icon_height));
+            bmps.emplace_back(bitmap_cache().mkclear(wide_space_icon_width, icon_height));
         }
-        bmps.emplace_back(is_system ? get_bmp_bundle("unlock_normal") : get_empty_bmp_bundle(norm_icon_width, icon_height));
-        bmp_bndl = bitmap_cache().insert_bndl(bitmap_key, bmps);
+        bmps.emplace_back(is_system ? create_scaled_bitmap("unlock_normal") : bitmap_cache().mkclear(norm_icon_width, icon_height));
+        bmp = bitmap_cache().insert(bitmap_key, bmps);
     }
 
-    return bmp_bndl;
+    return bmp;
 #endif
 }
 
-wxBitmapBundle* PresetComboBox::get_bmp(Preset const &preset)
+wxBitmap *PresetComboBox::get_bmp(Preset const &preset)
 {
-    static wxBitmapBundle sbmp;
+    static wxBitmap sbmp;
     if (m_type == Preset::TYPE_FILAMENT) {
         Preset const & preset2 = &m_collection->get_selected_preset() == &preset ? m_collection->get_edited_preset() : preset;
         wxString color = preset2.config.opt_string("default_filament_colour", 0);
         wxColour clr(color);
         if (clr.IsOk()) {
             std::string bitmap_key = "default_filament_colour_" + color.ToStdString();
-            wxBitmapBundle *bmp        = bitmap_cache().find_bndl(bitmap_key);
+            wxBitmap *bmp        = bitmap_cache().find(bitmap_key);
             if (bmp == nullptr) {
                 wxImage img(16, 16);
                 if (clr.Red() > 224 && clr.Blue() > 224 && clr.Green() > 224) {
@@ -533,8 +537,8 @@ wxBitmapBundle* PresetComboBox::get_bmp(Preset const &preset)
                 } else {
                     img.SetRGB(wxRect({0, 0}, img.GetSize()), clr.Red(), clr.Green(), clr.Blue());
                 }
-                bmp = new wxBitmapBundle(img);
-                bmp = bitmap_cache().insert_bndl(bitmap_key, *bmp);
+                bmp = new wxBitmap(img);
+                bmp = bitmap_cache().insert(bitmap_key, *bmp);
             }
             return bmp;
         }
@@ -542,14 +546,14 @@ wxBitmapBundle* PresetComboBox::get_bmp(Preset const &preset)
     return &sbmp;
 }
 
-wxBitmapBundle *PresetComboBox::get_bmp(std::string        bitmap_key,
+wxBitmap *PresetComboBox::get_bmp(std::string        bitmap_key,
                                   const std::string &main_icon_name,
                                   const std::string &next_icon_name,
                                     bool is_enabled/* = true*/, bool is_compatible/* = true*/, bool is_system/* = false*/)
 {
     // BBS: no icon
 #if 1
-    static wxBitmapBundle bmp;
+    static wxBitmap bmp;
     return &bmp;
 #else
     bitmap_key += !is_enabled ? "_disabled" : "";
@@ -559,25 +563,19 @@ wxBitmapBundle *PresetComboBox::get_bmp(std::string        bitmap_key,
     if (wxGetApp().dark_mode())
         bitmap_key += ",dark";
 
-    wxBitmapBundle* bmp = bitmap_cache().find_bndl(bitmap_key);
+    wxBitmap* bmp = bitmap_cache().find(bitmap_key);
     if (bmp == nullptr) {
         // Create the bitmap with color bars.
-        std::vector<wxBitmapBundle*> bmps;
-        bmps.emplace_back(m_type == Preset::TYPE_PRINTER ? get_bmp_bundle(main_icon_name, this, 16, !is_enabled) :
-                          is_compatible ? m_bitmapCompatible : m_bitmapIncompatible);
+        std::vector<wxBitmap> bmps;
+        bmps.emplace_back(m_type == Preset::TYPE_PRINTER ? create_scaled_bitmap(main_icon_name, this, 16, !is_enabled) :
+                          is_compatible ? m_bitmapCompatible.bmp() : m_bitmapIncompatible.bmp());
         // Paint a lock at the system presets.
-        bmps.emplace_back(is_system ? get_bmp_bundle(next_icon_name) : get_empty_bmp_bundle(norm_icon_width, icon_height));
-        bmp = bitmap_cache().insert_bndl(bitmap_key, bmps);
+        bmps.emplace_back(is_system ? create_scaled_bitmap(next_icon_name, this, 16, !is_enabled) : bitmap_cache().mkclear(norm_icon_width, icon_height));
+        bmp = bitmap_cache().insert(bitmap_key, bmps);
     }
 
     return bmp;
 #endif
-}
-
-wxBitmapBundle PresetComboBox::NullBitmapBndl()
-{
-    assert(null_icon_width > 0);
-    return *get_empty_bmp_bundle(null_icon_width, icon_height);
 }
 
 bool PresetComboBox::is_selected_physical_printer()
@@ -946,12 +944,10 @@ void PlaterPresetComboBox::update()
     // and draw a red flag in front of the selected preset.
     bool wide_icons = selected_preset && !selected_preset->is_compatible;
 
-    null_icon_width = (wide_icons ? 3 : 2) * norm_icon_width + thin_space_icon_width + wide_space_icon_width;
-
-    std::map<wxString, wxBitmapBundle*> nonsys_presets;
+    std::map<wxString, wxBitmap*> nonsys_presets;
     //BBS: add project embedded presets logic
-    std::map<wxString, wxBitmapBundle*>  project_embedded_presets;
-    std::map<wxString, wxBitmapBundle*>  system_presets;
+    std::map<wxString, wxBitmap*>  project_embedded_presets;
+    std::map<wxString, wxBitmap*>  system_presets;
 
     //BBS:  move system to the end
     wxString selected_system_preset;
@@ -961,7 +957,7 @@ void PlaterPresetComboBox::update()
 
     //BBS:  move system to the end
     /*if (!presets.front().is_visible)
-        this->set_label_marker(this->Append(separator(L("System presets")), NullBitmapBndl()));*/
+        this->set_label_marker(this->Append(separator(L("System presets")), wxNullBitmap));*/
 
     for (size_t i = presets.front().is_visible ? 0 : m_collection->num_default_presets(); i < presets.size(); ++i)
     {
@@ -989,7 +985,7 @@ void PlaterPresetComboBox::update()
 #endif
         }
 
-        wxBitmapBundle* bmp = get_bmp(preset);
+        wxBitmap* bmp = get_bmp(preset);
         assert(bmp);
 
         const std::string name = preset.alias.empty() ? preset.name : preset.alias;
@@ -1034,16 +1030,16 @@ void PlaterPresetComboBox::update()
     //BBS: add project embedded preset logic
     if (!project_embedded_presets.empty())
     {
-        set_label_marker(Append(separator(L("Project-inside presets")), NullBitmapBndl()));
-        for (std::map<wxString, wxBitmapBundle*>::iterator it = project_embedded_presets.begin(); it != project_embedded_presets.end(); ++it) {
+        set_label_marker(Append(separator(L("Project-inside presets")), wxNullBitmap));
+        for (std::map<wxString, wxBitmap*>::iterator it = project_embedded_presets.begin(); it != project_embedded_presets.end(); ++it) {
             Append(it->first, *it->second);
             validate_selection(it->first == selected_user_preset);
         }
     }
     if (!nonsys_presets.empty())
     {
-        set_label_marker(Append(separator(L("User presets")), NullBitmapBndl()));
-        for (std::map<wxString, wxBitmapBundle*>::iterator it = nonsys_presets.begin(); it != nonsys_presets.end(); ++it) {
+        set_label_marker(Append(separator(L("User presets")), wxNullBitmap));
+        for (std::map<wxString, wxBitmap*>::iterator it = nonsys_presets.begin(); it != nonsys_presets.end(); ++it) {
             Append(it->first, *it->second);
             validate_selection(it->first == selected_user_preset);
         }
@@ -1051,8 +1047,8 @@ void PlaterPresetComboBox::update()
     //BBS: move system to the end
     if (!system_presets.empty())
     {
-        set_label_marker(Append(separator(L("System presets")), NullBitmapBndl()));
-        for (std::map<wxString, wxBitmapBundle*>::iterator it = system_presets.begin(); it != system_presets.end(); ++it) {
+        set_label_marker(Append(separator(L("System presets")), wxNullBitmap));
+        for (std::map<wxString, wxBitmap*>::iterator it = system_presets.begin(); it != system_presets.end(); ++it) {
             Append(it->first, *it->second);
             validate_selection(it->first == selected_system_preset);
         }
@@ -1063,7 +1059,7 @@ void PlaterPresetComboBox::update()
     {
         // add Physical printers, if any exists
         if (!m_preset_bundle->physical_printers.empty()) {
-            set_label_marker(Append(separator(L("Physical printers")), NullBitmapBndl()));
+            set_label_marker(Append(separator(L("Physical printers")), wxNullBitmap));
             const PhysicalPrinterCollection& ph_printers = m_preset_bundle->physical_printers;
 
             for (PhysicalPrinterCollection::ConstIterator it = ph_printers.begin(); it != ph_printers.end(); ++it) {
@@ -1072,7 +1068,7 @@ void PlaterPresetComboBox::update()
                     if (!preset || !preset->is_visible)
                         continue;
                     std::string main_icon_name, bitmap_key = main_icon_name = preset->printer_technology() == ptSLA ? "sla_printer" : m_main_bitmap_name;
-                    auto bmp = get_bmp(main_icon_name, wide_icons, main_icon_name);
+                    wxBitmap* bmp = get_bmp(main_icon_name, wide_icons, main_icon_name);
                     assert(bmp);
 
                     set_label_marker(Append(from_u8(it->get_full_name(preset_name) + suffix(preset)), *bmp), LABEL_ITEM_PHYSICAL_PRINTER);
@@ -1083,7 +1079,7 @@ void PlaterPresetComboBox::update()
     }*/
 
     if (m_type == Preset::TYPE_PRINTER || m_type == Preset::TYPE_FILAMENT || m_type == Preset::TYPE_SLA_MATERIAL) {
-        wxBitmapBundle* bmp = get_bmp("edit_preset_list", wide_icons, "edit_uni");
+        wxBitmap* bmp = get_bmp("edit_preset_list", wide_icons, "edit_uni");
         assert(bmp);
 
         if (m_type == Preset::TYPE_FILAMENT)
@@ -1125,22 +1121,11 @@ void PlaterPresetComboBox::msw_rescale()
 
     if (clr_picker)
         clr_picker->SetSize(20 * m_em_unit / 10, 20 * m_em_unit / 10);
-#ifdef __WXMSW__
-    // Use this part of code just on Windows to avoid of some layout issues on Linux
-    // see https://github.com/prusa3d/PrusaSlicer/issues/5163 and https://github.com/prusa3d/PrusaSlicer/issues/5505
-    // Update control min size after rescale (changed Display DPI under MSW)
-    if (GetMinWidth() != 20 * m_em_unit)
-        SetMinSize(wxSize(20 * m_em_unit, GetSize().GetHeight()));
-#endif //__WXMSW__
-}
-
-void PlaterPresetComboBox::sys_color_changed()
-{
-    PresetComboBox::sys_color_changed();
     // BBS
     if (edit_btn != nullptr)
-        edit_btn->sys_color_changed();
+        edit_btn->msw_rescale();
 }
+
 
 // ---------------------------------
 // ***  TabPresetComboBox  ***
@@ -1208,16 +1193,16 @@ void TabPresetComboBox::update()
 
     const std::deque<Preset>& presets = m_collection->get_presets();
 
-    std::map<wxString, std::pair<wxBitmapBundle*, bool>> nonsys_presets;
+    std::map<wxString, std::pair<wxBitmap*, bool>> nonsys_presets;
     //BBS: add project embedded presets logic
-    std::map<wxString, std::pair<wxBitmapBundle*, bool>>  project_embedded_presets;
+    std::map<wxString, std::pair<wxBitmap*, bool>>  project_embedded_presets;
     //BBS:  move system to the end
-    std::map<wxString, std::pair<wxBitmapBundle*, bool>>  system_presets;
+    std::map<wxString, std::pair<wxBitmap*, bool>>  system_presets;
 
     wxString selected = "";
     //BBS:  move system to the end
     /*if (!presets.front().is_visible)
-        set_label_marker(Append(separator(L("System presets")), NullBitmapBndl()));*/
+        set_label_marker(Append(separator(L("System presets")), wxNullBitmap));*/
     size_t idx_selected = m_collection->get_selected_idx();
 
     if (m_type == Preset::TYPE_PRINTER && m_preset_bundle->physical_printers.has_selection()) {
@@ -1236,12 +1221,12 @@ void TabPresetComboBox::update()
         // marker used for disable incompatible printer models for the selected physical printer
         bool is_enabled = true;
 
-        wxBitmapBundle* bmp = get_bmp(preset);
+        wxBitmap* bmp = get_bmp(preset);
         assert(bmp);
 
         if (preset.is_default || preset.is_system) {
             //BBS: move system to the end
-            system_presets.emplace(get_preset_name(preset), std::pair<wxBitmapBundle *, bool>(bmp, is_enabled));
+            system_presets.emplace(get_preset_name(preset), std::pair<wxBitmap *, bool>(bmp, is_enabled));
             if (i == idx_selected)
                 selected = get_preset_name(preset);
             //int item_id = Append(get_preset_name(preset), *bmp);
@@ -1253,20 +1238,20 @@ void TabPresetComboBox::update()
         else if (preset.is_project_embedded)
         {
             //std::pair<wxBitmap*, bool> pair(bmp, is_enabled);
-            project_embedded_presets.emplace(get_preset_name(preset), std::pair<wxBitmapBundle *, bool>(bmp, is_enabled));
+            project_embedded_presets.emplace(get_preset_name(preset), std::pair<wxBitmap *, bool>(bmp, is_enabled));
             if (i == idx_selected)
                 selected = get_preset_name(preset);
         }
         else
         {
-            std::pair<wxBitmapBundle*, bool> pair(bmp, is_enabled);
-            nonsys_presets.emplace(get_preset_name(preset), std::pair<wxBitmapBundle*, bool>(bmp, is_enabled));
+            std::pair<wxBitmap*, bool> pair(bmp, is_enabled);
+            nonsys_presets.emplace(get_preset_name(preset), std::pair<wxBitmap*, bool>(bmp, is_enabled));
             if (i == idx_selected)
                 selected = get_preset_name(preset);
         }
         //BBS: move system to the end
         //if (i + 1 == m_collection->num_default_presets())
-        //    set_label_marker(Append(separator(L("System presets")), NullBitmapBndl()));
+        //    set_label_marker(Append(separator(L("System presets")), wxNullBitmap));
     }
 
     if (m_type == Preset::TYPE_FILAMENT && m_preset_bundle->is_bbl_vendor())
@@ -1276,7 +1261,7 @@ void TabPresetComboBox::update()
     if (!project_embedded_presets.empty())
     {
         set_label_marker(Append(separator(L("Project-inside presets")), wxNullBitmap));
-        for (std::map<wxString, std::pair<wxBitmapBundle*, bool>>::iterator it = project_embedded_presets.begin(); it != project_embedded_presets.end(); ++it) {
+        for (std::map<wxString, std::pair<wxBitmap*, bool>>::iterator it = project_embedded_presets.begin(); it != project_embedded_presets.end(); ++it) {
             int item_id = Append(it->first, *it->second.first);
             bool is_enabled = it->second.second;
             if (!is_enabled)
@@ -1286,8 +1271,8 @@ void TabPresetComboBox::update()
     }
     if (!nonsys_presets.empty())
     {
-        set_label_marker(Append(separator(L("User presets")), NullBitmapBndl()));
-        for (std::map<wxString, std::pair<wxBitmapBundle*, bool>>::iterator it = nonsys_presets.begin(); it != nonsys_presets.end(); ++it) {
+        set_label_marker(Append(separator(L("User presets")), wxNullBitmap));
+        for (std::map<wxString, std::pair<wxBitmap*, bool>>::iterator it = nonsys_presets.begin(); it != nonsys_presets.end(); ++it) {
             int item_id = Append(it->first, *it->second.first);
             bool is_enabled = it->second.second;
             if (!is_enabled)
@@ -1299,7 +1284,7 @@ void TabPresetComboBox::update()
     if (!system_presets.empty())
     {
         set_label_marker(Append(separator(L("System presets")), wxNullBitmap));
-        for (std::map<wxString, std::pair<wxBitmapBundle*, bool>>::iterator it = system_presets.begin(); it != system_presets.end(); ++it) {
+        for (std::map<wxString, std::pair<wxBitmap*, bool>>::iterator it = system_presets.begin(); it != system_presets.end(); ++it) {
             int item_id = Append(it->first, *it->second.first);
             bool is_enabled = it->second.second;
             if (!is_enabled)
@@ -1313,7 +1298,7 @@ void TabPresetComboBox::update()
         //BBS: remove unused pysical printer logic
         /*// add Physical printers, if any exists
         if (!m_preset_bundle->physical_printers.empty()) {
-            set_label_marker(Append(separator(L("Physical printers")), NullBitmapBndl()));
+            set_label_marker(Append(separator(L("Physical printers")), wxNullBitmap));
             const PhysicalPrinterCollection& ph_printers = m_preset_bundle->physical_printers;
 
             for (PhysicalPrinterCollection::ConstIterator it = ph_printers.begin(); it != ph_printers.end(); ++it) {
@@ -1323,7 +1308,7 @@ void TabPresetComboBox::update()
                         continue;
                     std::string main_icon_name = preset->printer_technology() == ptSLA ? "sla_printer" : m_main_bitmap_name;
 
-                    auto bmp = get_bmp(main_icon_name, main_icon_name, "", true, true, false);
+                    wxBitmap* bmp = get_bmp(main_icon_name, main_icon_name, "", true, true, false);
                     assert(bmp);
 
                     set_label_marker(Append(from_u8(it->get_full_name(preset_name) + suffix(preset)), *bmp), LABEL_ITEM_PHYSICAL_PRINTER);
@@ -1334,14 +1319,14 @@ void TabPresetComboBox::update()
 
         // add "Add/Remove printers" item
         //std::string icon_name = "edit_uni";
-        //auto bmp = get_bmp("edit_preset_list, tab,", icon_name, "");
+        //wxBitmap* bmp = get_bmp("edit_preset_list, tab,", icon_name, "");
         //assert(bmp);
 
         //set_label_marker(Append(separator(L("Add/Remove printers")), *bmp), LABEL_ITEM_WIZARD_PRINTERS);
     }
 
     // BBS Add/Remove filaments select
-    //wxBitmapBundle* bmp = get_bmp("edit_preset_list", false, "edit_uni");
+    //wxBitmap* bmp = get_bmp("edit_preset_list", false, "edit_uni");
     //assert(bmp);
     //if (m_type == Preset::TYPE_FILAMENT)
     //    set_label_marker(Append(separator(L("Add/Remove filaments")), *bmp), LABEL_ITEM_WIZARD_FILAMENTS);
@@ -1501,7 +1486,7 @@ void GUI::CalibrateFilamentComboBox::update()
             tooltip = get_tooltip(preset);
         }
 
-        wxBitmapBundle* bmp = get_bmp(preset);
+        wxBitmap* bmp = get_bmp(preset);
         assert(bmp);
 
         if (preset.is_default || preset.is_system) {
@@ -1544,7 +1529,7 @@ void GUI::CalibrateFilamentComboBox::msw_rescale()
     }
     // BBS
     if (edit_btn != nullptr)
-        edit_btn->sys_color_changed();
+        edit_btn->msw_rescale();
 }
 
 void GUI::CalibrateFilamentComboBox::OnSelect(wxCommandEvent &evt)

--- a/src/slic3r/GUI/PresetComboBoxes.hpp
+++ b/src/slic3r/GUI/PresetComboBoxes.hpp
@@ -1,7 +1,7 @@
 #ifndef slic3r_PresetComboBoxes_hpp_
 #define slic3r_PresetComboBoxes_hpp_
 
-#include <wx/bmpbndl.h>
+//#include <wx/bmpcbox.h>
 #include <wx/gdicmn.h>
 #include <wx/clrpicker.h>
 
@@ -37,7 +37,7 @@ public:
     PresetComboBox(wxWindow* parent, Preset::Type preset_type, const wxSize& size = wxDefaultSize, PresetBundle* preset_bundle = nullptr);
     ~PresetComboBox();
 
-	enum LabelItemType : size_t {
+	enum LabelItemType {
 		LABEL_ITEM_PHYSICAL_PRINTER = 0xffffff01,
 		LABEL_ITEM_DISABLED,
 		LABEL_ITEM_MARKER,
@@ -99,9 +99,9 @@ protected:
     static BitmapCache& bitmap_cache();
 
     // Indicator, that the preset is compatible with the selected printer.
-    wxBitmapBundle*      m_bitmapCompatible;
+    ScalableBitmap      m_bitmapCompatible;
     // Indicator, that the preset is NOT compatible with the selected printer.
-    wxBitmapBundle*      m_bitmapIncompatible;
+    ScalableBitmap      m_bitmapIncompatible;
 
     int m_last_selected;
     int m_em_unit;
@@ -115,7 +115,6 @@ protected:
     // parameters for an icon's drawing
     int icon_height;
     int norm_icon_width;
-    int null_icon_width;
     int thin_icon_width;
     int wide_icon_width;
     int space_icon_width;
@@ -140,16 +139,14 @@ protected:
 #endif // __linux__
     static wxString    separator(const std::string& label);
 
-    wxBitmapBundle* get_bmp(  std::string bitmap_key, bool wide_icons, const std::string& main_icon_name,
+    wxBitmap* get_bmp(  std::string bitmap_key, bool wide_icons, const std::string& main_icon_name, 
                         bool is_compatible = true, bool is_system = false, bool is_single_bar = false,
                         const std::string& filament_rgb = "", const std::string& extruder_rgb = "", const std::string& material_rgb = "");
 
-    wxBitmapBundle* get_bmp(  std::string bitmap_key, const std::string& main_icon_name, const std::string& next_icon_name,
+    wxBitmap* get_bmp(  std::string bitmap_key, const std::string& main_icon_name, const std::string& next_icon_name,
                         bool is_enabled = true, bool is_compatible = true, bool is_system = false);
 
-    wxBitmapBundle* get_bmp(Preset const &preset);
-
-    wxBitmapBundle NullBitmapBndl();
+    wxBitmap *get_bmp(Preset const &preset);
 
 private:
     void fill_width_height();
@@ -182,7 +179,6 @@ public:
     wxString get_preset_name(const Preset& preset) override;
     void update() override;
     void msw_rescale() override;
-    void sys_color_changed() override;
     void OnSelect(wxCommandEvent& evt) override;
 
 private:
@@ -249,8 +245,8 @@ private:
     bool m_filament_exist{false};
     bool m_is_compatible{true};
     const Preset* m_selected_preset = nullptr;
-    std::map<wxString, std::pair<std::string, wxBitmapBundle*>> m_nonsys_presets;
-    std::map<wxString, std::pair<std::string, wxBitmapBundle*>> m_system_presets;
+    std::map<wxString, std::pair<std::string, wxBitmap*>> m_nonsys_presets;
+    std::map<wxString, std::pair<std::string, wxBitmap*>> m_system_presets;
 };
 
 } // namespace GUI

--- a/src/slic3r/GUI/RecenterDialog.cpp
+++ b/src/slic3r/GUI/RecenterDialog.cpp
@@ -94,16 +94,16 @@ void RecenterDialog::render(wxDC& dc) {
 
     wxSize hint1_size = dc.GetTextExtent(hint1);
     wxPoint pos_hint1 = pos_start;
-    pos_hint1.y += (m_home_bmp.GetWidth() - hint1_size.y) / 2;
+    pos_hint1.y += (m_home_bmp.GetBmpWidth() - hint1_size.y) / 2;
     dc.DrawText(hint1, pos_hint1);
 
     wxPoint pos_bmp = pos_start;
     pos_bmp.x += hint1_size.x;
-    dc.DrawBitmap(m_home_bmp.get_bitmap(), pos_bmp);
+    dc.DrawBitmap(m_home_bmp.bmp(), pos_bmp);
 
     wxSize hint2_size = dc.GetTextExtent(hint2);
     wxPoint pos_hint2 = pos_hint1;
-    pos_hint2.x = pos_hint2.x + hint1_size.x + m_home_bmp.GetWidth();
+    pos_hint2.x = pos_hint2.x + hint1_size.x + m_home_bmp.GetBmpWidth();
 
     if (hint2_size.x + pos_hint2.x + BORDER > DRAW_PANEL_SIZE.x) {
         bool is_ch = false;

--- a/src/slic3r/GUI/SavePresetDialog.cpp
+++ b/src/slic3r/GUI/SavePresetDialog.cpp
@@ -57,7 +57,7 @@ SavePresetDialog::Item::Item(Preset::Type type, const std::string &suffix, wxBox
     label_top->SetForegroundColour(wxColour(38,46,48));
 
 
-    //    m_valid_bmp = new wxStaticBitmap(m_parent, wxID_ANY, *get_bmp_bundle("blank_16"));
+    //    m_valid_bmp = new wxStaticBitmap(m_parent, wxID_ANY, create_scaled_bitmap("blank_16", m_parent));
     //
     //    m_combo = new wxComboBox(m_parent, wxID_ANY, from_u8(preset_name), wxDefaultPosition, wxSize(35 * wxGetApp().em_unit(), -1));
     //    for (const std::string& value : values)
@@ -268,7 +268,7 @@ void SavePresetDialog::Item::update()
 void SavePresetDialog::Item::update_valid_bmp()
 {
     std::string bmp_name = m_valid_type == Warning ? "obj_warning" : m_valid_type == NoValid ? "cross" : "blank_16";
-    m_valid_bmp->SetBitmap(*get_bmp_bundle(bmp_name));
+    m_valid_bmp->SetBitmap(create_scaled_bitmap(bmp_name, m_parent));
 }
 
 void SavePresetDialog::Item::accept()

--- a/src/slic3r/GUI/Search.cpp
+++ b/src/slic3r/GUI/Search.cpp
@@ -829,8 +829,11 @@ void SearchDialog::msw_rescale()
 {
     /* const int &em = GUI::wxGetApp().em_unit();
 
+     search_list_model->msw_rescale();
      search_list->GetColumn(SearchListModel::colIcon      )->SetWidth(3  * em);
      search_list->GetColumn(SearchListModel::colMarkedText)->SetWidth(45 * em);
+
+     msw_buttons_rescale(this, em, { wxID_CANCEL });
 
      const wxSize& size = wxSize(40 * em, 30 * em);
      SetMinSize(size);
@@ -849,7 +852,7 @@ void SearchDialog::msw_rescale()
 //#endif
 //
 //    // msw_rescale updates just icons, so use it
-//    search_list_model->sys_color_changed();
+//    search_list_model->msw_rescale();
 //
 //    Refresh();
 //}
@@ -881,10 +884,9 @@ void SearchListModel::Prepend(const std::string &label)
     RowPrepended();
 }
 
-void SearchListModel::sys_color_changed()
+void SearchListModel::msw_rescale()
 {
-    for (ScalableBitmap &bmp : m_icon)
-        bmp.sys_color_changed();
+    for (ScalableBitmap &bmp : m_icon) bmp.msw_rescale();
 }
 
 wxString SearchListModel::GetColumnType(unsigned int col) const
@@ -896,7 +898,7 @@ wxString SearchListModel::GetColumnType(unsigned int col) const
 void SearchListModel::GetValueByRow(wxVariant &variant, unsigned int row, unsigned int col) const
 {
     switch (col) {
-    case colIcon: variant << m_icon[m_values[row].second].bmp().GetBitmapFor(m_icon[m_values[row].second].parent()); break;
+    case colIcon: variant << m_icon[m_values[row].second].bmp(); break;
     case colMarkedText: variant = m_values[row].first; break;
     case colMax: wxFAIL_MSG("invalid column");
     default: break;

--- a/src/slic3r/GUI/Search.hpp
+++ b/src/slic3r/GUI/Search.hpp
@@ -270,7 +270,7 @@ public:
 
     void Clear();
     void Prepend(const std::string &text);
-    void sys_color_changed();
+    void msw_rescale();
 
     // implementation of base class virtuals to define model
 

--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -212,9 +212,9 @@ void MachineObjectPanel::doRender(wxDC &dc)
     if (m_state == PrinterState::IN_LAN) { dwbitmap = m_printer_in_lan; }
 
     // dc.DrawCircle(left, size.y / 2, 3);
-    dc.DrawBitmap(dwbitmap.get_bitmap(), wxPoint(left, (size.y - dwbitmap.GetSize().y) / 2));
+    dc.DrawBitmap(dwbitmap.bmp(), wxPoint(left, (size.y - dwbitmap.GetBmpSize().y) / 2));
 
-    left += dwbitmap.GetSize().x + 8;
+    left += dwbitmap.GetBmpSize().x + 8;
     dc.SetFont(Label::Body_13);
     dc.SetBackgroundMode(wxTRANSPARENT);
     dc.SetTextForeground(StateColor::darkModeColorFor(SELECT_MACHINE_GREY900));
@@ -230,10 +230,10 @@ void MachineObjectPanel::doRender(wxDC &dc)
     auto        text_end     = 0;
 
     if (m_show_edit) {
-        text_end = size.x - m_unbind_img.GetSize().x - 30;
+        text_end = size.x - m_unbind_img.GetBmpSize().x - 30;
     }
     else {
-        text_end = size.x - m_unbind_img.GetSize().x;
+        text_end = size.x - m_unbind_img.GetBmpSize().x;
     }
 
     wxString finally_name =  dev_name;
@@ -261,14 +261,14 @@ void MachineObjectPanel::doRender(wxDC &dc)
 
         if (m_show_bind) {
             if (m_bind_state == ALLOW_UNBIND) {
-                left = size.x - m_unbind_img.GetSize().x - 6;
-                dc.DrawBitmap(m_unbind_img.get_bitmap(), left, (size.y - m_unbind_img.GetSize().y) / 2);
+                left = size.x - m_unbind_img.GetBmpSize().x - 6;
+                dc.DrawBitmap(m_unbind_img.bmp(), left, (size.y - m_unbind_img.GetBmpSize().y) / 2);
             }
         }
 
         if (m_show_edit) {
-            left = size.x - m_unbind_img.GetSize().x - 6 - m_edit_name_img.GetSize().x - 6;
-            dc.DrawBitmap(m_edit_name_img.get_bitmap(), left, (size.y - m_edit_name_img.GetSize().y) / 2);
+            left = size.x - m_unbind_img.GetBmpSize().x - 6 - m_edit_name_img.GetBmpSize().x - 6;
+            dc.DrawBitmap(m_edit_name_img.bmp(), left, (size.y - m_edit_name_img.GetBmpSize().y) / 2);
         }
     }
 
@@ -298,10 +298,10 @@ void MachineObjectPanel::on_mouse_left_up(wxMouseEvent &evt)
     if (m_is_my_devices) {
         // show edit
         if (m_show_edit) {
-            auto edit_left   = GetSize().x - m_unbind_img.GetSize().x - 6 - m_edit_name_img.GetSize().x - 6;
-            auto edit_right  = edit_left + m_edit_name_img.GetSize().x;
-            auto edit_top    = (GetSize().y - m_edit_name_img.GetSize().y) / 2;
-            auto edit_bottom = (GetSize().y - m_edit_name_img.GetSize().y) / 2 + m_edit_name_img.GetSize().y;
+            auto edit_left   = GetSize().x - m_unbind_img.GetBmpSize().x - 6 - m_edit_name_img.GetBmpSize().x - 6;
+            auto edit_right  = edit_left + m_edit_name_img.GetBmpSize().x;
+            auto edit_top    = (GetSize().y - m_edit_name_img.GetBmpSize().y) / 2;
+            auto edit_bottom = (GetSize().y - m_edit_name_img.GetBmpSize().y) / 2 + m_edit_name_img.GetBmpSize().y;
             if ((evt.GetPosition().x >= edit_left && evt.GetPosition().x <= edit_right) && evt.GetPosition().y >= edit_top && evt.GetPosition().y <= edit_bottom) {
                 wxCommandEvent event(EVT_EDIT_PRINT_NAME);
                 event.SetEventObject(this);
@@ -310,10 +310,10 @@ void MachineObjectPanel::on_mouse_left_up(wxMouseEvent &evt)
             }
         }
         if (m_show_bind) {
-            auto left   = GetSize().x - m_unbind_img.GetSize().x - 6;
-            auto right  = left + m_unbind_img.GetSize().x;
-            auto top    = (GetSize().y - m_unbind_img.GetSize().y) / 2;
-            auto bottom = (GetSize().y - m_unbind_img.GetSize().y) / 2 + m_unbind_img.GetSize().y;
+            auto left   = GetSize().x - m_unbind_img.GetBmpSize().x - 6;
+            auto right  = left + m_unbind_img.GetBmpSize().x;
+            auto top    = (GetSize().y - m_unbind_img.GetBmpSize().y) / 2;
+            auto bottom = (GetSize().y - m_unbind_img.GetBmpSize().y) / 2 + m_unbind_img.GetBmpSize().y;
 
             if ((evt.GetPosition().x >= left && evt.GetPosition().x <= right) && evt.GetPosition().y >= top && evt.GetPosition().y <= bottom) {
                 wxCommandEvent event(EVT_UNBIND_MACHINE, GetId());
@@ -2477,7 +2477,7 @@ void SelectMachineDialog::on_ok_btn(wxCommandEvent &event)
         std::string info;
 
         DeviceManager::check_filaments_in_blacklist(filament_brand, filament_type, in_blacklist, action, info);
-
+        
         if (in_blacklist && action == "prohibition") {
             has_prohibited_filament = true;
             prohibited_error = wxString::FromUTF8(info);
@@ -2513,12 +2513,12 @@ void SelectMachineDialog::on_ok_btn(wxCommandEvent &event)
         if (!is_same_nozzle_diameters(tag_nozzle_type, nozzle_diameter)) {
             has_slice_warnings = true;
             has_update_nozzle  = true;
-
+            
             wxString nozzle_in_preset = wxString::Format(_L("nozzle in preset: %s %s"),nozzle_diameter, "");
             wxString nozzle_in_printer = wxString::Format(_L("nozzle memorized: %.1f %s"), obj_->nozzle_diameter, "");
 
-            confirm_text.push_back(_L("Your nozzle diameter in preset is not consistent with memorized nozzle diameter. Did you change your nozzle lately?")
-                + "\n    " + nozzle_in_preset
+            confirm_text.push_back(_L("Your nozzle diameter in preset is not consistent with memorized nozzle diameter. Did you change your nozzle lately?") 
+                + "\n    " + nozzle_in_preset 
                 + "\n    " + nozzle_in_printer
                 + "\n");
         }
@@ -2531,7 +2531,7 @@ void SelectMachineDialog::on_ok_btn(wxCommandEvent &event)
             confirm_text.push_back(nozzle_in_preset + "\n");
         }
     }
-
+    
 
     if (has_slice_warnings) {
         wxString confirm_title = _L("Warning");
@@ -2553,11 +2553,11 @@ void SelectMachineDialog::on_ok_btn(wxCommandEvent &event)
             if (obj_ && !tag_nozzle_type.empty() && !nozzle_diameter.empty()) {
                 try
                 {
-                    float diameter = std::stof(nozzle_diameter);
+                    float diameter = std::stof(nozzle_diameter); 
                     diameter = round(diameter * 10) / 10;
                     obj_->command_set_printer_nozzle(tag_nozzle_type, diameter);
                 }
-                catch (...) {}
+                catch (...) {} 
             }
         });
 
@@ -3631,16 +3631,16 @@ void SelectMachineDialog::Enable_Send_Button(bool en)
 
 void SelectMachineDialog::on_dpi_changed(const wxRect &suggested_rect)
 {
-    print_time->sys_color_changed();
+    print_time->msw_rescale();
     timeimg->SetBitmap(print_time->bmp());
-    print_weight->sys_color_changed();
+    print_weight->msw_rescale();
     weightimg->SetBitmap(print_weight->bmp());
-    m_rename_button->sys_color_changed();
-    ams_editable->sys_color_changed();
-    ams_editable_light->sys_color_changed();
-    enable_ams_mapping->sys_color_changed();
+    m_rename_button->msw_rescale();
+    ams_editable->msw_rescale();
+    ams_editable_light->msw_rescale();
+    enable_ams_mapping->msw_rescale();
     img_amsmapping_tip->SetBitmap(enable_ams_mapping->bmp());
-    enable_ams->sys_color_changed();
+    enable_ams->msw_rescale();
     img_use_ams_tip->SetBitmap(enable_ams->bmp());
 
     m_button_refresh->SetMinSize(SELECT_MACHINE_DIALOG_BUTTON_SIZE);
@@ -3806,7 +3806,7 @@ void SelectMachineDialog::set_default()
     else if (m_print_type == PrintFromType::FROM_SDCARD_VIEW) {
         set_default_from_sdcard();
     }
-
+    
     Layout();
     Fit();
 }
@@ -3836,14 +3836,14 @@ void SelectMachineDialog::set_default_normal()
     std::vector<std::string> display_materials;
     std::vector<std::string> m_filaments_id;
 
-
+    
     auto preset_bundle = wxGetApp().preset_bundle;
 
     for (auto filament_name : preset_bundle->filament_presets) {
         for (int f_index = 0; f_index < preset_bundle->filaments.size(); f_index++) {
             PresetCollection* filament_presets = &wxGetApp().preset_bundle->filaments;
             Preset* preset = &filament_presets->preset(f_index);
-
+ 
             if (preset && filament_name.compare(preset->name) == 0) {
                 std::string display_filament_type;
                 std::string filament_type = preset->config.get_filament_type(display_filament_type);
@@ -3865,7 +3865,7 @@ void SelectMachineDialog::set_default_normal()
 
     //init MaterialItem
     auto        extruders = wxGetApp().plater()->get_partplate_list().get_curr_plate()->get_used_extruders();
-
+    
     MaterialHash::iterator iter = m_materialList.begin();
     while (iter != m_materialList.end()) {
         int       id = iter->first;
@@ -3914,7 +3914,7 @@ void SelectMachineDialog::set_default_normal()
             DeviceManager* dev_manager = Slic3r::GUI::wxGetApp().getDeviceManager();
             if (!dev_manager) return;
             MachineObject* obj_ = dev_manager->get_selected_machine();
-
+           
             if (obj_ && obj_->is_support_ams_mapping()) {
                 if (m_mapping_popup.IsShown()) return;
                 wxPoint pos = item->ClientToScreen(wxPoint(0, 0));
@@ -4437,12 +4437,12 @@ void EditDevNameDialog::on_edit_name(wxCommandEvent &e)
 
  void ThumbnailPanel::set_thumbnail(wxImage img)
  {
-     m_bitmap = img;
+     m_bitmap = img;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
      //Paint the background bitmap to the thumbnail bitmap with wxMemoryDC
      wxMemoryDC dc;
      bitmap_with_background.Create(wxSize(m_bitmap.GetWidth(), m_bitmap.GetHeight()));
      dc.SelectObject(bitmap_with_background);
-     dc.DrawBitmap(m_background_bitmap.get_bitmap(), 0, 0);
+     dc.DrawBitmap(m_background_bitmap.bmp(), 0, 0);
      dc.DrawBitmap(m_bitmap, 0, 0);
      dc.SelectObject(wxNullBitmap);
 
@@ -4455,7 +4455,7 @@ void EditDevNameDialog::on_edit_name(wxCommandEvent &e)
  }
 
  void ThumbnailPanel::render(wxDC& dc) {
-
+     
      if (wxGetApp().dark_mode()) {
          #ifdef __WXMSW__
              wxMemoryDC memdc;
@@ -4469,7 +4469,7 @@ void EditDevNameDialog::on_edit_name(wxCommandEvent &e)
      }
      else
          dc.DrawBitmap(m_bitmap, 0, 0);
-
+     
  }
 
  ThumbnailPanel::~ThumbnailPanel() {}

--- a/src/slic3r/GUI/StatusPanel.cpp
+++ b/src/slic3r/GUI/StatusPanel.cpp
@@ -271,7 +271,7 @@ void PrintingTaskPanel::create_panel(wxWindow* parent)
 
     bSizer_task_btn->Add(FromDIP(10), 0, 0);
 
-    m_button_pause_resume = new ScalableButton(m_panel_progress, wxID_ANY, "print_control_pause", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER);
+    m_button_pause_resume = new ScalableButton(m_panel_progress, wxID_ANY, "print_control_pause", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER,true);
 
     m_button_pause_resume->Bind(wxEVT_ENTER_WINDOW, [this](auto &e) {
         if (m_button_pause_resume->GetToolTipText() == _L("Pause")) {
@@ -294,7 +294,7 @@ void PrintingTaskPanel::create_panel(wxWindow* parent)
         }
     });
 
-    m_button_abort = new ScalableButton(m_panel_progress, wxID_ANY, "print_control_stop", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER);
+    m_button_abort = new ScalableButton(m_panel_progress, wxID_ANY, "print_control_stop", wxEmptyString, wxDefaultSize, wxDefaultPosition, wxBU_EXACTFIT | wxNO_BORDER, true);
     m_button_abort->SetToolTip(_L("Stop"));
 
     m_button_abort->Bind(wxEVT_ENTER_WINDOW, [this](auto &e) {
@@ -498,7 +498,7 @@ void PrintingTaskPanel::create_panel(wxWindow* parent)
     m_score_star.resize(5);
     for (int i = 0; i < m_score_star.size(); ++i) {
         m_score_star[i] = new ScalableButton(m_score_subtask_info, wxID_ANY, "score_star_dark", wxEmptyString, wxSize(FromDIP(26), FromDIP(26)), wxDefaultPosition,
-                                             wxBU_EXACTFIT | wxNO_BORDER, 26);
+                                             wxBU_EXACTFIT | wxNO_BORDER, true, 26);
         m_score_star[i]->Bind(wxEVT_LEFT_DOWN, [this, i](auto &e) {
             for (int j = 0; j < m_score_star.size(); ++j) {
                 ScalableBitmap light_star = ScalableBitmap(nullptr, "score_star_light", 26);
@@ -555,7 +555,7 @@ void PrintingTaskPanel::paint(wxPaintEvent&)
 {
     wxPaintDC dc(m_bitmap_thumbnail);
     if (wxGetApp().dark_mode())
-        dc.DrawBitmap(m_bitmap_background.get_bitmap(), 0, 0);
+        dc.DrawBitmap(m_bitmap_background.bmp(), 0, 0);
     dc.DrawBitmap(m_thumbnail_bmp_display, wxPoint(0, 0));
     dc.SetTextForeground(*wxBLACK);
     dc.SetFont(Label::Body_12);
@@ -583,7 +583,7 @@ void PrintingTaskPanel::msw_rescale()
     //m_staticText_printing->SetMinSize(wxSize(PAGE_TITLE_TEXT_WIDTH, PAGE_TITLE_HEIGHT));
     m_gauge_progress->SetHeight(PROGRESSBAR_HEIGHT);
     m_gauge_progress->Rescale();
-    m_button_abort->sys_color_changed();
+    m_button_abort->msw_rescale();
     m_bitmap_thumbnail->SetSize(TASK_THUMBNAIL_SIZE);
 }
 
@@ -619,7 +619,7 @@ void PrintingTaskPanel::show_error_msg(wxString msg)
 
 void PrintingTaskPanel::reset_printing_value()
 {
-    this->set_thumbnail_img(m_thumbnail_placeholder.get_bitmap());
+    this->set_thumbnail_img(m_thumbnail_placeholder.bmp());
     this->set_plate_index(-1);
 }
 
@@ -913,15 +913,15 @@ void StatusBasePanel::init_bitmaps()
     m_bitmap_extruder_empty_unload    = *cache.load_png("monitor_extruder_empty_unload", FromDIP(28), FromDIP(70), false, false);
     m_bitmap_extruder_filled_unload   = *cache.load_png("monitor_extruder_filled_unload", FromDIP(28), FromDIP(70), false, false);
 
-    m_bitmap_sdcard_state_abnormal = ScalableBitmap(this, wxGetApp().dark_mode() ? "sdcard_state_abnormal_dark" : "sdcard_state_abnormal",{38, 20});
-    m_bitmap_sdcard_state_normal = ScalableBitmap(this, wxGetApp().dark_mode() ? "sdcard_state_normal_dark" : "sdcard_state_normal", {38, 20});
-    m_bitmap_sdcard_state_no = ScalableBitmap(this, wxGetApp().dark_mode() ? "sdcard_state_no_dark" : "sdcard_state_no", {38, 20});
-    m_bitmap_recording_on = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_recording_on_dark" : "monitor_recording_on", {38, 20});
-    m_bitmap_recording_off = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_recording_off_dark" : "monitor_recording_off", {38, 20});
-    m_bitmap_timelapse_on = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_timelapse_on_dark" : "monitor_timelapse_on", {38, 20});
-    m_bitmap_timelapse_off = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_timelapse_off_dark" : "monitor_timelapse_off", {38, 20});
-    m_bitmap_vcamera_on = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_vcamera_on_dark" : "monitor_vcamera_on", {38, 20});
-    m_bitmap_vcamera_off = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_vcamera_off_dark" : "monitor_vcamera_off", {38, 20});
+    m_bitmap_sdcard_state_abnormal = ScalableBitmap(this, wxGetApp().dark_mode() ? "sdcard_state_abnormal_dark" : "sdcard_state_abnormal", 20);
+    m_bitmap_sdcard_state_normal = ScalableBitmap(this, wxGetApp().dark_mode() ? "sdcard_state_normal_dark" : "sdcard_state_normal", 20);
+    m_bitmap_sdcard_state_no = ScalableBitmap(this, wxGetApp().dark_mode() ? "sdcard_state_no_dark" : "sdcard_state_no", 20);
+    m_bitmap_recording_on = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_recording_on_dark" : "monitor_recording_on", 20);
+    m_bitmap_recording_off = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_recording_off_dark" : "monitor_recording_off", 20);
+    m_bitmap_timelapse_on = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_timelapse_on_dark" : "monitor_timelapse_on", 20);
+    m_bitmap_timelapse_off = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_timelapse_off_dark" : "monitor_timelapse_off", 20);
+    m_bitmap_vcamera_on = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_vcamera_on_dark" : "monitor_vcamera_on", 20);
+    m_bitmap_vcamera_off = ScalableBitmap(this, wxGetApp().dark_mode() ? "monitor_vcamera_off_dark" : "monitor_vcamera_off", 20);
 
 }
 
@@ -1920,7 +1920,7 @@ void StatusPanel::on_webrequest_state(wxWebRequestEvent &evt)
     case wxWebRequest::State_Failed:
     case wxWebRequest::State_Cancelled:
     case wxWebRequest::State_Unauthorized: {
-        m_project_task_panel->set_thumbnail_img(m_thumbnail_brokenimg.get_bitmap());
+        m_project_task_panel->set_thumbnail_img(m_thumbnail_brokenimg.bmp());
         m_project_task_panel->set_plate_index(-1);
         task_thumbnail_state = ThumbnailState::BROKEN_IMG;
         break;
@@ -4001,15 +4001,15 @@ void StatusPanel::rescale_camera_icons()
     m_setting_button->msw_rescale();
 
 
-    m_bitmap_sdcard_state_abnormal = ScalableBitmap(this, wxGetApp().dark_mode()?"sdcard_state_abnormal_dark":"sdcard_state_abnormal", {38, 20});
-    m_bitmap_sdcard_state_normal = ScalableBitmap(this, wxGetApp().dark_mode()?"sdcard_state_normal_dark":"sdcard_state_normal", {38, 20});
-    m_bitmap_sdcard_state_no = ScalableBitmap(this, wxGetApp().dark_mode()?"sdcard_state_no_dark":"sdcard_state_no", {38, 20});
-    m_bitmap_recording_on = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_recording_on_dark":"monitor_recording_on", {38, 20});
-    m_bitmap_recording_off = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_recording_off_dark":"monitor_recording_off", {38, 20});
-    m_bitmap_timelapse_on = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_timelapse_on_dark":"monitor_timelapse_on", {38, 20});
-    m_bitmap_timelapse_off = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_timelapse_off_dark":"monitor_timelapse_off", {38, 20});
-    m_bitmap_vcamera_on = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_vcamera_on_dark":"monitor_vcamera_on", {38, 20});
-    m_bitmap_vcamera_off = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_vcamera_off_dark":"monitor_vcamera_off", {38, 20});
+    m_bitmap_sdcard_state_abnormal = ScalableBitmap(this, wxGetApp().dark_mode()?"sdcard_state_abnormal_dark":"sdcard_state_abnormal", 20);
+    m_bitmap_sdcard_state_normal = ScalableBitmap(this, wxGetApp().dark_mode()?"sdcard_state_normal_dark":"sdcard_state_normal", 20);
+    m_bitmap_sdcard_state_no = ScalableBitmap(this, wxGetApp().dark_mode()?"sdcard_state_no_dark":"sdcard_state_no", 20);
+    m_bitmap_recording_on = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_recording_on_dark":"monitor_recording_on", 20);
+    m_bitmap_recording_off = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_recording_off_dark":"monitor_recording_off", 20);
+    m_bitmap_timelapse_on = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_timelapse_on_dark":"monitor_timelapse_on", 20);
+    m_bitmap_timelapse_off = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_timelapse_off_dark":"monitor_timelapse_off", 20);
+    m_bitmap_vcamera_on = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_vcamera_on_dark":"monitor_vcamera_on", 20);
+    m_bitmap_vcamera_off = ScalableBitmap(this, wxGetApp().dark_mode()?"monitor_vcamera_off_dark":"monitor_vcamera_off", 20);
 
     if (m_media_play_ctrl->IsStreaming()) {
         m_bitmap_vcamera_img->SetBitmap(m_bitmap_vcamera_on.bmp());
@@ -4046,8 +4046,8 @@ void StatusPanel::rescale_camera_icons()
 void StatusPanel::on_sys_color_changed()
 {
     m_project_task_panel->msw_rescale();
-    m_bitmap_speed.sys_color_changed();
-    m_bitmap_speed_active.sys_color_changed();
+    m_bitmap_speed.msw_rescale();
+    m_bitmap_speed_active.msw_rescale();
     m_switch_speed->SetImages(m_bitmap_speed, m_bitmap_speed);
     m_ams_control->msw_rescale();
     if (m_print_error_dlg) { m_print_error_dlg->msw_rescale(); }
@@ -4086,8 +4086,8 @@ void StatusPanel::msw_rescale()
     m_tempCtrl_chamber->SetMinSize(TEMP_CTRL_MIN_SIZE);
     m_tempCtrl_chamber->Rescale();
 
-    m_bitmap_speed.sys_color_changed();
-    m_bitmap_speed_active.sys_color_changed();
+    m_bitmap_speed.msw_rescale();
+    m_bitmap_speed_active.msw_rescale();
 
     m_switch_speed->SetImages(m_bitmap_speed, m_bitmap_speed);
     m_switch_speed->SetMinSize(MISC_BUTTON_2FAN_SIZE);
@@ -4352,10 +4352,10 @@ wxBoxSizer *ScoreDialog::get_star_sizer()
         }
         if (i < m_star_count) {
             m_score_star[i] = new ScalableButton(this, wxID_ANY, "score_star_light", wxEmptyString, wxSize(FromDIP(26), FromDIP(26)), wxDefaultPosition,
-                                                 wxBU_EXACTFIT | wxNO_BORDER, 26);
+                                                 wxBU_EXACTFIT | wxNO_BORDER, true, 26);
         } else
             m_score_star[i] = new ScalableButton(this, wxID_ANY, "score_star_dark", wxEmptyString, wxSize(FromDIP(26), FromDIP(26)), wxDefaultPosition,
-                                                 wxBU_EXACTFIT | wxNO_BORDER, 26);
+                                                 wxBU_EXACTFIT | wxNO_BORDER, true, 26);
 
         m_score_star[i]->Bind(wxEVT_LEFT_DOWN, [this, i](auto &e) {
             if (!m_success_printed && i >= 3) {

--- a/src/slic3r/GUI/SysInfoDialog.cpp
+++ b/src/slic3r/GUI/SysInfoDialog.cpp
@@ -95,8 +95,8 @@ SysInfoDialog::SysInfoDialog()
 	main_sizer->Add(hsizer, 1, wxEXPAND | wxALL, 10);
 
     // logo
-    m_logo = new wxStaticBitmap(this, wxID_ANY, *get_bmp_bundle(wxGetApp().logo_name(), 192));
-
+    m_logo_bmp = ScalableBitmap(this, wxGetApp().logo_name(), 192);
+    m_logo = new wxStaticBitmap(this, wxID_ANY, m_logo_bmp.bmp());
 	hsizer->Add(m_logo, 0, wxALIGN_CENTER_VERTICAL);
 
     wxBoxSizer* vsizer = new wxBoxSizer(wxVERTICAL);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -229,6 +229,8 @@ void Tab::create_preset_tab()
     //    add_scaled_button(panel, &m_btn_edit_ph_printer, "cog");
 
     m_show_incompatible_presets = false;
+    add_scaled_bitmap(this, m_bmp_show_incompatible_presets, "flag_red");
+    add_scaled_bitmap(this, m_bmp_hide_incompatible_presets, "flag_green");
 
     //add_scaled_button(panel, &m_btn_hide_incompatible_presets, m_bmp_hide_incompatible_presets.name());
 
@@ -393,7 +395,7 @@ void Tab::create_preset_tab()
 #endif
         m_mode_sizer = new ModeSizer(panel, int (0.5*em_unit(this)));
 
-    const float scale_factor = em_unit(this)*0.1;// GetContentScaleFactor();
+    const float scale_factor = /*wxGetApp().*/em_unit(this)*0.1;// GetContentScaleFactor();
     m_hsizer = new wxBoxSizer(wxHORIZONTAL);
     sizer->Add(m_hsizer, 0, wxEXPAND | wxBOTTOM, 3);
     m_hsizer->Add(m_presets_choice, 0, wxLEFT | wxRIGHT | wxTOP | wxALIGN_CENTER_VERTICAL, 3);
@@ -442,8 +444,11 @@ void Tab::create_preset_tab()
     m_tabctrl->Bind(wxEVT_RIGHT_DOWN, [this](auto &e) {}); // disable right select
     m_tabctrl->SetFont(Label::Body_14);
     //m_left_sizer->Add(m_tabctrl, 1, wxEXPAND);
-    // Index of the last icon inserted into m_tabctrl.
+    const int img_sz = int(32 * scale_factor + 0.5f);
+    m_icons = new wxImageList(img_sz, img_sz, false, 1);
+    // Index of the last icon inserted into $self->{icons}.
     m_icon_count = -1;
+    m_tabctrl->AssignImageList(m_icons);
     wxGetApp().UpdateDarkUI(m_tabctrl);
 
     // Delay processing of the following handler until the message queue is flushed.
@@ -521,22 +526,6 @@ void Tab::create_preset_tab()
     // Initialize the DynamicPrintConfig by default keys/values.
     build();
 
-    // Orca: shouldn't be needed bc TabCtrl doesn't use images passed through
-    // If needed, updated code is below. SetImages will need to be implemented in TabCtrl
-    // which should be easiest by adding wxWithImages mixin.
-    // This instance was added by PS when updating wx
-/*    if (!m_scaled_icons_list.empty()) {
-            // update icons for tree_ctrl
-            wxVector <wxBitmapBundle> img_bundles;
-            for (ScalableBitmap& bmp : m_scaled_icons_list) {
-                bmp.sys_color_changed();
-                img_bundles.push_back(bmp.bmp());
-            }
-            m_tabctrl->SetImages(img_bundles);
-    }*/
-
-
-
     // ys_FIXME: Following should not be needed, the function will be called later
     // (update_mode->update_visibility->rebuild_page_tree). This does not work, during the
     // second call of rebuild_page_tree m_tabctrl->GetFirstVisibleItem(); returns zero
@@ -552,7 +541,7 @@ void Tab::add_scaled_button(wxWindow* parent,
                             const wxString& label/* = wxEmptyString*/,
                             long style /*= wxBU_EXACTFIT | wxNO_BORDER*/)
 {
-    *btn = new ScalableButton(parent, wxID_ANY, icon_name, label, wxDefaultSize, wxDefaultPosition, style);
+    *btn = new ScalableButton(parent, wxID_ANY, icon_name, label, wxDefaultSize, wxDefaultPosition, style, true);
     (*btn)->SetBackgroundColour(parent->GetBackgroundColour());
     m_scaled_buttons.push_back(*btn);
 }
@@ -583,6 +572,7 @@ Slic3r::GUI::PageShp Tab::add_options_page(const wxString& title, const std::str
         if (icon_idx == -1) {
             // Add a new icon to the icon list.
             m_scaled_icons_list.push_back(ScalableBitmap(this, icon, 32, false, true));
+            //m_icons->Add(m_scaled_icons_list.back().bmp());
             icon_idx = ++m_icon_count;
             m_icon_index[icon] = icon_idx;
         }
@@ -897,6 +887,18 @@ void TabPrinter::init_options_list()
         m_options_list.emplace("extruders_count", m_opt_status_value);
 }
 
+void TabPrinter::msw_rescale()
+{
+    Tab::msw_rescale();
+
+    if (m_reset_to_filament_color)
+        m_reset_to_filament_color->msw_rescale();
+
+    //BBS: GUI refactor
+    //Layout();
+    m_parent->Layout();
+}
+
 void TabSLAMaterial::init_options_list()
 {
     if (!m_options_list.empty())
@@ -1172,30 +1174,35 @@ void Tab::msw_rescale()
 
     m_top_sizer->SetMinSize(-1, 3 * m_em_unit);
 
+    //BBS: GUI refactor
+    //if (m_mode_sizer)
+    //    m_mode_sizer->msw_rescale();
     if (m_presets_choice)
         m_presets_choice->msw_rescale();
+
     m_tabctrl->SetMinSize(wxSize(20 * m_em_unit, -1));
 
     // rescale buttons and cached bitmaps
+    for (const auto btn : m_scaled_buttons)
+        btn->msw_rescale();
     for (const auto bmp : m_scaled_bitmaps)
-        bmp->sys_color_changed();
+        bmp->msw_rescale();
 
     if (m_mode_view)
         m_mode_view->Rescale();
 
     if (m_detach_preset_btn)
-        m_detach_preset_btn->sys_color_changed();
+        m_detach_preset_btn->msw_rescale();
 
-    // Orca: shouldn't be needed bc TabCtrl doesn't use images passed through
-    // If needed, updated code is below. SetImages will need to be implemented in TabCtrl
-    // which should be easiest by adding wxWithImages mixin.
-    /*    // update icons for m_tabctrl
-        wxVector <wxBitmapBundle> img_bundles;
-        for (ScalableBitmap& bmp : m_scaled_icons_list) {
-            bmp.sys_color_changed();
-            img_bundles.push_back(bmp.bmp());
-        }
-        m_tabctrl->SetImages(img_bundles);*/
+    // rescale icons for tree_ctrl
+    for (ScalableBitmap& bmp : m_scaled_icons_list)
+        bmp.msw_rescale();
+    // recreate and set new ImageList for tree_ctrl
+    m_icons->RemoveAll();
+    m_icons = new wxImageList(m_scaled_icons_list.front().bmp().GetWidth(), m_scaled_icons_list.front().bmp().GetHeight(), false);
+    for (ScalableBitmap& bmp : m_scaled_icons_list)
+        //m_icons->Add(bmp.bmp());
+    m_tabctrl->AssignImageList(m_icons);
 
     // rescale options_groups
     if (m_active_page)
@@ -1215,24 +1222,21 @@ void Tab::sys_color_changed()
 
     // update buttons and cached bitmaps
     for (const auto btn : m_scaled_buttons)
-        btn->sys_color_changed();
+        btn->msw_rescale();
     for (const auto bmp : m_scaled_bitmaps)
-        bmp->sys_color_changed();
+        bmp->msw_rescale();
     if (m_detach_preset_btn)
-        m_detach_preset_btn->sys_color_changed();
+        m_detach_preset_btn->msw_rescale();
 
-    update_show_hide_incompatible_button();
-
-    // Orca: shouldn't be needed bc TabCtrl doesn't use images passed through
-    // If needed, updated code is below. SetImages will need to be implemented in TabCtrl
-    // which should be easiest by adding wxWithImages mixin.
-/*    // update icons for m_tabctrl
-    wxVector <wxBitmapBundle> img_bundles;
-    for (ScalableBitmap& bmp : m_scaled_icons_list) {
-        bmp.sys_color_changed();
-        img_bundles.push_back(bmp.bmp());
-    }
-    m_tabctrl->SetImages(img_bundles);*/
+    // update icons for tree_ctrl
+    for (ScalableBitmap& bmp : m_scaled_icons_list)
+        bmp.msw_rescale();
+    // recreate and set new ImageList for tree_ctrl
+    m_icons->RemoveAll();
+    m_icons = new wxImageList(m_scaled_icons_list.front().bmp().GetWidth(), m_scaled_icons_list.front().bmp().GetHeight(), false);
+    for (ScalableBitmap& bmp : m_scaled_icons_list)
+        //m_icons->Add(bmp.bmp());
+    m_tabctrl->AssignImageList(m_icons);
 
     // Colors for ui "decoration"
     update_label_colours();
@@ -1240,7 +1244,7 @@ void Tab::sys_color_changed()
     wxWindowUpdateLocker noUpdates(this);
     //BBS: GUI refactor
     //if (m_mode_sizer)
-    //    m_mode_sizer->sys_color_changed();
+    //    m_mode_sizer->msw_rescale();
     wxGetApp().UpdateDarkUI(this);
     wxGetApp().UpdateDarkUI(m_tabctrl);
 #endif
@@ -1253,7 +1257,6 @@ void Tab::sys_color_changed()
     //BBS: GUI refactor
     //Layout();
     m_parent->Layout();
-    m_parent->Refresh();
 }
 
 Field* Tab::get_field(const t_config_option_key& opt_key, int opt_index/* = -1*/) const
@@ -1734,7 +1737,7 @@ void Tab::build_preset_description_line(ConfigOptionsGroup* optgroup)
 
     auto detach_preset_btn = [this](wxWindow* parent) {
         m_detach_preset_btn = new ScalableButton(parent, wxID_ANY, "lock_normal_sys", "",
-                                                 wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT);
+                                                 wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT, true);
         ScalableButton* btn = m_detach_preset_btn;
         btn->SetFont(Slic3r::GUI::wxGetApp().normal_font());
 
@@ -2200,7 +2203,7 @@ void TabPrint::build()
         optgroup->append_single_option_line(option);
 
 #if 0
-    //page = add_options_page(L("Dependencies"), "advanced");
+    //page = add_options_page(L("Dependencies"), "advanced.png");
     //    optgroup = page->new_optgroup(L("Profile dependencies"));
 
     //    create_line_with_widget(optgroup.get(), "compatible_printers", "", [this](wxWindow* parent) {
@@ -3611,7 +3614,7 @@ void TabPrinter::build_sla()
     //optgroup->append_single_option_line("min_initial_exposure_time");
     //optgroup->append_single_option_line("max_initial_exposure_time");
 
-    //page = add_options_page(L("Dependencies"), "wrench");
+    //page = add_options_page(L("Dependencies"), "wrench.png");
     //optgroup = page->new_optgroup(L("Profile dependencies"));
 
     //build_preset_description_line(optgroup.get());
@@ -3883,7 +3886,7 @@ if (is_marlin_flavor)
 
             //auto reset_to_filament_color = [this, extruder_idx](wxWindow* parent) {
             //    m_reset_to_filament_color = new ScalableButton(parent, wxID_ANY, "undo", _L("Reset to Filament Color"),
-            //                                                   wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT);
+            //                                                   wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT, true);
             //    ScalableButton* btn = m_reset_to_filament_color;
             //    btn->SetFont(Slic3r::GUI::wxGetApp().normal_font());
             //    btn->SetSize(btn->GetBestSize());
@@ -5246,7 +5249,8 @@ void Tab::toggle_show_hide_incompatible()
 void Tab::update_show_hide_incompatible_button()
 {
     //BBS: GUI refactor
-    /*m_btn_hide_incompatible_presets->SetBitmap(*get_bmp_bundle(m_show_incompatible_presets ? "flag_red" : "flag_green"));
+    /*m_btn_hide_incompatible_presets->SetBitmap_(m_show_incompatible_presets ?
+        m_bmp_show_incompatible_presets : m_bmp_hide_incompatible_presets);
     m_btn_hide_incompatible_presets->SetToolTip(m_show_incompatible_presets ?
         "Both compatible an incompatible presets are shown. Click to hide presets not compatible with the current printer." :
         "Only compatible presets are shown. Click to show both the presets compatible and not compatible with the current printer.");*/
@@ -5293,7 +5297,7 @@ wxSizer* Tab::compatible_widget_create(wxWindow* parent, PresetDependencies &dep
     deps.checkbox->SetFont(Slic3r::GUI::wxGetApp().normal_font());
     wxGetApp().UpdateDarkUI(deps.checkbox, false, true);
     deps.btn = new ScalableButton(parent, wxID_ANY, "printer", from_u8((boost::format(" %s %s") % _utf8(L("Set")) % std::string(dots.ToUTF8())).str()),
-                                  wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT);
+                                  wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT, true);
     deps.btn->SetFont(Slic3r::GUI::wxGetApp().normal_font());
     deps.btn->SetSize(deps.btn->GetBestSize());
 
@@ -5368,7 +5372,7 @@ wxSizer* Tab::compatible_widget_create(wxWindow* parent, PresetDependencies &dep
 wxSizer* TabPrinter::create_bed_shape_widget(wxWindow* parent)
 {
     ScalableButton* btn = new ScalableButton(parent, wxID_ANY, "printer", " " + _(L("Set")) + " " + dots,
-        wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT);
+        wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT, true);
     btn->SetFont(wxGetApp().normal_font());
     btn->SetSize(btn->GetBestSize());
 
@@ -5786,7 +5790,7 @@ void TabSLAMaterial::build()
 
     //optgroup->append_line(line);
 
-    //page = add_options_page(L("Dependencies"), "wrench");
+    //page = add_options_page(L("Dependencies"), "wrench.png");
     //optgroup = page->new_optgroup(L("Profile dependencies"));
 
     //create_line_with_widget(optgroup.get(), "compatible_printers", "", [this](wxWindow* parent) {
@@ -5807,7 +5811,7 @@ void TabSLAMaterial::build()
 
     //build_preset_description_line(optgroup.get());
 
-    //page = add_options_page(L("Material printing profile"), "printer");
+    //page = add_options_page(L("Material printing profile"), "printer.png");
     //optgroup = page->new_optgroup(L("Material printing profile"));
     //option = optgroup->get_option("material_print_speed");
     //optgroup->append_single_option_line(option);

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -154,6 +154,7 @@ protected:
 	//wxBoxSizer*			m_hsizer;
 	//wxBoxSizer*			m_left_sizer;
 	TabCtrl*			m_tabctrl;
+	wxImageList*		m_icons;
 
 	wxScrolledWindow*	m_page_view {nullptr};
 	//wxBoxSizer*			m_page_sizer {nullptr};
@@ -188,6 +189,10 @@ protected:
     StaticBox *				m_search_item;
     TextInput *				m_search_input;
 
+	// Cached bitmaps.
+	// A "flag" icon to be displayned next to the preset name in the Tab's combo box.
+	ScalableBitmap			m_bmp_show_incompatible_presets;
+	ScalableBitmap			m_bmp_hide_incompatible_presets;
 	// Bitmaps to be shown on the "Revert to system" aka "Lock to system" button next to each input field.
 	ScalableBitmap 			m_bmp_value_lock;
 	ScalableBitmap 			m_bmp_value_unlock;
@@ -605,6 +610,7 @@ public:
 	void		build_unregular_pages(bool from_initial_build = false);
 	void		on_preset_loaded() override;
 	void		init_options_list() override;
+	void		msw_rescale() override;
 	bool 		supports_printer_technology(const PrinterTechnology /* tech */) const override { return true; }
 
 	wxSizer*	create_bed_shape_widget(wxWindow* parent);

--- a/src/slic3r/GUI/TabButton.cpp
+++ b/src/slic3r/GUI/TabButton.cpp
@@ -148,7 +148,7 @@ void TabButton::render(wxDC &dc)
             // BBS norrow size between text and icon
             szContent.x += 5;
         }
-        szIcon = icon.GetSize();
+        szIcon = icon.GetBmpSize();
         szContent.x += szIcon.x;
         if (szIcon.y > szContent.y) szContent.y = szIcon.y;
     }
@@ -169,9 +169,9 @@ void TabButton::render(wxDC &dc)
     }
 
     if (icon.bmp().IsOk()) {
-        pt.x = size.x - icon.GetWidth() - paddingSize.y;
-        pt.y = (size.y - icon.GetHeight()) / 2;
-        dc.DrawBitmap(icon.get_bitmap(), pt);
+        pt.x = size.x - icon.GetBmpWidth() - paddingSize.y;
+        pt.y = (size.y - icon.GetBmpHeight()) / 2;
+        dc.DrawBitmap(icon.bmp(), pt);
     }
 }
 
@@ -189,7 +189,7 @@ void TabButton::messureSize()
             // BBS norrow size between text and icon
             szContent.x += 5;
         }
-        wxSize szIcon = this->icon.GetSize();
+        wxSize szIcon = this->icon.GetBmpSize();
         szContent.x += szIcon.x;
         if (szIcon.y > szContent.y) szContent.y = szIcon.y;
     }

--- a/src/slic3r/GUI/UpgradePanel.cpp
+++ b/src/slic3r/GUI/UpgradePanel.cpp
@@ -341,15 +341,15 @@ void MachineInfoPanel::init_bitmaps()
 
 void MachineInfoPanel::rescale_bitmaps()
 {
-    m_img_printer.sys_color_changed();
+    m_img_printer.msw_rescale();
     m_printer_img->SetBitmap(m_img_printer.bmp());
-    m_img_monitor_ams.sys_color_changed();
+    m_img_monitor_ams.msw_rescale();
     m_ams_img->SetBitmap(m_img_monitor_ams.bmp());
-    m_img_ext.sys_color_changed();
+    m_img_ext.msw_rescale();
     m_ext_img->SetBitmap(m_img_ext.bmp());
-    upgrade_green_icon.sys_color_changed();
-    upgrade_gray_icon.sys_color_changed();
-    upgrade_yellow_icon.sys_color_changed();
+    upgrade_green_icon.msw_rescale();
+    upgrade_gray_icon.msw_rescale();
+    upgrade_yellow_icon.msw_rescale();
     m_ota_new_version_img->SetBitmap(upgrade_green_icon.bmp());
 }
 
@@ -1287,8 +1287,8 @@ bool UpgradePanel::Show(bool show)
 
  }
 
- void AmsPanel::msw_rescale() {
-     upgrade_green_icon.sys_color_changed();
+ void AmsPanel::msw_rescale() { 
+     upgrade_green_icon.msw_rescale();
      m_ams_new_version_img->SetBitmap(upgrade_green_icon.bmp());
  }
 
@@ -1361,8 +1361,8 @@ bool UpgradePanel::Show(bool show)
  }
 
  void ExtensionPanel::msw_rescale() 
- {
-     upgrade_green_icon.sys_color_changed();
+ { 
+     upgrade_green_icon.msw_rescale();
      m_ext_new_version_img->SetBitmap(upgrade_green_icon.bmp());
  }
 

--- a/src/slic3r/GUI/Widgets/AMSControl.cpp
+++ b/src/slic3r/GUI/Widgets/AMSControl.cpp
@@ -230,11 +230,11 @@ void AMSrefresh::paintEvent(wxPaintEvent &evt)
     auto colour = StateColor::darkModeColorFor(AMS_CONTROL_GRAY700);
     if (!wxWindow::IsEnabled()) { colour = AMS_CONTROL_GRAY500; }
 
-    auto pot = wxPoint((size.x - m_bitmap_selected.GetSize().x) / 2, (size.y - m_bitmap_selected.GetSize().y) / 2);
+    auto pot = wxPoint((size.x - m_bitmap_selected.GetBmpSize().x) / 2, (size.y - m_bitmap_selected.GetBmpSize().y) / 2);
 
     if (!m_disable_mode) {
         if (!m_play_loading) {
-            dc.DrawBitmap(m_selected ? m_bitmap_selected.get_bitmap() : m_bitmap_normal.get_bitmap(), pot);
+            dc.DrawBitmap(m_selected ? m_bitmap_selected.bmp() : m_bitmap_normal.bmp(), pot);
         }
         else {
             /* m_bitmap_rotation    = ScalableBitmap(this, "ams_refresh_normal", 30);
@@ -249,7 +249,7 @@ void AMSrefresh::paintEvent(wxPaintEvent &evt)
                 m_rotation_angle = 0;
             }
             if (m_rfid_bitmap_list.size() <= 0)return;
-            dc.DrawBitmap(m_rfid_bitmap_list[m_rotation_angle].get_bitmap(), pot);
+            dc.DrawBitmap(m_rfid_bitmap_list[m_rotation_angle].bmp(), pot);
         }
     }
 
@@ -360,7 +360,7 @@ void AMSextruderImage::doRender(wxDC &dc)
     dc.SetPen(*wxTRANSPARENT_PEN);
     dc.SetBrush(m_colour);
     dc.DrawRectangle(0, FromDIP(18), size.x, size.y - FromDIP(18) - FromDIP(5));
-    dc.DrawBitmap(m_ams_extruder.get_bitmap(), wxPoint((size.x - m_ams_extruder.GetSize().x) / 2, (size.y - m_ams_extruder.GetSize().y) / 2));
+    dc.DrawBitmap(m_ams_extruder.bmp(), wxPoint((size.x - m_ams_extruder.GetBmpSize().x) / 2, (size.y - m_ams_extruder.GetBmpSize().y) / 2));
 }
 
 
@@ -688,11 +688,11 @@ void AMSLib::on_left_down(wxMouseEvent &evt)
             auto bottom = 0;
 
             if (m_ams_model == AMSModel::GENERIC_AMS) {
-                top = (size.y - FromDIP(15) - m_bitmap_editable_light.GetSize().y);
+                top = (size.y - FromDIP(15) - m_bitmap_editable_light.GetBmpSize().y);
                 bottom = size.y - FromDIP(15);
             }
             else if (m_ams_model == AMSModel::EXTRA_AMS) {
-                top = (size.y - FromDIP(20) - m_bitmap_editable_light.GetSize().y);
+                top = (size.y - FromDIP(20) - m_bitmap_editable_light.GetBmpSize().y);
                 bottom = size.y - FromDIP(20);
             }
 
@@ -1022,21 +1022,21 @@ void AMSLib::render_extra_lib(wxDC& dc)
         if (m_info.material_state != AMSCanType::AMS_CAN_TYPE_EMPTY && m_info.material_state != AMSCanType::AMS_CAN_TYPE_NONE)
         {
             if (m_info.material_state == AMSCanType::AMS_CAN_TYPE_THIRDBRAND || m_info.material_state == AMSCanType::AMS_CAN_TYPE_VIRTUAL)
-                dc.DrawBitmap(temp_bitmap_third.get_bitmap(), (size.x - temp_bitmap_third.GetSize().x) / 2 + FromDIP(2), (size.y - FromDIP(18) - temp_bitmap_third.GetSize().y));
+                dc.DrawBitmap(temp_bitmap_third.bmp(), (size.x - temp_bitmap_third.GetBmpSize().x) / 2 + FromDIP(2), (size.y - FromDIP(18) - temp_bitmap_third.GetBmpSize().y));
             if (m_info.material_state == AMSCanType::AMS_CAN_TYPE_BRAND)
-                dc.DrawBitmap(temp_bitmap_brand.get_bitmap(), (size.x - temp_bitmap_brand.GetSize().x) / 2 + FromDIP(2), (size.y - FromDIP(18) - temp_bitmap_brand.GetSize().y));
+                dc.DrawBitmap(temp_bitmap_brand.bmp(), (size.x - temp_bitmap_brand.GetBmpSize().x) / 2 + FromDIP(2), (size.y - FromDIP(18) - temp_bitmap_brand.GetBmpSize().y));
         }
     }
 
     // selected & hover
     if (m_selected) {
-        dc.DrawBitmap(tray_bitmap_selected.get_bitmap(), (size.x - tray_bitmap_selected.GetSize().x) / 2, (size.y - tray_bitmap_selected.GetSize().y) / 2);
+        dc.DrawBitmap(tray_bitmap_selected.bmp(), (size.x - tray_bitmap_selected.GetBmpSize().x) / 2, (size.y - tray_bitmap_selected.GetBmpSize().y) / 2);
     }
     else if (!m_selected && m_hover) {
-        dc.DrawBitmap(tray_bitmap_hover.get_bitmap(), (size.x - tray_bitmap_hover.GetSize().x) / 2, (size.y - tray_bitmap_hover.GetSize().y) / 2);
+        dc.DrawBitmap(tray_bitmap_hover.bmp(), (size.x - tray_bitmap_hover.GetBmpSize().x) / 2, (size.y - tray_bitmap_hover.GetBmpSize().y) / 2);
     }
     else {
-        dc.DrawBitmap(tray_bitmap.get_bitmap(), (size.x - tray_bitmap.GetSize().x) / 2, (size.y - tray_bitmap.GetSize().y) / 2);
+        dc.DrawBitmap(tray_bitmap.bmp(), (size.x - tray_bitmap.GetBmpSize().x) / 2, (size.y - tray_bitmap.GetBmpSize().y) / 2);
     }
 }
 
@@ -1116,7 +1116,7 @@ void AMSLib::render_generic_lib(wxDC &dc)
         //transparent
         auto alpha = m_info.material_colour.Alpha();
         if (alpha == 0) {
-            dc.DrawBitmap(m_bitmap_transparent.get_bitmap(), FromDIP(4), FromDIP(4));
+            dc.DrawBitmap(m_bitmap_transparent.bmp(), FromDIP(4), FromDIP(4));
         }
 
         //gradient
@@ -1187,9 +1187,9 @@ void AMSLib::render_generic_lib(wxDC &dc)
         if (m_info.material_state != AMSCanType::AMS_CAN_TYPE_EMPTY && m_info.material_state != AMSCanType::AMS_CAN_TYPE_NONE)
         {
             if (m_info.material_state == AMSCanType::AMS_CAN_TYPE_THIRDBRAND || m_info.material_state == AMSCanType::AMS_CAN_TYPE_VIRTUAL)
-                dc.DrawBitmap(temp_bitmap_third.get_bitmap(), (size.x - temp_bitmap_third.GetSize().x) / 2, (size.y - FromDIP(10) - temp_bitmap_third.GetSize().y));
+                dc.DrawBitmap(temp_bitmap_third.bmp(), (size.x - temp_bitmap_third.GetBmpSize().x) / 2, (size.y - FromDIP(10) - temp_bitmap_third.GetBmpSize().y));
             if (m_info.material_state == AMSCanType::AMS_CAN_TYPE_BRAND)
-                dc.DrawBitmap(temp_bitmap_brand.get_bitmap(), (size.x - temp_bitmap_brand.GetSize().x) / 2, (size.y - FromDIP(10) - temp_bitmap_brand.GetSize().y));
+                dc.DrawBitmap(temp_bitmap_brand.bmp(), (size.x - temp_bitmap_brand.GetBmpSize().x) / 2, (size.y - FromDIP(10) - temp_bitmap_brand.GetBmpSize().y));
         }
     }
 }
@@ -1244,7 +1244,8 @@ void AMSLib::UnSelected()
 bool AMSLib::Enable(bool enable) { return wxWindow::Enable(enable); }
 
 void AMSLib::msw_rescale()
-{ m_bitmap_transparent.sys_color_changed();
+{
+    m_bitmap_transparent.msw_rescale();
 }
 
 /*************************************************
@@ -1451,20 +1452,20 @@ void AMSRoad::doRender(wxDC &dc)
         else {m_show_humidity = false;}
 
         if (m_amsinfo.ams_humidity == 5) {
-            dc.DrawBitmap(ams_humidity_4.get_bitmap(), wxPoint(size.x - ams_humidity_4.GetSize().x - FromDIP(4), size.y - ams_humidity_4.GetSize().y - FromDIP(8)));
+            dc.DrawBitmap(ams_humidity_4.bmp(), wxPoint(size.x - ams_humidity_4.GetBmpSize().x - FromDIP(4), size.y - ams_humidity_4.GetBmpSize().y - FromDIP(8)));
         }
         else if (m_amsinfo.ams_humidity == 4) {
-            dc.DrawBitmap(ams_humidity_3.get_bitmap(), wxPoint(size.x - ams_humidity_3.GetSize().x - FromDIP(4), size.y - ams_humidity_3.GetSize().y - FromDIP(8)));
+            dc.DrawBitmap(ams_humidity_3.bmp(), wxPoint(size.x - ams_humidity_3.GetBmpSize().x - FromDIP(4), size.y - ams_humidity_3.GetBmpSize().y - FromDIP(8)));
         }
         else if (m_amsinfo.ams_humidity == 3) {
     
-            dc.DrawBitmap(ams_humidity_2.get_bitmap(), wxPoint(size.x - ams_humidity_2.GetSize().x - FromDIP(4), size.y - ams_humidity_2.GetSize().y - FromDIP(8)));
+            dc.DrawBitmap(ams_humidity_2.bmp(), wxPoint(size.x - ams_humidity_2.GetBmpSize().x - FromDIP(4), size.y - ams_humidity_2.GetBmpSize().y - FromDIP(8)));
         }
         else if (m_amsinfo.ams_humidity == 2) {
-            dc.DrawBitmap(ams_humidity_1.get_bitmap(), wxPoint(size.x - ams_humidity_1.GetSize().x - FromDIP(4), size.y - ams_humidity_1.GetSize().y - FromDIP(8)));
+            dc.DrawBitmap(ams_humidity_1.bmp(), wxPoint(size.x - ams_humidity_1.GetBmpSize().x - FromDIP(4), size.y - ams_humidity_1.GetBmpSize().y - FromDIP(8)));
         }
         else if (m_amsinfo.ams_humidity == 1) {
-            dc.DrawBitmap(ams_humidity_0.get_bitmap(), wxPoint(size.x - ams_humidity_0.GetSize().x - FromDIP(4), size.y - ams_humidity_0.GetSize().y - FromDIP(8)));
+            dc.DrawBitmap(ams_humidity_0.bmp(), wxPoint(size.x - ams_humidity_0.GetBmpSize().x - FromDIP(4), size.y - ams_humidity_0.GetBmpSize().y - FromDIP(8)));
         }
         else {
             /*dc.DrawBitmap(ams_humidity_4.bmp(), wxPoint(size.x - ams_humidity_4.GetBmpSize().x - FromDIP(4), size.y - ams_humidity_4.GetBmpSize().y - FromDIP(8)));*/
@@ -1661,7 +1662,7 @@ void AMSItem::doRender(wxDC &dc)
 
         }else {
             if (iter->material_colour.Alpha() == 0) {
-                dc.DrawBitmap(m_ts_bitmap_cube->get_bitmap(),left,(size.y - AMS_ITEM_CUBE_SIZE.y) / 2);
+                dc.DrawBitmap(m_ts_bitmap_cube->bmp(),left,(size.y - AMS_ITEM_CUBE_SIZE.y) / 2);
             }
             else {
                 wxRect rect(left, (size.y - AMS_ITEM_CUBE_SIZE.y) / 2, AMS_ITEM_CUBE_SIZE.x, AMS_ITEM_CUBE_SIZE.y);
@@ -2091,7 +2092,7 @@ void AmsCans::render(wxDC& dc)
 void AmsCans::doRender(wxDC& dc)
 {
     wxSize     size = GetSize();
-    dc.DrawBitmap(m_bitmap_extra_framework.get_bitmap(), (size.x - m_bitmap_extra_framework.GetSize().x) / 2, (size.y - m_bitmap_extra_framework.GetSize().y) / 2);
+    dc.DrawBitmap(m_bitmap_extra_framework.bmp(), (size.x - m_bitmap_extra_framework.GetBmpSize().x) / 2, (size.y - m_bitmap_extra_framework.GetBmpSize().y) / 2);
 
     //road for extra
     if (m_ams_model == AMSModel::EXTRA_AMS) {
@@ -2981,9 +2982,9 @@ void AMSControl::StopRridLoading(wxString amsid, wxString canid)
 
 void AMSControl::msw_rescale()
 {
-    m_button_ams_setting_normal.sys_color_changed();
-    m_button_ams_setting_hover.sys_color_changed();
-    m_button_ams_setting_press.sys_color_changed();
+    m_button_ams_setting_normal.msw_rescale();
+    m_button_ams_setting_hover.msw_rescale();
+    m_button_ams_setting_press.msw_rescale();
     m_button_ams_setting->SetBitmap(m_button_ams_setting_normal.bmp());
 
     m_extruder->msw_rescale();

--- a/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
+++ b/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
@@ -212,8 +212,7 @@ void AxisCtrlButton::render(wxDC& dc)
     gc->DrawPath(home_path);
 
     if (m_icon.bmp().IsOk()) {
-        gc->DrawBitmap(m_icon.get_bitmap(), -1 * m_icon.GetWidth() / 2, -1 * m_icon.GetHeight() / 2, m_icon.GetWidth(),
-                       m_icon.GetHeight());
+        gc->DrawBitmap(m_icon.bmp(), -1 * m_icon.GetBmpWidth() / 2, -1 * m_icon.GetBmpHeight() / 2, m_icon.GetBmpWidth(), m_icon.GetBmpHeight());
     }
     gc->PopState();
 

--- a/src/slic3r/GUI/Widgets/Button.cpp
+++ b/src/slic3r/GUI/Widgets/Button.cpp
@@ -146,10 +146,10 @@ bool Button::GetValue() const { return state_handler.states() & StateHandler::Ch
 void Button::Rescale()
 {
     if (this->active_icon.bmp().IsOk())
-        this->active_icon.sys_color_changed();
+        this->active_icon.msw_rescale();
 
     if (this->inactive_icon.bmp().IsOk())
-        this->inactive_icon.sys_color_changed();
+        this->inactive_icon.msw_rescale();
 
     messureSize();
 }
@@ -187,7 +187,7 @@ void Button::render(wxDC& dc)
             //BBS norrow size between text and icon
             szContent.x += padding;
         }
-        szIcon = icon.GetSize();
+        szIcon = icon.GetBmpSize();
         szContent.x += szIcon.x;
         if (szIcon.y > szContent.y)
             szContent.y = szIcon.y;
@@ -206,7 +206,7 @@ void Button::render(wxDC& dc)
     wxPoint pt = rcContent.GetLeftTop();
     if (icon.bmp().IsOk()) {
         pt.y += (rcContent.height - szIcon.y) / 2;
-        dc.DrawBitmap(icon.get_bitmap(), pt);
+        dc.DrawBitmap(icon.bmp(), pt);
         //BBS norrow size between text and icon
         pt.x += szIcon.x + padding;
         pt.y = rcContent.y;
@@ -239,7 +239,7 @@ void Button::messureSize()
             //BBS norrow size between text and icon
             szContent.x += 5;
         }
-        wxSize szIcon = this->active_icon.GetSize();
+        wxSize szIcon = this->active_icon.GetBmpSize();
         szContent.x += szIcon.x;
         if (szIcon.y > szContent.y)
             szContent.y = szIcon.y;

--- a/src/slic3r/GUI/Widgets/CheckBox.cpp
+++ b/src/slic3r/GUI/Widgets/CheckBox.cpp
@@ -24,8 +24,8 @@ CheckBox::CheckBox(wxWindow *parent, int id)
     Bind(wxEVT_ENTER_WINDOW, &CheckBox::updateBitmap, this);
     Bind(wxEVT_LEAVE_WINDOW, &CheckBox::updateBitmap, this);
 #endif
-	SetSize(m_on.GetSize());
-	SetMinSize(m_on.GetSize());
+	SetSize(m_on.GetBmpSize());
+	SetMinSize(m_on.GetBmpSize());
 	update();
 }
 
@@ -43,16 +43,16 @@ void CheckBox::SetHalfChecked(bool value)
 
 void CheckBox::Rescale()
 {
-    m_on.sys_color_changed();
-    m_half.sys_color_changed();
-    m_off.sys_color_changed();
-    m_on_disabled.sys_color_changed();
-    m_half_disabled.sys_color_changed();
-    m_off_disabled.sys_color_changed();
-    m_on_focused.sys_color_changed();
-    m_half_focused.sys_color_changed();
-    m_off_focused.sys_color_changed();
-    SetSize(m_on.GetSize());
+    m_on.msw_rescale();
+    m_half.msw_rescale();
+    m_off.msw_rescale();
+    m_on_disabled.msw_rescale();
+    m_half_disabled.msw_rescale();
+    m_off_disabled.msw_rescale();
+    m_on_focused.msw_rescale();
+    m_half_focused.msw_rescale();
+    m_off_focused.msw_rescale();
+    SetSize(m_on.GetBmpSize());
 	update();
 }
 

--- a/src/slic3r/GUI/Widgets/ComboBox.hpp
+++ b/src/slic3r/GUI/Widgets/ComboBox.hpp
@@ -10,7 +10,7 @@
 class ComboBox : public wxWindowWithItems<TextInput, wxItemContainer>
 {
     std::vector<wxString>         texts;
-    std::vector<wxBitmapBundle>   icons;
+    std::vector<wxBitmap>         icons;
     std::vector<void *>           datas;
     std::vector<wxClientDataType> types;
 
@@ -32,9 +32,10 @@ public:
 
     virtual bool SetFont(wxFont const & font) override;
 
-    int Append(const wxString &item, const wxBitmapBundle &bitmap = wxNullBitmap);
+public:
+    int Append(const wxString &item, const wxBitmap &bitmap = wxNullBitmap);
 
-    int Append(const wxString &item, const wxBitmapBundle &bitmap, void *clientData);
+    int Append(const wxString &item, const wxBitmap &bitmap, void *clientData);
 
     unsigned int GetCount() const override;
 
@@ -59,12 +60,8 @@ public:
     void     SetString(unsigned int n, wxString const &value) override;
 
     wxBitmap GetItemBitmap(unsigned int n);
-    void     SetItemBitmap(unsigned int n, wxBitmapBundle const &bitmap);
-
-    void ToggleDropDown();
-    bool Enable(bool enable = true) override;
-    void SetIcon(const wxBitmapBundle &icon) override;
-
+    void     SetItemBitmap(unsigned int n, wxBitmap const &bitmap);
+    bool     is_drop_down(){return drop_down;}
 protected:
     virtual int  DoInsertItems(const wxArrayStringsAdapter &items,
                                unsigned int                 pos,

--- a/src/slic3r/GUI/Widgets/DropDown.cpp
+++ b/src/slic3r/GUI/Widgets/DropDown.cpp
@@ -29,7 +29,7 @@ END_EVENT_TABLE()
  */
 
 DropDown::DropDown(std::vector<wxString> &texts,
-                   std::vector<wxBitmapBundle> &icons)
+                   std::vector<wxBitmap> &icons)
     : texts(texts)
     , icons(icons)
     , state_handler(this)
@@ -44,7 +44,7 @@ DropDown::DropDown(std::vector<wxString> &texts,
 
 DropDown::DropDown(wxWindow *             parent,
                    std::vector<wxString> &texts,
-                   std::vector<wxBitmapBundle> &icons,
+                   std::vector<wxBitmap> &icons,
                    long           style)
     : DropDown(texts, icons)
 {
@@ -188,6 +188,15 @@ void DropDown::paintNow()
     Refresh();
 }
 
+static wxSize GetBmpSize(wxBitmap & bmp)
+{
+#ifdef __APPLE__
+    return bmp.GetScaledSize();
+#else
+    return bmp.GetSize();
+#endif
+}
+
 /*
  * Here we do the actual rendering. I put it in a separate
  * method so that it can work no matter what type of DC
@@ -256,13 +265,13 @@ void DropDown::render(wxDC &dc)
     rcContent.x += 5;
     rcContent.width -= 5;
     if (check_bitmap.bmp().IsOk()) {
-        auto szBmp = check_bitmap.GetSize();
+        auto szBmp = check_bitmap.GetBmpSize();
         if (selection >= 0) {
             wxPoint pt = rcContent.GetLeftTop();
             pt.y += (rcContent.height - szBmp.y) / 2;
             pt.y += rowSize.y * selection;
             if (pt.y + szBmp.y > 0 && pt.y < size.y)
-                dc.DrawBitmap(check_bitmap.get_bitmap(), pt);
+                dc.DrawBitmap(check_bitmap.bmp(), pt);
         }
         rcContent.x += szBmp.x + 5;
         rcContent.width -= szBmp.x + 5;
@@ -277,17 +286,17 @@ void DropDown::render(wxDC &dc)
         if (rcContent.y > size.y) break;
         wxPoint pt   = rcContent.GetLeftTop();
         auto & icon = icons[i];
-        auto size2 = get_preferred_size(icon, m_parent);
+        auto size2 = GetBmpSize(icon);
         if (iconSize.x > 0) {
             if (icon.IsOk()) {
                 pt.y += (rcContent.height - size2.y) / 2;
-                dc.DrawBitmap(icon.GetBitmapFor(m_parent), pt);
+                dc.DrawBitmap(icon, pt);
             }
             pt.x += iconSize.x + 5;
             pt.y = rcContent.y;
         } else if (icon.IsOk()) {
             pt.y += (rcContent.height - size2.y) / 2;
-            dc.DrawBitmap(icon.GetBitmapFor(m_parent), pt);
+            dc.DrawBitmap(icon, pt);
             pt.x += size2.x + 5;
             pt.y = rcContent.y;
         }
@@ -317,7 +326,7 @@ void DropDown::messureSize()
     for (size_t i = 0; i < texts.size(); ++i) {
         wxSize size1 = text_off ? wxSize() : dc.GetMultiLineTextExtent(texts[i]);
         if (icons[i].IsOk()) {
-            wxSize size2 = get_preferred_size(icons[i], m_parent);
+            wxSize size2 = GetBmpSize(icons[i]);
             if (size2.x > iconSize.x) iconSize = size2;
             if (!align_icon) {
                 size1.x += size2.x + (text_off ? 0 : 5);
@@ -329,7 +338,7 @@ void DropDown::messureSize()
     wxSize szContent = textSize;
     szContent.x += 10;
     if (check_bitmap.bmp().IsOk()) {
-        auto szBmp = check_bitmap.GetSize();
+        auto szBmp = check_bitmap.GetBmpSize();
         szContent.x += szBmp.x + 5;
     }
     if (iconSize.x > 0) szContent.x += iconSize.x + (text_off ? 0 : 5);

--- a/src/slic3r/GUI/Widgets/DropDown.hpp
+++ b/src/slic3r/GUI/Widgets/DropDown.hpp
@@ -15,7 +15,7 @@ wxDECLARE_EVENT(EVT_DISMISS, wxCommandEvent);
 class DropDown : public PopupWindow
 {
     std::vector<wxString> &       texts;
-    std::vector<wxBitmapBundle> &     icons;
+    std::vector<wxBitmap> &     icons;
     bool                          need_sync  = false;
     int                         selection = -1;
     int                         hover_item = -1;
@@ -44,11 +44,11 @@ class DropDown : public PopupWindow
 
 public:
     DropDown(std::vector<wxString> &texts,
-             std::vector<wxBitmapBundle> &icons);
+             std::vector<wxBitmap> &icons);
     
     DropDown(wxWindow *     parent,
              std::vector<wxString> &texts,
-             std::vector<wxBitmapBundle> &icons,
+             std::vector<wxBitmap> &icons,
              long           style     = 0);
     
     void Create(wxWindow *     parent,

--- a/src/slic3r/GUI/Widgets/FanControl.cpp
+++ b/src/slic3r/GUI/Widgets/FanControl.cpp
@@ -62,8 +62,8 @@ void Fan::create(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wxSi
 //    SetMinSize(wxSize(FromDIP(100), FromDIP(100) + FromDIP(6)));
 //    SetMaxSize(wxSize(FromDIP(100), FromDIP(100) + FromDIP(6)));
 //#else
-    SetMinSize(wxSize(m_bitmap_bk.GetSize().x, m_bitmap_bk.GetSize().y + FromDIP(6)));
-    SetMaxSize(wxSize(m_bitmap_bk.GetSize().x, m_bitmap_bk.GetSize().y + FromDIP(6)));
+    SetMinSize(wxSize(m_bitmap_bk.GetBmpSize().x, m_bitmap_bk.GetBmpSize().y + FromDIP(6)));
+    SetMaxSize(wxSize(m_bitmap_bk.GetBmpSize().x, m_bitmap_bk.GetBmpSize().y + FromDIP(6)));
 //#endif // __APPLE__
     
     Bind(wxEVT_PAINT, &Fan::paintEvent, this);
@@ -115,7 +115,7 @@ void Fan::doRender(wxDC& dc)
     auto rpm = wxT("rpm");
 
     wxSize size = GetSize();
-    dc.DrawBitmap(m_bitmap_bk.get_bitmap(), wxPoint(0,0));
+    dc.DrawBitmap(m_bitmap_bk.bmp(), wxPoint(0,0));
 
     //fan scale
     /*auto central_point = wxPoint(size.x / 2, size.y / 2 + FromDIP(15));
@@ -133,8 +133,8 @@ void Fan::doRender(wxDC& dc)
     //fan pointer
     //auto pointer_central_point = wxPoint((size.x - m_img_pointer.GetSize().x) / 2, (size.y - m_img_pointer.GetSize().y) / 2);
     //auto bmp = m_img_pointer.Rotate(m_rotate_offsets[m_current_speeds].rotate, wxPoint(size.x / 2,size.y / 2));
-    auto central_point = wxPoint((size.x  - m_bitmap_scales[m_current_speeds].GetSize().x) / 2, (size.y  - m_bitmap_scales[m_current_speeds].GetSize().y) / 2 - FromDIP(4));
-    dc.DrawBitmap(m_bitmap_scales[m_current_speeds].get_bitmap(), central_point.x, central_point.y);
+    auto central_point = wxPoint((size.x  - m_bitmap_scales[m_current_speeds].GetBmpSize().x) / 2, (size.y  - m_bitmap_scales[m_current_speeds].GetBmpSize().y) / 2 - FromDIP(4));
+    dc.DrawBitmap(m_bitmap_scales[m_current_speeds].bmp(), central_point.x, central_point.y);
 
     //fan val
     dc.SetTextForeground(DRAW_TEXT_COLOUR);
@@ -147,7 +147,8 @@ void Fan::doRender(wxDC& dc)
     //dc.DrawText(rpm, (size.x - dc.GetTextExtent(rpm).x) / 2, size.y - dc.GetTextExtent(rpm).y);
 }
 
-void Fan::msw_rescale() { m_bitmap_bk.sys_color_changed();
+void Fan::msw_rescale() {
+   m_bitmap_bk.msw_rescale();
 }
 
 void Fan::DoSetSize(int x, int y, int width, int height, int sizeFlags)
@@ -279,8 +280,8 @@ void FanOperate::doRender(wxDC& dc)
     dc.DrawLine(left_fir, FromDIP(4), left_fir, size.y - FromDIP(4));
     dc.DrawLine(left_fir * 2, FromDIP(4), left_fir * 2, size.y - FromDIP(4));
 
-    dc.DrawBitmap(m_bitmap_decrease.get_bitmap(), (left_fir - m_bitmap_decrease.GetSize().x) / 2, (size.y - m_bitmap_decrease.GetSize().y) / 2);
-    dc.DrawBitmap(m_bitmap_add.get_bitmap(), (left_fir * 2 + (left_fir - m_bitmap_decrease.GetSize().x) / 2), (size.y - m_bitmap_add.GetSize().y) / 2);
+    dc.DrawBitmap(m_bitmap_decrease.bmp(), (left_fir - m_bitmap_decrease.GetBmpSize().x) / 2, (size.y - m_bitmap_decrease.GetBmpSize().y) / 2);
+    dc.DrawBitmap(m_bitmap_add.bmp(), (left_fir * 2 + (left_fir - m_bitmap_decrease.GetBmpSize().x) / 2), (size.y - m_bitmap_add.GetBmpSize().y) / 2);
 
     //txt
     dc.SetFont(::Label::Body_12);

--- a/src/slic3r/GUI/Widgets/ImageSwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/ImageSwitchButton.cpp
@@ -110,12 +110,12 @@ void ImageSwitchButton::render(wxDC& dc)
 	wxSize szContent = textSize;
     ScalableBitmap &icon      = GetValue() ? m_on : m_off;
 	
-	int content_height = icon.GetHeight() + textSize.y + m_padding;
+	int content_height = icon.GetBmpHeight() + textSize.y + m_padding;
 
-	wxPoint pt = wxPoint((size.x - icon.GetWidth()) / 2, (size.y - content_height) / 2);
+	wxPoint pt = wxPoint((size.x - icon.GetBmpWidth()) / 2, (size.y - content_height) / 2);
 	if (icon.bmp().IsOk()) {
-		dc.DrawBitmap(icon.get_bitmap(), pt);
-		pt.y += m_padding + icon.GetHeight();
+		dc.DrawBitmap(icon.bmp(), pt);
+		pt.y += m_padding + icon.GetBmpHeight();
 	}
 	pt.x = (size.x - textSize.x) / 2;
 	dc.SetFont(GetFont());
@@ -273,7 +273,7 @@ void FanSwitchButton::render(wxDC& dc)
     //int content_height = icon.GetBmpHeight() + textSize.y + m_padding;
     int content_height = m_padding;
 
-    wxPoint pt = wxPoint((size.x - icon.GetWidth()) / 2, (size.y - content_height) / 2);
+    wxPoint pt = wxPoint((size.x - icon.GetBmpWidth()) / 2, (size.y - content_height) / 2);
 
     pt.x = (size.x - textSize.x) / 2;
     dc.SetFont(GetFont());
@@ -298,10 +298,10 @@ void FanSwitchButton::render(wxDC& dc)
         dc.DrawText(fina_txt,  wxPoint(pt.x, content_height));
     }
 
-    pt = wxPoint((size.x - icon.GetWidth()) / 2, content_height + textSize.y);
+    pt = wxPoint((size.x - icon.GetBmpWidth()) / 2, content_height + textSize.y);
     if (icon.bmp().IsOk()) {
-        dc.DrawBitmap(icon.get_bitmap(), pt);
-        pt.y += m_padding + icon.GetHeight();
+        dc.DrawBitmap(icon.bmp(), pt);
+        pt.y += m_padding + icon.GetBmpHeight();
     }
 
     auto speed = wxString::Format("%d%%", m_speed);

--- a/src/slic3r/GUI/Widgets/RadioBox.cpp
+++ b/src/slic3r/GUI/Widgets/RadioBox.cpp
@@ -10,8 +10,8 @@ RadioBox::RadioBox(wxWindow *parent)
     // SetBackgroundStyle(wxBG_STYLE_TRANSPARENT);
     if (parent) SetBackgroundColour(parent->GetBackgroundColour());
     // Bind(wxEVT_TOGGLEBUTTON, [this](auto& e) { update(); e.Skip(); });
-    SetSize(m_on.GetSize());
-    SetMinSize(m_on.GetSize());
+    SetSize(m_on.GetBmpSize());
+    SetMinSize(m_on.GetBmpSize());
     update();
 }
 
@@ -29,9 +29,9 @@ bool RadioBox::GetValue()
 
 void RadioBox::Rescale()
 {
-    m_on.sys_color_changed();
-    m_off.sys_color_changed();
-    SetSize(m_on.GetSize());
+    m_on.msw_rescale();
+    m_off.msw_rescale();
+    SetSize(m_on.GetBmpSize());
     update();
 }
 

--- a/src/slic3r/GUI/Widgets/SideButton.cpp
+++ b/src/slic3r/GUI/Widgets/SideButton.cpp
@@ -157,7 +157,7 @@ bool SideButton::Enable(bool enable)
 void SideButton::Rescale()
 {
     if (this->icon.bmp().IsOk())
-        this->icon.sys_color_changed();
+        this->icon.msw_rescale();
     messureSize();
 }
 
@@ -246,7 +246,7 @@ void SideButton::dorender(wxDC& dc, wxDC& text_dc)
             //BBS norrow size between text and icon
             szContent.x += 5;
         }
-        szIcon = icon.GetSize();
+        szIcon = icon.GetBmpSize();
         szContent.x += szIcon.x;
         if (szIcon.y > szContent.y)
             szContent.y = szIcon.y;
@@ -270,7 +270,7 @@ void SideButton::dorender(wxDC& dc, wxDC& text_dc)
         //BBS extra pixels for icon
         pt.x += icon_offset;
         pt.y += (rcContent.height - szIcon.y) / 2;
-        dc.DrawBitmap(icon.get_bitmap(), pt);
+        dc.DrawBitmap(icon.bmp(), pt);
         //BBS norrow size between text and icon
         pt.x += szIcon.x + 5;
         pt.y = rcContent.y;
@@ -299,7 +299,7 @@ void SideButton::messureSize()
         if (szContent.y > 0) {
             szContent.x += 5;
         }
-        wxSize szIcon = this->icon.GetSize();
+        wxSize szIcon = this->icon.GetBmpSize();
         szContent.x += szIcon.x;
         if (szIcon.y > szContent.y)
             szContent.y = szIcon.y;

--- a/src/slic3r/GUI/Widgets/SideTools.cpp
+++ b/src/slic3r/GUI/Widgets/SideTools.cpp
@@ -150,19 +150,19 @@ void SideToolsPanel::doRender(wxDC &dc)
         dc.SetBrush(SIDE_TOOLS_BRAND);
         dc.DrawRectangle(0, 0, size.x, size.y);
 
-        dc.DrawBitmap(m_none_printing_img.get_bitmap(), left, (size.y - m_none_printing_img.GetSize().y) / 2);
+        dc.DrawBitmap(m_none_printing_img.bmp(), left, (size.y - m_none_printing_img.GetBmpSize().y) / 2);
 
-        left += (m_none_printing_img.GetSize().x + FromDIP(15));
-        dc.DrawBitmap(m_none_arrow_img.get_bitmap(), left, (size.y - m_none_arrow_img.GetSize().y) / 2);
+        left += (m_none_printing_img.GetBmpSize().x + FromDIP(15));
+        dc.DrawBitmap(m_none_arrow_img.bmp(), left, (size.y - m_none_arrow_img.GetBmpSize().y) / 2);
 
-        left += (m_none_arrow_img.GetSize().x + FromDIP(6));
+        left += (m_none_arrow_img.GetBmpSize().x + FromDIP(6));
         dc.SetFont(::Label::Body_14);
         dc.SetBackgroundMode(wxTRANSPARENT);
         dc.SetTextForeground(*wxWHITE);
 
         wxString no_printer_str = _L("No printer");
         auto sizet = dc.GetTextExtent(no_printer_str);
-        auto left_add_bitmap = size.x - FromDIP(30) - m_wifi_none_img.GetSize().x - m_none_add_img.GetSize().x;
+        auto left_add_bitmap = size.x - FromDIP(30) - m_wifi_none_img.GetBmpSize().x - m_none_add_img.GetBmpSize().x;
         auto size_width = left_add_bitmap - left;
 
         if (sizet.x > size_width) {
@@ -181,21 +181,21 @@ void SideToolsPanel::doRender(wxDC &dc)
 
         dc.DrawText(no_printer_str, wxPoint(left, (size.y - sizet.y) / 2));
 
-        left = size.x - FromDIP(30) - m_wifi_none_img.GetSize().x;
-        dc.DrawBitmap(m_none_add_img.get_bitmap(), left, (size.y - m_none_add_img.GetSize().y) / 2);
+        left = size.x - FromDIP(30) - m_wifi_none_img.GetBmpSize().x;
+        dc.DrawBitmap(m_none_add_img.bmp(), left, (size.y - m_none_add_img.GetBmpSize().y) / 2);
     } else {
-        dc.DrawBitmap(m_printing_img.get_bitmap(), left, (size.y - m_printing_img.GetSize().y) / 2);
+        dc.DrawBitmap(m_printing_img.bmp(), left, (size.y - m_printing_img.GetBmpSize().y) / 2);
 
-        left += (m_printing_img.GetSize().x + FromDIP(5));
-        dc.DrawBitmap(m_arrow_img.get_bitmap(), left, (size.y - m_arrow_img.GetSize().y) / 2);
+        left += (m_printing_img.GetBmpSize().x + FromDIP(5));
+        dc.DrawBitmap(m_arrow_img.bmp(), left, (size.y - m_arrow_img.GetBmpSize().y) / 2);
 
-        left += (m_arrow_img.GetSize().x + FromDIP(6));
+        left += (m_arrow_img.GetBmpSize().x + FromDIP(6));
         dc.SetFont(::Label::Body_14);
         dc.SetBackgroundMode(wxTRANSPARENT);
         dc.SetTextForeground(StateColor::darkModeColorFor(SIDE_TOOLS_GREY900));
 
         auto sizet = dc.GetTextExtent(m_dev_name);
-        auto text_end = size.x - m_wifi_none_img.GetSize().x - 20;
+        auto text_end = size.x - m_wifi_none_img.GetBmpSize().x - 20;
         
         std::string finally_name = m_dev_name.ToStdString();
         if (sizet.x > (text_end - left)) {
@@ -212,12 +212,12 @@ void SideToolsPanel::doRender(wxDC &dc)
 
         dc.DrawText(finally_name, wxPoint(left, (size.y - sizet.y) / 2));
 
-        left = size.x - FromDIP(18) - m_wifi_none_img.GetSize().x;
-        if (m_wifi_type == WifiSignal::NONE) dc.DrawBitmap(m_wifi_none_img.get_bitmap(), left, (size.y - m_wifi_none_img.GetSize().y) / 2);
-        if (m_wifi_type == WifiSignal::WEAK) dc.DrawBitmap(m_wifi_weak_img.get_bitmap(), left, (size.y - m_wifi_weak_img.GetSize().y) / 2);
-        if (m_wifi_type == WifiSignal::MIDDLE) dc.DrawBitmap(m_wifi_middle_img.get_bitmap(), left, (size.y - m_wifi_middle_img.GetSize().y) / 2);
-        if (m_wifi_type == WifiSignal::STRONG) dc.DrawBitmap(m_wifi_strong_img.get_bitmap(), left, (size.y - m_wifi_strong_img.GetSize().y) / 2);
-        if (m_wifi_type == WifiSignal::WIRED)  dc.DrawBitmap(m_network_wired_img.get_bitmap(), left, (size.y - m_network_wired_img.GetSize().y) / 2);
+        left = size.x - FromDIP(18) - m_wifi_none_img.GetBmpSize().x;
+        if (m_wifi_type == WifiSignal::NONE) dc.DrawBitmap(m_wifi_none_img.bmp(), left, (size.y - m_wifi_none_img.GetBmpSize().y) / 2);
+        if (m_wifi_type == WifiSignal::WEAK) dc.DrawBitmap(m_wifi_weak_img.bmp(), left, (size.y - m_wifi_weak_img.GetBmpSize().y) / 2);
+        if (m_wifi_type == WifiSignal::MIDDLE) dc.DrawBitmap(m_wifi_middle_img.bmp(), left, (size.y - m_wifi_middle_img.GetBmpSize().y) / 2);
+        if (m_wifi_type == WifiSignal::STRONG) dc.DrawBitmap(m_wifi_strong_img.bmp(), left, (size.y - m_wifi_strong_img.GetBmpSize().y) / 2);
+        if (m_wifi_type == WifiSignal::WIRED)  dc.DrawBitmap(m_network_wired_img.bmp(), left, (size.y - m_network_wired_img.GetBmpSize().y) / 2);
     }
 
     if (m_hover) {

--- a/src/slic3r/GUI/Widgets/StaticLine.cpp
+++ b/src/slic3r/GUI/Widgets/StaticLine.cpp
@@ -46,7 +46,7 @@ void StaticLine::SetLineColour(wxColour color)
 void StaticLine::Rescale()
 {
     if (this->icon.bmp().IsOk())
-        this->icon.sys_color_changed();
+        this->icon.msw_rescale();
     messureSize();
 }
 
@@ -67,7 +67,7 @@ void StaticLine::messureSize()
             // BBS norrow size between text and icon
             szContent.x += 5;
         }
-        wxSize szIcon = this->icon.GetSize();
+        wxSize szIcon = this->icon.GetBmpSize();
         szContent.x += szIcon.x;
         if (szIcon.y > szContent.y) szContent.y = szIcon.y;
     }
@@ -90,13 +90,13 @@ void StaticLine::render(wxDC& dc)
     auto   label = GetLabel();
     if (!label.IsEmpty()) textSize = dc.GetTextExtent(label);
     wxRect titleRect{{0, 0}, size};
-    titleRect.height = wxMax(icon.GetHeight(), textSize.GetHeight());
-    int contentWidth = icon.GetWidth() + ((icon.bmp().IsOk() && textSize.GetWidth() > 0) ? 5 : 0) +
+    titleRect.height = wxMax(icon.GetBmpHeight(), textSize.GetHeight());
+    int contentWidth = icon.GetBmpWidth() + ((icon.bmp().IsOk() && textSize.GetWidth() > 0) ? 5 : 0) +
                 textSize.GetWidth();
     if (vertical) titleRect.Deflate((size.GetWidth() - contentWidth) / 2, 0);
     if (icon.bmp().IsOk()) {
-        dc.DrawBitmap(icon.get_bitmap(), {0, (size.y - icon.GetHeight()) / 2});
-        titleRect.x += icon.GetWidth() + 5;
+        dc.DrawBitmap(icon.bmp(), {0, (size.y - icon.GetBmpHeight()) / 2});
+        titleRect.x += icon.GetBmpWidth() + 5;
     }
     if (!label.IsEmpty()) {
         dc.SetTextForeground(StateColor::darkModeColorFor(GetForegroundColour()));

--- a/src/slic3r/GUI/Widgets/StepCtrl.cpp
+++ b/src/slic3r/GUI/Widgets/StepCtrl.cpp
@@ -122,15 +122,15 @@ StepCtrl::StepCtrl(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wx
     , bmp_thumb(this, "step_thumb", 36)
 {
     StaticBox::border_width = 3;
-    radius = radius * bmp_thumb.GetHeight() / 36;
-    bar_width = bar_width * bmp_thumb.GetHeight() / 36;
+    radius = radius * bmp_thumb.GetBmpHeight() / 36;
+    bar_width = bar_width * bmp_thumb.GetBmpHeight() / 36;
 }
 
 void StepCtrl::Rescale()
 {
-    bmp_thumb.sys_color_changed();
-    radius    = radius * bmp_thumb.GetHeight() / 36;
-    bar_width = bar_width * bmp_thumb.GetHeight() / 36;
+    bmp_thumb.msw_rescale();
+    radius    = radius * bmp_thumb.GetBmpHeight() / 36;
+    bar_width = bar_width * bmp_thumb.GetBmpHeight() / 36;
 }
 
 void StepCtrl::mouseDown(wxMouseEvent &event)
@@ -141,7 +141,7 @@ void StepCtrl::mouseDown(wxMouseEvent &event)
     int    itemWidth = size.x / steps.size();
     wxRect rcBar     = {0, (size.y - 60) / 2, size.x, 60};
     int    circleX   = itemWidth / 2 + itemWidth * step;
-    wxRect rcThumb   = {{circleX, size.y / 2}, bmp_thumb.GetSize()};
+    wxRect rcThumb   = {{circleX, size.y / 2}, bmp_thumb.GetBmpSize()};
     rcThumb.x -= rcThumb.width / 2;
     rcThumb.y -= rcThumb.height / 2;
     if (rcThumb.Contains(pt)) {
@@ -235,8 +235,8 @@ void StepCtrl::doRender(wxDC &dc)
             dc.SetTextForeground(clr_tip.colorForStates(states));
             wxSize sz = dc.GetTextExtent(tips[i]);
             dc.DrawText(tips[i], circleX - sz.x / 2, circleY - 20 - sz.y);
-            sz = bmp_thumb.GetSize();
-            dc.DrawBitmap(bmp_thumb.get_bitmap(), circleX - sz.x / 2, circleY - sz.y / 2);
+            sz = bmp_thumb.GetBmpSize();
+            dc.DrawBitmap(bmp_thumb.bmp(), circleX - sz.x / 2, circleY - sz.y / 2);
         }
         circleX += itemWidth;
     }
@@ -260,16 +260,16 @@ StepIndicator::StepIndicator(wxWindow *parent, wxWindowID id, const wxPoint &pos
             std::make_pair(0x6B6B6B, 0));
     clr_tip = *wxWHITE;
     StaticBox::border_width = 0;
-    radius    = bmp_ok.GetHeight() / 2;
-    bar_width = bmp_ok.GetHeight() / 20;
+    radius    = bmp_ok.GetBmpHeight() / 2;
+    bar_width = bmp_ok.GetBmpHeight() / 20;
     if (bar_width < 2) bar_width = 2;
 }
 
 void StepIndicator::Rescale()
 {
-    bmp_ok.sys_color_changed();
-    radius    = bmp_ok.GetHeight() / 2;
-    bar_width = bmp_ok.GetHeight() / 20;
+    bmp_ok.msw_rescale();
+    radius    = bmp_ok.GetBmpHeight() / 2;
+    bar_width = bmp_ok.GetBmpHeight() / 20;
     if (bar_width < 2) bar_width = 2;
 }
 
@@ -319,8 +319,8 @@ void StepIndicator::doRender(wxDC &dc)
         dc.DrawEllipse(circleX - radius, circleY - radius, radius * 2, radius * 2);
         // Draw content ( icon or text ) in circle
         if (disabled) {
-            wxSize sz = bmp_ok.GetSize();
-            dc.DrawBitmap(bmp_ok.get_bitmap(), circleX - radius, circleY - radius);
+            wxSize sz = bmp_ok.GetBmpSize();
+            dc.DrawBitmap(bmp_ok.bmp(), circleX - radius, circleY - radius);
         } else {
             dc.SetFont(font_tip);
             dc.SetTextForeground(clr_tip.colorForStates(states));

--- a/src/slic3r/GUI/Widgets/SwitchButton.cpp
+++ b/src/slic3r/GUI/Widgets/SwitchButton.cpp
@@ -9,8 +9,8 @@
 
 SwitchButton::SwitchButton(wxWindow* parent, wxWindowID id)
 	: wxBitmapToggleButton(parent, id, wxNullBitmap, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE | wxBU_EXACTFIT)
-	, m_on(this, "toggle_on", {28, 16})
-	, m_off(this, "toggle_off", {28, 16})
+	, m_on(this, "toggle_on", 16)
+	, m_off(this, "toggle_off", 16)
     , text_color(std::pair{0xfffffe, (int) StateColor::Checked}, std::pair{0x6B6B6B, (int) StateColor::Normal})
 	, track_color(0xD9D9D9)
     , thumb_color(std::pair{0x009688, (int) StateColor::Checked}, std::pair{0xD9D9D9, (int) StateColor::Normal})
@@ -58,8 +58,8 @@ void SwitchButton::SetValue(bool value)
 void SwitchButton::Rescale()
 {
 	if (labels[0].IsEmpty()) {
-        m_on.sys_color_changed();
-        m_off.sys_color_changed();
+		m_on.msw_rescale();
+		m_off.msw_rescale();
 	}
 	else {
         SetBackgroundColour(StaticBox::GetParentBackgroundColor(GetParent()));
@@ -101,8 +101,7 @@ void SwitchButton::Rescale()
 		for (int i = 0; i < 2; ++i) {
 			wxMemoryDC memdc(&dc);
 #ifdef __WXMSW__
-            wxBitmap bmp;
-            bmp.CreateWithDIPSize(ToDIP(trackSize), GetDPIScaleFactor());
+			wxBitmap bmp(trackSize.x, trackSize.y);
 			memdc.SelectObject(bmp);
 			memdc.SetBackground(wxBrush(GetBackgroundColour()));
 			memdc.Clear();
@@ -139,12 +138,11 @@ void SwitchButton::Rescale()
 			(i == 0 ? m_off : m_on).bmp() = bmp;
 		}
 	}
-	SetSize(m_on.GetSize());
+	SetSize(m_on.GetBmpSize());
 	update();
 }
 
 void SwitchButton::update()
 {
 	SetBitmap((GetValue() ? m_on : m_off).bmp());
-
 }

--- a/src/slic3r/GUI/Widgets/TabCtrl.cpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.cpp
@@ -43,7 +43,9 @@ TabCtrl::TabCtrl(wxWindow *      parent,
 }
 
 TabCtrl::~TabCtrl()
-{}
+{
+    delete images;
+}
 
 int TabCtrl::GetSelection() const { return sel; }
 
@@ -163,6 +165,13 @@ void TabCtrl::SetItemData(unsigned int item, void* clientData)
 {
     if (item >= btns.size()) return;
     btns[item]->SetClientData(clientData);
+}
+
+void TabCtrl::AssignImageList(wxImageList* imageList)
+{
+    if (images == imageList) return;
+    delete images;
+    images = imageList;
 }
 
 void TabCtrl::SetItemTextColour(unsigned int item, const StateColor &col)

--- a/src/slic3r/GUI/Widgets/TabCtrl.hpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.hpp
@@ -9,6 +9,7 @@ wxDECLARE_EVENT( wxEVT_TAB_SEL_CHANGED, wxCommandEvent );
 class TabCtrl : public StaticBox
 {
     std::vector<Button*> btns;
+    wxImageList* images = nullptr;
     wxBoxSizer * sizer = nullptr;
 
     int sel = -1;
@@ -51,6 +52,8 @@ public:
 
     void*    GetItemData(unsigned int item) const;
     void     SetItemData(unsigned int item, void *clientData);
+    
+    void AssignImageList(wxImageList *imageList);
 
     void SetItemTextColour(unsigned int item, const StateColor& col);
 

--- a/src/slic3r/GUI/Widgets/TempInput.cpp
+++ b/src/slic3r/GUI/Widgets/TempInput.cpp
@@ -280,10 +280,8 @@ void TempInput::SetLabelColor(StateColor const &color)
 
 void TempInput::Rescale()
 {
-    if (this->normal_icon.bmp().IsOk())
-        this->normal_icon.sys_color_changed();
-    if (this->degree_icon.bmp().IsOk())
-        this->degree_icon.sys_color_changed();
+    if (this->normal_icon.bmp().IsOk()) this->normal_icon.msw_rescale();
+    if (this->degree_icon.bmp().IsOk()) this->degree_icon.msw_rescale();
     messureSize();
 }
 
@@ -319,7 +317,7 @@ void TempInput::DoSetSize(int x, int y, int width, int height, int sizeFlags)
     auto       left = padding_left;
     wxClientDC dc(this);
     if (normal_icon.bmp().IsOk()) {
-        wxSize szIcon = normal_icon.GetSize();
+        wxSize szIcon = normal_icon.GetBmpSize();
         left += szIcon.x;
     }
 
@@ -381,18 +379,18 @@ void TempInput::render(wxDC &dc)
     // start draw
     wxPoint pt = {padding_left, 0};
     if (actice_icon.bmp().IsOk() && actice) {
-        wxSize szIcon = actice_icon.GetSize();
+        wxSize szIcon = actice_icon.GetBmpSize();
         pt.y          = (size.y - szIcon.y) / 2;
-        dc.DrawBitmap(actice_icon.get_bitmap(), pt);
+        dc.DrawBitmap(actice_icon.bmp(), pt);
         pt.x += szIcon.x + 9;
     } else {
         actice = false;
     }
 
     if (normal_icon.bmp().IsOk() && !actice) {
-        wxSize szIcon = normal_icon.GetSize();
+        wxSize szIcon = normal_icon.GetBmpSize();
         pt.y          = (size.y - szIcon.y) / 2;
-        dc.DrawBitmap(normal_icon.get_bitmap(), pt);
+        dc.DrawBitmap(normal_icon.bmp(), pt);
         pt.x += szIcon.x + 9;
     }
 
@@ -437,10 +435,10 @@ void TempInput::render(wxDC &dc)
     // flag
     if (degree_icon.bmp().IsOk()) {
         auto   pos    = text_ctrl->GetPosition();
-        wxSize szIcon = degree_icon.GetSize();
+        wxSize szIcon = degree_icon.GetBmpSize();
         pt.y          = (size.y - szIcon.y) / 2;
         pt.x          = pos.x + text_ctrl->GetSize().x;
-        dc.DrawBitmap(degree_icon.get_bitmap(), pt);
+        dc.DrawBitmap(degree_icon.bmp(), pt);
     }
 }
 
@@ -454,7 +452,7 @@ void TempInput::messureMiniSize()
 
     wxClientDC dc(this);
     if (normal_icon.bmp().IsOk()) {
-        wxSize szIcon = normal_icon.GetSize();
+        wxSize szIcon = normal_icon.GetBmpSize();
         width += szIcon.x;
         height = szIcon.y;
     }
@@ -483,7 +481,7 @@ void TempInput::messureMiniSize()
     height = textSize.y > height ? textSize.y : height;
 
     // flag flag
-    auto flagSize = degree_icon.GetSize();
+    auto flagSize = degree_icon.GetBmpSize();
     width += flagSize.x;
     height = flagSize.y > height ? flagSize.y : height;
 
@@ -508,7 +506,7 @@ void TempInput::messureSize()
 
     wxClientDC dc(this);
     if (normal_icon.bmp().IsOk()) {
-        wxSize szIcon = normal_icon.GetSize();
+        wxSize szIcon = normal_icon.GetBmpSize();
         width += szIcon.x;
         height = szIcon.y;
     }
@@ -537,7 +535,7 @@ void TempInput::messureSize()
     height = textSize.y > height ? textSize.y : height;
 
     // flag flag
-    auto flagSize = degree_icon.GetSize();
+    auto flagSize = degree_icon.GetBmpSize();
     width += flagSize.x;
     height = flagSize.y > height ? flagSize.y : height;
 

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -76,7 +76,7 @@ void TextInput::Create(wxWindow *     parent,
     });
     text_ctrl->Bind(wxEVT_RIGHT_DOWN, [this](auto &e) {}); // disable context menu
     if (!icon.IsEmpty()) {
-        this->drop_down_icon = ScalableBitmap(this, icon.ToStdString(), 16);
+        this->icon = ScalableBitmap(this, icon.ToStdString(), 16);
     }
     messureSize();
 }
@@ -94,9 +94,11 @@ void TextInput::SetLabel(const wxString& label)
     Refresh();
 }
 
-void TextInput::SetIcon(const wxBitmapBundle &icon_in)
+void TextInput::SetIcon(const wxBitmap &icon)
 {
-    icon = icon_in;
+    this->icon = ScalableBitmap();
+    this->icon.bmp() = icon;
+    Rescale();
 }
 
 void TextInput::SetLabelColor(StateColor const &color)
@@ -113,9 +115,8 @@ void TextInput::SetTextColor(StateColor const& color)
 
 void TextInput::Rescale()
 {
-    if (text_ctrl)
-        text_ctrl->SetInitialSize(text_ctrl->GetBestSize());
-
+    if (!this->icon.name().empty())
+        this->icon.msw_rescale();
     messureSize();
     Refresh();
 }
@@ -151,22 +152,16 @@ void TextInput::DoSetSize(int x, int y, int width, int height, int sizeFlags)
     if (sizeFlags & wxSIZE_USE_EXISTING) return;
     wxSize size = GetSize();
     wxPoint textPos = {5, 0};
-    if (this->icon.IsOk()) {
-        wxSize szIcon = get_preferred_size(icon, m_parent);
+    if (this->icon.bmp().IsOk()) {
+        wxSize szIcon = this->icon.GetBmpSize();
         textPos.x += szIcon.x;
     }
-    wxSize dd_icon_size = wxSize(0,0);
-    if (this->drop_down_icon.bmp().IsOk())
-        dd_icon_size = this->drop_down_icon.GetSize();
-
     bool align_right = GetWindowStyle() & wxRIGHT;
     if (align_right)
         textPos.x += labelSize.x;
     if (text_ctrl) {
         wxSize textSize = text_ctrl->GetSize();
-        wxClientDC dc(this);
-        const int r_shift = int((dd_icon_size.x == 0 ? 3. : 2.) * dc.GetContentScaleFactor());
-        textSize.x = size.x - textPos.x - labelSize.x - dd_icon_size.x - r_shift;
+        textSize.x = size.x - textPos.x - labelSize.x - 10;
         text_ctrl->SetSize(textSize);
         text_ctrl->SetPosition({textPos.x, (size.y - textSize.y) / 2});
     }
@@ -198,26 +193,12 @@ void TextInput::render(wxDC& dc)
     bool   align_right = GetWindowStyle() & wxRIGHT;
     // start draw
     wxPoint pt = {5, 0};
-    if (icon.IsOk()) {
-        wxSize szIcon = get_preferred_size(icon, m_parent);
+    if (icon.bmp().IsOk()) {
+        wxSize szIcon = icon.GetBmpSize();
         pt.y = (size.y - szIcon.y) / 2;
-#ifdef __WXGTK3__
-        dc.DrawBitmap(icon.GetBitmap(szIcon), pt);
-#else
-        dc.DrawBitmap(icon.GetBitmapFor(m_parent), pt);
-#endif
+        dc.DrawBitmap(icon.bmp(), pt);
         pt.x += szIcon.x + 0;
     }
-
-    // drop_down_icon draw
-    wxPoint pt_r = {size.x, 0};
-    if (drop_down_icon.bmp().IsOk()) {
-        wxSize szIcon = drop_down_icon.GetSize();
-        pt_r.x -= szIcon.x + 2;
-        pt_r.y = (size.y - szIcon.y) / 2;
-        dc.DrawBitmap(drop_down_icon.get_bitmap(), pt_r);
-    }
-
     auto text = wxWindow::GetLabel();
     if (!text.IsEmpty()) {
         wxSize textSize = text_ctrl->GetSize();

--- a/src/slic3r/GUI/Widgets/TextInput.hpp
+++ b/src/slic3r/GUI/Widgets/TextInput.hpp
@@ -8,11 +8,10 @@ class TextInput : public wxNavigationEnabled<StaticBox>
 {
 
     wxSize labelSize;
-    wxBitmapBundle icon;
-    ScalableBitmap drop_down_icon;
+    ScalableBitmap icon;
     StateColor     label_color;
     StateColor     text_color;
-    wxTextCtrl*    text_ctrl{nullptr};
+    wxTextCtrl * text_ctrl;
 
     static const int TextInputWidth = 200;
     static const int TextInputHeight = 50;
@@ -41,7 +40,7 @@ public:
 
     void SetLabel(const wxString& label);
 
-    virtual void SetIcon(const wxBitmapBundle & icon);
+    void SetIcon(const wxBitmap & icon);
 
     void SetLabelColor(StateColor const &color);
 

--- a/src/slic3r/GUI/WipeTowerDialog.cpp
+++ b/src/slic3r/GUI/WipeTowerDialog.cpp
@@ -14,6 +14,7 @@
 
 #include <wx/sizer.h>
 
+
 using namespace Slic3r::GUI;
 
 int scale(const int val) { return val * Slic3r::GUI::wxGetApp().em_unit() / 10; }
@@ -89,7 +90,7 @@ RammingDialog::RammingDialog(wxWindow* parent,const std::string& parameters)
 
 #ifdef _WIN32
 #define style wxSP_ARROW_KEYS | wxBORDER_SIMPLE
-#else
+#else 
 #define style wxSP_ARROW_KEYS
 #endif
 
@@ -125,9 +126,9 @@ RammingPanel::RammingPanel(wxWindow* parent, const std::string& parameters)
 #endif
  	sizer_chart->Add(m_chart, 0, wxALL, 5);
 
-    m_widget_time						= new wxSpinCtrlDouble(this,wxID_ANY,wxEmptyString,wxDefaultPosition,wxSize(ITEM_WIDTH()*2.5, -1),style,0.,5.0,3.,0.5);
-    m_widget_volume							  = new wxSpinCtrl(this,wxID_ANY,wxEmptyString,wxDefaultPosition,wxSize(ITEM_WIDTH()*2.5, -1),style,0,10000,0);
-    m_widget_ramming_line_width_multiplicator = new wxSpinCtrl(this,wxID_ANY,wxEmptyString,wxDefaultPosition,wxSize(ITEM_WIDTH()*2.5, -1),style,10,200,100);
+    m_widget_time						= new wxSpinCtrlDouble(this,wxID_ANY,wxEmptyString,wxDefaultPosition,wxSize(ITEM_WIDTH()*2.5, -1),style,0.,5.0,3.,0.5);        
+    m_widget_volume							  = new wxSpinCtrl(this,wxID_ANY,wxEmptyString,wxDefaultPosition,wxSize(ITEM_WIDTH()*2.5, -1),style,0,10000,0);        
+    m_widget_ramming_line_width_multiplicator = new wxSpinCtrl(this,wxID_ANY,wxEmptyString,wxDefaultPosition,wxSize(ITEM_WIDTH()*2.5, -1),style,10,200,100);        
     m_widget_ramming_step_multiplicator		  = new wxSpinCtrl(this,wxID_ANY,wxEmptyString,wxDefaultPosition,wxSize(ITEM_WIDTH()*2.5, -1),style,10,200,100);
 
 #ifdef _WIN32
@@ -156,7 +157,7 @@ RammingPanel::RammingPanel(wxWindow* parent, const std::string& parameters)
     m_widget_volume->SetValue(m_chart->get_volume());
     m_widget_volume->Disable();
     m_widget_ramming_line_width_multiplicator->SetValue(m_ramming_line_width_multiplicator);
-    m_widget_ramming_step_multiplicator->SetValue(m_ramming_step_multiplicator);
+    m_widget_ramming_step_multiplicator->SetValue(m_ramming_step_multiplicator);        
     
     m_widget_ramming_step_multiplicator->Bind(wxEVT_TEXT,[this](wxCommandEvent&) { line_parameters_changed(); });
     m_widget_ramming_line_width_multiplicator->Bind(wxEVT_TEXT,[this](wxCommandEvent&) { line_parameters_changed(); });
@@ -170,7 +171,7 @@ RammingPanel::RammingPanel(wxWindow* parent, const std::string& parameters)
 
     m_widget_time->Bind(wxEVT_TEXT,[this](wxCommandEvent&) {m_chart->set_xy_range(m_widget_time->GetValue(),-1);});
     m_widget_time->Bind(wxEVT_CHAR,[](wxKeyEvent&){});      // do nothing - prevents the user to change the value
-    m_widget_volume->Bind(wxEVT_CHAR,[](wxKeyEvent&){});    // do nothing - prevents the user to change the value
+    m_widget_volume->Bind(wxEVT_CHAR,[](wxKeyEvent&){});    // do nothing - prevents the user to change the value   
     Bind(EVT_WIPE_TOWER_CHART_CHANGED,[this](wxCommandEvent&) {m_widget_volume->SetValue(m_chart->get_volume()); m_widget_time->SetValue(m_chart->get_time());} );
     Refresh(true); // erase background
 }
@@ -188,7 +189,7 @@ std::string RammingPanel::get_parameters()
     stream << m_ramming_line_width_multiplicator << " " << m_ramming_step_multiplicator;
     for (const float& speed_value : speeds)
         stream << " " << speed_value;
-    stream << "|";
+    stream << "|";    
     for (const auto& button : buttons)
         stream << " " << button.first << " " << button.second;
     return stream.str();
@@ -197,7 +198,7 @@ std::string RammingPanel::get_parameters()
 
 #ifdef _WIN32
 #define style wxSP_ARROW_KEYS | wxBORDER_SIMPLE
-#else
+#else 
 #define style wxSP_ARROW_KEYS
 #endif
 
@@ -253,7 +254,7 @@ wxBoxSizer* WipingDialog::create_btn_sizer(long flags)
     );
 
     if (flags & wxRESET) {
-        Button *calc_btn = new Button(this, _L("Recalculate"));
+        Button *calc_btn = new Button(this, _L("Auto-Calc"));
         calc_btn->SetMinSize(wxSize(FromDIP(75), FromDIP(24)));
         calc_btn->SetCornerRadius(FromDIP(12));
         calc_btn->SetBackgroundColor(calc_btn_bg);
@@ -261,7 +262,7 @@ wxBoxSizer* WipingDialog::create_btn_sizer(long flags)
         calc_btn->SetTextColor(calc_btn_text);
         calc_btn->SetFocus();
         calc_btn->SetId(wxID_RESET);
-        btn_sizer->Add(calc_btn, 0, wxLEFT | wxRIGHT | wxALIGN_CENTER_VERTICAL, BTN_GAP);
+        btn_sizer->Add(calc_btn, 0, wxRIGHT | wxALIGN_CENTER_VERTICAL, BTN_GAP);
         m_button_list[wxRESET] = calc_btn;
     }
     if (flags & wxOK) {
@@ -284,7 +285,7 @@ wxBoxSizer* WipingDialog::create_btn_sizer(long flags)
         cancel_btn->SetBorderColor(cancel_btn_bd_);
         cancel_btn->SetTextColor(cancel_btn_text);
         cancel_btn->SetId(wxID_CANCEL);
-        btn_sizer->Add(cancel_btn, 0, wxRIGHT | wxALIGN_CENTER_VERTICAL, BTN_GAP / 2);
+        btn_sizer->Add(cancel_btn, 0, wxRIGHT | wxALIGN_CENTER_VERTICAL, BTN_GAP);
         m_button_list[wxCANCEL] = cancel_btn;
     }
 
@@ -292,11 +293,40 @@ wxBoxSizer* WipingDialog::create_btn_sizer(long flags)
 
 }
 
+wxBoxSizer* WipingPanel::create_calc_btn_sizer(wxWindow* parent) {
+    auto btn_sizer = new wxBoxSizer(wxHORIZONTAL);
+    StateColor calc_btn_bg(
+        std::pair<wxColour, int>(wxColour(0, 137, 123), StateColor::Pressed),
+        std::pair<wxColour, int>(wxColour(38, 166, 154), StateColor::Hovered),
+        std::pair<wxColour, int>(wxColour(0, 150, 136), StateColor::Normal)
+    );
+
+    StateColor calc_btn_bd(
+        std::pair<wxColour, int>(wxColour(0, 150, 136), StateColor::Normal)
+    );
+
+    StateColor calc_btn_text(
+        std::pair<wxColour, int>(wxColour(255, 255, 254), StateColor::Normal)
+    );
+
+    Button* calc_btn = new Button(parent, _L("Re-calculate"));
+    calc_btn->SetFont(Label::Body_13);
+    calc_btn->SetMinSize(wxSize(FromDIP(75), FromDIP(24)));
+    calc_btn->SetCornerRadius(FromDIP(12));
+    calc_btn->SetBackgroundColor(calc_btn_bg);
+    calc_btn->SetBorderColor(calc_btn_bd);
+    calc_btn->SetTextColor(calc_btn_text);
+    calc_btn->SetFocus();
+    btn_sizer->Add(calc_btn, 0, wxRIGHT | wxALIGN_CENTER_VERTICAL, BTN_GAP);
+    calc_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) { calc_flushing_volumes(); });
+
+    return btn_sizer;
+}
 void WipingDialog::on_dpi_changed(const wxRect &suggested_rect)
 {
-    for (auto button_item : m_button_list)
+    for (auto button_item : m_button_list) 
     {
-        if (button_item.first == wxRESET)
+        if (button_item.first == wxRESET) 
         {
             button_item.second->SetMinSize(wxSize(FromDIP(75), FromDIP(24)));
             button_item.second->SetCornerRadius(FromDIP(12));
@@ -332,20 +362,20 @@ WipingDialog::WipingDialog(wxWindow* parent, const std::vector<float>& matrix, c
 
     this->SetBackgroundColour(*wxWHITE);
     this->SetMinSize(wxSize(MIN_WIPING_DIALOG_WIDTH, -1));
-
+    
 
     m_panel_wiping = new WipingPanel(this, matrix, extruders, extruder_colours, nullptr, extra_flush_volume, flush_multiplier);
 
     auto main_sizer = new wxBoxSizer(wxVERTICAL);
     main_sizer->Add(m_line_top, 0, wxEXPAND, 0);
-
+    
     // set min sizer width according to extruders count
     auto sizer_width = (int)((sqrt(matrix.size()) + 2.8)*ITEM_WIDTH());
     sizer_width = sizer_width > MIN_WIPING_DIALOG_WIDTH ? sizer_width : MIN_WIPING_DIALOG_WIDTH;
     main_sizer->SetMinSize(wxSize(sizer_width, -1));
     main_sizer->Add(m_panel_wiping, 1, wxEXPAND | wxALL, 0);
 
-    auto btn_sizer = create_btn_sizer(wxOK | wxCANCEL | wxRESET);
+    auto btn_sizer = create_btn_sizer(wxOK | wxCANCEL);
     main_sizer->Add(btn_sizer, 0, wxBOTTOM | wxRIGHT | wxEXPAND, BTN_GAP);
     SetSizer(main_sizer);
     main_sizer->SetSizeHints(this);
@@ -353,6 +383,7 @@ WipingDialog::WipingDialog(wxWindow* parent, const std::vector<float>& matrix, c
     if (this->FindWindowById(wxID_OK, this)) {
         this->FindWindowById(wxID_OK, this)->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {                 // if OK button is clicked..
             m_output_matrix = m_panel_wiping->read_matrix_values();    // ..query wiping panel and save returned values
+            m_output_extruders = m_panel_wiping->read_extruders_values(); // so they can be recovered later by calling get_...()
             EndModal(wxID_OK);
             }, wxID_OK);
     }
@@ -362,16 +393,18 @@ WipingDialog::WipingDialog(wxWindow* parent, const std::vector<float>& matrix, c
 
     }
 
+    /*
     if (this->FindWindowById(wxID_RESET, this)) {
         this->FindWindowById(wxID_RESET, this)->Bind(wxEVT_BUTTON, [this](wxCommandEvent &) { m_panel_wiping->calc_flushing_volumes(); });
     }
+    */
 
     this->Bind(wxEVT_CLOSE_WINDOW, [this](wxCloseEvent& e) { EndModal(wxCANCEL); });
     this->Bind(wxEVT_CHAR_HOOK, [this](wxKeyEvent& e) {
         if (e.GetKeyCode() == WXK_ESCAPE) {
             if (this->IsModal())
                 this->EndModal(wxID_CANCEL);
-            else
+            else 
                 this->Close();
         }
         else
@@ -394,7 +427,6 @@ void WipingPanel::create_panels(wxWindow* parent, const int num) {
         icon->SetCanFocus(false);
         icon_list2.push_back(icon);
 
-        sizer->AddStretchSpacer();
         sizer->AddSpacer(ROW_BEG_PADDING);
         sizer->Add(icon, 0, wxALIGN_CENTER_VERTICAL | wxTOP | wxBOTTOM, ROW_VERT_PADDING);
 
@@ -406,9 +438,8 @@ void WipingPanel::create_panels(wxWindow* parent, const int num) {
             sizer->Add(edit_boxes[j][i], 0, wxALIGN_CENTER_VERTICAL, 0);
         }
         sizer->AddSpacer(ROW_END_PADDING);
-        sizer->AddStretchSpacer();
 
-        m_sizer->Add(panel, 0, wxRIGHT | wxLEFT | wxEXPAND, TABLE_BORDER);
+        m_sizer_advanced->Add(panel, 0, wxRIGHT | wxLEFT | wxEXPAND, TABLE_BORDER);
         panel->Layout();
     }
 }
@@ -426,12 +457,22 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
         Slic3r::decode_color(color, rgb);
         m_colours.push_back(wxColor(rgb.r_uchar(), rgb.g_uchar(), rgb.b_uchar()));
     }
-
     auto sizer_width = (int)((sqrt(matrix.size())) * ITEM_WIDTH() + (sqrt(matrix.size()) + 1) * HEADER_BEG_PADDING);
     sizer_width = sizer_width > MIN_WIPING_DIALOG_WIDTH ? sizer_width : MIN_WIPING_DIALOG_WIDTH;
-    m_sizer = new wxBoxSizer(wxVERTICAL);
-    this->SetBackgroundColour(*wxWHITE);
-    update_ui(this);
+    // Create two switched panels with their own sizers
+    m_sizer_simple          = new wxBoxSizer(wxVERTICAL);
+    m_sizer_advanced        = new wxBoxSizer(wxVERTICAL);
+    m_page_simple			= new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_page_advanced			= new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_page_simple->SetSizer(m_sizer_simple);
+    m_page_advanced->SetSizer(m_sizer_advanced);
+    m_page_advanced->SetBackgroundColour(*wxWHITE);
+
+    update_ui(m_page_simple);
+    update_ui(m_page_advanced);
+
+    auto gridsizer_simple   = new wxGridSizer(3, 5, 10);
+    m_gridsizer_advanced = new wxGridSizer(m_number_of_extruders + 1, 5, 1);
 
     // First create controls for advanced mode and assign them to m_page_advanced:
     for (unsigned int i = 0; i < m_number_of_extruders; ++i) {
@@ -439,17 +480,17 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
 
         for (unsigned int j = 0; j < m_number_of_extruders; ++j) {
 #ifdef _WIN32
-            wxTextCtrl* text = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(ITEM_WIDTH(), -1), wxTE_CENTER | wxBORDER_NONE | wxTE_PROCESS_ENTER);
+            wxTextCtrl* text = new wxTextCtrl(m_page_advanced, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(ITEM_WIDTH(), -1), wxTE_CENTER | wxBORDER_NONE | wxTE_PROCESS_ENTER);
             update_ui(text);
             edit_boxes.back().push_back(text);
 #else
-            edit_boxes.back().push_back(new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(ITEM_WIDTH(), -1)));
+            edit_boxes.back().push_back(new wxTextCtrl(m_page_advanced, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(ITEM_WIDTH(), -1)));
 #endif
             if (i == j) {
                 edit_boxes[i][j]->SetValue(wxString("-"));
                 edit_boxes[i][j]->SetEditable(false);
-                edit_boxes[i][j]->Bind(wxEVT_KILL_FOCUS, [](wxFocusEvent&) {});
-                edit_boxes[i][j]->Bind(wxEVT_SET_FOCUS, [](wxFocusEvent&) {});
+                edit_boxes[i][j]->Bind(wxEVT_KILL_FOCUS, [this](wxFocusEvent&) {});
+                edit_boxes[i][j]->Bind(wxEVT_SET_FOCUS, [this](wxFocusEvent&) {});
             }
             else {
                 edit_boxes[i][j]->SetValue(wxString("") << int(m_matrix[m_number_of_extruders * j + i] * flush_multiplier));
@@ -478,13 +519,13 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
     }
 
     // BBS
-    m_sizer->AddSpacer(FromDIP(10));
-    auto tip_message_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
-    tip_message_panel->SetBackgroundColour(*wxWHITE);
+    m_sizer_advanced->AddSpacer(FromDIP(10));
+    auto tip_message_panel = new wxPanel(m_page_advanced, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    tip_message_panel->SetBackgroundColour(wxColour(238, 238, 238));
     auto message_sizer = new wxBoxSizer(wxVERTICAL);
     tip_message_panel->SetSizer(message_sizer);
     {
-        wxString message = _L("Orca recalculates your flushing volumes everytime the filament colors change. You can change this behavior in Preferences.");
+        wxString message = _L("Studio would re-calculate your flushing volumes everytime the filaments color changed. You could disable the auto-calculate in Bambu Studio > Preferences");
         m_tip_message_label = new Label(tip_message_panel, wxEmptyString);
         wxClientDC dc(tip_message_panel);
         wxString multiline_message;
@@ -492,20 +533,21 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
         m_tip_message_label->SetLabel(multiline_message);
         m_tip_message_label->SetFont(Label::Body_13);
         message_sizer->Add(m_tip_message_label, 0, wxEXPAND | wxALL, TIP_MESSAGES_PADDING);
-        update_ui(m_tip_message_label);
     }
-    m_sizer->Add(tip_message_panel, 0, wxEXPAND | wxRIGHT | wxLEFT, TABLE_BORDER);
+    m_sizer_advanced->Add(tip_message_panel, 0, wxEXPAND | wxRIGHT | wxLEFT, TABLE_BORDER);
     bool is_show = wxGetApp().app_config->get("auto_calculate") == "true";
     tip_message_panel->Show(is_show);
-    m_sizer->AddSpacer(FromDIP(10));
-
-    m_sizer->AddSpacer(FromDIP(5));
-    header_line_panel = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
+    m_sizer_advanced->AddSpacer(FromDIP(10));
+    auto calc_btn_sizer = create_calc_btn_sizer(m_page_advanced);
+    m_sizer_advanced->Add(calc_btn_sizer, 0, wxEXPAND | wxLEFT, FromDIP(30));
+    
+    //m_sizer_advanced->AddSpacer(FromDIP(10));
+    m_sizer_advanced->AddSpacer(FromDIP(5));
+    header_line_panel = new wxPanel(m_page_advanced, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
     header_line_panel->SetBackgroundColour(wxColour(238, 238, 238));
     auto header_line_sizer = new wxBoxSizer(wxHORIZONTAL);
     header_line_panel->SetSizer(header_line_sizer);
 
-    wxSizerItem* stretch_spacer = header_line_sizer->AddStretchSpacer();
     header_line_sizer->AddSpacer(HEADER_BEG_PADDING);
     for (unsigned int i = 0; i < m_number_of_extruders; ++i) {
         wxButton* icon = new wxButton(header_line_panel, wxID_ANY, {}, wxDefaultPosition, ICON_SIZE, wxBORDER_NONE | wxBU_AUTODRAW);
@@ -517,24 +559,23 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
         header_line_sizer->Add(icon, 0, wxALIGN_CENTER_VERTICAL | wxTOP | wxBOTTOM, HEADER_VERT_PADDING);
     }
     header_line_sizer->AddSpacer(HEADER_END_PADDING);
-    header_line_sizer->AddStretchSpacer();
+    
+    m_sizer_advanced->Add(header_line_panel, 0, wxEXPAND | wxRIGHT | wxLEFT, TABLE_BORDER);
+    
+    create_panels(m_page_advanced, m_number_of_extruders);
 
-    m_sizer->Add(header_line_panel, 0, wxEXPAND | wxRIGHT | wxLEFT, TABLE_BORDER);
-
-    create_panels(this, m_number_of_extruders);
-
-    m_sizer->AddSpacer(FromDIP(5));
+    //m_sizer_advanced->AddSpacer(BTN_SIZE.y);
 
     // BBS: for tunning flush volumes
     {
-        auto multi_desc_label = new wxStaticText(this, wxID_ANY, _(L("Flushing volume (mm³) for each filament pair.")), wxDefaultPosition, wxDefaultSize, 0);
+        auto multi_desc_label = new wxStaticText(m_page_advanced, wxID_ANY, _(L("Flushing volume (mm³) for each filament pair.")), wxDefaultPosition, wxDefaultSize, 0);
         multi_desc_label->SetForegroundColour(g_text_color);
-        m_sizer->Add(multi_desc_label, 0, wxEXPAND | wxLEFT, TEXT_BEG_PADDING);
+        m_sizer_advanced->Add(multi_desc_label, 0, wxEXPAND | wxLEFT, TEXT_BEG_PADDING);
 
         wxString min_flush_str = wxString::Format(_L("Suggestion: Flushing Volume in range [%d, %d]"), m_min_flush_volume, m_max_flush_volume);
-        m_min_flush_label = new wxStaticText( this, wxID_ANY, min_flush_str, wxDefaultPosition, wxDefaultSize, 0);
+        m_min_flush_label = new wxStaticText(m_page_advanced, wxID_ANY, min_flush_str, wxDefaultPosition, wxDefaultSize, 0);
         m_min_flush_label->SetForegroundColour(g_text_color);
-        m_sizer->Add(m_min_flush_label, 0, wxEXPAND | wxLEFT, TEXT_BEG_PADDING);
+        m_sizer_advanced->Add(m_min_flush_label, 0, wxEXPAND | wxLEFT, TEXT_BEG_PADDING);
 
         auto on_apply_text_modify = [this](wxEvent& e) {
             wxString str = m_flush_multiplier_ebox->GetValue();
@@ -549,8 +590,6 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
             }
             for (unsigned int i = 0; i < m_number_of_extruders; ++i) {
                 for (unsigned int j = 0; j < m_number_of_extruders; ++j) {
-                    if (i == j)
-                        continue; // if it is from/to the same extruder, don't change the value and continue
                     edit_boxes[i][j]->SetValue(to_string(int(m_matrix[m_number_of_extruders * j + i] * multiplier)));
                 }
             }
@@ -559,32 +598,91 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
             e.Skip();
         };
 
-        m_sizer->AddSpacer(10);
+        m_sizer_advanced->AddSpacer(10);
 
         wxBoxSizer* param_sizer = new wxBoxSizer(wxHORIZONTAL);
-        wxStaticText* flush_multiplier_title = new wxStaticText(this, wxID_ANY, _L("Multiplier"));
+        wxStaticText* flush_multiplier_title = new wxStaticText(m_page_advanced, wxID_ANY, _L("Multiplier"));
         param_sizer->Add(flush_multiplier_title, 0, wxALIGN_CENTER | wxALL, 0);
         param_sizer->AddSpacer(FromDIP(5));
-        m_flush_multiplier_ebox = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(50), -1), wxTE_PROCESS_ENTER);
+        m_flush_multiplier_ebox = new wxTextCtrl(m_page_advanced, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(50), -1), wxTE_PROCESS_ENTER);
         char flush_multi_str[32] = { 0 };
         snprintf(flush_multi_str, sizeof(flush_multi_str), "%.2f", flush_multiplier);
         m_flush_multiplier_ebox->SetValue(flush_multi_str);
         param_sizer->Add(m_flush_multiplier_ebox, 0, wxALIGN_CENTER | wxALL, 0);
         param_sizer->AddStretchSpacer(1);
-        m_sizer->Add(param_sizer, 0, wxEXPAND | wxLEFT, TEXT_BEG_PADDING);
-
-        m_sizer->AddSpacer(BTN_SIZE.y);
+        m_sizer_advanced->Add(param_sizer, 0, wxEXPAND | wxLEFT, TEXT_BEG_PADDING);
 
         m_flush_multiplier_ebox->Bind(wxEVT_TEXT_ENTER, on_apply_text_modify);
         m_flush_multiplier_ebox->Bind(wxEVT_KILL_FOCUS, on_apply_text_modify);
     }
     this->update_warning_texts();
 
+    m_page_advanced->Hide(); 
+
+    // Now the same for simple mode:
+    gridsizer_simple->Add(new wxStaticText(m_page_simple, wxID_ANY, wxString("")), 0, wxALIGN_CENTER | wxALIGN_CENTER_VERTICAL);
+    gridsizer_simple->Add(new wxStaticText(m_page_simple, wxID_ANY, wxString(_(L("unloaded")))), 0, wxALIGN_CENTER | wxALIGN_CENTER_VERTICAL);
+    gridsizer_simple->Add(new wxStaticText(m_page_simple,wxID_ANY,wxString(_(L("loaded")))), 0, wxALIGN_CENTER | wxALIGN_CENTER_VERTICAL);
+
+    auto add_spin_ctrl = [this](std::vector<wxSpinCtrl*>& vec, float initial)
+    {
+        wxSpinCtrl* spin_ctrl = new wxSpinCtrl(m_page_simple, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(ITEM_WIDTH(), -1), style | wxALIGN_RIGHT, 0, 300, (int)initial);
+        update_ui(spin_ctrl);
+        vec.push_back(spin_ctrl);
+
+#ifdef __WXOSX__
+        // On OSX / Cocoa, wxSpinCtrl::GetValue() doesn't return the new value
+        // when it was changed from the text control, so the on_change callback
+        // gets the old one, and on_kill_focus resets the control to the old value.
+        // As a workaround, we get the new value from $event->GetString and store
+        // here temporarily so that we can return it from get_value()
+        spin_ctrl->Bind(wxEVT_TEXT, ([spin_ctrl](wxCommandEvent e)
+        {
+            long value;
+            const bool parsed = e.GetString().ToLong(&value);
+            int tmp_value = parsed && value >= INT_MIN && value <= INT_MAX ? (int)value : INT_MIN;
+
+            // Forcibly set the input value for SpinControl, since the value 
+            // inserted from the keyboard or clipboard is not updated under OSX
+            if (tmp_value != INT_MIN) {
+                spin_ctrl->SetValue(tmp_value);
+
+                // But in SetValue() is executed m_text_ctrl->SelectAll(), so
+                // discard this selection and set insertion point to the end of string
+                spin_ctrl->GetText()->SetInsertionPointEnd();
+            }
+        }), spin_ctrl->GetId());
+#endif
+    };
+
+    for (unsigned int i=0;i<m_number_of_extruders;++i) {
+        add_spin_ctrl(m_old, extruders[2 * i]);
+        add_spin_ctrl(m_new, extruders[2 * i+1]);
+
+        auto hsizer = new wxBoxSizer(wxHORIZONTAL);
+        wxWindow* w = new wxWindow(m_page_simple, wxID_ANY, wxDefaultPosition, ICON_SIZE, wxBORDER_SIMPLE);
+        w->SetCanFocus(false);
+        w->SetBackgroundColour(m_colours[i]);
+        hsizer->Add(w, wxALIGN_CENTER_VERTICAL);
+        hsizer->AddSpacer(10);
+        hsizer->Add(new wxStaticText(m_page_simple, wxID_ANY, wxString(_(L("Filament #"))) << i + 1 << ": "), 0, wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL);
+
+        gridsizer_simple->Add(hsizer, 1, wxEXPAND | wxALIGN_CENTER_VERTICAL);
+        gridsizer_simple->Add(m_old.back(),0);
+        gridsizer_simple->Add(m_new.back(),0);
+    }
+
+    m_sizer = new wxBoxSizer(wxVERTICAL);
+    m_sizer->Add(m_page_simple, 0, wxEXPAND, 0);
+    m_sizer->Add(m_page_advanced, 0, wxEXPAND, 0);
+
     m_sizer->SetSizeHints(this);
     SetSizer(m_sizer);
     this->Layout();
 
-    header_line_panel->Bind(wxEVT_PAINT, [this, stretch_spacer](wxPaintEvent&) {
+    toggle_advanced(); // to show/hide what is appropriate
+    
+    header_line_panel->Bind(wxEVT_PAINT, [this](wxPaintEvent&) {
         wxPaintDC dc(header_line_panel);
         wxString from_text = _L("From");
         wxString to_text = _L("To");
@@ -593,7 +691,7 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
 
         int base_y = (header_line_panel->GetSize().y - from_text_size.y - to_text_size.y) / 2;
         int vol_width = ROW_BEG_PADDING + EDIT_BOXES_GAP / 2 + ICON_SIZE.x;
-        int base_x = stretch_spacer->GetSize().x + (vol_width - from_text_size.x - to_text_size.x) / 2;
+        int base_x = (vol_width - from_text_size.x - to_text_size.x) / 2;
 
         // draw from text
         int x = base_x;
@@ -635,7 +733,7 @@ void WipingPanel::update_warning_texts()
         auto& box_vec = edit_boxes[i];
         for (int j = 0; j < box_vec.size(); j++) {
             if (i == j)
-                continue; // if it is from/to the same extruder, don't change the value and continue
+                continue;
 
             auto text_box = box_vec[j];
             wxString str = text_box->GetValue();
@@ -660,8 +758,8 @@ void WipingPanel::update_warning_texts()
         m_min_flush_label->SetForegroundColour(g_warning_color);
         m_min_flush_label->Refresh();
     }
-    else if (!has_exception_flush && m_min_flush_label->GetForegroundColour() != StateColor::darkModeColorFor(g_text_color)) {
-        m_min_flush_label->SetForegroundColour(StateColor::darkModeColorFor(g_text_color));
+    else if (!has_exception_flush && m_min_flush_label->GetForegroundColour() != g_text_color) {
+        m_min_flush_label->SetForegroundColour(g_text_color);
         m_min_flush_label->Refresh();
     }
 }
@@ -672,24 +770,27 @@ void WipingPanel::calc_flushing_volumes()
         const wxColour& from = m_colours[from_idx];
         bool is_from_support = is_support_filament(from_idx);
         for (int to_idx = 0; to_idx < m_colours.size(); to_idx++) {
-            if (from_idx == to_idx)
-                continue; // if it is from/to the same extruder, don't change the value and continue
-
             bool is_to_support = is_support_filament(to_idx);
-            int flushing_volume = 0;
-            if (is_to_support) {
-                flushing_volume = Slic3r::g_flush_volume_to_support;
+            if (from_idx == to_idx) {
+                edit_boxes[to_idx][from_idx]->SetValue(std::to_string(0));
             }
             else {
-                const wxColour& to = m_colours[to_idx];
-                flushing_volume = calc_flushing_volume(from, to);
-                if (is_from_support) {
-                    flushing_volume = std::max(Slic3r::g_min_flush_volume_from_support, flushing_volume);
+                int flushing_volume = 0;
+                if (is_to_support) {
+                    flushing_volume = Slic3r::g_flush_volume_to_support;
                 }
+                else {
+                    const wxColour& to = m_colours[to_idx];
+                    flushing_volume = calc_flushing_volume(from, to);
+                    if (is_from_support) {
+                        flushing_volume = std::max(Slic3r::g_min_flush_volume_from_support, flushing_volume);
+                    }
+                }
+
+                m_matrix[m_number_of_extruders * from_idx + to_idx] = flushing_volume;
+                flushing_volume = int(flushing_volume * get_flush_multiplier());
+                edit_boxes[to_idx][from_idx]->SetValue(std::to_string(flushing_volume));
             }
-            m_matrix[m_number_of_extruders * from_idx + to_idx] = flushing_volume;
-            flushing_volume = int(flushing_volume * get_flush_multiplier());
-            edit_boxes[to_idx][from_idx]->SetValue(std::to_string(flushing_volume));
         }
     }
 
@@ -707,6 +808,8 @@ void WipingPanel::msw_rescale()
 
 // Reads values from the (advanced) wiping matrix:
 std::vector<float> WipingPanel::read_matrix_values() {
+    if (!m_advanced)
+        fill_in_matrix();
     std::vector<float> output;
     for (unsigned int i=0;i<m_number_of_extruders;++i) {
         for (unsigned int j=0;j<m_number_of_extruders;++j) {
@@ -722,4 +825,59 @@ std::vector<float> WipingPanel::read_matrix_values() {
         }
     }
     return output;
+}
+
+// Reads values from simple mode to save them for next time:
+std::vector<float> WipingPanel::read_extruders_values() {
+    std::vector<float> output;
+    for (unsigned int i=0;i<m_number_of_extruders;++i) {
+        output.push_back(m_old[i]->GetValue());
+        output.push_back(m_new[i]->GetValue());
+    }
+    return output;
+}
+
+// This updates the "advanced" matrix based on values from "simple" mode
+void WipingPanel::fill_in_matrix() {
+    for (unsigned i=0;i<m_number_of_extruders;++i) {
+        for (unsigned j=0;j<m_number_of_extruders;++j) {
+            if (i==j) continue;
+                edit_boxes[j][i]->SetValue(wxString("")<< (m_old[i]->GetValue() + m_new[j]->GetValue()));
+        }
+    }
+}
+
+
+
+// Function to check if simple and advanced settings are matching
+bool WipingPanel::advanced_matches_simple() {
+    for (unsigned i=0;i<m_number_of_extruders;++i) {
+        for (unsigned j=0;j<m_number_of_extruders;++j) {
+            if (i==j) continue;
+            if (edit_boxes[j][i]->GetValue() != (wxString("")<< (m_old[i]->GetValue() + m_new[j]->GetValue())))
+                return false;
+        }
+    }
+    return true;
+}
+
+
+// Switches the dialog from simple to advanced mode and vice versa
+void WipingPanel::toggle_advanced(bool user_action) {
+    if (user_action)
+        m_advanced = !m_advanced;                // user demands a change -> toggle
+    else {
+        // BBS: show advanced mode by default
+        //m_advanced = !advanced_matches_simple(); // if called from constructor, show what is appropriate
+        m_advanced = true;
+    }
+
+    (m_advanced ? m_page_advanced : m_page_simple)->Show();
+    (!m_advanced ? m_page_advanced : m_page_simple)->Hide();
+
+    if (m_advanced)
+        if (user_action) fill_in_matrix();  // otherwise keep values loaded from config
+
+   m_sizer->Layout();
+   Refresh();
 }

--- a/src/slic3r/GUI/WipeTowerDialog.hpp
+++ b/src/slic3r/GUI/WipeTowerDialog.hpp
@@ -48,9 +48,12 @@ public:
     WipingPanel(wxWindow* parent, const std::vector<float>& matrix, const std::vector<float>& extruders, const std::vector<std::string>& extruder_colours, Button* calc_button,
         int extra_flush_volume, float flush_multiplier);
     std::vector<float> read_matrix_values();
+    std::vector<float> read_extruders_values();
+    void toggle_advanced(bool user_action = false);
     void create_panels(wxWindow* parent, const int num);
     void calc_flushing_volumes();
     void msw_rescale();
+    wxBoxSizer* create_calc_btn_sizer(wxWindow* parent);
 
     float get_flush_multiplier()
     {
@@ -61,14 +64,25 @@ public:
     }
 
 private:
+    void fill_in_matrix();
+    bool advanced_matches_simple();
     int calc_flushing_volume(const wxColour& from, const wxColour& to);
     void update_warning_texts();
-
+        
+    std::vector<wxSpinCtrl*> m_old;
+    std::vector<wxSpinCtrl*> m_new;
     std::vector<std::vector<wxTextCtrl*>> edit_boxes;
     std::vector<wxColour> m_colours;
     unsigned int m_number_of_extruders  = 0;
+    bool m_advanced                     = false;
+	wxPanel*	m_page_simple = nullptr;
+	wxPanel*	m_page_advanced = nullptr;
     wxPanel* header_line_panel = nullptr;
-    wxBoxSizer* m_sizer        = nullptr;
+    wxBoxSizer*	m_sizer = nullptr;
+    wxBoxSizer* m_sizer_simple = nullptr;
+    wxBoxSizer* m_sizer_advanced = nullptr;
+    wxGridSizer* m_gridsizer_advanced = nullptr;
+    wxButton* m_widget_button     = nullptr;
     Label* m_tip_message_label = nullptr;
 
     std::vector<wxButton *> icon_list1;
@@ -93,6 +107,7 @@ public:
     WipingDialog(wxWindow* parent, const std::vector<float>& matrix, const std::vector<float>& extruders, const std::vector<std::string>& extruder_colours,
         int extra_flush_volume, float flush_multiplier);
     std::vector<float> get_matrix() const    { return m_output_matrix; }
+    std::vector<float> get_extruders() const { return m_output_extruders; }
     wxBoxSizer* create_btn_sizer(long flags);
 
     float get_flush_multiplier()
@@ -108,6 +123,7 @@ public:
 private:
     WipingPanel*  m_panel_wiping  = nullptr;
     std::vector<float> m_output_matrix;
+    std::vector<float> m_output_extruders;
     std::unordered_map<int, Button *> m_button_list;
 };
 

--- a/src/slic3r/GUI/wxExtensions.hpp
+++ b/src/slic3r/GUI/wxExtensions.hpp
@@ -18,17 +18,14 @@
 
 #include "Widgets/PopupWindow.hpp"
 
-#ifndef __linux__
-void sys_color_changed_menu(wxMenu* menu);
-#else
-inline void sys_color_changed_menu(wxMenu* /* menu */) {}
-#endif // no __linux__
-
-[[deprecated("Function renamed to sys_color_changed_menu. This function now redirects to sys_color_changed_menu")]]
-inline void msw_rescale_menu(wxMenu* menu) { sys_color_changed_menu(menu); }
+#ifdef __WXMSW__
+void                msw_rescale_menu(wxMenu* menu);
+#else /* __WXMSW__ */
+inline void         msw_rescale_menu(wxMenu* /* menu */) {}
+#endif /* __WXMSW__ */
 
 wxMenuItem* append_menu_item(wxMenu* menu, int id, const wxString& string, const wxString& description,
-    std::function<void(wxCommandEvent& event)> cb, wxBitmapBundle* icon, wxEvtHandler* event_handler = nullptr,
+    std::function<void(wxCommandEvent& event)> cb, const wxBitmap& icon, wxEvtHandler* event_handler = nullptr,
     std::function<bool()> const cb_condition = []() { return true;}, wxWindow* parent = nullptr, int insert_pos = wxNOT_FOUND);
 wxMenuItem* append_menu_item(wxMenu* menu, int id, const wxString& string, const wxString& description,
     std::function<void(wxCommandEvent& event)> cb, const std::string& icon = "", wxEvtHandler* event_handler = nullptr,
@@ -55,9 +52,7 @@ void    msw_buttons_rescale(wxDialog* dlg, const int em_unit, const std::vector<
 int     em_unit(wxWindow* win);
 int     mode_icon_px_size();
 
-wxBitmapBundle* get_bmp_bundle(const std::string& bmp_name, int width = 16, int height = -1);
-wxBitmapBundle* get_empty_bmp_bundle(int width, int height);
-wxBitmapBundle* get_solid_bmp_bundle(int width, int height, const std::string& color);
+wxBitmap create_menu_bitmap(const std::string& bmp_name);
 
 // BBS: support resize by fill border
 #if 1
@@ -71,8 +66,8 @@ wxBitmap create_scaled_bitmap(const std::string& bmp_name, wxWindow *win = nullp
 #endif
 
 wxBitmap* get_default_extruder_color_icon(bool thin_icon = false);
-std::vector<wxBitmapBundle *> get_extruder_color_icons(bool thin_icon = false);
-wxBitmapBundle * get_extruder_color_icon(std::string color, std::string label, int icon_width, int icon_height);
+std::vector<wxBitmap *> get_extruder_color_icons(bool thin_icon = false);
+wxBitmap * get_extruder_color_icon(std::string color, std::string label, int icon_width, int icon_height);
 
 namespace Slic3r {
 namespace GUI {
@@ -145,17 +140,6 @@ public:
     void				SetItemsCnt(int cnt) { m_cnt_open_items = cnt; }
 };
 
-inline wxSize get_preferred_size(const wxBitmapBundle& bmp, wxWindow* parent)
-{
-    if (!bmp.IsOk())
-        return wxSize(0, 0);
-#ifdef __WIN32__
-    return bmp.GetPreferredBitmapSizeFor(parent);
-#else
-    return bmp.GetDefaultSize();
-#endif
-}
-
 
 // ----------------------------------------------------------------------------
 // ScalableBitmap
@@ -167,47 +151,31 @@ public:
     ScalableBitmap() {};
     ScalableBitmap( wxWindow *parent,
                     const std::string& icon_name = "",
-                    const int px_cnt = 16,
+                    const int px_cnt = 16, 
                     const bool grayscale = false,
-                    const bool resize = false, 
-                    const bool use_legacy_bmp = true);
-    ScalableBitmap( wxWindow *parent,
-                    const std::string& icon_name,
-                    const wxSize size,
-                    const bool grayscale = false,
-                    const bool resize = false);
+                    const bool resize = false); // BBS: support resize by fill border
 
     ~ScalableBitmap() {}
 
-    [[deprecated("Function renamed to sys_color_changed. This function now redirects to sys_color_changed")]]
-    inline void msw_rescale() { sys_color_changed(); }
-    void sys_color_changed();
+    wxSize  GetBmpSize() const;
+    int     GetBmpWidth() const;
+    int     GetBmpHeight() const;
 
-    const wxBitmapBundle&     bmp() const { return m_bmp; }
-    wxBitmapBundle&           bmp()       { return m_bmp; }
-    wxBitmap                  get_bitmap() const { return m_bmp.GetBitmapFor(m_parent); }
-    wxWindow*                 parent() const { return m_parent;}
-    const std::string&        name() const{ return m_icon_name; }
-    int                       px_cnt() const { return m_size.x; }
+    void                msw_rescale();
 
-    wxSize              GetSize()   const {
-#ifdef __WIN32__
-        return m_bmp.GetPreferredBitmapSizeFor(m_parent);
-#else
-        return m_bmp.GetDefaultSize();
-#endif
-    }
-    int                 GetWidth()  const { return GetSize().GetWidth(); }
-    int                 GetHeight() const { return GetSize().GetHeight(); }
+    const wxBitmap&     bmp() const { return m_bmp; }
+    wxBitmap&           bmp()       { return m_bmp; }
+    const std::string&  name() const{ return m_icon_name; }
+
+    int                 px_cnt()const           {return m_px_cnt;}
 
 private:
     wxWindow*       m_parent{ nullptr };
-    wxBitmapBundle  m_bmp = wxBitmapBundle();
+    wxBitmap        m_bmp = wxBitmap();
     std::string     m_icon_name = "";
-    wxSize          m_size {16, 16};
+    int             m_px_cnt {16};
     bool            m_grayscale{ false };
     bool            m_resize{ false };
-    bool            m_legacy_bmp{ false };
 };
 
 
@@ -234,9 +202,7 @@ public:
     void    enable()                        { m_disabled = false; }
     void    disable()                       { m_disabled = true;  }
 
-    [[deprecated("Function renamed to sys_color_changed. This function now redirects to sys_color_changed")]]
-    inline void msw_rescale() { sys_color_changed(); }
-    void sys_color_changed();
+    void    msw_rescale();
 
 protected:
     void    update_button_bitmaps();
@@ -268,6 +234,7 @@ public:
         const wxSize&       size = wxDefaultSize,
         const wxPoint&      pos = wxDefaultPosition,
         long                style = wxBU_EXACTFIT | wxNO_BORDER,
+        bool                use_default_disabled_bitmap = false,
         int                 bmp_px_cnt = 16);
 
     ScalableButton(
@@ -283,10 +250,9 @@ public:
     bool SetBitmap_(const std::string& bmp_name);
     void SetBitmapDisabled_(const ScalableBitmap &bmp);
     int  GetBitmapHeight();
+    void UseDefaultBitmapDisabled();
 
-    [[deprecated("Function renamed to sys_color_changed. This function now redirects to sys_color_changed")]]
-    inline void msw_rescale() { sys_color_changed(); }
-    void    sys_color_changed();
+    void    msw_rescale();
 
 private:
     wxWindow*       m_parent { nullptr };
@@ -294,6 +260,8 @@ private:
     std::string     m_disabled_icon_name;
     int             m_width {-1}; // should be multiplied to em_unit
     int             m_height{-1}; // should be multiplied to em_unit
+
+    bool            m_use_default_disabled_bitmap {false};
 
     // bitmap dimensions 
     int             m_px_cnt{ 16 };
@@ -360,9 +328,7 @@ public:
     void set_items_flag(int flag);
     void set_items_border(int border);
 
-    [[deprecated("Function renamed to sys_color_changed. This function now redirects to sys_color_changed")]]
-    inline void msw_rescale() { sys_color_changed(); }
-    void sys_color_changed();
+    void msw_rescale();
     const std::vector<ModeButton*>& get_btns() { return m_mode_btns; }
 
 private:
@@ -410,11 +376,12 @@ public:
 
     ~BlinkingBitmap() {}
 
+    void    msw_rescale();
     void    invalidate();
     void    activate();
     void    blink();
 
-    const wxBitmapBundle& get_bmp() const { return bmp.bmp(); }
+    const wxBitmap& get_bmp() const { return bmp.bmp(); }
 
 private:
     ScalableBitmap  bmp;


### PR DESCRIPTION
Temporarily revert to wxWidgets 3.1. 
wxWidgets handles DPI automatically starting from version 3.2, while OrcaSlicer handles DPI independently.

It would be beneficial to have wxWidgets handle DPI in the future, but due to the amount of work and especially testing effort required, I've decided not to implement this for OrcaSlicer 1.9.

Now, scaling works as expected. The following screenshot is at a 200% scale.
![image](https://github.com/SoftFever/OrcaSlicer/assets/103989404/94a5f345-54cd-4d29-92d6-f8a7a85ba3ff)




-----------------For future reference----------------------
NOTE for future upgrade:
By disable Orca's DPI scaling  in `create_scaled_bitmap` function, I'm able to get most UI work with wxWidgets 3.2.
But there are two small UI glitches at 200% which I decide to not investigate at the moment.
glitches with 3.2:
![15d99b5ee8ea266514634dacc225d856](https://github.com/SoftFever/OrcaSlicer/assets/103989404/5324e74e-8111-462d-aee1-865f6bcd6ac6)
![cf2c7513df190d9d20e7f09cfe2a6810](https://github.com/SoftFever/OrcaSlicer/assets/103989404/76c6da5f-126a-4479-806b-a1412a766f03)
@Ocraftyone @Noisyfox FYI in case you are interested to know the status of 3.2.

