### PR TITLE
Creality Sermoon V1 - added generic filaments and machine settings

### DIFF
--- a/resources/profiles/Creality/filament/Creality Generic ABS.json
+++ b/resources/profiles/Creality/filament/Creality Generic ABS.json
@@ -19,6 +19,7 @@
 		"Creality CR-6 Max 0.4 nozzle",
 		"Creality CR-6 Max 0.6 nozzle",
 		"Creality CR-6 Max 0.8 nozzle",
+		"Creality Sermoon V1 0.4 nozzle",
 		"Creality Ender-3 0.2 nozzle",
 		"Creality Ender-3 0.4 nozzle",
 		"Creality Ender-3 0.6 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PETG.json
+++ b/resources/profiles/Creality/filament/Creality Generic PETG.json
@@ -29,6 +29,7 @@
 		"Creality CR-6 Max 0.4 nozzle",
 		"Creality CR-6 Max 0.6 nozzle",
 		"Creality CR-6 Max 0.8 nozzle",
+		"Creality Sermoon V1 0.4 nozzle",
 		"Creality Ender-3 0.2 nozzle",
 		"Creality Ender-3 0.4 nozzle",
 		"Creality Ender-3 0.6 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA.json
@@ -20,6 +20,7 @@
 		"Creality CR-6 Max 0.4 nozzle",
 		"Creality CR-6 Max 0.6 nozzle",
 		"Creality CR-6 Max 0.8 nozzle",
+		"Creality Sermoon V1 0.4 nozzle",
 		"Creality Ender-3 0.2 nozzle",
 		"Creality Ender-3 0.4 nozzle",
 		"Creality Ender-3 0.6 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic TPU.json
+++ b/resources/profiles/Creality/filament/Creality Generic TPU.json
@@ -16,6 +16,7 @@
         "Creality K1 Max (0.4 nozzle)",
         "Creality K1 Max (0.6 nozzle)",
         "Creality K1 Max (0.8 nozzle)",
+	"Creality Sermoon V1 0.4 nozzle",
         "Creality CR-10 SE 0.2 nozzle",
 		"Creality CR-10 SE 0.4 nozzle",
 		"Creality CR-10 SE 0.6 nozzle",

--- a/resources/profiles/Creality/machine/Creality Sermoon V1 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Sermoon V1 0.4 nozzle.json
@@ -63,6 +63,9 @@
     "64x64",
     "400x400"
   ],
+  "extruder_clearance_height_to_lid": "125",
+  "extruder_clearance_height_to_rod": "40",
+  "extruder_clearance_radius": "50",
   "printable_height": "165",
   "change_filament_gcode": "; S1 Pause For Filament change\nM125",
   "nozzle_type": "brass",

--- a/resources/profiles/Creality/machine/Creality Sermoon V1 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Sermoon V1 0.4 nozzle.json
@@ -60,11 +60,11 @@
   "print_host_webui": "10.0.0.51",
   "gcode_flavor": "marlin",
   "thumbnails": [
-    "32x32",
+    "64x64",
     "400x400"
   ],
   "printable_height": "165",
   "change_filament_gcode": "; S1 Pause For Filament change\nM125",
-  "nozzle_type": "undefine",
+  "nozzle_type": "brass",
   "auxiliary_fan": "1"
 }

--- a/resources/profiles/Creality/machine/Creality Sermoon V1.json
+++ b/resources/profiles/Creality/machine/Creality Sermoon V1.json
@@ -11,5 +11,5 @@
       "Spiral Lift"
     ],
     "hotend_model": "",
-    "default_materials": "Creality Generic PLA;Creality Generic PETG;Creality Generic ABS"
+    "default_materials": "Creality Generic PLA;Creality Generic PETG;Creality Generic ABS;Creality Generic TPU"
 }


### PR DESCRIPTION
Description - Creality Sermoon V1 - added generic filaments and machine settings

Added Creality Generic PLA, TPU, ABS and PETG.  Updated the thumbnail size from 32x32 to 64x64.  Added initial extruder clearance values.  Set to brass nozzle type.