### PR TITLE
e3v3se: remove jerk settings

### DIFF
--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.2 nozzle.json
@@ -68,20 +68,20 @@
 		"5"
 	],
 	"machine_max_jerk_e": [
-		"5",
-		"5"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_x": [
-		"10",
-		"10"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_y": [
-		"10",
-		"10"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_z": [
-		"0.4",
-		"0.4"
+		"0",
+		"0"
 	],
 	"max_layer_height": [
 		"0.32"

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.4 nozzle.json
@@ -68,20 +68,20 @@
 		"5"
 	],
 	"machine_max_jerk_e": [
-		"5",
-		"5"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_x": [
-		"10",
-		"10"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_y": [
-		"10",
-		"10"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_z": [
-		"0.4",
-		"0.4"
+		"0",
+		"0"
 	],
 	"max_layer_height": [
 		"0.32"

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.6 nozzle.json
@@ -68,20 +68,20 @@
 		"5"
 	],
 	"machine_max_jerk_e": [
-		"5",
-		"5"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_x": [
-		"10",
-		"10"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_y": [
-		"10",
-		"10"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_z": [
-		"0.4",
-		"0.4"
+		"0",
+		"0"
 	],
 	"max_layer_height": [
 		"0.32"

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.8 nozzle.json
@@ -68,20 +68,20 @@
 		"5"
 	],
 	"machine_max_jerk_e": [
-		"5",
-		"5"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_x": [
-		"10",
-		"10"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_y": [
-		"10",
-		"10"
+		"0",
+		"0"
 	],
 	"machine_max_jerk_z": [
-		"0.4",
-		"0.4"
+		"0",
+		"0"
 	],
 	"max_layer_height": [
 		"0.32"

--- a/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3SE 0.2.json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3SE 0.2.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3SE 0.4.json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3SE 0.4.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.4 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3SE 0.6.json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3SE 0.6.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.6 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3SE 0.8.json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3SE 0.8.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.8 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3SE 0.2.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3SE 0.2.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3SE 0.4.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3SE 0.4.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.4 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3SE 0.6.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3SE 0.6.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.6 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3SE 0.8.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3SE 0.8.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.8 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3SE 0.2.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3SE 0.2.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3SE 0.4.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3SE 0.4.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.4 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3SE 0.6.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3SE 0.6.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.6 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3SE 0.8.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3SE 0.8.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.8 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3SE 0.2.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3SE 0.2.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.2 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3SE 0.4.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3SE 0.4.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.4 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3SE 0.6.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3SE 0.6.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.6 nozzle"
 	]

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3SE 0.8.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3SE 0.8.json
@@ -105,13 +105,6 @@
 	"prime_tower_width": "60",
 	"xy_hole_compensation": "0",
 	"xy_contour_compensation": "0",
-	"default_jerk": "8",
-	"outer_wall_jerk": "20",
-	"inner_wall_jerk": "20",
-	"infill_jerk": "20",
-	"top_surface_jerk": "20",
-	"initial_layer_jerk": "8",
-	"travel_jerk": "8",
 	"compatible_printers": [
 		"Creality Ender-3 V3 SE 0.8 nozzle"
 	]


### PR DESCRIPTION
# Description

Completely remove jerk settings from Ender3 V3 SE machine and processes.

This is due to E3 V3 SE does not use jerk, but has junction deviation enabled instead. Those two modes are mutually exclusive according to marlin configuration page:
    https://marlinfw.org/docs/configuration/configuration.html#default-acceleration-
    https://marlinfw.org/docs/configuration/configuration.html#junction-deviation-

Based on M503 output, E3V3SE hase junction deviation enabled:

  echo:; Advanced: B<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate> J<junc_dev>
  echo:  M205 B20000.00 S0.00 T0.00 J0.10

Setting jerk settings via M205 Xn Yn Zn does not have any effect.

Removing jerk settings also fixes issue with "jerk exceeded" popup.

## Tests

Manual tests (modified gcode):
- altering jerk (M205 Xn Yn) does not affect print quality
- altering junction (M205 Jn) deviation does affect print quality