### PR TITLE
Revert automatic application of reduced internal bridge filtering for lightning infill

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -2059,9 +2059,9 @@ void PrintObject::bridge_over_infill()
                 unsupported_area = closing(unsupported_area, float(SCALED_EPSILON));
                 
                 // Orca:
-                // Lightning infill benefits from always having a bridge layer so don't filter out small unsupported areas. Also, don't filter small internal unsupported areas if the user has requested so.
+                // Don't filter small internal unsupported areas if the user has requested so.
                 double expansion_multiplier = 3;
-                if(has_lightning_infill || po->config().dont_filter_internal_bridges.value !=ibfDisabled){
+                if(po->config().dont_filter_internal_bridges.value !=ibfDisabled){
                     expansion_multiplier = 1;
                 }
                 // By expanding the lower layer solids, we avoid making bridges from the tiny internal overhangs that are (very likely) supported by previous layer solids


### PR DESCRIPTION
Reverting the automatic application of reduced infill bridge filtering for lightning infill introduced in this PR https://github.com/SoftFever/OrcaSlicer/pull/3319 as:
1. this is now a user option anyway and 
2. I've found it created too many bridges when printing with a 0.25 nozzle and lightning infill on some models.

![Screenshot 2024-03-22 at 12 04 38](https://github.com/SoftFever/OrcaSlicer/assets/59056762/bc4f5313-811f-45db-a2d0-4f47c8789a4a)
