### PR TITLE
[Fix] Fixed error in Anycubic Kobra 2 profile using "rectilinear" sparse infill

### DIFF
--- a/resources/profiles/Anycubic/process/0.15mm Optimal @Anycubic Kobra2.json
+++ b/resources/profiles/Anycubic/process/0.15mm Optimal @Anycubic Kobra2.json
@@ -29,7 +29,7 @@
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",
-	"sparse_infill_pattern": "rectilinear",
+	"sparse_infill_pattern": "zig-zag",
 	"initial_layer_acceleration": "2000",
 	"travel_acceleration": "0",
 	"inner_wall_acceleration": "0",

--- a/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra2.json
+++ b/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra2.json
@@ -29,7 +29,7 @@
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",
-	"sparse_infill_pattern": "rectilinear",
+	"sparse_infill_pattern": "zig-zag",
 	"initial_layer_acceleration": "2000",
 	"travel_acceleration": "0",
 	"inner_wall_acceleration": "0",

--- a/resources/profiles/Anycubic/process/0.30mm Draft @Anycubic Kobra2.json
+++ b/resources/profiles/Anycubic/process/0.30mm Draft @Anycubic Kobra2.json
@@ -29,7 +29,7 @@
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",
-	"sparse_infill_pattern": "rectilinear",
+	"sparse_infill_pattern": "zig-zag",
 	"initial_layer_acceleration": "2000",
 	"travel_acceleration": "0",
 	"inner_wall_acceleration": "0",


### PR DESCRIPTION
Sparse infill of type "rectilinear" doesn't exist, it is "zig-zag"
This will fix #2467