### PR TITLE
Fixed G-code icons on Creality K1 and K1 Max (solves #3033)

### DIFF
--- a/resources/profiles/Creality/machine/Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 (0.4 nozzle).json
@@ -7,6 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1",
 	"gcode_flavor": "klipper",
+	"thumbnails": "96x96, 300x300",
 	"default_print_profile": "0.20mm Standard @Creality K1 (0.4 nozzle)",
 	"nozzle_diameter": ["0.4"],
 	"printer_variant": "0.4",

--- a/resources/profiles/Creality/machine/Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 (0.4 nozzle).json
@@ -7,7 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1",
 	"gcode_flavor": "klipper",
-	"thumbnails": "96x96, 300x300",
+	"thumbnails": ["96x96", "300x300"],
 	"default_print_profile": "0.20mm Standard @Creality K1 (0.4 nozzle)",
 	"nozzle_diameter": ["0.4"],
 	"printer_variant": "0.4",

--- a/resources/profiles/Creality/machine/Creality K1 (0.6 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 (0.6 nozzle).json
@@ -7,7 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1",
 	"gcode_flavor": "klipper",
-	"thumbnails": "96x96, 300x300",
+	"thumbnails": ["96x96", "300x300"],
 	"default_print_profile": "0.30mm Standard @Creality K1 (0.6 nozzle)",
 	"nozzle_diameter": ["0.6"],
 	"printer_variant": "0.6",

--- a/resources/profiles/Creality/machine/Creality K1 (0.6 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 (0.6 nozzle).json
@@ -7,6 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1",
 	"gcode_flavor": "klipper",
+	"thumbnails": "96x96, 300x300",
 	"default_print_profile": "0.30mm Standard @Creality K1 (0.6 nozzle)",
 	"nozzle_diameter": ["0.6"],
 	"printer_variant": "0.6",

--- a/resources/profiles/Creality/machine/Creality K1 (0.8 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 (0.8 nozzle).json
@@ -7,7 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1",
 	"gcode_flavor": "klipper",
-	"thumbnails": "96x96, 300x300",
+	"thumbnails": ["96x96", "300x300"],
 	"default_print_profile": "0.40mm Standard @Creality K1 (0.8 nozzle)",
 	"nozzle_diameter": ["0.8"],
 	"printer_variant": "0.8",

--- a/resources/profiles/Creality/machine/Creality K1 (0.8 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 (0.8 nozzle).json
@@ -7,6 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1",
 	"gcode_flavor": "klipper",
+	"thumbnails": "96x96, 300x300",
 	"default_print_profile": "0.40mm Standard @Creality K1 (0.8 nozzle)",
 	"nozzle_diameter": ["0.8"],
 	"printer_variant": "0.8",

--- a/resources/profiles/Creality/machine/Creality K1 Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 Max (0.4 nozzle).json
@@ -7,7 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1 Max",
 	"gcode_flavor": "klipper",
-	"thumbnails": "96x96, 300x300",
+	"thumbnails": ["96x96", "300x300"],
 	"default_print_profile": "0.20mm Standard @Creality K1Max (0.4 nozzle)",
 	"nozzle_diameter": ["0.4"],
 	"printer_variant": "0.4",

--- a/resources/profiles/Creality/machine/Creality K1 Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 Max (0.4 nozzle).json
@@ -7,6 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1 Max",
 	"gcode_flavor": "klipper",
+	"thumbnails": "96x96, 300x300",
 	"default_print_profile": "0.20mm Standard @Creality K1Max (0.4 nozzle)",
 	"nozzle_diameter": ["0.4"],
 	"printer_variant": "0.4",

--- a/resources/profiles/Creality/machine/Creality K1 Max (0.6 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 Max (0.6 nozzle).json
@@ -7,6 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1 Max",
 	"gcode_flavor": "klipper",
+	"thumbnails": "96x96, 300x300",
 	"default_print_profile": "0.30mm Standard @Creality K1Max (0.6 nozzle)",
 	"nozzle_diameter": ["0.6"],
 	"printer_variant": "0.6",

--- a/resources/profiles/Creality/machine/Creality K1 Max (0.6 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 Max (0.6 nozzle).json
@@ -7,7 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1 Max",
 	"gcode_flavor": "klipper",
-	"thumbnails": "96x96, 300x300",
+	"thumbnails": ["96x96", "300x300"],
 	"default_print_profile": "0.30mm Standard @Creality K1Max (0.6 nozzle)",
 	"nozzle_diameter": ["0.6"],
 	"printer_variant": "0.6",

--- a/resources/profiles/Creality/machine/Creality K1 Max (0.8 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 Max (0.8 nozzle).json
@@ -7,7 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1 Max",
 	"gcode_flavor": "klipper",
-	"thumbnails": "96x96, 300x300",
+	"thumbnails": ["96x96", "300x300"],
 	"default_print_profile": "0.40mm Standard @Creality K1Max (0.8 nozzle)",
 	"nozzle_diameter": ["0.8"],
 	"printer_variant": "0.8",

--- a/resources/profiles/Creality/machine/Creality K1 Max (0.8 nozzle).json
+++ b/resources/profiles/Creality/machine/Creality K1 Max (0.8 nozzle).json
@@ -7,6 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality K1 Max",
 	"gcode_flavor": "klipper",
+	"thumbnails": "96x96, 300x300",
 	"default_print_profile": "0.40mm Standard @Creality K1Max (0.8 nozzle)",
 	"nozzle_diameter": ["0.8"],
 	"printer_variant": "0.8",


### PR DESCRIPTION
The Creality K1 and K1 Max doesn't display the icons of G-code files that have been uploaded but the preview is visible after clicking on it on the Klipper touchscreen.
This is because it wants two different thumbnails, one should be 96x96 for the icon and another 300x300 for the preview.