### PR TITLE
Added i3 printer_structure to Creality printers

### DIFF
--- a/resources/profiles/Creality/machine/Creality CR-10 Max 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-10 Max 0.4 nozzle.json
@@ -6,6 +6,7 @@
   "instantiation": "true",
   "inherits": "fdm_creality_common",
   "printer_model": "Creality CR-10 Max",
+  "printer_structure": "i3",
   "default_filament_profile": [
     "Creality Generic PLA"
   ],

--- a/resources/profiles/Creality/machine/Creality CR-10 V2 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-10 V2 0.4 nozzle.json
@@ -6,6 +6,7 @@
 	"instantiation": "true",
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality CR-10 V2",
+	"printer_structure": "i3",
 	"default_print_profile": "0.20mm Standard @Creality CR10V2",
 	"nozzle_diameter": [
 		"0.4"

--- a/resources/profiles/Creality/machine/Creality CR-6 Max 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 Max 0.2 nozzle.json
@@ -6,6 +6,7 @@
   "instantiation": "true",
   "inherits": "fdm_creality_common",
   "printer_model": "Creality CR-6 Max",
+  "printer_structure": "i3",
   "default_filament_profile": [
     "Creality Generic PLA"
   ],

--- a/resources/profiles/Creality/machine/Creality CR-6 Max 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 Max 0.4 nozzle.json
@@ -6,6 +6,7 @@
   "instantiation": "true",
   "inherits": "fdm_creality_common",
   "printer_model": "Creality CR-6 Max",
+  "printer_structure": "i3",
   "default_filament_profile": [
     "Creality Generic PLA"
   ],

--- a/resources/profiles/Creality/machine/Creality CR-6 Max 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 Max 0.6 nozzle.json
@@ -6,6 +6,7 @@
   "instantiation": "true",
   "inherits": "fdm_creality_common",
   "printer_model": "Creality CR-6 Max",
+  "printer_structure": "i3",
   "default_filament_profile": [
     "Creality Generic PLA"
   ],

--- a/resources/profiles/Creality/machine/Creality CR-6 Max 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 Max 0.8 nozzle.json
@@ -6,6 +6,7 @@
   "instantiation": "true",
   "inherits": "fdm_creality_common",
   "printer_model": "Creality CR-6 Max",
+  "printer_structure": "i3",
   "default_filament_profile": [
     "Creality Generic PLA"
   ],

--- a/resources/profiles/Creality/machine/Creality CR-6 SE 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 SE 0.2 nozzle.json
@@ -6,6 +6,7 @@
   "instantiation": "true",
   "inherits": "fdm_creality_common",
   "printer_model": "Creality CR-6 SE",
+  "printer_structure": "i3",
   "default_filament_profile": [
     "Creality Generic PLA"
   ],

--- a/resources/profiles/Creality/machine/Creality CR-6 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 SE 0.4 nozzle.json
@@ -6,6 +6,7 @@
   "instantiation": "true",
   "inherits": "fdm_creality_common",
   "printer_model": "Creality CR-6 SE",
+  "printer_structure": "i3",
   "default_filament_profile": [
     "Creality Generic PLA"
   ],

--- a/resources/profiles/Creality/machine/Creality CR-6 SE 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 SE 0.6 nozzle.json
@@ -6,6 +6,7 @@
   "instantiation": "true",
   "inherits": "fdm_creality_common",
   "printer_model": "Creality CR-6 SE",
+  "printer_structure": "i3",
   "default_filament_profile": [
     "Creality Generic PLA"
   ],

--- a/resources/profiles/Creality/machine/Creality CR-6 SE 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 SE 0.8 nozzle.json
@@ -6,6 +6,7 @@
   "instantiation": "true",
   "inherits": "fdm_creality_common",
   "printer_model": "Creality CR-6 SE",
+  "printer_structure": "i3",
   "default_filament_profile": [
     "Creality Generic PLA"
   ],

--- a/resources/profiles/Creality/machine/Creality Ender-3 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 0.4 nozzle.json
@@ -6,6 +6,7 @@
 	"instantiation": "true",
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality Ender-3",
+	"printer_structure": "i3",
 	"default_print_profile": "0.20mm Standard @Creality Ender3",
 	"thumbnails": [""],
 	"nozzle_diameter": [

--- a/resources/profiles/Creality/machine/Creality Ender-3 S1 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 S1 0.4 nozzle.json
@@ -6,6 +6,7 @@
 	"instantiation": "true",
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality Ender-3 S1",
+	"printer_structure": "i3",
 	"default_print_profile": "0.20mm Standard @Creality Ender3S1",
 	"nozzle_diameter": [
 		"0.4"

--- a/resources/profiles/Creality/machine/Creality Ender-3 S1 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 S1 Pro 0.4 nozzle.json
@@ -6,6 +6,7 @@
 	"instantiation": "true",
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality Ender-3 S1 Pro",
+	"printer_structure": "i3",
 	"default_print_profile": "0.20mm Standard @Creality Ender3S1Pro",
 	"nozzle_diameter": [
 		"0.4"

--- a/resources/profiles/Creality/machine/Creality Ender-3 V2 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V2 0.4 nozzle.json
@@ -6,6 +6,7 @@
   "instantiation": "true",
   "inherits": "fdm_creality_common",
   "printer_model": "Creality Ender-3 V2",
+  "printer_structure": "i3",
   "default_filament_profile": [
     "Creality Generic PLA"
   ],


### PR DESCRIPTION
An option has been added with A1 printers from BBL, it's called "printer_structure".
When it is set to "i3", that option automatically ticks the box to align parts on Y axis in order to improve quality.
I added this parameter to every i3 printers from Creality.