### PR TITLE
Display accurate precision for percent config values

### DIFF
--- a/src/slic3r/GUI/OptionsGroup.cpp
+++ b/src/slic3r/GUI/OptionsGroup.cpp
@@ -981,8 +981,7 @@ boost::any ConfigOptionsGroup::get_config_value(const DynamicPrintConfig& config
 	}
 	case coPercent:{
 		double val = config.option<ConfigOptionPercent>(opt_key)->value;
-		text_value = wxString::Format(_T("%i"), int(val));
-		ret = text_value;// += "%";
+		ret = double_to_string(val);// += "%";
 	}
 		break;
 	case coPercents:


### PR DESCRIPTION
Percent config values are managed as float types, but decimal precision is not displayed in the GUI. This change uses the `double_to_string()` converstion rather than casting to an int when retrieving the config option value.

I noticed this specifically when fine tuning the infill density for some large weight sensitive prints and the decimal values were lost each time the field was redisplayed in the GUI. The confusing thing was the correct precision value was still being used for all slicing calculations.