### PR TITLE
Hide revert and delete preset buttons while search box focused

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -319,6 +319,8 @@ void Tab::create_preset_tab()
         if (m_presets_choice) m_presets_choice->Show();
 
         m_btn_save_preset->Show();
+	m_btn_delete_preset->Show(); // ORCA: fixes delete preset button visible while search box focused
+        m_undo_btn->Show();          // ORCA: fixes revert preset button visible while search box focused
         m_btn_search->Show();
         m_search_item->Hide();
 
@@ -347,6 +349,8 @@ void Tab::create_preset_tab()
              m_presets_choice->Hide();
 
          m_btn_save_preset->Hide();
+	 m_btn_delete_preset->Hide(); // ORCA: fixes delete preset button visible while search box focused
+         m_undo_btn->Hide();          // ORCA: fixes revert preset button visible while search box focused
          m_btn_search->Hide();
          m_search_item->Show();
 


### PR DESCRIPTION
Before
![Screenshot-20240503213414](https://github.com/SoftFever/OrcaSlicer/assets/28517890/463b5332-c03a-4ba4-a1f9-92d4c5f7c8b9)

After
![Screenshot-20240503213610](https://github.com/SoftFever/OrcaSlicer/assets/28517890/741da392-8ad7-4dcc-93e5-41aa888e1279)

I'm planning to fix all margin related problems at separate commit