### PR TITLE
[RFC] Wall layers interlock

### DIFF
--- a/src/libslic3r/Arachne/BeadingStrategy/BeadingStrategyFactory.hpp
+++ b/src/libslic3r/Arachne/BeadingStrategy/BeadingStrategyFactory.hpp
@@ -27,6 +27,7 @@ public:
         coord_t max_bead_count = 0,
         coord_t outer_wall_offset = 0,
         int inward_distributed_center_wall_count = 2,
+        unsigned int internal_wall_interlock = 0,
         double minimum_variable_line_width = 0.5
     );
 };

--- a/src/libslic3r/Arachne/BeadingStrategy/PushInternalWallsBeadingStrategy.cpp
+++ b/src/libslic3r/Arachne/BeadingStrategy/PushInternalWallsBeadingStrategy.cpp
@@ -1,0 +1,67 @@
+#include "PushInternalWallsBeadingStrategy.hpp"
+
+namespace Slic3r::Arachne
+{
+
+PushInternalWallsBeadingStrategy::PushInternalWallsBeadingStrategy(BeadingStrategyPtr parent, unsigned int interlock_percent_)
+    : BeadingStrategy(*parent)
+    , parent(std::move(parent))
+    , interlock_percent(interlock_percent_)
+{
+}
+
+std::string PushInternalWallsBeadingStrategy::toString() const
+{
+    return std::string("PushInternalWalls+") + parent->toString();
+}
+
+PushInternalWallsBeadingStrategy::Beading PushInternalWallsBeadingStrategy::compute(coord_t thickness, coord_t bead_count) const
+{
+    auto ret = parent->compute(thickness, bead_count);
+
+    if (bead_count > 1) {
+        coord_t push_width = ret.bead_widths[1] *  interlock_percent / 100;
+
+        ret.bead_widths[1] += push_width;
+        ret.toolpath_locations[1] += push_width / 2;
+
+        for (unsigned i = 2; i < bead_count; i++) {
+            ret.toolpath_locations[i] += push_width;
+        }
+
+    }
+
+    return ret;
+}
+
+coord_t PushInternalWallsBeadingStrategy::getOptimalThickness(coord_t bead_count) const
+{
+    return parent->getOptimalThickness(bead_count);
+}
+
+coord_t PushInternalWallsBeadingStrategy::getTransitionThickness(coord_t lower_bead_count) const
+{
+    return parent->getTransitionThickness(lower_bead_count);
+}
+
+coord_t PushInternalWallsBeadingStrategy::getOptimalBeadCount(coord_t thickness) const
+{
+    return parent->getOptimalBeadCount(thickness);
+}
+
+coord_t PushInternalWallsBeadingStrategy::getTransitioningLength(coord_t lower_bead_count) const
+{
+    return parent->getTransitioningLength(lower_bead_count);
+}
+
+float PushInternalWallsBeadingStrategy::getTransitionAnchorPos(coord_t lower_bead_count) const
+{
+    return parent->getTransitionAnchorPos(lower_bead_count);
+}
+
+std::vector<coord_t> PushInternalWallsBeadingStrategy::getNonlinearThicknesses(coord_t lower_bead_count) const
+{
+    return parent->getNonlinearThicknesses(lower_bead_count);
+}
+
+} // namespace Slic3r::Arachne

--- a/src/libslic3r/Arachne/BeadingStrategy/PushInternalWallsBeadingStrategy.hpp
+++ b/src/libslic3r/Arachne/BeadingStrategy/PushInternalWallsBeadingStrategy.hpp
@@ -1,0 +1,40 @@
+#ifndef PUSH_INTERNAL_WALLS_BEADING_STRATEGY_H
+#define PUSH_INTERNAL_WALLS_BEADING_STRATEGY_H
+
+#include "BeadingStrategy.hpp"
+
+namespace Slic3r::Arachne
+{
+
+/*!
+ * This strategy intended to incrrease outer shell strength by interlocking layers.
+ *
+ * Idea is to make cross section to look like bricklayer. To do this second perimeter width
+ * increased by given percentage effectively pushing rest of internal perimetern inwards
+ */
+class PushInternalWallsBeadingStrategy : public BeadingStrategy
+{
+public:
+    /*!
+     * Takes responsibility for deleting \param parent
+     */
+    PushInternalWallsBeadingStrategy(BeadingStrategyPtr parent, unsigned int interlock_percent_);
+
+    ~PushInternalWallsBeadingStrategy() override = default;
+
+    Beading compute(coord_t thickness, coord_t bead_count) const override;
+    coord_t getOptimalThickness(coord_t bead_count) const override;
+    coord_t getTransitionThickness(coord_t lower_bead_count) const override;
+    coord_t getOptimalBeadCount(coord_t thickness) const override;
+    coord_t getTransitioningLength(coord_t lower_bead_count) const override;
+    float getTransitionAnchorPos(coord_t lower_bead_count) const override;
+    std::vector<coord_t> getNonlinearThicknesses(coord_t lower_bead_count) const override;
+    std::string toString() const override;
+
+protected:
+    BeadingStrategyPtr parent;
+    unsigned int interlock_percent = 0;
+};
+
+} // namespace Slic3r::Arachne
+#endif // PUSH_INTERNAL_WALLS_BEADING_STRATEGY_H

--- a/src/libslic3r/Arachne/WallToolPaths.cpp
+++ b/src/libslic3r/Arachne/WallToolPaths.cpp
@@ -44,6 +44,8 @@ WallToolPathsParams make_paths_params(const int layer_id, const PrintObjectConfi
                 input_params.min_bead_width = min_bead_width_opt.value * 0.01 * min_nozzle_diameter;
         }
 
+        input_params.internal_wall_interlock_percent = (layer_id %2) ? print_object_config.inner_wall_interlock.value : 0;
+
         if (const auto &wall_transition_filter_deviation_opt = print_object_config.wall_transition_filter_deviation)
             input_params.wall_transition_filter_deviation = wall_transition_filter_deviation_opt.value * 0.01 * min_nozzle_diameter;
 
@@ -525,7 +527,8 @@ const std::vector<VariableWidthLines> &WallToolPaths::generate()
             wall_add_middle_threshold,
             max_bead_count,
             wall_0_inset,
-            wall_distribution_count
+            wall_distribution_count,
+            this->m_params.internal_wall_interlock_percent
         );
     const coord_t transition_filter_dist   = scaled<coord_t>(100.f);
     const coord_t allowed_filter_deviation = wall_transition_filter_deviation;

--- a/src/libslic3r/Arachne/WallToolPaths.hpp
+++ b/src/libslic3r/Arachne/WallToolPaths.hpp
@@ -31,6 +31,7 @@ public:
     float   wall_transition_filter_deviation;
     int     wall_distribution_count;
     bool    is_top_or_bottom_layer;
+    unsigned internal_wall_interlock_percent;
 };
 
 WallToolPathsParams make_paths_params(const int layer_id, const PrintObjectConfig &print_object_config, const PrintConfig &print_config);

--- a/src/libslic3r/CMakeLists.txt
+++ b/src/libslic3r/CMakeLists.txt
@@ -422,6 +422,8 @@ set(lisbslic3r_sources
     Arachne/BeadingStrategy/LimitedBeadingStrategy.cpp
     Arachne/BeadingStrategy/OuterWallInsetBeadingStrategy.hpp
     Arachne/BeadingStrategy/OuterWallInsetBeadingStrategy.cpp
+    Arachne/BeadingStrategy/PushInternalWallsBeadingStrategy.hpp
+    Arachne/BeadingStrategy/PushInternalWallsBeadingStrategy.cpp
     Arachne/BeadingStrategy/RedistributeBeadingStrategy.hpp
     Arachne/BeadingStrategy/RedistributeBeadingStrategy.cpp
     Arachne/BeadingStrategy/WideningBeadingStrategy.hpp

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -820,6 +820,7 @@ static std::vector<std::string> s_Preset_print_options {
      "wipe_tower_rotation_angle", "tree_support_branch_distance_organic", "tree_support_branch_diameter_organic", "tree_support_branch_angle_organic",
      "hole_to_polyhole", "hole_to_polyhole_threshold", "hole_to_polyhole_twisted", "mmu_segmented_region_max_width", "mmu_segmented_region_interlocking_depth",
      "small_area_infill_flow_compensation", "small_area_infill_flow_compensation_model",
+     "inner_wall_interlock",
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold"
 };
 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5019,6 +5019,17 @@ def = this->add("filament_loading_speed", coFloats);
     def->max = 25.0;
     def->set_default_value(new ConfigOptionFloat(0.5));
 
+    def = this->add("inner_wall_interlock", coInt);
+    def->label = L("Internal wall interlock");
+    def->category = L("Strength");
+    def->tooltip = L("Internal perimeter interlock percentage. If non zero, internal perimeters will be shifted inwards by this "
+                     "amount every other layer making cross-section to look like bricklayer pattern");
+    def->min = 0;
+    def->max = 50;
+    def->sidetext = L("%");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionInt(0));
+
     def = this->add("initial_layer_min_bead_width", coPercent);
     def->label = L("First layer minimum wall width");
     def->category = L("Quality");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -842,6 +842,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,              tree_support_branch_angle_organic))
     ((ConfigOptionEnum<GapFillTarget>,gap_fill_target))
     ((ConfigOptionFloat,              min_length_factor))
+    ((ConfigOptionInt,                inner_wall_interlock))
 
     // Move all acceleration and jerk settings to object
     ((ConfigOptionFloat,              default_acceleration))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1109,6 +1109,7 @@ bool PrintObject::invalidate_state_by_config_options(
             steps.emplace_back(posPrepareInfill);
         } else if (
                opt_key == "outer_wall_line_width"
+            || opt_key == "inner_wall_interlock"
             || opt_key == "wall_filament"
             || opt_key == "fuzzy_skin"
             || opt_key == "fuzzy_skin_thickness"

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -766,6 +766,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     toggle_field("seam_slope_min_length", !config->opt_bool("seam_slope_entire_loop"));
     toggle_line("scarf_angle_threshold", has_seam_slope && config->opt_bool("seam_slope_conditional"));
     toggle_line("scarf_overhang_threshold", has_seam_slope && config->opt_bool("seam_slope_conditional"));
+
+    toggle_field("inner_wall_interlock", (config->opt_int("wall_loops") > 1) && have_arachne);
 }
 
 void ConfigManipulation::update_print_sla_config(DynamicPrintConfig* config, const bool is_global_config/* = false*/)

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9717,6 +9717,7 @@ void Plater::calib_max_vol_speed(const Calib_Params& params)
     obj_cfg.set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     obj_cfg.set_key_value("overhang_reverse", new ConfigOptionBool(false));
     obj_cfg.set_key_value("outer_wall_line_width", new ConfigOptionFloatOrPercent(line_width, false));
+    obj_cfg.set_key_value("inner_wall_interlock", new ConfigOptionInt(0));
     obj_cfg.set_key_value("layer_height", new ConfigOptionFloat(layer_height));
     obj_cfg.set_key_value("brim_type", new ConfigOptionEnum<BrimType>(btOuterAndInner));
     obj_cfg.set_key_value("brim_width", new ConfigOptionFloat(5.0));

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2111,6 +2111,7 @@ void TabPrint::build()
         optgroup = page->new_optgroup(L("Walls"), L"param_wall");
         optgroup->append_single_option_line("wall_loops");
         optgroup->append_single_option_line("alternate_extra_wall");
+        optgroup->append_single_option_line("inner_wall_interlock");
         optgroup->append_single_option_line("detect_thin_wall");
 
         optgroup = page->new_optgroup(L("Top/bottom shells"), L"param_shell");


### PR DESCRIPTION
# Description

This PR is a Request For Comments and not intended to me merged as is. Intention is to get community response to see if (a) community is interested in this change and (b) what could be improved in feature design.

Background: I mostly print engineering parts and often use more than 3 walls. Having more than 3 walls I often see 3rd and subsequent walls (counting from outer inwards) may have bad adhesion or even came completely separated while printing vertical walls.

It may look like this:
1. Test cube with no infill, top or bottom layers at 5 perimeters (sliced with OrcaSlicer). 
![PXL_20240503_230754770](https://github.com/SoftFever/OrcaSlicer/assets/46728448/0c0b1db4-4c97-4e4a-bba9-1c4f0dd73ccd)
![PXL_20240503_232911575](https://github.com/SoftFever/OrcaSlicer/assets/46728448/8d23bd68-c244-4487-adc7-2b79804a24c0)
![PXL_20240503_232931415](https://github.com/SoftFever/OrcaSlicer/assets/46728448/78f7fb17-649c-46ec-a078-695f96a058ac)
2. Actual part (sliced with PrusaSlicer)
![PXL_20240224_010905357](https://github.com/SoftFever/OrcaSlicer/assets/46728448/1b16b91f-f7ae-4c77-83ba-1b6b2ba9bbb5)

I tried to fix this by adjusting existing set of parameters, but with no success. My flow rate looks OK since layer fill comes out completely flat with no gaps.

I also heard from colleague who use Cura that he also see this kind of artifacts.

So I've decided to do a patch which makes cross-section of wall layers to look like bricklayer pattern:
![Untitled Diagram drawio(2)](https://github.com/SoftFever/OrcaSlicer/assets/46728448/fee75d5f-1b43-4781-81a5-af39a58967b9)

New parameter called "Outer wall line width variance" is added which defines a difference of outer wall line width for two consecutive layers.

# Screenshots/Recordings/Graphs

Here are cross-section for 5 perimeters printed with 0, 25 and 50 outer wall width variance:
![PXL_20240503_233407005(1)](https://github.com/SoftFever/OrcaSlicer/assets/46728448/2790fc62-7998-4890-a785-a8bbe9c14175)

- 0% variance has distinctive vertical lines formed by gaps between inner walls (2, 3, 4, 5).
- 25% has less distinctive lines
- 50% does not have vertical lines.

Also, setting non-zero variance makes internal wall no longer smooth. That side effect may also increase part strength by making stronger internal fill bond just like "Alternate extra wall" feature, but in this case there are no extra wall added.

# Downside of current implementation

Since two adjacent layers of outside perimeter being squished to a different width, outside wall looks slightly less smooth. Outside dimensions are kept the same though.

# Testing

If you going to try test build, new parameter called "Outer wall width variance" is added to the "Strength" setting page. Enable advanced parameters to see it.
![Screenshot from 2024-05-04 08-41-01](https://github.com/SoftFever/OrcaSlicer/assets/46728448/02c685f4-2cc0-4f9c-9140-53db6d5a5e2e)
