### PR TITLE
Fix wipe tower not showing purged filament volume for non BBL SEMM

### DIFF
--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -76,6 +76,9 @@ public:
         m_gcode_flavor(flavor),
         m_filpar(filament_parameters)
         {
+            // ORCA: This class is only used by BBL printers, so set the parameter appropriately.
+            // This fixes an issue where the wipe tower was using BBL tags resulting in statistics for purging in the purge tower not being displayed.
+            GCodeProcessor::s_IsBBLPrinter = true;
             // adds tag for analyzer:
             std::ostringstream str;
             str << ";" << GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Height) << std::to_string(m_layer_height) << "\n"; // don't rely on GCodeAnalyzer knowing the layer height - it knows nothing at priming


### PR DESCRIPTION
When using a non BBL printer (i.e. klipper or other) the wipe tower filament use statistics where displaying 0 for all filaments except one and incorrectly counting the purge volume in the wipe tower per filament. The total volume was correct though.

See below:
![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/1b0cb635-5480-49cb-8a93-33266a9709f5)
![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/c4bb170b-59e8-4975-b263-cae16260dcc3)

This PR addresses this issue by correctly tagging the start and end of the wipe tower and correctly assigning the printer type (BBL or non BBL) in the Gcode processor when the corresponding Wipe towers are initialised.

![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/cca45ab6-ce21-4e82-9fe2-1ee25c873939)
![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/a95aeb96-ff00-44f4-a1d0-9add7d92360e)
