### PR TITLE
Linux - Nvidia specific detection and fixes

### DIFF
--- a/deps/GLFW/GLFW.cmake
+++ b/deps/GLFW/GLFW.cmake
@@ -6,22 +6,15 @@ else()
     set(_build_static ON)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(_glfw_use_wayland "-DGLFW_USE_WAYLAND=ON")
-else()
-    set(_glfw_use_wayland "-DGLFW_USE_WAYLAND=FF")
-endif()
-
 orcaslicer_add_cmake_project(GLFW
-    URL https://github.com/glfw/glfw/archive/refs/tags/3.3.7.zip
-    URL_HASH SHA256=e02d956935e5b9fb4abf90e2c2e07c9a0526d7eacae8ee5353484c69a2a76cd0
+    URL https://github.com/glfw/glfw/archive/refs/tags/3.4.zip
+    URL_HASH SHA256=a133ddc3d3c66143eba9035621db8e0bcf34dba1ee9514a9e23e96afd39fd57a
     #DEPENDS dep_Boost
     CMAKE_ARGS
-        -DBUILD_SHARED_LIBS=${_build_shared} 
+        -DBUILD_SHARED_LIBS=${_build_shared}
         -DGLFW_BUILD_DOCS=OFF
         -DGLFW_BUILD_EXAMPLES=OFF
 	-DGLFW_BUILD_TESTS=OFF
-	${_glfw_use_wayland}
 )
 
 if (MSVC)


### PR DESCRIPTION
# Description

Without these changes, Linux users with a _discrete_ Nvidia GPU can not see the **Home** or **Project** tabs.

In fact attempting to access either of them results in increased CPU utilization and the following output over and over to the console in a loop:

```
AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer
AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer
AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer
AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer
AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer
AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer
AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer
AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer
AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer
AcceleratedSurfaceDMABuf was unable to construct a complete framebuffer
```

With these changes, Orca Slicer can reliably detect which GPU it is being run on and set the appropriate environment variables as needed.

## Tests

Built and tested on Arch Linux on systems with:
* AMD graphics
* Intel **and** Nvidia running in Optimus (aka hybrid mode)
* Intel **and** Nvidia running in discrete mode

In each case the appropriate system was detected and the appropriate settings set.