### PR TITLE
Fix invalid nozzle_type undefined for 'Anycubic Kobra 2 0.4 nozzle' system machine

### DIFF
--- a/resources/profiles/Anycubic/machine/Anycubic Kobra 2 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/machine/Anycubic Kobra 2 0.4 nozzle.json
@@ -17,7 +17,7 @@
 		"0x220"
 	],
 	"printable_height": "250",
-	"nozzle_type": "undefined",
+	"nozzle_type": "undefine",
 	"auxiliary_fan": "0",
 	"machine_max_acceleration_extruding": [
 		"2500",


### PR DESCRIPTION
The correct value is undefine.

Related to a comment in https://github.com/SoftFever/OrcaSlicer/issues/3991#issuecomment-2079796653

# Description

Filament loading will crash if this value is `undefined` instead of `undefine`.


# Screenshots/Recordings/Graphs

```text
[error]	2024-04-26 19:34:05.440249[Thread 0x00003784]:Slic3r::ConfigBase::load_from_json: parse C:\Users\Kristian\AppData\Roaming\OrcaSlicer\system/Anycubic/machine/Anycubic Kobra 2 0.4 nozzle.json got a generic exception, reason = Invalid value provided for parameter nozzle_type: undefined
[error]	2024-04-26 19:34:05.440249[Thread 0x00003784]:Slic3r::PresetBundle::load_vendor_configs_from_json::<lambda_2e6da75a0232aea84d16ba067e6fa242>::operator (): load config file C:\Users\Kristian\AppData\Roaming\OrcaSlicer\system/Anycubic/machine/Anycubic Kobra 2 0.4 nozzle.json Failed!
[error]	2024-04-26 19:34:05.440249[Thread 0x00003784]:Slic3r::PresetBundle::load_vendor_configs_from_json, got error when parse printer setting from C:\Users\Kristian\AppData\Roaming\OrcaSlicer\system/Anycubic/machine/Anycubic Kobra 2 0.4 nozzle.json
```

## Tests

Edited the file on my machine directly. It works.
