### PR TITLE
FIX: Support building with latest Xcode 15.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ if (NOT MSVC AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMP
         add_compile_options(-Wno-deprecated-declarations)
     endif()
 
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+    if (${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 15)
         add_compile_options(-Wno-error=enum-constexpr-conversion)
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,10 @@ if (NOT MSVC AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMP
         add_compile_options(-Wno-deprecated-declarations)
     endif()
 
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+        add_compile_options(-Wno-error=enum-constexpr-conversion)
+    endif()
+
     #GCC generates loads of -Wunknown-pragmas when compiling igl. The fix is not easy due to a bug in gcc, see
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66943 or
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431

--- a/deps/TIFF/TIFF.cmake
+++ b/deps/TIFF/TIFF.cmake
@@ -11,6 +11,7 @@ if (APPLE)
             -Dwebp:BOOL=OFF
             -Djbig:BOOL=OFF
             -Dzstd:BOOL=OFF
+            -Dlibdeflate:BOOL=OFF
             -Dpixarlog:BOOL=OFF
     )
 else()


### PR DESCRIPTION
Downgrade `enum-constexpr-conversion` error to warning.
Explicitly disable `libdeflate support` in `TIFF` depencency.
[PrusaSlicer already does that](https://github.com/prusa3d/PrusaSlicer/blob/4f035bceb75661719b23d13fceddc62ccab6c54e/deps/%2BTIFF/TIFF.cmake#L12)




Signed-off-by: Dzmitry Neviadomski <nevack.d@gmail.com>