### PR TITLE
appimage: bundle libraries which may be absent on modern hosts

### DIFF
--- a/src/platform/unix/BuildLinuxImage.sh.in
+++ b/src/platform/unix/BuildLinuxImage.sh.in
@@ -21,11 +21,8 @@ echo -n "[9/9] Generating Linux app..."
     if [ -d "package" ]
     then
         rm -rf package/*
-        rm -rf package/.* 2&>/dev/null
-    else
-        mkdir package
     fi
-    mkdir package/bin
+    mkdir -p package/bin
 
     # copy Resources
     cp -Rf ../resources package/resources
@@ -33,15 +30,49 @@ echo -n "[9/9] Generating Linux app..."
     # remove unneeded po from resources
     ## find package/resources/localization -name "*.po" -type f -delete ## FIXME: DD - do we need this?
 
+    # Copy dynamic libraries
+    HOST_DEPS=(
+        libjpeg.so*
+        libwebp.so*
+        libwoff2dec.so*
+        libwoff2common.so*
+        libharfbuzz-icu.so*
+        libsoup-2.4.so*
+        libhyphen.so*
+        libspnav.so*
+        libatomic.so*
+        webkit2gtk-4.*
+        libicudata.so*
+        libicui18n.so*
+        libicuuc.so*
+        libjavascriptcoregtk-4.*
+        libwebkit2gtk-4.*
+    )
+
+    mkdir -p package/lib/x86_64-linux-gnu
+    for dep in "${HOST_DEPS[@]}"
+    do
+        libpath=$(ldd src/orca-slicer | awk "/${dep}/{print \$3}")
+        cp -aL $libpath  package/lib/x86_64-linux-gnu/
+    done
+
+    # Copy webkit binaries we've built against.
+    cp -aL /usr/lib/x86_64-linux-gnu/webkit2gtk-4.* package/lib/x86_64-linux-gnu/
+    find package/lib/ -name 'libwebkit*' -type f -exec sed -i -e "s|/usr|././|g" '{}' \;
+
     # create bin
 cat << EOF >@SLIC3R_APP_CMD@
 #!/bin/bash
 DIR=\$(readlink -f "\$0" | xargs dirname)
-export LD_LIBRARY_PATH="\$DIR/bin"
+export LD_LIBRARY_PATH="\$DIR/bin:\$DIR/lib/x86_64-linux-gnu"
 
 # FIXME: OrcaSlicer segfault workarounds
 # 1) OrcaSlicer will segfault on systems where locale info is not as expected (i.e. Holo-ISO arch-based distro)
 export LC_ALL=C
+
+# WORKAROUND: change CWD to appimage root, so webkit would be
+#             able to start itself using relative path
+cd \$DIR
 
 exec "\$DIR/bin/@SLIC3R_APP_CMD@" "\$@"
 EOF

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1937,9 +1937,6 @@ void GUI_App::init_app_config()
         if (!boost::filesystem::exists(data_dir_path)){
             boost::filesystem::create_directory(data_dir_path);
         }
-
-        // Change current dirtory of application
-        chdir(encode_path((Slic3r::data_dir() + "/log").c_str()).c_str());
     } else {
         m_datadir_redefined = true;
     }
@@ -1950,7 +1947,7 @@ void GUI_App::init_app_config()
     std::stringstream buf;
     buf << std::put_time(now_time, "debug_%a_%b_%d_%H_%M_%S_");
     buf << get_current_pid() << ".log";
-    std::string log_filename = buf.str();
+    std::string log_filename = Slic3r::data_dir() + "/log/" + buf.str();
 #if !BBL_RELEASE_TO_PUBLIC
     set_log_path_and_level(log_filename, 5);
 #else


### PR DESCRIPTION
# Description

Bundle minimal set of libraries to run on modern hosts like Ubuntu 24.04, Fedora40, Aurora Linux.

Modify startup script and GUI_App to set current working dir to the appimage root in order to workaround webkit2gtk hard-coded paths.

Fixes #4616

## Tests

Tested by community members at  #4616