### PR TITLE
Allow AppImage generation in aarch64 build hosts

### DIFF
--- a/src/platform/unix/build_appimage.sh.in
+++ b/src/platform/unix/build_appimage.sh.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-APPIMAGETOOLURL="https://github.com/AppImage/AppImageKit/releases/latest/download/appimagetool-x86_64.AppImage"
+APPIMAGETOOLURL="https://github.com/AppImage/AppImageKit/releases/latest/download/appimagetool-$(uname -m).AppImage"
 
 
 APP_IMAGE="@SLIC3R_APP_KEY@_Linux_V@SoftFever_VERSION@.AppImage"
@@ -35,5 +35,5 @@ else
   ../appimagetool.AppImage . $([ ! -z "${container}" ] && echo '--appimage-extract-and-run')
 fi
 
-mv @SLIC3R_APP_KEY@-x86_64.AppImage ${APP_IMAGE}
+mv @SLIC3R_APP_KEY@-$(uname -m).AppImage ${APP_IMAGE}
 chmod +x ${APP_IMAGE}


### PR DESCRIPTION
AppImageTool no longer hardcoded to _x86_64_ to allow generation of AppImage files on _aarch64_ build hosts