### PR TITLE
fix an issue that pressure eq may cause 0 feedrate in vase mode

### DIFF
--- a/src/libslic3r/GCode/PressureEqualizer.cpp
+++ b/src/libslic3r/GCode/PressureEqualizer.cpp
@@ -769,8 +769,11 @@ inline bool is_just_line_with_extrude_set_speed_tag(const std::string &line)
     return p_line <= line_end && is_eol(*p_line);
 }
 
-void PressureEqualizer::push_line_to_output(const size_t line_idx, const float new_feedrate, const char *comment)
+void PressureEqualizer::push_line_to_output(const size_t line_idx, float new_feedrate, const char *comment)
 {
+    // Orca: sanity check, 1 mm/s is the minimum feedrate.
+    if (new_feedrate < 60)
+        new_feedrate = 60;
     const GCodeLine &line = m_gcode_lines[line_idx];
     if (line_idx > 0 && output_buffer_length > 0) {
         const std::string prev_line_str = std::string(output_buffer.begin() + int(this->output_buffer_prev_length),

--- a/src/libslic3r/GCode/PressureEqualizer.hpp
+++ b/src/libslic3r/GCode/PressureEqualizer.hpp
@@ -132,7 +132,8 @@ private:
         float       time()          const { return dist_xyz() / feedrate(); }
         float       time_inv()      const { return feedrate() / dist_xyz(); }
         float       volumetric_correction_avg() const { 
-            float avg_correction = 0.5f * (volumetric_extrusion_rate_start + volumetric_extrusion_rate_end) / volumetric_extrusion_rate; 
+        // Orca: cap the correction to 0.05 - 1.00000001 to avoid zero feedrate
+            float avg_correction = std::max(0.05f,0.5f * (volumetric_extrusion_rate_start + volumetric_extrusion_rate_end) / volumetric_extrusion_rate); 
             assert(avg_correction > 0.f);
             assert(avg_correction <= 1.00000001f);
             return avg_correction;


### PR DESCRIPTION
The regression is introduced when we allow apply "Extrusion rate smoothing" on vase mode in #4264 
Specifically, at the transition point from normal printing to vase mode, the volumetric_extrusion_rate_end becomes significantly smaller than volumetric_extrusion_rate_start. This discrepancy can cause a feed rate of 0 if the extrusion rate smoothing value is set too low.

![image](https://github.com/SoftFever/OrcaSlicer/assets/103989404/1e1eacfd-4c2c-4d95-a5c9-7896ff4f1230)
_image from Discord member: NigelTufnel_

