### PR TITLE
Update HMS.cpp set language code to en by default for PL language

### DIFF
--- a/src/slic3r/GUI/HMS.cpp
+++ b/src/slic3r/GUI/HMS.cpp
@@ -146,6 +146,7 @@ std::string HMSQuery::hms_language_code()
     std::string lang_code = wxGetApp().app_config->get_language_code();
     if (lang_code.compare("uk") == 0
         || lang_code.compare("cs") == 0
+	|| lang_code.compare("pl") == 0
         || lang_code.compare("ru") == 0) {
         BOOST_LOG_TRIVIAL(info) << "HMS: using english for lang_code = " << lang_code;
         return "en";


### PR DESCRIPTION
The default 'en' language for HMS errors has been added for the Polish language. Nevertheless, the optimal solution would be to allow disabling updates for languages that are not supported on the BambuLab server and retain only local reading