### PR TITLE
Add feature to clean short disconnected solid infill paths

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4890,6 +4890,12 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
 {
     std::string gcode;
 
+    if (path.role() == erSolidInfill && m_config.min_fill_path_length.value > 0) {
+        if (unscale_(path.length()) < m_config.min_fill_path_length.value) {
+            return gcode;
+        }
+    }
+
     if (is_bridge(path.role()))
         description += " (bridge)";
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -772,7 +772,7 @@ static std::vector<std::string> s_Preset_print_options {
     "top_shell_layers", "top_shell_thickness", "bottom_shell_layers", "bottom_shell_thickness",
     "extra_perimeters_on_overhangs", "ensure_vertical_shell_thickness","reduce_wall_solid_infill", "reduce_crossing_wall", "detect_thin_wall", "detect_overhang_wall", "overhang_reverse", "overhang_reverse_threshold","overhang_reverse_internal_only",
     "seam_position", "staggered_inner_seams", "wall_sequence", "is_infill_first", "sparse_infill_density", "sparse_infill_pattern", "top_surface_pattern", "bottom_surface_pattern",
-    "infill_direction", "counterbole_hole_bridging",
+    "infill_direction", "counterbole_hole_bridging", "min_fill_path_length",
     "minimum_sparse_infill_area", "reduce_infill_retraction","internal_solid_infill_pattern","gap_fill_target",
     "ironing_type", "ironing_pattern", "ironing_flow", "ironing_speed", "ironing_spacing", "ironing_angle",
     "max_travel_detour_distance",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3563,6 +3563,16 @@ def = this->add("filament_loading_speed", coFloats);
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(15));
 
+    def = this->add("min_fill_path_length", coFloat);
+    def->label = L("Minimum solid infill path length");
+    def->category = L("Strength");
+    def->tooltip = L("Areas of solid infill with extrusion lengths shorter than this value are removed in order to prevent small extrusions "
+        "which may unnecessarily increase the total print time or lead to undesirable print artifacts. Set to 0 to disable.");
+    def->sidetext = L("mm");
+    def->min = 0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(1.0f));
+
     def = this->add("solid_infill_filament", coInt);
     //def->label = L("Solid infill");
     //def->category = L("Extruders");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -809,6 +809,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,              tree_support_branch_angle_organic))
     ((ConfigOptionEnum<GapFillTarget>,gap_fill_target))
     ((ConfigOptionFloat,              min_length_factor))
+    ((ConfigOptionFloat,              min_fill_path_length))
 
     // Move all acceleration and jerk settings to object
     ((ConfigOptionFloat,              default_acceleration))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1067,6 +1067,7 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "bottom_shell_thickness"
             || opt_key == "top_shell_thickness"
             || opt_key == "minimum_sparse_infill_area"
+            || opt_key == "min_fill_path_length"
             || opt_key == "sparse_infill_filament"
             || opt_key == "solid_infill_filament"
             || opt_key == "sparse_infill_line_width"

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2063,6 +2063,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("infill_direction");
         optgroup->append_single_option_line("bridge_angle");
         optgroup->append_single_option_line("minimum_sparse_infill_area");
+        optgroup->append_single_option_line("min_fill_path_length");
         optgroup->append_single_option_line("infill_combination");
         optgroup->append_single_option_line("detect_narrow_internal_solid_infill");
         optgroup->append_single_option_line("ensure_vertical_shell_thickness");


### PR DESCRIPTION
## Description

I've found that there are often very short, disconnected extrusion paths generated with internal solid infill. With certain filaments, these can generate blobs and other undesirable print artifacts, and generally just waste print time for minimal benefit. 

This change simply removes any internal solid infill paths below a configurable length during the gcode generation step.

See images below for an example of very short and disconnected infill paths before and after.

This only affects internal solid infill (purple), not sparse infill or other extrusion path types.

## Example

#### Before

![image](https://github.com/SoftFever/OrcaSlicer/assets/19617165/ded8751d-097b-471c-8686-3685460001c7)


#### After

![image](https://github.com/SoftFever/OrcaSlicer/assets/19617165/733329c6-969f-4f7a-b602-202153a51577)
