### PR TITLE
Fixup docker build/run

### DIFF
--- a/DockerRun.sh
+++ b/DockerRun.sh
@@ -20,6 +20,8 @@ docker run \
   --privileged=true \
   `# Attach tty for running orca slicer with command line things` \
   -ti \
+  `# Clean up after yourself` \
+  --rm \
   `# Pass all parameters from this script to the orca slicer  ENTRYPOINT binary` \
   orcaslicer $* 
   

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install  -y \
     libsoup2.4-dev \
     libssl3 \
     libssl-dev \
+    libtool \
     libudev-dev \
     libwayland-dev \
     libwebkit2gtk-4.0-dev \
@@ -67,9 +68,8 @@ WORKDIR OrcaSlicer
 RUN ./BuildLinux.sh -u
 
 # Build dependencies in ./deps
-RUN ./BuildLinux.sh -d; exit 0
+RUN ./BuildLinux.sh -d
 
-RUN apt-get install -y libcgal-dev
 # Build slic3r
 RUN ./BuildLinux.sh -s
 


### PR DESCRIPTION
DockerBuild.sh was failing on dependencies, masked by exit 0. Cause was the addition of an autoreconf to the MPFR cmake, requires libtool which was missing from the package install in the Dockerfile.

Added --rm to DockerRun.sh for convenience.