### PR TITLE
Fix segmentation fault when running CLI

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1312,14 +1312,14 @@ int CLI::run(int argc, char **argv)
                         old_height_to_rod = config.opt_float("extruder_clearance_height_to_rod");
                     if (config.option<ConfigOptionFloat>("extruder_clearance_height_to_lid"))
                         old_height_to_lid = config.opt_float("extruder_clearance_height_to_lid");
-                    if (config.option<ConfigOptionFloat>("extruder_clearance_max_radius"))
-                        old_max_radius = config.opt_float("extruder_clearance_max_radius");
+                    if (config.option<ConfigOptionFloat>("extruder_clearance_radius"))
+                        old_max_radius = config.opt_float("extruder_clearance_radius");
                     if (config.option<ConfigOptionFloats>("max_layer_height"))
                         old_max_layer_height = config.option<ConfigOptionFloats>("max_layer_height")->values;
                     if (config.option<ConfigOptionFloats>("min_layer_height"))
                         old_min_layer_height = config.option<ConfigOptionFloats>("min_layer_height")->values;
                     BOOST_LOG_TRIVIAL(info) << boost::format("old printable size from 3mf: {%1%, %2%, %3%}")%old_printable_width %old_printable_depth %old_printable_height;
-                    BOOST_LOG_TRIVIAL(info) << boost::format("old extruder_clearance_height_to_rod %1%, extruder_clearance_height_to_lid %2%, extruder_clearance_max_radius %3%}")%old_height_to_rod %old_height_to_lid %old_max_radius;
+                    BOOST_LOG_TRIVIAL(info) << boost::format("old extruder_clearance_height_to_rod %1%, extruder_clearance_height_to_lid %2%, extruder_clearance_radius %3%}")%old_height_to_rod %old_height_to_lid %old_max_radius;
                 }
                 else
                 {
@@ -2774,7 +2774,7 @@ int CLI::run(int argc, char **argv)
     double print_height = m_print_config.opt_float("printable_height");
     double height_to_lid = m_print_config.opt_float("extruder_clearance_height_to_lid");
     double height_to_rod = m_print_config.opt_float("extruder_clearance_height_to_rod");
-    double cleareance_radius = m_print_config.opt_float("extruder_clearance_max_radius");
+    double cleareance_radius = m_print_config.opt_float("extruder_clearance_radius");
     //double plate_stride;
     std::string bed_texture;
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2000,7 +2000,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
 
     // if thumbnail type of BTT_TFT, insert above header
     // if not, it is inserted under the header in its normal spot
-    GCodeThumbnailsFormat m_gcode_thumbnail_format = GCodeThumbnailsFormat::BTT_TFT;
+    GCodeThumbnailsFormat m_gcode_thumbnail_format = GCodeThumbnailsFormat::PNG;
     if (thumbnail_cb != nullptr) {
         m_gcode_thumbnail_format = print.full_print_config().opt_enum<GCodeThumbnailsFormat>("thumbnails_format");
         if (m_gcode_thumbnail_format == GCodeThumbnailsFormat::BTT_TFT)

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2000,13 +2000,16 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
 
     // if thumbnail type of BTT_TFT, insert above header
     // if not, it is inserted under the header in its normal spot
-    const GCodeThumbnailsFormat m_gcode_thumbnail_format = print.full_print_config().opt_enum<GCodeThumbnailsFormat>("thumbnails_format");
-    if (m_gcode_thumbnail_format == GCodeThumbnailsFormat::BTT_TFT)
-        GCodeThumbnails::export_thumbnails_to_file(
-            thumbnail_cb, print.get_plate_index(), print.full_print_config().option<ConfigOptionPoints>("thumbnails")->values,
-            m_gcode_thumbnail_format,
-            [&file](const char *sz) { file.write(sz); },
-            [&print]() { print.throw_if_canceled(); });
+    GCodeThumbnailsFormat m_gcode_thumbnail_format = GCodeThumbnailsFormat::BTT_TFT;
+    if (thumbnail_cb != nullptr) {
+        m_gcode_thumbnail_format = print.full_print_config().opt_enum<GCodeThumbnailsFormat>("thumbnails_format");
+        if (m_gcode_thumbnail_format == GCodeThumbnailsFormat::BTT_TFT)
+            GCodeThumbnails::export_thumbnails_to_file(
+                thumbnail_cb, print.get_plate_index(), print.full_print_config().option<ConfigOptionPoints>("thumbnails")->values,
+                m_gcode_thumbnail_format,
+                [&file](const char *sz) { file.write(sz); },
+                [&print]() { print.throw_if_canceled(); });
+    }
 
     file.write_format("; HEADER_BLOCK_START\n");
     // Write information on the generator.
@@ -2067,32 +2070,32 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
       // as configuration key / value pairs to be parsable by older versions of
       // PrusaSlicer G-code viewer.
     {
-      if (is_bbl_printers) {
-        file.write("; CONFIG_BLOCK_START\n");
-        std::string full_config;
-        append_full_config(print, full_config);
-        if (!full_config.empty())
-          file.write(full_config);
+        if (is_bbl_printers) {
+            file.write("; CONFIG_BLOCK_START\n");
+            std::string full_config;
+            append_full_config(print, full_config);
+            if (!full_config.empty())
+                file.write(full_config);
 
-        // SoftFever: write compatiple image
-        int first_layer_bed_temperature = get_bed_temperature(0, true, print.config().curr_bed_type);
-        file.write_format("; first_layer_bed_temperature = %d\n",
-                          first_layer_bed_temperature);
-        file.write_format(
-            "; first_layer_temperature = %d\n",
-            print.config().nozzle_temperature_initial_layer.get_at(0));
-        file.write("; CONFIG_BLOCK_END\n\n");
-      } else {
-        if (m_gcode_thumbnail_format != GCodeThumbnailsFormat::BTT_TFT) {
-            auto thumbnaim_fmt = m_gcode_thumbnail_format;
-            // Orca: if the thumbnail format is ColPic, we write PNG in the beginning of gcode file and ColPic in the end of gcode file. 
-            if(m_gcode_thumbnail_format == GCodeThumbnailsFormat::ColPic)
-                thumbnaim_fmt = GCodeThumbnailsFormat::PNG;
-          GCodeThumbnails::export_thumbnails_to_file(
-              thumbnail_cb, print.get_plate_index(), print.full_print_config().option<ConfigOptionPoints>("thumbnails")->values,
-              thumbnaim_fmt, [&file](const char* sz) { file.write(sz); }, [&print]() { print.throw_if_canceled(); });
+            // SoftFever: write compatiple image
+            int first_layer_bed_temperature = get_bed_temperature(0, true, print.config().curr_bed_type);
+            file.write_format("; first_layer_bed_temperature = %d\n",
+                                first_layer_bed_temperature);
+            file.write_format(
+                "; first_layer_temperature = %d\n",
+                print.config().nozzle_temperature_initial_layer.get_at(0));
+            file.write("; CONFIG_BLOCK_END\n\n");
+        } else if (thumbnail_cb != nullptr) {
+            if (m_gcode_thumbnail_format != GCodeThumbnailsFormat::BTT_TFT) {
+                auto thumbnaim_fmt = m_gcode_thumbnail_format;
+                // Orca: if the thumbnail format is ColPic, we write PNG in the beginning of gcode file and ColPic in the end of gcode file. 
+                if (m_gcode_thumbnail_format == GCodeThumbnailsFormat::ColPic)
+                    thumbnaim_fmt = GCodeThumbnailsFormat::PNG;
+                GCodeThumbnails::export_thumbnails_to_file(
+                    thumbnail_cb, print.get_plate_index(), print.full_print_config().option<ConfigOptionPoints>("thumbnails")->values,
+                    thumbnaim_fmt, [&file](const char* sz) { file.write(sz); }, [&print]() { print.throw_if_canceled(); });
+            }
         }
-      }
     }
 
 

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -2356,11 +2356,13 @@ void PartPlate::generate_logo_polygon(ExPolygon &logo_polygon)
 {
 	if (m_shape.size() == 4)
 	{
-	    auto preset_bundle = wxGetApp().preset_bundle;
-
         bool is_bbl_vendor = false;
-        if (preset_bundle)
-            is_bbl_vendor = preset_bundle->is_bbl_vendor();
+
+		if (m_plater) {
+            if (auto preset_bundle = wxGetApp().preset_bundle; preset_bundle)
+                is_bbl_vendor = preset_bundle->is_bbl_vendor();
+		}
+
         //rectangle case
 		for (int i = 0; i < 4; i++)
 		{
@@ -2545,8 +2547,8 @@ bool PartPlate::set_shape(const Pointfs& shape, const Pointfs& exclude_areas, Ve
 
 		ExPolygon logo_poly;
 		generate_logo_polygon(logo_poly);
-        m_logo_triangles.reset();
-        if (!init_model_from_poly(m_logo_triangles, logo_poly, GROUND_Z + 0.02f))
+		m_logo_triangles.reset();
+		if (!init_model_from_poly(m_logo_triangles, logo_poly, GROUND_Z + 0.02f))
 			BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << ":Unable to create logo triangles\n";
 
 		ExPolygon poly;
@@ -2576,8 +2578,10 @@ bool PartPlate::set_shape(const Pointfs& shape, const Pointfs& exclude_areas, Ve
         calc_vertex_for_icons(4, m_plate_settings_icon);
 		//calc_vertex_for_number(0, (m_plate_index < 9), m_plate_idx_icon);
 		calc_vertex_for_number(0, false, m_plate_idx_icon);
-		// calc vertex for plate name
-		generate_plate_name_texture();
+		if (m_plater) {
+			// calc vertex for plate name
+            generate_plate_name_texture();
+		}
 	}
 
 	calc_height_limit();


### PR DESCRIPTION
Fixes: #1194

Changes:
- Replaced `extruder_clearance_max_radius` with `extruder_clearance_radius` to resolve the CLI error
- Add `if (m_plater)` before accessing preset_bundle in `generate_logo_polygon` and before `generate_plate_name_texture`
- Add thumbnails to export only if thumbnail callback is defined