### PR TITLE
Fix issue that painter sphere is rendered at the wrong position

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoPainterBase.cpp
@@ -245,7 +245,7 @@ void GLGizmoPainterBase::render_cursor_sphere(const Transform3d& trafo) const
     if (shader == nullptr)
         return;
 
-    const Transform3d complete_scaling_matrix_inverse = Geometry::Transformation(trafo).get_matrix_no_scaling_factor().inverse();
+    const Transform3d complete_scaling_matrix_inverse = Geometry::Transformation(trafo).get_scaling_factor_matrix().inverse();
 
     // BBS
     ColorRGBA render_color = this->get_cursor_hover_color();


### PR DESCRIPTION
Fix this issue:

https://github.com/SoftFever/OrcaSlicer/assets/1537155/de9d8a33-807b-49a9-bd2e-34701a7fab4c

