### PR TITLE
Display filament labels in "change filament" context menus

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -897,8 +897,20 @@ void MenuFactory::append_menu_item_change_extruder(wxMenu* menu)
         bool is_active_extruder = i == initial_extruder;
         int icon_idx = i == 0 ? 0 : i - 1;
 
-        const wxString& item_name = (i == 0 ? _L("Default") : wxString::Format(_L("Filament %d"), i)) +
-            (is_active_extruder ? " (" + _L("active") + ")" : "");
+        wxString item_name = _L("Default");
+
+        if (i > 0) {
+            auto preset = wxGetApp().preset_bundle->filaments.find_preset(wxGetApp().preset_bundle->filament_presets[i - 1]);
+            if (preset == nullptr) {
+                item_name = wxString::Format(_L("Filament %d"), i);
+            } else {
+                item_name = from_u8(preset->label(false));
+            }
+        }
+
+        if (is_active_extruder) {
+            item_name << " (" + _L("current") + ")";
+        }
 
         if (icon_idx >= 0 && icon_idx < icons.size()) {
             append_menu_item(
@@ -1881,8 +1893,20 @@ void MenuFactory::append_menu_item_change_filament(wxMenu* menu)
         //bool is_active_extruder = i == initial_extruder;
         bool is_active_extruder = false;
 
-        const wxString& item_name = (i == 0 ? _L("Default") : wxString::Format(_L("Filament %d"), i)) +
-            (is_active_extruder ? " (" + _L("current") + ")" : "");
+        wxString item_name = _L("Default");
+
+        if (i > 0) {
+            auto preset = wxGetApp().preset_bundle->filaments.find_preset(wxGetApp().preset_bundle->filament_presets[i - 1]);
+            if (preset == nullptr) {
+                item_name = wxString::Format(_L("Filament %d"), i);
+            } else {
+                item_name = from_u8(preset->label(false));
+            }
+        }
+
+        if (is_active_extruder) {
+            item_name << " (" + _L("current") + ")";
+        }
 
         append_menu_item(extruder_selection_menu, wxID_ANY, item_name, "",
             [i](wxCommandEvent&) { obj_list()->set_extruder_for_selected_items(i); }, i == 0 ? wxNullBitmap : *icons[i - 1], menu,
@@ -1958,10 +1982,10 @@ void MenuFactory::append_menu_item_plate_name(wxMenu *menu)
     // Delete old menu item
     const int item_id = menu->FindItem(name);
     if (item_id != wxNOT_FOUND) menu->Destroy(item_id);
-    
+
     PartPlate *plate = plater()->get_partplate_list().get_selected_plate();
     assert(plate);
-   
+
     auto item = append_menu_item(
         menu, wxID_ANY, name, "",
         [plate](wxCommandEvent &e) {
@@ -1973,7 +1997,7 @@ void MenuFactory::append_menu_item_plate_name(wxMenu *menu)
             else
             {
                 plater()->select_plate_by_hover_id(hover_idx, false, true);
-            } 
+            }
             plater()->get_current_canvas3D()->post_event(SimpleEvent(EVT_GLCANVAS_PLATE_NAME_CHANGE));
         },
         "", nullptr, []() { return true; }, m_parent);


### PR DESCRIPTION
Show the actual filament labels in the "Change Filament" context menu instead of "Filament 1", "Filament 2", etc.

This makes it much quicker to tell what filament is being selected, especially when utilizing the "sync from AMS" button with a printer with several AMS units attached.

**This is not yet tested** due to https://github.com/SoftFever/OrcaSlicer/issues/4920, but the [corresponding PR I opened against Bambu Studio](https://github.com/bambulab/BambuStudio/pull/3830) has been tested and works fine - both in the main view (which uses `append_menu_item_change_filament`) and in the assemble view (which uses `append_menu_item_change_extruder`), as well as with both built-in filament profiles and with user- and project-custom filament profiles.

### Before:

<img width="360" alt="Screenshot 2024-04-07 at 6 31 16 AM" src="https://github.com/bambulab/BambuStudio/assets/874635/e5f09b0c-5906-4860-a671-5f52b1b858e1">

### After:

<img width="516" alt="Screenshot 2024-04-07 at 6 33 47 AM" src="https://github.com/bambulab/BambuStudio/assets/874635/08471a60-7fa0-4183-8952-459b40d8363b">

