### PR TITLE
Ender3 v3 maximum jerk fix

### DIFF
--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 0.4 nozzle.json
@@ -73,12 +73,12 @@
         "2.5"
     ],
     "machine_max_jerk_x": [
-        "10",
-        "10"
+        "12",
+        "12"
     ],
     "machine_max_jerk_y": [
-        "10",
-        "10"
+        "12",
+        "12"
     ],
     "machine_max_jerk_z": [
         "2",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 0.6 nozzle.json
@@ -73,12 +73,12 @@
         "2.5"
     ],
     "machine_max_jerk_x": [
-        "10",
-        "10"
+        "12",
+        "12"
     ],
     "machine_max_jerk_y": [
-        "10",
-        "10"
+        "12",
+        "12"
     ],
     "machine_max_jerk_z": [
         "2",


### PR DESCRIPTION
# Description

Orca complains that the jerk of the basic profile is higher than the maximum jerk of the printer. Since the printer is as capable as a K1, I increased the printer's maximum jerk to 12 to be able to quickly print the infill.
