### PR TITLE
corrected printable_area

### DIFF
--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.2 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.2 nozzle).json
@@ -13,15 +13,14 @@
 	],
 	"printer_variant": "0.2",
 	"printable_area": [
-		"0x0",
-		"225x0",
-		"225x225",
-		"0x225"
+		"0x5",
+		"235x5",
+		"235x235",
+		"0x235"
 	],
 	"printable_height": "265",
 	"nozzle_type": "hardened_steel",
 	"auxiliary_fan": "0",
-
 	"max_layer_height": [
 		"0.16"
 	],

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.2 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.2 nozzle).json
@@ -13,10 +13,10 @@
 	],
 	"printer_variant": "0.2",
 	"printable_area": [
-		"0x5",
-		"235x5",
-		"235x235",
-		"0x235"
+		"0x0",
+		"235x0",
+		"235x230",
+		"0x230"
 	],
 	"printable_height": "265",
 	"nozzle_type": "hardened_steel",

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.4 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.4 nozzle).json
@@ -13,10 +13,10 @@
 	],
 	"printer_variant": "0.4",
 	"printable_area": [
-		"0x5",
-		"235x5",
-		"235x235",
-		"0x235"
+		"0x0",
+		"235x0",
+		"235x230",
+		"0x230"
 	],
 	"printable_height": "265",
 	"nozzle_type": "hardened_steel",

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.4 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.4 nozzle).json
@@ -13,15 +13,14 @@
 	],
 	"printer_variant": "0.4",
 	"printable_area": [
-		"0x0",
-		"225x0",
-		"225x225",
-		"0x225"
+		"0x5",
+		"235x5",
+		"235x235",
+		"0x235"
 	],
 	"printable_height": "265",
 	"nozzle_type": "hardened_steel",
 	"auxiliary_fan": "0",
-
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.6 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.6 nozzle).json
@@ -8,26 +8,50 @@
 	"printer_model": "Elegoo Neptune 4 Pro",
 	"default_print_profile": "0.20mm Standard @Elegoo Neptune4Pro (0.6 nozzle)",
 	"gcode_flavor": "klipper",
-	"nozzle_diameter": ["0.6"],
+	"nozzle_diameter": [
+		"0.6"
+	],
 	"printer_variant": "0.6",
-	"printable_area": ["0x0", "225x0", "225x225", "0x225"],
+	"printable_area": [
+		"0x5",
+		"235x5",
+		"235x235",
+		"0x235"
+	],
 	"printable_height": "265",
 	"nozzle_type": "hardened_steel",
 	"auxiliary_fan": "0",
-
-	"max_layer_height": ["0.4"],
-	"min_layer_height": ["0.08"],
+	"max_layer_height": [
+		"0.4"
+	],
+	"min_layer_height": [
+		"0.08"
+	],
 	"printer_settings_id": "Elegoo",
-	"retraction_minimum_travel": ["1"],
-	"retract_before_wipe": ["85%"],
-	"retraction_length": ["2.5"],
-	"retraction_speed": ["60"],
-	"retract_length_toolchange": ["2"],
-	"deretraction_speed": ["45"],
+	"retraction_minimum_travel": [
+		"1"
+	],
+	"retract_before_wipe": [
+		"85%"
+	],
+	"retraction_length": [
+		"2.5"
+	],
+	"retraction_speed": [
+		"60"
+	],
+	"retract_length_toolchange": [
+		"2"
+	],
+	"deretraction_speed": [
+		"45"
+	],
 	"single_extruder_multi_material": "1",
 	"change_filament_gcode": "M600",
 	"machine_pause_gcode": "PAUSE",
-	"default_filament_profile": ["Elegoo Generic PLA @0.6 nozzle"],
+	"default_filament_profile": [
+		"Elegoo Generic PLA @0.6 nozzle"
+	],
 	"machine_start_gcode": ";ELEGOO NEPTUNE 4 PRO\nM220 S100 ;Set the feed speed to 100%\nM221 S100 ;Set the flow rate to 100%\nM104 S140\nM190 S[bed_temperature_initial_layer_single]\nG90\nG28 ;home\nG1 Z10 F300\nG1 X67.5 Y0 F6000\nG1 Z0 F300\nM109 S[nozzle_temperature_initial_layer]\nG92 E0 ;Reset Extruder\nG1 X67.5 Y0 Z0.4 F300 ;Move to start position\nG1 X167.5 E30 F400 ;Draw the first line\nG1 Z0.6 F120.0 ;Move to side a little\nG1 X162.5 F3000\nG92 E0 ;Reset Extruder",
 	"machine_end_gcode": ";PRINT END\nG91 ;Relative positionning\nG1 E-2 F2700 ;Retract a bit\nG1 E-8 X5 Y5 Z3 F3000 ;Retract\nG90 ;Absolute positionning\nG1 X10 Y220 F6000;Finish print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\nM84 X Y E ;Disable all steppers but Z",
 	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\nG92 E0\n;[layer_z]\n\n",

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.6 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.6 nozzle).json
@@ -13,10 +13,10 @@
 	],
 	"printer_variant": "0.6",
 	"printable_area": [
-		"0x5",
-		"235x5",
-		"235x235",
-		"0x235"
+		"0x0",
+		"235x0",
+		"235x230",
+		"0x230"
 	],
 	"printable_height": "265",
 	"nozzle_type": "hardened_steel",

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.8 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.8 nozzle).json
@@ -13,10 +13,10 @@
   ],
   "printer_variant": "0.8",
   "printable_area": [
-    "0x5",
-    "235x5",
-    "235x235",
-    "0x235"
+    "0x0",
+    "235x0",
+    "235x230",
+    "0x230"
   ],
   "printable_height": "265",
   "nozzle_type": "hardened_steel",

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.8 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 Pro (0.8 nozzle).json
@@ -8,42 +8,112 @@
   "printer_model": "Elegoo Neptune 4 Pro",
   "gcode_flavor": "klipper",
   "default_print_profile": "0.20mm Standard @Elegoo Neptune4Pro (0.8 nozzle)",
-  "nozzle_diameter": ["0.8"],
+  "nozzle_diameter": [
+    "0.8"
+  ],
   "printer_variant": "0.8",
-  "printable_area": ["0x0", "225x0", "225x225", "0x225"],
+  "printable_area": [
+    "0x5",
+    "235x5",
+    "235x235",
+    "0x235"
+  ],
   "printable_height": "265",
   "nozzle_type": "hardened_steel",
   "auxiliary_fan": "0",
-  "machine_max_acceleration_e": ["5000", "5000"],
-  "machine_max_acceleration_extruding": ["20000", "20000"],
-  "machine_max_acceleration_retracting": ["5000", "5000"],
-  "machine_max_acceleration_travel": ["20000", "20000"],
-  "machine_max_acceleration_x": ["20000", "20000"],
-  "machine_max_acceleration_y": ["20000", "20000"],
-  "machine_max_acceleration_z": ["500", "200"],
-  "machine_max_speed_e": ["25", "25"],
-  "machine_max_speed_x": ["500", "200"],
-  "machine_max_speed_y": ["500", "200"],
-  "machine_max_speed_z": ["12", "12"],
-  "machine_max_jerk_e": ["2.5", "2.5"],
-  "machine_max_jerk_x": ["12", "12"],
-  "machine_max_jerk_y": ["12", "12"],
-  "machine_max_jerk_z": ["0.2", "0.4"],
-  "max_layer_height": ["0.6"],
-  "min_layer_height": ["0.08"],
+  "machine_max_acceleration_e": [
+    "5000",
+    "5000"
+  ],
+  "machine_max_acceleration_extruding": [
+    "20000",
+    "20000"
+  ],
+  "machine_max_acceleration_retracting": [
+    "5000",
+    "5000"
+  ],
+  "machine_max_acceleration_travel": [
+    "20000",
+    "20000"
+  ],
+  "machine_max_acceleration_x": [
+    "20000",
+    "20000"
+  ],
+  "machine_max_acceleration_y": [
+    "20000",
+    "20000"
+  ],
+  "machine_max_acceleration_z": [
+    "500",
+    "200"
+  ],
+  "machine_max_speed_e": [
+    "25",
+    "25"
+  ],
+  "machine_max_speed_x": [
+    "500",
+    "200"
+  ],
+  "machine_max_speed_y": [
+    "500",
+    "200"
+  ],
+  "machine_max_speed_z": [
+    "12",
+    "12"
+  ],
+  "machine_max_jerk_e": [
+    "2.5",
+    "2.5"
+  ],
+  "machine_max_jerk_x": [
+    "12",
+    "12"
+  ],
+  "machine_max_jerk_y": [
+    "12",
+    "12"
+  ],
+  "machine_max_jerk_z": [
+    "0.2",
+    "0.4"
+  ],
+  "max_layer_height": [
+    "0.6"
+  ],
+  "min_layer_height": [
+    "0.08"
+  ],
   "printer_settings_id": "Elegoo",
-  "retraction_minimum_travel": ["1"],
-  "retract_before_wipe": ["85%"],
-  "retraction_length": ["0.8"],
-  "retraction_speed": ["60"],
-  "retract_length_toolchange": ["2"],
-  "deretraction_speed": ["45"],
+  "retraction_minimum_travel": [
+    "1"
+  ],
+  "retract_before_wipe": [
+    "85%"
+  ],
+  "retraction_length": [
+    "0.8"
+  ],
+  "retraction_speed": [
+    "60"
+  ],
+  "retract_length_toolchange": [
+    "2"
+  ],
+  "deretraction_speed": [
+    "45"
+  ],
   "single_extruder_multi_material": "1",
   "change_filament_gcode": "M600",
   "machine_pause_gcode": "PAUSE",
-  "default_filament_profile": ["Elegoo Generic PLA @0.8 nozzle"],
-	"machine_start_gcode": ";ELEGOO NEPTUNE 4 PRO\nM220 S100 ;Set the feed speed to 100%\nM221 S100 ;Set the flow rate to 100%\nM104 S140\nM190 S[bed_temperature_initial_layer_single]\nG90\nG28 ;home\nG1 Z10 F300\nG1 X67.5 Y0 F6000\nG1 Z0 F300\nM109 S[nozzle_temperature_initial_layer]\nG92 E0 ;Reset Extruder\nG1 X67.5 Y0 Z0.4 F300 ;Move to start position\nG1 X167.5 E30 F400 ;Draw the first line\nG1 Z0.6 F120.0 ;Move to side a little\nG1 X162.5 F3000\nG92 E0 ;Reset Extruder",
-	"machine_end_gcode": ";PRINT END\nG91 ;Relative positionning\nG1 E-2 F2700 ;Retract a bit\nG1 E-8 X5 Y5 Z3 F3000 ;Retract\nG90 ;Absolute positionning\nG1 X10 Y220 F6000;Finish print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\nM84 X Y E ;Disable all steppers but Z",
+  "default_filament_profile": [
+    "Elegoo Generic PLA @0.8 nozzle"
+  ],
+  "machine_start_gcode": ";ELEGOO NEPTUNE 4 PRO\nM220 S100 ;Set the feed speed to 100%\nM221 S100 ;Set the flow rate to 100%\nM104 S140\nM190 S[bed_temperature_initial_layer_single]\nG90\nG28 ;home\nG1 Z10 F300\nG1 X67.5 Y0 F6000\nG1 Z0 F300\nM109 S[nozzle_temperature_initial_layer]\nG92 E0 ;Reset Extruder\nG1 X67.5 Y0 Z0.4 F300 ;Move to start position\nG1 X167.5 E30 F400 ;Draw the first line\nG1 Z0.6 F120.0 ;Move to side a little\nG1 X162.5 F3000\nG92 E0 ;Reset Extruder",
+  "machine_end_gcode": ";PRINT END\nG91 ;Relative positionning\nG1 E-2 F2700 ;Retract a bit\nG1 E-8 X5 Y5 Z3 F3000 ;Retract\nG90 ;Absolute positionning\nG1 X10 Y220 F6000;Finish print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\nM84 X Y E ;Disable all steppers but Z",
   "before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\nG92 E0\n;[layer_z]\n\n",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",
   "scan_first_layer": "0"


### PR DESCRIPTION
This PR corrects the Neptune 4 Pro's `printable_area`.

# Motivation
I was printing some drawer divider bins that pushed right up to the limits of the N4P's build plate size.  These adjustments were required to prevent the printer from printing into voids or encountering firmware-imposed limits on bed travel.

# Specific Problems Addressed
These are the issues I encountered:

## X-Coordinate
- The build plate is 235mm wide, not 225 mm wide.  
- This discrepancy results objects being printed left of where is expected, and renders space on the right side of the build plate unreachable / unusable.
- This isn't a big deal compared to the Y-Coordinate issues.

## Y-Coordinate
- On the N4P, `0x0` is not on the usable build plate area.
  - `y=0` is in the center of the build plate's easy-remove tab.
  - It's OK to print the priming strip near `115x0`, but it isn't OK to let the slicer place printable objects near`0x0` or `235x0`.  It will attempt to print into the void to the left/right of the tab.
- Rectangular area of the build plate is physically 235mm deep, but attempting to reach `y=240` which accounts for the distance from home to the distance of the back of the build plate causes the machine to halt with an MCU error.  It appears that firmware only allows reaching `y=235`, which leaves a portion of the plate unreachable.

# Adjustments Made
- `x` range from `0-225` => `0-235`
  - Centers objects on x-axis as expected (i.e. GUI representation matches what is actually printed)
  - Makes all build space usable
- `y` range from `0-225` => `5-235`:
  - Prevents slicer from trying to use the voids on either side of the tab to place objects while still allowing use of `y=0` to print the priming strip
  - Centers objects on y-axis expected
  - Makes all build space usable (at least the coordinates accessible via the limits of the firmware)

# Supporting Documentation
Here are comparisons of the slicer's Preview vs what was actually printed on the bed.  Tan filament on a gold bed didn't make the best photos but I think they still serve the purpose.  In the future I'll change to something with more contrast!

## Default Settings
### Slicer Preview
<img width="752" alt="225_225_0_0" src="https://github.com/SoftFever/OrcaSlicer/assets/84366264/495ba9e6-0092-4f99-9d46-38d096345f7e">

### Actual Result
- Priming line prints further forward than depicted
- Brim is shifted to the left
- Brim is shifted forward
![IMG_2211](https://github.com/SoftFever/OrcaSlicer/assets/84366264/d472c670-b8c6-4003-ba79-d0c08c227d69)

## Settings in this PR
### Slicer Preview
- The background image doesn't display properly any more.  I'm not sure how to adjust this.
<img width="761" alt="235_230_0_-5" src="https://github.com/SoftFever/OrcaSlicer/assets/84366264/82ea74fc-8642-42ed-b559-eff8032a39fa">

### Actual Result
- Brim is centered on x-axis as expected
- Brim is centered on y-axis as expected
![IMG_2212](https://github.com/SoftFever/OrcaSlicer/assets/84366264/94203c14-eb65-413b-ae60-4df3c28d3160)

## Settings Attempting to use Full Y-Axis
### Slicer Preview
<img width="746" alt="235_235_0_-5" src="https://github.com/SoftFever/OrcaSlicer/assets/84366264/569d1e06-3292-4d76-8ac1-2f90d102e059">

### Actual Result
- You can see where the machine stopped printing in the back-right corner.
![IMG_2213](https://github.com/SoftFever/OrcaSlicer/assets/84366264/d093df0c-5703-46c1-a447-0199d7d39be9)

# Additional Considerations
- This PR looks larger than it is because of formatting changes.  When I looked at other comparable files, I saw that most are formatted with the extra line breaks and these files were the odd-ones-out.  As a result I left the format updates as part of this PR.  I don't know what the community feeling is on changes like this and I don't mean to step on any toes here.
- Similar changes might be warranted on other machines, but I only specifically have a Neptune 4 Pro to test with.