### PR TITLE
gui: fix media eject on linux (#4700)

### DIFF
--- a/src/slic3r/GUI/RemovableDriveManager.cpp
+++ b/src/slic3r/GUI/RemovableDriveManager.cpp
@@ -370,17 +370,19 @@ std::string RemovableDriveManager::get_removable_drive_path(const std::string &p
 
 std::string RemovableDriveManager::get_removable_drive_from_path(const std::string& path)
 {
-	std::size_t found = path.find_last_of("/");
-	std::string new_path = found == path.size() - 1 ? path.substr(0, found) : path;
-    // trim the filename
-    found = new_path.find_last_of("/");
-    new_path = new_path.substr(0, found);
-    
+	std::string new_path(path);
+	if (!boost::filesystem::is_directory(path)) {
+		std::size_t found = path.find_last_of("/");
+		if (found != std::string::npos)
+			new_path.erase(found);
+	}
+
 	// check if same filesystem
 	std::scoped_lock<std::mutex> lock(m_drives_mutex);
-	for (const DriveData &drive_data : m_current_drives)
+	for (const DriveData &drive_data : m_current_drives) {
 		if (search_for_drives_internal::compare_filesystem_id(new_path, drive_data.path))
 			return drive_data.path;
+	}
 	return std::string();
 }
 #endif

--- a/src/slic3r/GUI/RemovableDriveManager.cpp
+++ b/src/slic3r/GUI/RemovableDriveManager.cpp
@@ -379,10 +379,9 @@ std::string RemovableDriveManager::get_removable_drive_from_path(const std::stri
 
 	// check if same filesystem
 	std::scoped_lock<std::mutex> lock(m_drives_mutex);
-	for (const DriveData &drive_data : m_current_drives) {
+	for (const DriveData &drive_data : m_current_drives)
 		if (search_for_drives_internal::compare_filesystem_id(new_path, drive_data.path))
 			return drive_data.path;
-	}
 	return std::string();
 }
 #endif


### PR DESCRIPTION
Removable media is not ejected on linux platform

Make get_removable_drive_from_path() check if path is a dir or not. Trim last component in latter case only.