### PR TITLE
TwoTrees SK1 Profiles : New filament (PLA Matte) and tuned volumetric flow rates

### DIFF
--- a/resources/profiles/TwoTrees.json
+++ b/resources/profiles/TwoTrees.json
@@ -173,6 +173,10 @@
             "sub_path": "filament/TwoTrees Generic PLA-CF @SK1.json"
         },
         {
+            "name": "TwoTrees Generic PLA Matte @SK1",
+            "sub_path": "filament/TwoTrees Generic PLA Matte @SK1.json"
+        },
+        {
             "name": "TwoTrees Generic PLA Silk @SK1",
             "sub_path": "filament/TwoTrees Generic PLA Silk @SK1.json"
         }

--- a/resources/profiles/TwoTrees/filament/TwoTrees Generic PETG @SK1.json
+++ b/resources/profiles/TwoTrees/filament/TwoTrees Generic PETG @SK1.json
@@ -37,7 +37,7 @@
         "0.95"
     ],
     "filament_max_volumetric_speed": [
-        "9"
+        "13"
     ],
     "enable_pressure_advance": [
         "1"

--- a/resources/profiles/TwoTrees/filament/TwoTrees Generic PLA Matte @SK1.json
+++ b/resources/profiles/TwoTrees/filament/TwoTrees Generic PLA Matte @SK1.json
@@ -1,0 +1,15 @@
+{
+    "type": "filament",
+    "instantiation": "true",
+    "name": "TwoTrees Generic PLA Matte @SK1",
+    "inherits": "TwoTrees Generic PLA @SK1",
+    "from": "system",
+    "filament_id": "GFSL05",
+    "setting_id": "GFSL05_00",
+    "compatible_printers": [
+        "TwoTrees SK1 0.4 nozzle"
+    ],
+    "filament_max_volumetric_speed": [
+        "18"
+    ]
+}

--- a/resources/profiles/TwoTrees/filament/TwoTrees Generic PLA Silk @SK1.json
+++ b/resources/profiles/TwoTrees/filament/TwoTrees Generic PLA Silk @SK1.json
@@ -10,7 +10,7 @@
         "TwoTrees SK1 0.4 nozzle"
     ],
 	"filament_max_volumetric_speed": [
-		"12"
+		"15"
 	],
 	"slow_down_layer_time": [
 		"8"

--- a/resources/profiles/TwoTrees/filament/TwoTrees Generic PLA-CF @SK1.json
+++ b/resources/profiles/TwoTrees/filament/TwoTrees Generic PLA-CF @SK1.json
@@ -28,7 +28,7 @@
         "0.95"
     ],
 	"filament_max_volumetric_speed": [
-		"12"
+		"18"
 	],
 	"slow_down_layer_time": [
 		"7"

--- a/resources/profiles/TwoTrees/machine/TwoTrees SK1.json
+++ b/resources/profiles/TwoTrees/machine/TwoTrees SK1.json
@@ -8,5 +8,5 @@
     "bed_model": "TwoTrees SK1_buildplate_model.stl",
     "bed_texture": "",
     "hotend_model": "",
-    "default_materials": "TwoTrees Generic 95A TPU @SK1;TwoTrees Generic PETG @SK1;TwoTrees Generic HS PLA @SK1;TwoTrees Generic PLA @SK1;TwoTrees Generic PLA-CF @SK1;TwoTrees Generic PLA Silk @SK1"
+    "default_materials": "TwoTrees Generic 95A TPU @SK1;TwoTrees Generic PETG @SK1;TwoTrees Generic HS PLA @SK1;TwoTrees Generic PLA @SK1;TwoTrees Generic PLA-CF @SK1;TwoTrees Generic PLA Matte @SK1;TwoTrees Generic PLA Silk @SK1"
 }

--- a/src/slic3r/GUI/Gizmos/GizmoObjectManipulation.cpp
+++ b/src/slic3r/GUI/Gizmos/GizmoObjectManipulation.cpp
@@ -266,11 +266,8 @@ void GizmoObjectManipulation::change_position_value(int axis, double value)
     selection.setup_cache();
     TransformationType trafo_type;
     trafo_type.set_relative();
-    switch (m_coordinates_type)
-    {
-    case ECoordinatesType::Instance: { trafo_type.set_instance(); break; }
-    case ECoordinatesType::Local:    { trafo_type.set_local(); break; }
-    default:                         { break; }
+    if (selection.requires_local_axes()) {
+        trafo_type.set_local();
     }
     selection.translate(position - m_cache.position, trafo_type);
     m_glcanvas.do_move(L("Set Position"));


### PR DESCRIPTION
Profile changes for TwoTrees SK1 : 

- New filament : PLA Matte
- Changed flow rate for PLA-CF, PLA Silk and PETG