### PR TITLE
Fix for postprocessing scripts not working on UNIX when $SHELL is undefined

### DIFF
--- a/src/libslic3r/GCode/PostProcessor.cpp
+++ b/src/libslic3r/GCode/PostProcessor.cpp
@@ -157,7 +157,7 @@ static int run_script(const std::string &script, const std::string &gcode, std::
 {
     // Try to obtain user's default shell
     const char *shell = ::getenv("SHELL");
-    if (shell == nullptr) { shell = "sh"; }
+    if (shell == nullptr) { shell = "/bin/sh"; }
 
     // Quote and escape the gcode path argument
     std::string command { script };


### PR DESCRIPTION
If `$SHELL` is not defined on unix, setting postprocessing scripts errors with `execve failed: No such file or directory`.
A workaround is to make sure that `$SHELL` is set to the full path to a shell. The issue is that `execv`, used to execute postprocessing scripts, requires the full path to an executable as it doesn't seem to take `$PATH` into account.

Copied from https://github.com/prusa3d/PrusaSlicer/commit/87a51165f321f0f4853ed5d6f76108e0073c12ba
