### PR TITLE
Fixed Ender 3 profile inheritance

### DIFF
--- a/resources/profiles/Creality/filament/Creality Generic TPU.json
+++ b/resources/profiles/Creality/filament/Creality Generic TPU.json
@@ -10,7 +10,6 @@
         "3.2"
     ],
     "compatible_printers": [
-		"Creality Ender-3 V3 SE 0.4 nozzle",
         "Creality K1 (0.4 nozzle)",
         "Creality K1 (0.6 nozzle)",
         "Creality K1 (0.8 nozzle)",

--- a/resources/profiles/Creality/machine/Creality Ender-3 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 0.2 nozzle.json
@@ -6,6 +6,7 @@
 	"instantiation": "true",
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality Ender-3",
+	"printer_structure": "i3",
 	"default_print_profile": "0.20mm Standard @Creality Ender3 0.2",
 	"thumbnails": [""],
 	"nozzle_diameter": [

--- a/resources/profiles/Creality/machine/Creality Ender-3 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 0.4 nozzle.json
@@ -7,7 +7,7 @@
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality Ender-3",
 	"printer_structure": "i3",
-	"default_print_profile": "0.20mm Standard @Creality Ender3 0.4",
+	"default_print_profile": "0.20mm Standard @Creality Ender3",
 	"thumbnails": [""],
 	"nozzle_diameter": [
 		"0.4"

--- a/resources/profiles/Creality/machine/Creality Ender-3 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 0.6 nozzle.json
@@ -6,6 +6,7 @@
 	"instantiation": "true",
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality Ender-3",
+	"printer_structure": "i3",
 	"default_print_profile": "0.20mm Standard @Creality Ender3 0.6",
 	"thumbnails": [""],
 	"nozzle_diameter": [

--- a/resources/profiles/Creality/machine/Creality Ender-3 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 0.8 nozzle.json
@@ -6,6 +6,7 @@
 	"instantiation": "true",
 	"inherits": "fdm_creality_common",
 	"printer_model": "Creality Ender-3",
+	"printer_structure": "i3",
 	"default_print_profile": "0.20mm Standard @Creality Ender3 0.8",
 	"thumbnails": [""],
 	"nozzle_diameter": [


### PR DESCRIPTION
A regression has been introduced in https://github.com/SoftFever/OrcaSlicer/commit/31d1d03578398e5de1f5e173548b5a83e23d7553

Should fix #4087 

I also added missing "i3" printer_structure