### PR TITLE
Added PAUSE command for change_filament_gcode in Neptune 4 series

### DIFF
--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.2 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.2 nozzle).json
@@ -45,7 +45,7 @@
 		"45"
 	],
 	"single_extruder_multi_material": "1",
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.2 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.4 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.4 nozzle).json
@@ -45,7 +45,7 @@
 		"45"
 	],
 	"single_extruder_multi_material": "1",
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.4 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.6 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.6 nozzle).json
@@ -45,7 +45,7 @@
 		"45"
 	],
 	"single_extruder_multi_material": "1",
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.6 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.8 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.8 nozzle).json
@@ -45,7 +45,7 @@
 		"45"
 	],
 	"single_extruder_multi_material": "1",
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.8 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Max (0.2 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Max (0.2 nozzle).json
@@ -75,7 +75,7 @@
     "wipe_distance": ["1"],
     "z_hop": ["0.4"],
     "z_hop_types": ["Normal Lift"],
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.2 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Max (0.4 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Max (0.4 nozzle).json
@@ -75,7 +75,7 @@
     "wipe_distance": ["1"],
     "z_hop": ["0.4"],
     "z_hop_types": ["Normal Lift"],
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.4 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Max (0.6 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Max (0.6 nozzle).json
@@ -75,7 +75,7 @@
     "wipe_distance": ["1"],
     "z_hop": ["0.4"],
     "z_hop_types": ["Normal Lift"],
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.6 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Max (0.8 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Max (0.8 nozzle).json
@@ -75,7 +75,7 @@
     "wipe_distance": ["1"],
     "z_hop": ["0.4"],
     "z_hop_types": ["Normal Lift"],
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.8 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Plus (0.2 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Plus (0.2 nozzle).json
@@ -81,7 +81,7 @@
     "wipe_distance": ["1"],
     "z_hop": ["0.4"],
     "z_hop_types": ["Normal Lift"],
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.2 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Plus (0.4 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Plus (0.4 nozzle).json
@@ -81,7 +81,7 @@
     "wipe_distance": ["1"],
     "z_hop": ["0.4"],
     "z_hop_types": ["Normal Lift"],
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.4 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Plus (0.6 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Plus (0.6 nozzle).json
@@ -81,7 +81,7 @@
     "wipe_distance": ["1"],
     "z_hop": ["0.4"],
     "z_hop_types": ["Normal Lift"],
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.6 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Plus (0.8 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Plus (0.8 nozzle).json
@@ -81,7 +81,7 @@
     "wipe_distance": ["1"],
     "z_hop": ["0.4"],
     "z_hop_types": ["Normal Lift"],
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.8 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.2 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.2 nozzle).json
@@ -48,7 +48,7 @@
 		"45"
 	],
 	"single_extruder_multi_material": "1",
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.2 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.4 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.4 nozzle).json
@@ -48,7 +48,7 @@
 		"45"
 	],
 	"single_extruder_multi_material": "1",
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": [
 		"Elegoo Generic PLA @0.4 nozzle"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.6 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.6 nozzle).json
@@ -25,7 +25,7 @@
 	"retract_length_toolchange": ["2"],
 	"deretraction_speed": ["45"],
 	"single_extruder_multi_material": "1",
-	"change_filament_gcode": "",
+	"change_filament_gcode": "PAUSE",
 	"machine_pause_gcode": "M0",
 	"default_filament_profile": ["Elegoo Generic PLA @0.6 nozzle"],
 	"machine_start_gcode": "M413 S0 ; disable Power Loss Recovery\nG90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S120 ; set temporary nozzle temp to prevent oozing during homing and auto bed leveling\nM140 S[bed_temperature_initial_layer_single] ; set final bed temp\nG4 S10 ; allow partial nozzle warmup\nG28 ; home all axis\n;G29 ; run abl mesh\nM420 S1 ; load mesh\nG1 Z50 F240\nG1 X2 Y10 F3000\n\nM190 S[bed_temperature_initial_layer_single] ; wait for bed temp to stabilize\nM109 S[nozzle_temperature_initial_layer] ; wait for nozzle temp to stabilize\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; prime the nozzle\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; prime the nozzle\nG92 E0",

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.8 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.8 nozzle).json
@@ -39,7 +39,7 @@
   "retract_length_toolchange": ["2"],
   "deretraction_speed": ["45"],
   "single_extruder_multi_material": "1",
-  "change_filament_gcode": "",
+  "change_filament_gcode": "PAUSE",
   "machine_pause_gcode": "M0",
   "default_filament_profile": ["Elegoo Generic PLA @0.8 nozzle"],
   "machine_start_gcode": "M413 S0 ; disable Power Loss Recovery\nG90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S120 ; set temporary nozzle temp to prevent oozing during homing and auto bed leveling\nM140 S[bed_temperature_initial_layer_single] ; set final bed temp\nG4 S10 ; allow partial nozzle warmup\nG28 ; home all axis\n;G29 ; run abl mesh\nM420 S1 ; load mesh\nG1 Z50 F240\nG1 X2 Y10 F3000\n\nM190 S[bed_temperature_initial_layer_single] ; wait for bed temp to stabilize\nM109 S[nozzle_temperature_initial_layer] ; wait for nozzle temp to stabilize\nG1 Z0.28 F240\nG92 E0\nG1 Y140 E10 F1500 ; prime the nozzle\nG1 X2.3 F5000\nG92 E0\nG1 Y10 E10 F1200 ; prime the nozzle\nG92 E0",


### PR DESCRIPTION
The Elegoo Neptune 4 series implements PAUSE command correctly in order to use it directly as change_filament_gcode.
So I suggest using it as the default command for that action.
The users are free to change it anyway, but for newbies, it will be easier to use.