### PR TITLE
SEMM: Introduced parameter to control the maximum speed used for purging in the purge tower

### DIFF
--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -551,7 +551,7 @@ WipeTower2::WipeTower2(const PrintConfig& config, const PrintRegionConfig& defau
     m_perimeter_speed(default_region_config.inner_wall_speed),
     m_current_tool(initial_tool),
     wipe_volumes(wiping_matrix),
-    m_wipe_tower_max_purge_speed(float(config.wipe_tower_max_purge_speed)*60.f)
+    m_wipe_tower_max_purge_speed(float(config.wipe_tower_max_purge_speed))
 {
     // Read absolute value of first layer speed, if given as percentage,
     // it is taken over following default. Speeds from config are not
@@ -1100,7 +1100,7 @@ void WipeTower2::toolchange_Wipe(
     // All the calculations in all other places take the spacing into account for all the layers.
 
 	// If spare layers are excluded->if 1 or less toolchange has been done, it must be sill the first layer, too.So slow down.
-    const float target_speed = is_first_layer() || (m_num_tool_changes <= 1 && m_no_sparse_layers) ? m_first_layer_speed * 60.f : std::min(m_wipe_tower_max_purge_speed, m_infill_speed * 60.f);
+    const float target_speed = is_first_layer() || (m_num_tool_changes <= 1 && m_no_sparse_layers) ? m_first_layer_speed * 60.f : std::min(m_wipe_tower_max_purge_speed * 60.f, m_infill_speed * 60.f);
     float wipe_speed = 0.33f * target_speed;
 
     // if there is less than 2.5*m_perimeter_width to the edge, advance straightaway (there is likely a blob anyway)

--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -550,7 +550,8 @@ WipeTower2::WipeTower2(const PrintConfig& config, const PrintRegionConfig& defau
     m_infill_speed(default_region_config.sparse_infill_speed),
     m_perimeter_speed(default_region_config.inner_wall_speed),
     m_current_tool(initial_tool),
-    wipe_volumes(wiping_matrix)
+    wipe_volumes(wiping_matrix),
+    m_wipe_tower_max_purge_speed(float(config.wipe_tower_max_purge_speed)*60.f)
 {
     // Read absolute value of first layer speed, if given as percentage,
     // it is taken over following default. Speeds from config are not
@@ -1099,7 +1100,7 @@ void WipeTower2::toolchange_Wipe(
     // All the calculations in all other places take the spacing into account for all the layers.
 
 	// If spare layers are excluded->if 1 or less toolchange has been done, it must be sill the first layer, too.So slow down.
-    const float target_speed = is_first_layer() || (m_num_tool_changes <= 1 && m_no_sparse_layers) ? m_first_layer_speed * 60.f : std::min(5400.f, m_infill_speed * 60.f);
+    const float target_speed = is_first_layer() || (m_num_tool_changes <= 1 && m_no_sparse_layers) ? m_first_layer_speed * 60.f : std::min(m_wipe_tower_max_purge_speed, m_infill_speed * 60.f);
     float wipe_speed = 0.33f * target_speed;
 
     // if there is less than 2.5*m_perimeter_width to the edge, advance straightaway (there is likely a blob anyway)

--- a/src/libslic3r/GCode/WipeTower2.hpp
+++ b/src/libslic3r/GCode/WipeTower2.hpp
@@ -189,6 +189,7 @@ private:
     int    m_old_temperature    = -1;   // To keep track of what was the last temp that we set (so we don't issue the command when not neccessary)
     float  m_travel_speed       = 0.f;
 	float  m_infill_speed       = 0.f;
+    float  m_wipe_tower_max_purge_speed   = 90.f;
 	float  m_perimeter_speed    = 0.f;
     float  m_first_layer_speed  = 0.f;
     size_t m_first_layer_idx    = size_t(-1);

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -816,7 +816,7 @@ static std::vector<std::string> s_Preset_print_options {
      "tree_support_brim_width", "gcode_comments", "gcode_label_objects",
      "initial_layer_travel_speed", "exclude_object", "slow_down_layers", "infill_anchor", "infill_anchor_max","initial_layer_min_bead_width",
      "make_overhang_printable", "make_overhang_printable_angle", "make_overhang_printable_hole_size" ,"notes",
-     "wipe_tower_cone_angle", "wipe_tower_extra_spacing", "wipe_tower_extruder", "wiping_volumes_extruders","wipe_tower_bridging", "single_extruder_multi_material_priming",
+     "wipe_tower_cone_angle", "wipe_tower_extra_spacing","wipe_tower_max_purge_speed", "wipe_tower_extruder", "wiping_volumes_extruders","wipe_tower_bridging", "single_extruder_multi_material_priming",
      "wipe_tower_rotation_angle", "tree_support_branch_distance_organic", "tree_support_branch_diameter_organic", "tree_support_branch_angle_organic",
      "hole_to_polyhole", "hole_to_polyhole_threshold", "hole_to_polyhole_twisted", "mmu_segmented_region_max_width", "mmu_segmented_region_interlocking_depth",
      "small_area_infill_flow_compensation", "small_area_infill_flow_compensation_model",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -304,6 +304,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "slow_down_layers"
             || opt_key == "wipe_tower_cone_angle"
             || opt_key == "wipe_tower_extra_spacing"
+            || opt_key == "wipe_tower_max_purge_speed"
             || opt_key == "wipe_tower_extruder"
             || opt_key == "wiping_volumes_extruders"
             || opt_key == "enable_filament_ramming"

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4758,14 +4758,14 @@ def = this->add("filament_loading_speed", coFloats);
     def->max = 300.;
     def->set_default_value(new ConfigOptionPercent(100.));
     
-    def = this->add("wipe_tower_max_purge_speed", coInt);
+    def = this->add("wipe_tower_max_purge_speed", coFloat);
     def->label = L("Maximum purge print speed");
     def->tooltip = L("The maximum print speed when purging in the wipe tower. If the sparse infill speed"
                      " or calculated speed from the filament volumetric flow rate is lower, those speeds will be used instead.");
     def->sidetext = L("mm/s");
     def->mode = comAdvanced;
     def->min = 10;
-    def->set_default_value(new ConfigOptionInt(90));
+    def->set_default_value(new ConfigOptionFloat(90.));
 
     def = this->add("wipe_tower_extruder", coInt);
     def->label = L("Wipe tower extruder");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4757,6 +4757,15 @@ def = this->add("filament_loading_speed", coFloats);
     def->min = 100.;
     def->max = 300.;
     def->set_default_value(new ConfigOptionPercent(100.));
+    
+    def = this->add("wipe_tower_max_purge_speed", coInt);
+    def->label = L("Maximum purge print speed");
+    def->tooltip = L("The maximum print speed when purging in the wipe tower. If the sparse infill speed"
+                     " or calculated speed from the filament volumetric flow rate is lower, those speeds will be used instead.");
+    def->sidetext = L("mm/s");
+    def->mode = comAdvanced;
+    def->min = 10;
+    def->set_default_value(new ConfigOptionInt(90));
 
     def = this->add("wipe_tower_extruder", coInt);
     def->label = L("Wipe tower extruder");

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4760,8 +4760,11 @@ def = this->add("filament_loading_speed", coFloats);
     
     def = this->add("wipe_tower_max_purge_speed", coFloat);
     def->label = L("Maximum purge print speed");
-    def->tooltip = L("The maximum print speed when purging in the wipe tower. If the sparse infill speed"
-                     " or calculated speed from the filament max volumetric speed is lower, the lowest speed will be used instead.");
+    def->tooltip = L("The maximum print speed when purging in the wipe tower. If the sparse infill speed "
+                     "or calculated speed from the filament max volumetric speed is lower, the lowest speed will be used instead.\n"
+                     "Increasing this speed may affect the tower's stability, as purging can be performed over "
+                     "sparse layers. Before increasing this parameter beyond the default of 90mm/sec, make sure your printer can reliably "
+                     "bridge at the increased speeds.");
     def->sidetext = L("mm/s");
     def->mode = comAdvanced;
     def->min = 10;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4761,7 +4761,7 @@ def = this->add("filament_loading_speed", coFloats);
     def = this->add("wipe_tower_max_purge_speed", coFloat);
     def->label = L("Maximum purge print speed");
     def->tooltip = L("The maximum print speed when purging in the wipe tower. If the sparse infill speed"
-                     " or calculated speed from the filament volumetric flow rate is lower, those speeds will be used instead.");
+                     " or calculated speed from the filament max volumetric speed is lower, the lowest speed will be used instead.");
     def->sidetext = L("mm/s");
     def->mode = comAdvanced;
     def->min = 10;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4759,7 +4759,7 @@ def = this->add("filament_loading_speed", coFloats);
     def->set_default_value(new ConfigOptionPercent(100.));
     
     def = this->add("wipe_tower_max_purge_speed", coFloat);
-    def->label = L("Maximum purge print speed");
+    def->label = L("Maximum print speed when purging");
     def->tooltip = L("The maximum print speed when purging in the wipe tower. If the sparse infill speed "
                      "or calculated speed from the filament max volumetric speed is lower, the lowest speed will be used instead.\n"
                      "Increasing this speed may affect the tower's stability, as purging can be performed over "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1240,6 +1240,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     // Orca: mmu support
     ((ConfigOptionFloat,              wipe_tower_cone_angle))
     ((ConfigOptionPercent,            wipe_tower_extra_spacing))
+    ((ConfigOptionInt,                wipe_tower_max_purge_speed))
     ((ConfigOptionInt,                wipe_tower_extruder))
     ((ConfigOptionFloats,             wiping_volumes_extruders))
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1240,7 +1240,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     // Orca: mmu support
     ((ConfigOptionFloat,              wipe_tower_cone_angle))
     ((ConfigOptionPercent,            wipe_tower_extra_spacing))
-    ((ConfigOptionInt,                wipe_tower_max_purge_speed))
+    ((ConfigOptionFloat,                wipe_tower_max_purge_speed))
     ((ConfigOptionInt,                wipe_tower_extruder))
     ((ConfigOptionFloats,             wiping_volumes_extruders))
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -678,7 +678,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     
     bool purge_in_primetower = preset_bundle->printers.get_edited_preset().config.opt_bool("purge_in_prime_tower");
     
-    for (auto el : {"wipe_tower_rotation_angle", "wipe_tower_cone_angle", "wipe_tower_extra_spacing", "wipe_tower_bridging", "wipe_tower_no_sparse_layers"})
+    for (auto el : {"wipe_tower_rotation_angle", "wipe_tower_cone_angle", "wipe_tower_extra_spacing", "wipe_tower_max_purge_speed", "wipe_tower_bridging", "wipe_tower_no_sparse_layers"})
         toggle_line(el, have_prime_tower && purge_in_primetower);
     
     toggle_line("prime_volume",have_prime_tower && !purge_in_primetower);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2706,7 +2706,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
         "brim_width", "wall_loops", "wall_filament", "sparse_infill_density", "sparse_infill_filament", "top_shell_layers",
         "enable_support", "support_filament", "support_interface_filament",
         "support_top_z_distance", "support_bottom_z_distance", "raft_layers",
-        "wipe_tower_rotation_angle", "wipe_tower_cone_angle", "wipe_tower_extra_spacing", "wipe_tower_extruder",
+        "wipe_tower_rotation_angle", "wipe_tower_cone_angle", "wipe_tower_extra_spacing","wipe_tower_max_purge_speed", "wipe_tower_extruder",
         "best_object_pos"
         }))
     , sidebar(new Sidebar(q))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2283,6 +2283,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("wipe_tower_bridging");
         optgroup->append_single_option_line("wipe_tower_cone_angle");
         optgroup->append_single_option_line("wipe_tower_extra_spacing");
+        optgroup->append_single_option_line("wipe_tower_max_purge_speed");
         optgroup->append_single_option_line("wipe_tower_no_sparse_layers");
         // optgroup->append_single_option_line("single_extruder_multi_material_priming");
 


### PR DESCRIPTION
# Description

This PR aims to address the static coded nature of the maximum speed used for purging in the purge tower. Currently the speed limit is set to 90mm/sec which works well; however speed gains can be made by increasing this if the printer is able to bridge at higher speeds in the wipe tower.

This PR introduces a max speed limit for the purge tower. The existing, as is limits of volumetric flow for the filament and sparse infill speeds are respected. Same for the ramping up of purge speed up to the limit.

**Before:**
![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/369693d1-eea5-4da3-827a-98cbd9914f45)
![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/c30597d8-4cdc-4193-a244-7146486cdbb4)

**After:**
![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/366e25a3-b458-47a0-9a26-f5463e1104e2)
![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/8cb8ff4f-0898-418d-ac4d-85de7728bcfe)


## Tests

Tested on my V2.4 350 with ERCF successfully with 150mm/sec with no adverse effect on the prime tower stability, while saving a considerable amount of time from the print - in the example above around 4 hours...!

Regression test: Confirmed that option is not visible on BBL printers (X1C profile).
