### PR TITLE
Close Variable layer height gizmo when other toolbar buttons clicked

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -6387,6 +6387,7 @@ bool GLCanvas3D::_init_main_toolbar()
     item.icon_filename = m_is_dark ? "toolbar_variable_layer_height_dark.svg" : "toolbar_variable_layer_height.svg";
     item.tooltip = _utf8(L("Variable layer height"));
     item.sprite_id++;
+    item.left.toggable = true; // ORCA Closes popup if other toolbar icon clicked and it allows closing popup when clicked its button
     item.left.action_callback = [this]() { if (m_canvas != nullptr) wxPostEvent(m_canvas, SimpleEvent(EVT_GLTOOLBAR_LAYERSEDITING)); };
     item.visibility_callback = [this]()->bool {
         bool res = current_printer_technology() == ptFFF;


### PR DESCRIPTION
• This allows closing when other toolbar icon clicked
• Also allows closing gizmo when its icon clicked
• Gizmo still keeps open when other areas clicked

Before (GIF)
• Clicking other gizmos not closing variable layer height and overlaps with other gizmos
![orca-slicer_vyWrhY9jmU](https://github.com/SoftFever/OrcaSlicer/assets/28517890/6b8fbc76-f845-4a1a-96d0-f14c47e3b09b)

After (GIF)
• Gizmo closes itself when other gizmos activated
![orca-slicer_W3GNbExuRN](https://github.com/SoftFever/OrcaSlicer/assets/28517890/fe3148b4-174e-42f5-a649-ab01d9c0e4bc)

I have tried rotate while variable layer height gizmo open. but it resets it self and i guess its not a planned feature. Recommended to use as a popup window if that's used like this

What's your opinion on this?