### PR TITLE
Fixes Anker M5C profiles

### DIFF
--- a/resources/profiles/Anker/filament/Anker Generic ABS.json
+++ b/resources/profiles/Anker/filament/Anker Generic ABS.json
@@ -8,6 +8,6 @@
     "compatible_printers": [
         "Anker M5 0.4 nozzle",
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic ASA.json
+++ b/resources/profiles/Anker/filament/Anker Generic ASA.json
@@ -8,6 +8,6 @@
     "compatible_printers": [
         "Anker M5 0.4 nozzle",
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic PA-CF.json
+++ b/resources/profiles/Anker/filament/Anker Generic PA-CF.json
@@ -7,6 +7,6 @@
     "instantiation": "true",
     "compatible_printers": [
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic PA.json
+++ b/resources/profiles/Anker/filament/Anker Generic PA.json
@@ -7,6 +7,6 @@
     "instantiation": "true",
     "compatible_printers": [
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic PC.json
+++ b/resources/profiles/Anker/filament/Anker Generic PC.json
@@ -7,6 +7,6 @@
     "instantiation": "true",
     "compatible_printers": [
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic PETG-CF.json
+++ b/resources/profiles/Anker/filament/Anker Generic PETG-CF.json
@@ -8,6 +8,6 @@
     "compatible_printers": [
         "Anker M5 0.4 nozzle",
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic PETG.json
+++ b/resources/profiles/Anker/filament/Anker Generic PETG.json
@@ -8,6 +8,6 @@
     "compatible_printers": [
         "Anker M5 0.4 nozzle",
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic PLA Silk.json
+++ b/resources/profiles/Anker/filament/Anker Generic PLA Silk.json
@@ -8,6 +8,6 @@
     "compatible_printers": [
         "Anker M5 0.4 nozzle",
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic PLA+.json
+++ b/resources/profiles/Anker/filament/Anker Generic PLA+.json
@@ -8,6 +8,6 @@
     "compatible_printers": [
         "Anker M5 0.4 nozzle",
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic PLA-CF.json
+++ b/resources/profiles/Anker/filament/Anker Generic PLA-CF.json
@@ -8,6 +8,6 @@
     "compatible_printers": [
         "Anker M5 0.4 nozzle",
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic PLA.json
+++ b/resources/profiles/Anker/filament/Anker Generic PLA.json
@@ -8,6 +8,6 @@
     "compatible_printers": [
         "Anker M5 0.4 nozzle",
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic PVA.json
+++ b/resources/profiles/Anker/filament/Anker Generic PVA.json
@@ -8,6 +8,6 @@
     "compatible_printers": [
         "Anker M5 0.4 nozzle",
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/filament/Anker Generic TPU.json
+++ b/resources/profiles/Anker/filament/Anker Generic TPU.json
@@ -8,6 +8,6 @@
     "compatible_printers": [
         "Anker M5 0.4 nozzle",
         "Anker M5 All-Metal 0.4 nozzle",
-        "Anker M5c 0.4 nozzle"
+        "Anker M5C 0.4 nozzle"
     ]
 }

--- a/resources/profiles/Anker/process/fdm_process_anker_common.json
+++ b/resources/profiles/Anker/process/fdm_process_anker_common.json
@@ -16,6 +16,6 @@
     "compatible_printers": [
       "Anker M5 0.4 nozzle",
       "Anker M5 All-Metal 0.4 nozzle",
-      "Anker M5c 0.4 nozzle"
+      "Anker M5C 0.4 nozzle"
     ]
 }


### PR DESCRIPTION
Previous PR ( https://github.com/SoftFever/OrcaSlicer/pull/3845 ) has an error with the M5c profiles that will cause it to break filament and process profiles for existing users. This PR corrects that error.