### PR TITLE
Act adjustments

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -28,13 +28,13 @@ jobs:
     env:
       date:
     steps:
-      
+
       # Setup the environment
       - name: Checkout
         uses: actions/checkout@v4
         with:
           lfs: 'true'
-        
+
       - name: load cached deps
         uses: actions/cache@v4
         with:
@@ -49,13 +49,13 @@ jobs:
         if: inputs.os != 'windows-latest'
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_ENV
         shell: bash
-        
+
       - name: Get the date on Windows
         if: inputs.os == 'windows-latest'
         run: echo "date=$(Get-Date -Format 'yyyyMMdd')" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
         shell: pwsh
 
-        
+
       # Build Dependencies
       - name: Build on Windows
         if: inputs.os == 'windows-latest'
@@ -98,8 +98,8 @@ jobs:
             ./BuildLinux.sh -dr
             cd deps/build
             tar -czvf OrcaSlicer_dep_ubuntu_$(date +"%Y%m%d").tar.gz destdir
-      
-            
+
+
       # Upload Artifacts
       - name: Upload Mac ${{ inputs.arch }} artifacts
         if: inputs.os == 'macos-12'
@@ -121,7 +121,7 @@ jobs:
         with:
           name: OrcaSlicer_dep_ubuntu_${{ env.date }}
           path: ${{ github.workspace }}/deps/build/OrcaSlicer_dep_ubuntu_*.tar.gz
-          
+
   build_orca:
     name: Build OrcaSlicer
     needs: [build_deps]
@@ -133,4 +133,3 @@ jobs:
       os: ${{ inputs.os }}
       arch: ${{ inputs.arch }}
     secrets: inherit
-        

--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -116,7 +116,7 @@ jobs:
           path: ${{ github.workspace }}/deps/build/OrcaSlicer_dep*.zip
 
       - name: Upload Ubuntu artifacts
-        if: inputs.os == 'ubuntu-20.04'
+        if: ${{ ! env.ACT && inputs.os == 'ubuntu-20.04' }}
         uses: actions/upload-artifact@v4
         with:
           name: OrcaSlicer_dep_ubuntu_${{ env.date }}

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -257,14 +257,14 @@ jobs:
           zip -r orca_custom_preset_tests.zip user/
 
       - name: Upload artifacts Ubuntu
-        if: inputs.os == 'ubuntu-20.04'
+        if: ${{ ! env.ACT && inputs.os == 'ubuntu-20.04' }}
         uses: actions/upload-artifact@v4
         with:
           name: OrcaSlicer_Linux_${{ env.ver }}
           path: './build/OrcaSlicer_Linux_${{ env.ver }}.AppImage'
 
       - name: Deploy Ubuntu release
-        if: github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-20.04'
+        if: ${{ ! env.ACT && github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-20.04' }}
         uses: WebFreak001/deploy-nightly@v3.1.0
         with:
           upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label}
@@ -275,7 +275,7 @@ jobs:
           max_releases: 1 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
 
       - name: Deploy orca_custom_preset_tests
-        if: github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-20.04'
+        if: ${{ ! env.ACT && github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-20.04' }}
         uses: WebFreak001/deploy-nightly@v3.1.0
         with:
           upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label}

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -57,7 +57,7 @@ jobs:
           $ref = "${{ github.ref }}"
           $eventName = "${{ github.event_name }}"
           $prNumber = "${{ github.event.number }}"
-      
+
           if ($eventName -eq 'pull_request') {
               $ver = "PR" + $prNumber
           } else {
@@ -67,12 +67,12 @@ jobs:
               }
               $ver = "V$ver"
           }
-      
+
           echo "ver=$ver" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
           echo "date=$date" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
           echo "date: ${{ env.date }} version: ${{ env.ver }}"
         shell: pwsh
-        
+
 #   Mac
       - name: Install tools mac
         if: inputs.os == 'macos-12'
@@ -134,11 +134,11 @@ jobs:
         if: github.ref == 'refs/heads/main' && inputs.os == 'macos-12'
         uses: WebFreak001/deploy-nightly@v3.1.0
         with:
-          upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label} 
-          release_id: 137995723 
+          upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label}
+          release_id: 137995723
           asset_path: ${{ github.workspace }}/OrcaSlicer_Mac_${{inputs.arch}}_${{ env.ver }}.dmg
           asset_name: OrcaSlicer_Mac_${{inputs.arch}}_${{ env.ver }}.dmg
-          asset_content_type: application/octet-stream 
+          asset_content_type: application/octet-stream
           max_releases: 1 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
 
 # Windows
@@ -174,7 +174,7 @@ jobs:
         working-directory: ${{ github.workspace }}/build/src/Release
         shell: cmd
         run: '"C:/Program Files/7-Zip/7z.exe" a -m0=lzma2 -mx9 Debug_PDB_${{ env.ver }}_for_developers_only.7z  *.pdb'
-          
+
       - name: Upload artifacts Win zip
         if: inputs.os == 'windows-latest'
         uses: actions/upload-artifact@v4
@@ -200,23 +200,23 @@ jobs:
         if: github.ref == 'refs/heads/main' && inputs.os == 'windows-latest'
         uses: WebFreak001/deploy-nightly@v3.1.0
         with:
-          upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label} 
-          release_id: 137995723 
+          upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label}
+          release_id: 137995723
           asset_path: ${{ github.workspace }}/build/OrcaSlicer_Windows_${{ env.ver }}_portable.zip
           asset_name: OrcaSlicer_Windows_${{ env.ver }}_portable.zip
-          asset_content_type: application/x-zip-compressed 
-          max_releases: 1 
+          asset_content_type: application/x-zip-compressed
+          max_releases: 1
 
       - name: Deploy Windows release installer
         if: github.ref == 'refs/heads/main' && inputs.os == 'windows-latest'
         uses: WebFreak001/deploy-nightly@v3.1.0
         with:
-          upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label} 
-          release_id: 137995723 
+          upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label}
+          release_id: 137995723
           asset_path: ${{ github.workspace }}/build/OrcaSlicer_Windows_Installer_${{ env.ver }}.exe
           asset_name: OrcaSlicer_Windows_Installer_${{ env.ver }}.exe
           asset_content_type: application/x-msdownload
-          max_releases: 1 
+          max_releases: 1
 
 # Ubuntu
       - name: Install dependencies
@@ -267,8 +267,8 @@ jobs:
         if: github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-20.04'
         uses: WebFreak001/deploy-nightly@v3.1.0
         with:
-          upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label} 
-          release_id: 137995723 
+          upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label}
+          release_id: 137995723
           asset_path: ./build/OrcaSlicer_Linux_${{ env.ver }}.AppImage
           asset_name: OrcaSlicer_Linux_${{ env.ver }}.AppImage
           asset_content_type: application/octet-stream
@@ -278,9 +278,9 @@ jobs:
         if: github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-20.04'
         uses: WebFreak001/deploy-nightly@v3.1.0
         with:
-          upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label} 
-          release_id: 137995723 
+          upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label}
+          release_id: 137995723
           asset_path: ${{ github.workspace }}/resources/profiles/orca_custom_preset_tests.zip
           asset_name: orca_custom_preset_tests.zip
           asset_content_type: application/octet-stream
-          max_releases: 1 
+          max_releases: 1

--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   publish_docs_to_wiki:
+    if: ${{ !env.ACT }} # Skip if using `act`
     name: Publish docs to Wiki
     runs-on: ubuntu-latest
     steps:  


### PR DESCRIPTION
# Description

Allow workflow to be run by developers locally through [act](https://github.com/nektos/act)

# Screenshots/Recordings/Graphs

Before:

```
[Build Deps/build_deps.yml/Build Deps]   ✅  Success - Main Build on Ubuntu
[Build Deps/build_deps.yml/Build Deps] ⭐ Run Main Upload Ubuntu artifacts
[Build Deps/build_deps.yml/Build Deps]   🐳  docker cp src=/home/jamin/.cache/act/actions-upload-artifact@v4/ dst=/var/run/act/actions/actions-upload-artifact@v4/
[Build Deps/build_deps.yml/Build Deps]   🐳  docker exec cmd=[node /var/run/act/actions/actions-upload-artifact@v4/dist/upload/index.js] user= workdir=
[Build Deps/build_deps.yml/Build Deps]   💬  ::debug::followSymbolicLinks 'true'
[Build Deps/build_deps.yml/Build Deps]   💬  ::debug::implicitDescendants 'true'
[Build Deps/build_deps.yml/Build Deps]   💬  ::debug::omitBrokenSymbolicLinks 'true'
[Build Deps/build_deps.yml/Build Deps]   💬  ::debug::followSymbolicLinks 'true'
[Build Deps/build_deps.yml/Build Deps]   💬  ::debug::implicitDescendants 'true'
[Build Deps/build_deps.yml/Build Deps]   💬  ::debug::matchDirectories 'true'
[Build Deps/build_deps.yml/Build Deps]   💬  ::debug::omitBrokenSymbolicLinks 'true'
[Build Deps/build_deps.yml/Build Deps]   💬  ::debug::Search path '/home/jamin/proj/3d-printing/OrcaSlicer/deps/build'
[Build Deps/build_deps.yml/Build Deps]   💬  ::debug::File:/home/jamin/proj/3d-printing/OrcaSlicer/deps/build/OrcaSlicer_dep_ubuntu_20240410.tar.gz was found using the provided searchPath
| With the provided path, there will be 1 file uploaded
[Build Deps/build_deps.yml/Build Deps]   💬  ::debug::Root artifact directory is /home/jamin/proj/3d-printing/OrcaSlicer/deps/build
| Artifact name is valid!
| Root directory input is valid!
[Build Deps/build_deps.yml/Build Deps]   ❗  ::error::Unable to get the ACTIONS_RUNTIME_TOKEN env variable
[Build Deps/build_deps.yml/Build Deps]   ❌  Failure - Main Upload Ubuntu artifacts
[Build Deps/build_deps.yml/Build Deps] exitcode '1': failure
[Build Deps/build_deps.yml/Build Deps] 🏁  Job failed
```

After:
```
[Build OrcaSlicer/build_orca.yml/Build OrcaSlicer]   ✅  Success - Main Build slicer
[Build OrcaSlicer/build_orca.yml/Build OrcaSlicer] ⭐ Run Post load cached deps
[Build OrcaSlicer/build_orca.yml/Build OrcaSlicer]   🐳  docker exec cmd=[node /var/run/act/actions/actions-cache@v4/dist/save/index.js] user= workdir=
[Build OrcaSlicer/build_orca.yml/Build OrcaSlicer]   💬  ::debug::Cache state/key: linux-cache-orcaslicer_deps-build-6fd40b94f87c17bf20ab1131f2f8d8631805175715c84c26f6115f233c295b76
| Cache hit occurred on the primary key Linux-cache-orcaslicer_deps-build-6fd40b94f87c17bf20ab1131f2f8d8631805175715c84c26f6115f233c295b76, not saving cache.
[Build OrcaSlicer/build_orca.yml/Build OrcaSlicer]   ✅  Success - Post load cached deps
[Build OrcaSlicer/build_orca.yml/Build OrcaSlicer] Cleaning up container for job Build OrcaSlicer
[Build OrcaSlicer/build_orca.yml/Build OrcaSlicer] 🏁  Job succeeded
```

## Tests

Ran workflows with and without the changes locally.