### PR TITLE
Enforce retraction before wipe

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -343,13 +343,9 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
         // return the remaining retraction length to be retracted during the wipe
         if (retractionDuringWipe - retraction_length_remaining > EPSILON) return {retractionBeforeWipe,retraction_length_remaining};
         
-        // If the user has requested any retract before wipe, proceed with incrementing the retraction amount before wiping with the difference
+        // We will always proceed with incrementing the retraction amount before wiping with the difference
         // and return the maximum allowed wipe amount to be retracted during the wipe move
-        // If the user has not requested any retract before wipe, the retraction amount before wiping should not be incremented and left to the parent
-        // function to retract after wipe is done.
-        if(gcodegen.config().retract_before_wipe.get_at(gcodegen.writer().extruder()->id()) > EPSILON){
-            retractionBeforeWipe += retraction_length_remaining - retractionDuringWipe;
-        }
+        retractionBeforeWipe += retraction_length_remaining - retractionDuringWipe;
         return {retractionBeforeWipe, retractionDuringWipe};
     }
 


### PR DESCRIPTION
I received feedback that stringing has slightly worsened in some cases since version 1.9. After investigating and testing, it turns out that this issue occurs when `retract amount before wipe` is set to 0. This is because, after restricting the retraction speed during the wipe, Orca tends to perform a large amount of retraction after the wipe is completed in this scenario. This, to some degree, defeats the purpose of the wipe.

![Screenshot 2024-01-29 at 9 44 18 PM](https://github.com/SoftFever/OrcaSlicer/assets/103989404/ce131933-fa3f-407a-af86-844ed6e5c499)

Before the fix:  
![A6E702E2-4EFC-4683-817F-C4DA5629C890_1_105_c](https://github.com/SoftFever/OrcaSlicer/assets/103989404/21b25789-8e63-4a6d-8c2c-d7a8be979a6c)

After the fix:  
![17E3D8FA-6830-44EA-84A4-4C2FECE22701_1_105_c](https://github.com/SoftFever/OrcaSlicer/assets/103989404/8df8a042-347b-4cd3-8f99-ac4136bff001)


@igiannakas 