### PR TITLE
[FEATURE] Max volumetric flow rate per printer

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5060,6 +5060,13 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
     //        m_config.max_volumetric_speed.value / _mm3_per_mm
     //    );
     //}
+    if (EXTRUDER_CONFIG(max_volumetric_flow_rate) > 0) {
+        // cap speed with max_volumetric_flow_rate from extruder
+        speed = std::min(
+            speed,
+            EXTRUDER_CONFIG(max_volumetric_flow_rate) / _mm3_per_mm
+        );
+    }
     if (EXTRUDER_CONFIG(filament_max_volumetric_speed) > 0) {
         // cap speed with max_volumetric_speed anyway (even if user is not using autospeed)
         speed = std::min(

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -881,7 +881,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "cooling_tube_retraction",
     "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "purge_in_prime_tower", "enable_filament_ramming",
     "z_offset",
-    "disable_m73", "preferred_orientation", "emit_machine_limits_to_gcode", "support_multi_bed_types"
+    "disable_m73", "preferred_orientation", "emit_machine_limits_to_gcode", "support_multi_bed_types", "max_volumetric_flow_rate"
     };
 
 static std::vector<std::string> s_Preset_sla_print_options {

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -213,6 +213,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "activate_chamber_temp_control",
         "manual_filament_change",
         "disable_m73",
+        "max_volumetric_flow_rate",
     };
 
     static std::unordered_set<std::string> steps_ignore;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3425,6 +3425,16 @@ def = this->add("filament_loading_speed", coFloats);
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 
+    def = this->add("max_volumetric_flow_rate", coFloats);
+    def->label = L("Max volumetric flow rate");
+    def->tooltip = L("This setting control for how much volume of filament can be melted and extruded per second. "
+                     "Printing speed is limited by max volumetric flow rate, in case of too high and unreasonable speed setting. "
+                     "Set to zero to disable limiting.");
+    def->sidetext = L("mm³/s");
+    def->min = 0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloats { 0. });
+
     def = this->add("seam_position", coEnum);
     def->label = L("Seam position");
     def->category = L("Quality");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1050,6 +1050,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloatOrPercent,      initial_layer_travel_speed))
     ((ConfigOptionBool,                bbl_calib_mark_logo))
     ((ConfigOptionBool,                disable_m73))
+    ((ConfigOptionFloats,              max_volumetric_flow_rate))
 
     // Orca: mmu
     ((ConfigOptionFloat,               cooling_tube_retraction))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3969,6 +3969,9 @@ if (is_marlin_flavor)
                 update();
             };
 
+            optgroup = page->new_optgroup(L("Flow"), L"param_flow", -1, true);
+            optgroup->append_single_option_line("max_volumetric_flow_rate", "", extruder_idx);
+
             optgroup = page->new_optgroup(L("Layer height limits"), L"param_layer_height", -1, true);
             optgroup->append_single_option_line("min_layer_height", "", extruder_idx);
             optgroup->append_single_option_line("max_layer_height", "", extruder_idx);


### PR DESCRIPTION
Allow defining a max volumentric flow rate in the printer settings. This accounts for the fact that max volumentric flow is mostly defined by physical printer features (nozzle type, hotend and extruder choice) as well as filament properties (material, nozzle temp).
The filament properties today already allow limiting the flow rate but this is cumbersome if you own multiple printers that are limited by their extruder or hotend and not by material properties, resulting in requiring multiple filament profiles (with per printer limits) or multiple process settings (with different speeds).

With the per printer setting the max speed will be limited to the lower number derived from printer and filament settings.
A printer setting of 40mm3/s and a filament setting of 11mm3/s will limit to 11mm3/s while a filament setting of 40mm3/s and a printer setting of 15mm3/s will limit to 15mm3/s.

Settin the printer limit to 0 (the default value) will disable limiting based on printer setting.
