### PR TITLE
Default Anker support_base_pattern (Fixes #3326)

### DIFF
--- a/resources/profiles/Anker/process/fdm_process_common.json
+++ b/resources/profiles/Anker/process/fdm_process_common.json
@@ -71,7 +71,7 @@
     "support_interface_bottom_layers": "2",
     "support_interface_spacing": "0.5",
     "support_interface_speed": "80",
-    "support_base_pattern": "zig-zag",
+    "support_base_pattern": "default",
     "support_base_pattern_spacing": "2.5",
     "support_speed": "125",
     "support_threshold_angle": "40",


### PR DESCRIPTION
Correct support_base_pattern to not cause import failure when adding an Anker printer