### PR TITLE
Adding units [mm] for filter_out_gap_fill in PrintConfig.cpp

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2378,6 +2378,7 @@ def = this->add("filament_loading_speed", coFloats);
     def->label = L("Filter out tiny gaps");
     def->category = L("Layers and Perimeters");
     def->tooltip = L("Filter out gaps smaller than the threshold specified");
+    def->sidetext = L("mm");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0));
     


### PR DESCRIPTION
adding units to the input field for the filter_out_gap_fill float for better comprehension and consistency