### PR TITLE
Fix measure gizmo "Copy to Clipboard" button icon for dark mode

### DIFF
--- a/src/imgui/imconfig.h
+++ b/src/imgui/imconfig.h
@@ -201,14 +201,14 @@ namespace ImGui
     const wchar_t BlockNotifErrorIcon        = 0x0835;
     const wchar_t ClipboardBtnDarkIcon       = 0x0836;
 
-    const wchar_t PrevArrowBtnIcon         = 0x0836; 
-    const wchar_t PrevArrowHoverBtnIcon    = 0x0837; 
-    const wchar_t NextArrowBtnIcon         = 0x0838;
-    const wchar_t NextArrowHoverBtnIcon    = 0x0839;
-    const wchar_t OpenArrowIcon            = 0x0840;
-    const wchar_t CollapseArrowIcon        = 0x0841;
-    const wchar_t ExpandArrowIcon          = 0x0842;
-    const wchar_t CompleteIcon             = 0x0843;
+    const wchar_t PrevArrowBtnIcon         = 0x0837; 
+    const wchar_t PrevArrowHoverBtnIcon    = 0x0838; 
+    const wchar_t NextArrowBtnIcon         = 0x0839;
+    const wchar_t NextArrowHoverBtnIcon    = 0x0840;
+    const wchar_t OpenArrowIcon            = 0x0841;
+    const wchar_t CollapseArrowIcon        = 0x0842;
+    const wchar_t ExpandArrowIcon          = 0x0843;
+    const wchar_t CompleteIcon             = 0x0844;
 
 //    void MyFunction(const char* name, const MyMatrix44& v);
 }


### PR DESCRIPTION
Problem is both shares same ID on code
```
const wchar_t ClipboardBtnDarkIcon       = 0x0836;
const wchar_t PrevArrowBtnIcon            = 0x0836; 
```

Before

![Screenshot-20240502020321](https://github.com/SoftFever/OrcaSlicer/assets/28517890/bb563676-405b-4716-9744-744cac068c01)

After

![Screenshot-20240502042330](https://github.com/SoftFever/OrcaSlicer/assets/28517890/bd80dbb6-5f4f-4357-b02e-6d9eaf988f51)
