### PR TITLE
Fix bed mesh algorithm for 3 point bicubic algorightm

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2352,11 +2352,17 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         auto probe_dist_y  = std::max(1., m_config.bed_mesh_probe_distance.value.y());
         int  probe_count_x = std::max(3, (int) std::ceil(mesh_bbox.size().x() / probe_dist_x));
         int  probe_count_y = std::max(3, (int) std::ceil(mesh_bbox.size().y() / probe_dist_y));
-        this->placeholder_parser().set("bed_mesh_probe_count", new ConfigOptionInts({probe_count_x, probe_count_y}));
         auto bed_mesh_algo = "bicubic";
-        if (probe_count_x < 4 || probe_count_y < 4) {
+        int min_points = 4; // bicubic needs 4 probe points per axis
+        if (probe_count_x + probe_count_y <= 6) { // lagrange needs up to a total of 6 mesh points
             bed_mesh_algo = "lagrange";
+            min_points = 3;
         }
+        if(print.config().gcode_flavor == gcfKlipper){
+            probe_count_x = std::max(probe_count_x,min_points);
+            probe_count_y = std::max(probe_count_y,min_points);
+        }
+        this->placeholder_parser().set("bed_mesh_probe_count", new ConfigOptionInts({probe_count_x, probe_count_y}));
         this->placeholder_parser().set("bed_mesh_algo", bed_mesh_algo);
         // get center without wipe tower
         BoundingBoxf bbox_wo_wt; // bounding box without wipe tower

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2354,7 +2354,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         int  probe_count_y = std::max(3, (int) std::ceil(mesh_bbox.size().y() / probe_dist_y));
         auto bed_mesh_algo = "bicubic";
         int min_points = 4; // bicubic needs 4 probe points per axis
-        if (probe_count_x * probe_count_y <= 6) { // lagrange needs up to a total of 6 mesh points
+        if (std::max(probe_count_x, probe_count_y) <= 6) { // lagrange needs up to a total of 6 mesh points
             bed_mesh_algo = "lagrange";
             min_points = 3;
         }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2354,7 +2354,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         int  probe_count_y = std::max(3, (int) std::ceil(mesh_bbox.size().y() / probe_dist_y));
         auto bed_mesh_algo = "bicubic";
         int min_points = 4; // bicubic needs 4 probe points per axis
-        if (probe_count_x + probe_count_y <= 6) { // lagrange needs up to a total of 6 mesh points
+        if (probe_count_x * probe_count_y <= 6) { // lagrange needs up to a total of 6 mesh points
             bed_mesh_algo = "lagrange";
             min_points = 3;
         }

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2353,15 +2353,15 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         int  probe_count_x = std::max(3, (int) std::ceil(mesh_bbox.size().x() / probe_dist_x));
         int  probe_count_y = std::max(3, (int) std::ceil(mesh_bbox.size().y() / probe_dist_y));
         auto bed_mesh_algo = "bicubic";
-        int min_points = 4; // bicubic needs 4 probe points per axis
-        if (std::max(probe_count_x, probe_count_y) <= 6) { // lagrange needs up to a total of 6 mesh points
+        if (probe_count_x * probe_count_y <= 6) { // lagrange needs up to a total of 6 mesh points
             bed_mesh_algo = "lagrange";
-            min_points = 3;
         }
-        if(print.config().gcode_flavor == gcfKlipper){
-            probe_count_x = std::max(probe_count_x,min_points);
-            probe_count_y = std::max(probe_count_y,min_points);
-        }
+        else
+            if(print.config().gcode_flavor == gcfKlipper){
+              // bicubic needs 4 probe points per axis
+              probe_count_x = std::max(probe_count_x,4);
+              probe_count_y = std::max(probe_count_y,4);
+            }
         this->placeholder_parser().set("bed_mesh_probe_count", new ConfigOptionInts({probe_count_x, probe_count_y}));
         this->placeholder_parser().set("bed_mesh_algo", bed_mesh_algo);
         // get center without wipe tower

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1015,7 +1015,7 @@ wxWindow* PreferencesDialog::create_general_page()
     std::vector<wxString> Regions         = {_L("Asia-Pacific"), _L("China"), _L("Europe"), _L("North America"), _L("Others")};
     auto                  item_region= create_item_region_combobox(_L("Login Region"), page, _L("Login Region"), Regions);
 
-    auto item_stealth_mode = create_item_checkbox(_L("Stealth Mode"), page, _L("Stealth Mode"), 50, "stealth_mode");
+    auto item_stealth_mode = create_item_checkbox(_L("Stealth Mode"), page, _L("This stops the transmission of data to Bambu's cloud services. Users who don't use BBL machines or use LAN mode only can safely turn on this function."), 50, "stealth_mode");
     auto item_enable_plugin = create_item_checkbox(_L("Enable network plugin"), page, _L("Enable network plugin"), 50, "installed_networking");
     auto item_check_stable_version_only = create_item_checkbox(_L("Check for stable updates only"), page, _L("Check for stable updates only"), 50, "check_stable_update_only");
 


### PR DESCRIPTION
# Description
Fixes #4875, #4694 

Checks the below conditions for Klipper firmware:
1. If the total number of mesh points is 6 -> use Lagrange interpolation
2. If the total number of mesh points is greater than 6, use Bicubic
3. If bicubic is used, ensure that at least 4 points are present in both X and Y. 

This appears consistent with the Klipper documentation below and the KAMP implementation.

algorithm: lagrange
Default Value: lagrange
The algorithm used to interpolate the mesh. May be lagrange or bicubic. **Lagrange interpolation is capped at 6 probed points** as oscillation tends to occur with a larger number of samples. **Bicubic interpolation requires a minimum of 4 probed points along each axis**, if less than 4 points are specified then lagrange sampling is forced. If mesh_pps is set to 0 then this value is ignored as no mesh interpolation is done.