### PR TITLE
Add missing "Edit SVG" item for Add/Negative/Modifier SVG objects in object list

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -1347,6 +1347,7 @@ void ObjectList::show_context_menu(const bool evt_context_menu)
                 const ModelVolume *volume = object(obj_idx)->volumes[vol_idx];
 
                 menu = volume->is_text() ? plater->text_part_menu() :
+			volume->is_svg() ? plater->svg_part_menu() : // ORCA fixes missing "Edit SVG" item for Add/Negative/Modifier SVG objects in object list
                     plater->part_menu();
             }
             else


### PR DESCRIPTION
• Add cube
• Add SVG as Positive/Negative/Modifier
• Right click SVG on object list
Normally it should show "Edit SVG" for this item like "Edit Text" but not. this commit fixes it

Left (fixed) - Right shows generic menu
![Screenshot-20240418230253](https://github.com/SoftFever/OrcaSlicer/assets/28517890/22baae0f-88df-43b8-bf33-ea75a1121985)
