### PR TITLE
Add z offset to pressure advance calibration (line and pattern)

### DIFF
--- a/src/libslic3r/calib.hpp
+++ b/src/libslic3r/calib.hpp
@@ -268,6 +268,7 @@ private:
     void _refresh_writer(bool is_bbl_machine, const Model &model, const Vec3d &origin);
 
     double    height_first_layer() const { return m_config.option<ConfigOptionFloat>("initial_layer_print_height")->value; };
+    double    height_z_offset() const { return m_config.option<ConfigOptionFloat>("z_offset")->value; };
     double    height_layer() const { return m_config.option<ConfigOptionFloat>("layer_height")->value; };
     const int get_num_patterns() const { return std::ceil((m_params.end - m_params.start) / m_params.step + 1); }
 


### PR DESCRIPTION
Printer z offset is not accounted for in the line and pattern pressure advance calibration gcode generators.

Tested with positive and negative z offsets.