### PR TITLE
Fix move gizmo on parts

### DIFF
--- a/src/slic3r/GUI/Gizmos/GizmoObjectManipulation.cpp
+++ b/src/slic3r/GUI/Gizmos/GizmoObjectManipulation.cpp
@@ -266,11 +266,8 @@ void GizmoObjectManipulation::change_position_value(int axis, double value)
     selection.setup_cache();
     TransformationType trafo_type;
     trafo_type.set_relative();
-    switch (m_coordinates_type)
-    {
-    case ECoordinatesType::Instance: { trafo_type.set_instance(); break; }
-    case ECoordinatesType::Local:    { trafo_type.set_local(); break; }
-    default:                         { break; }
+    if (selection.requires_local_axes()) {
+        trafo_type.set_local();
     }
     selection.translate(position - m_cache.position, trafo_type);
     m_glcanvas.do_move(L("Set Position"));


### PR DESCRIPTION
This fixes this bug:
![orca_part_move](https://github.com/SoftFever/OrcaSlicer/assets/1537155/ee3a42a5-c57d-4ffe-82ab-a5389ca2e90f)
