### PR TITLE
Fix for #4047

### DIFF
--- a/resources/profiles/Creality.json
+++ b/resources/profiles/Creality.json
@@ -467,10 +467,6 @@
 			"sub_path": "process/0.24mm Draft @Creality Ender3 0.6.json"
 		},
 		{
-			"name": "0.20mm Standard @Creality K1Max (0.4 nozzle)",
-			"sub_path": "process/0.20mm Standard @Creality K1Max (0.4 nozzle).json"
-		},
-		{
 			"name": "0.24mm Draft @Creality Ender3 0.8",
 			"sub_path": "process/0.24mm Draft @Creality Ender3 0.8.json"
 		},


### PR DESCRIPTION
It looks like a regression has been introduced in https://github.com/SoftFever/OrcaSlicer/commit/31d1d03578398e5de1f5e173548b5a83e23d7553
"0.20mm Standard @Creality K1Max (0.4 nozzle)" is loaded twice, this PR should fix the issue.

And then fix #4047