### PR TITLE
Add "Add Models" to plate and background context menu

### DIFF
--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1241,8 +1241,7 @@ void MenuFactory::create_default_menu()
         []() {return true; }, m_parent);
     append_submenu(&m_default_menu, sub_menu_handy, wxID_ANY, _L("Add Handy models"), "", "menu_add_part",
         []() {return true; }, m_parent);
-    // ORCA: Add Model
-    append_menu_item(&m_default_menu, wxID_ANY, _L("Add Model"), "",
+    append_menu_item(&m_default_menu, wxID_ANY, _L("Add Models"), "", // ORCA: Add Models
         [](wxCommandEvent&) { plater()->add_file(); }, "menu_add_part", &m_default_menu,
         []() {return wxGetApp().plater()->can_add_model(); }, m_parent);
 #else
@@ -1250,8 +1249,7 @@ void MenuFactory::create_default_menu()
         []() {return true; }, m_parent);
     append_submenu(&m_default_menu, sub_menu_handy, wxID_ANY, _L("Add Handy models"), "", "",
         []() {return true; }, m_parent);
-    // ORCA: Add Model
-    append_menu_item(&m_default_menu, wxID_ANY, _L("Add Model"), "",
+    append_menu_item(&m_default_menu, wxID_ANY, _L("Add Models"), "", // ORCA: Add Models
         [](wxCommandEvent&) { plater()->add_file(); }, "", &m_default_menu,
         []() {return wxGetApp().plater()->can_add_model(); }, m_parent);
 #endif
@@ -1555,8 +1553,7 @@ void MenuFactory::create_plate_menu()
         []() {return true; }, m_parent);
     append_submenu(menu, sub_menu_handy, wxID_ANY, _L("Add Handy models"), "", "menu_add_part",
         []() {return true; }, m_parent);
-    // ORCA: Add Model
-    append_menu_item(menu, wxID_ANY, _L("Add Model"), "",
+    append_menu_item(menu, wxID_ANY, _L("Add Models"), "", // ORCA: Add Models
         [](wxCommandEvent&) { plater()->add_file(); }, "menu_add_part", menu,
         []() {return wxGetApp().plater()->can_add_model(); }, m_parent);
 #else
@@ -1564,8 +1561,7 @@ void MenuFactory::create_plate_menu()
         []() {return true; }, m_parent);
     append_submenu(menu, sub_menu_handy, wxID_ANY, _L("Add Handy models"), "", "",
         []() {return true; }, m_parent);
-    // ORCA: Add Model
-    append_menu_item(menu, wxID_ANY, _L("Add Model"), "",
+    append_menu_item(menu, wxID_ANY, _L("Add Models"), "", // ORCA: Add Models
         [](wxCommandEvent&) { plater()->add_file(); }, "", menu,
         []() {return wxGetApp().plater()->can_add_model(); }, m_parent);
 #endif

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1252,7 +1252,7 @@ void MenuFactory::create_default_menu()
         []() {return true; }, m_parent);
     // ORCA: Add Model
     append_menu_item(&m_default_menu, wxID_ANY, _L("Add Model"), "",
-        [](wxCommandEvent&) { plater()->add_file(); }, "menu_add_part", &m_default_menu,
+        [](wxCommandEvent&) { plater()->add_file(); }, "", &m_default_menu,
         []() {return wxGetApp().plater()->can_add_model(); }, m_parent);
 #endif
 
@@ -1558,7 +1558,7 @@ void MenuFactory::create_plate_menu()
     // ORCA: Add Model
     append_menu_item(menu, wxID_ANY, _L("Add Model"), "",
         [](wxCommandEvent&) { plater()->add_file(); }, "menu_add_part", menu,
-        []() {  return wxGetApp().plater()->can_add_model(); }, m_parent);
+        []() {return wxGetApp().plater()->can_add_model(); }, m_parent);
 #else
     append_submenu(menu, sub_menu_primitives, wxID_ANY, _L("Add Primitive"), "", "",
         []() {return true; }, m_parent);
@@ -1567,7 +1567,7 @@ void MenuFactory::create_plate_menu()
     // ORCA: Add Model
     append_menu_item(menu, wxID_ANY, _L("Add Model"), "",
         [](wxCommandEvent&) { plater()->add_file(); }, "", menu,
-        []() {  return wxGetApp().plater()->can_add_model(); }, m_parent);
+        []() {return wxGetApp().plater()->can_add_model(); }, m_parent);
 #endif
 
 

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -1241,11 +1241,19 @@ void MenuFactory::create_default_menu()
         []() {return true; }, m_parent);
     append_submenu(&m_default_menu, sub_menu_handy, wxID_ANY, _L("Add Handy models"), "", "menu_add_part",
         []() {return true; }, m_parent);
+    // ORCA: Add Model
+    append_menu_item(&m_default_menu, wxID_ANY, _L("Add Model"), "",
+        [](wxCommandEvent&) { plater()->add_file(); }, "menu_add_part", &m_default_menu,
+        []() {return wxGetApp().plater()->can_add_model(); }, m_parent);
 #else
     append_submenu(&m_default_menu, sub_menu_primitives, wxID_ANY, _L("Add Primitive"), "", "",
         []() {return true; }, m_parent);
     append_submenu(&m_default_menu, sub_menu_handy, wxID_ANY, _L("Add Handy models"), "", "",
         []() {return true; }, m_parent);
+    // ORCA: Add Model
+    append_menu_item(&m_default_menu, wxID_ANY, _L("Add Model"), "",
+        [](wxCommandEvent&) { plater()->add_file(); }, "menu_add_part", &m_default_menu,
+        []() {return wxGetApp().plater()->can_add_model(); }, m_parent);
 #endif
 
     m_default_menu.AppendSeparator();
@@ -1547,11 +1555,19 @@ void MenuFactory::create_plate_menu()
         []() {return true; }, m_parent);
     append_submenu(menu, sub_menu_handy, wxID_ANY, _L("Add Handy models"), "", "menu_add_part",
         []() {return true; }, m_parent);
+    // ORCA: Add Model
+    append_menu_item(menu, wxID_ANY, _L("Add Model"), "",
+        [](wxCommandEvent&) { plater()->add_file(); }, "menu_add_part", menu,
+        []() {  return wxGetApp().plater()->can_add_model(); }, m_parent);
 #else
     append_submenu(menu, sub_menu_primitives, wxID_ANY, _L("Add Primitive"), "", "",
         []() {return true; }, m_parent);
     append_submenu(menu, sub_menu_handy, wxID_ANY, _L("Add Handy models"), "", "",
         []() {return true; }, m_parent);
+    // ORCA: Add Model
+    append_menu_item(menu, wxID_ANY, _L("Add Model"), "",
+        [](wxCommandEvent&) { plater()->add_file(); }, "", menu,
+        []() {  return wxGetApp().plater()->can_add_model(); }, m_parent);
 #endif
 
 


### PR DESCRIPTION
Adds "Add Model" item for plate and background context menus

• One of the most used functions like arrange, split or etc. they are already exist on toolbar and context menu
• Knowing add / import function on context menu is useful and adds a alternative way to import model
• you don't have to move mouse to toolbar. reduces mouse movements
• I'm sure many people will found useful. especially people that came from cura. I'm still searching this item on context menu
• I added menu item to end of menu to keep same order otherwise old users will click to "add model" every time instead "add primitive"
• "Add models" already exist in translations. Does not require additional translations

![Screenshot-20240515034827](https://github.com/SoftFever/OrcaSlicer/assets/28517890/2e42ba4c-30fe-4a2b-ad3c-ab8a53d7ecf1)
![Screenshot-20240515034812](https://github.com/SoftFever/OrcaSlicer/assets/28517890/5bc39dfa-cee8-4e32-83b6-1fe8ce72a595)



Code can be shorter if it was used like this

```
#ifdef __WINDOWS__
    auto add_icon = "menu_add_part"
#else
    auto add_icon = ""
#endif
append_submenu(menu, sub_menu_primitives, wxID_ANY, _L("Add Primitive"), "", add_icon,
    []() {return true; }, m_parent);
append_submenu(menu, sub_menu_handy, wxID_ANY, _L("Add Handy models"), "", add_icon,
    []() {return true; }, m_parent);
// ORCA: Add Model
append_menu_item(menu, wxID_ANY, _L("Add Model"), "",
    [](wxCommandEvent&) { plater()->add_file(); }, add_icon, menu,
    []() {  return wxGetApp().plater()->can_add_model(); }, m_parent);
```