### PR TITLE
Security: skip writing print_host and apikey in gcode

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4371,7 +4371,10 @@ void GCode::append_full_config(const Print &print, std::string &str)
     // Sorted list of config keys, which shall not be stored into the G-code. Initializer list.
     static constexpr auto banned_keys = {
         "compatible_printers"sv,
-        "compatible_prints"sv
+        "compatible_prints"sv,
+        "print_host"sv,
+        "printhost_apikey"sv,
+        "printhost_cafile"sv
     };
     assert(std::is_sorted(banned_keys.begin(), banned_keys.end()));
     auto is_banned = [](const std::string &key) {


### PR DESCRIPTION
Thank Gina Häußge for reporting the issue.