### PR TITLE
Adjusted start g-code for Qidi X-Max/X-Plus 1 and 2.

### DIFF
--- a/resources/profiles/Qidi/machine/Qidi X-Max 0.4 nozzle.json
+++ b/resources/profiles/Qidi/machine/Qidi X-Max 0.4 nozzle.json
@@ -100,7 +100,7 @@
 	"default_filament_profile": [
 		"Qidi Generic PLA"
 	],
-	"machine_start_gcode": "G28\nG92 E0\nG0 X5 Y5 Z0.3 F3600\nM190 S[bed_temperature_initial_layer_single]\nM109 S[first_layer_temperature]\n",
+	"machine_start_gcode": "G28\nG92 E0\nG0 X300 Y5 Z50 F3600\nM190 S[bed_temperature_initial_layer_single]\nM109 S[first_layer_temperature]\nG92 E-19\n",
 	"machine_end_gcode": "M104 S0\nM140 S0\n;Retract the filament\nG92 E0\nG1 E-3 F300\nG28\nM84\n",
 	"scan_first_layer": "0"
 }

--- a/resources/profiles/Qidi/machine/Qidi X-Max 0.4 nozzle.json
+++ b/resources/profiles/Qidi/machine/Qidi X-Max 0.4 nozzle.json
@@ -100,7 +100,7 @@
 	"default_filament_profile": [
 		"Qidi Generic PLA"
 	],
-	"machine_start_gcode": "G28\nG92 E0\nG0 X5 Y5 Z0.3 F3600\n",
+	"machine_start_gcode": "G28\nG92 E0\nG0 X5 Y5 Z0.3 F3600\nM190 S[bed_temperature_initial_layer_single]\nM109 S[first_layer_temperature]\n",
 	"machine_end_gcode": "M104 S0\nM140 S0\n;Retract the filament\nG92 E0\nG1 E-3 F300\nG28\nM84\n",
 	"scan_first_layer": "0"
 }

--- a/resources/profiles/Qidi/machine/Qidi X-Plus 0.4 nozzle.json
+++ b/resources/profiles/Qidi/machine/Qidi X-Plus 0.4 nozzle.json
@@ -100,7 +100,7 @@
 	"default_filament_profile": [
 		"Qidi Generic PLA"
 	],
-	"machine_start_gcode": "G28\nG92 E0\nG0 X5 Y5 Z0.3 F3600\nM190 S[bed_temperature_initial_layer_single]\nM109 S[first_layer_temperature]\n",
+	"machine_start_gcode": "G28\nG92 E0\nG0 X270 Y5 Z50 F3600\nM190 S[bed_temperature_initial_layer_single]\nM109 S[first_layer_temperature]\nG92 E-16\n",
 	"machine_end_gcode": "M104 S0\nM140 S0\n;Retract the filament\nG92 E0\nG1 E-3 F300\nG28\nM84\n",
 	"scan_first_layer": "0"
 }

--- a/resources/profiles/Qidi/machine/Qidi X-Plus 0.4 nozzle.json
+++ b/resources/profiles/Qidi/machine/Qidi X-Plus 0.4 nozzle.json
@@ -100,7 +100,7 @@
 	"default_filament_profile": [
 		"Qidi Generic PLA"
 	],
-	"machine_start_gcode": "G28\nG92 E0\nG0 X5 Y5 Z0.3 F3600\n",
+	"machine_start_gcode": "G28\nG92 E0\nG0 X5 Y5 Z0.3 F3600\nM190 S[bed_temperature_initial_layer_single]\nM109 S[first_layer_temperature]\n",
 	"machine_end_gcode": "M104 S0\nM140 S0\n;Retract the filament\nG92 E0\nG1 E-3 F300\nG28\nM84\n",
 	"scan_first_layer": "0"
 }


### PR DESCRIPTION
# Description

The current start G-Code for Qidi X-Max 1/2 and X-Plus 1/2 will start printing before the first-layer temperature is reached.
Resulting is usually a big blog of filament on the nozzle and failed print.

This PR will add the original g-code for setting start temperature (M109 and M190) and the printer will wait until temperature is reached.

# Screenshots/Recordings/Graphs
Reference full (original) Qidi start code for a X-Plus printer setting bed temp to 63 and nozzle to 215
```
M82 ;absolute extrusion mode
G28
G0 X270 Y5 Z50 F3600
M190 S63
M109 S215.0
G92 E-16
G0 Y5 Z0.3 F3600
G1 X5 E0 F2400
```

## Tests
![24-04-22 13-00-03 0209](https://github.com/SoftFever/OrcaSlicer/assets/21292774/54f74aea-c5e3-46cc-a9d0-7ce1f5841a8c)
Tested and works.
