### PR TITLE
Enable detect_thin_wall for Qidi printers

### DIFF
--- a/resources/profiles/Qidi/process/fdm_process_qidi_x3_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_qidi_x3_common.json
@@ -95,7 +95,7 @@
     "tree_support_branch_diameter": "2",
     "tree_support_branch_angle": "45",
     "tree_support_wall_count": "1",
-    "detect_thin_wall": "0",
+    "detect_thin_wall": "1",
     "top_surface_pattern": "monotonicline",
     "top_surface_line_width": "0.42",
     "top_surface_acceleration": "2000",


### PR DESCRIPTION
Hi,

I faced an issue with the Qidi profile, the "detect_thin_wall" feature is disabled.
This caused bad extrusion for some parts of ERCFv2 that have supports integrated, like this part : 

<img width="497" alt="Capture d’écran 2024-03-22 à 09 44 51" src="https://github.com/SoftFever/OrcaSlicer/assets/108102/94dee13c-3bd6-43b1-9598-719109ff314d">

Without thin walls detection : 
<img width="574" alt="Capture d’écran 2024-03-22 à 09 45 20" src="https://github.com/SoftFever/OrcaSlicer/assets/108102/60185bfa-6cef-4309-bf48-bb7a11920e3e">

With thin walls detection : 
<img width="484" alt="Capture d’écran 2024-03-22 à 09 45 04" src="https://github.com/SoftFever/OrcaSlicer/assets/108102/a6814ef2-669d-47e1-b15f-fd1aa2970cb5">

@Hukete I mention to check if you agree with this change