### PR TITLE
Add spacing between icons of objects list item if it has multiple icons

### DIFF
--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -558,17 +558,19 @@ void ObjectDataViewModel::UpdateBitmapForNode(ObjectDataViewModelNode *node)
         std::vector<wxBitmap> bmps;
         if (node->has_warning_icon())
             bmps.emplace_back(node->warning_icon_name() == WarningIcon ? m_warning_bmp : m_warning_manifold_bmp);
-        if (node->has_warning_icon() && node->has_lock()) // ORCA: Add spacing between icons if there are multiple
-            bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));
-        if (node->has_lock())
+        if (node->has_lock()) {
+            if (!bmps.empty()) // ORCA: Add spacing between icons if there are multiple
+                bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));
             bmps.emplace_back(m_lock_bmp);
-        if (is_volume_node && (node->has_lock() || node->has_warning_icon())) // ORCA: Add spacing between icons if there are multiple
-            bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));
-        if (is_volume_node)
+        }
+        if (is_volume_node) {
+            if (!bmps.empty()) // ORCA: Add spacing between icons if there are multiple
+                bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));
             bmps.emplace_back(
                 node->is_text_volume() ? m_text_volume_bmps[vol_type] :
                 node->is_svg_volume() ? m_svg_volume_bmps[vol_type] : 
                 m_volume_bmps[vol_type]);
+        }
         bmp = m_bitmap_cache->insert(scaled_bitmap_name, bmps);
     }
 

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -558,13 +558,11 @@ void ObjectDataViewModel::UpdateBitmapForNode(ObjectDataViewModelNode *node)
         std::vector<wxBitmap> bmps;
         if (node->has_warning_icon())
             bmps.emplace_back(node->warning_icon_name() == WarningIcon ? m_warning_bmp : m_warning_manifold_bmp);
-        // ORCA: Add spacing between icons if there are multiple // Condition > Cut/Connector and Warning
-        if (node->has_warning_icon() && node->has_lock())
+        if (node->has_warning_icon() && node->has_lock()) // ORCA: Add spacing between icons if there are multiple
             bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));
         if (node->has_lock())
             bmps.emplace_back(m_lock_bmp);
-        // ORCA: Add spacing between icons if there are multiple // Condition > (Cut/Connector and Volume) or (Warning and Volume)
-        if ((node->has_lock() && is_volume_node) || (node->has_warning_icon() && is_volume_node))
+        if (is_volume_node && (node->has_lock() || node->has_warning_icon())) // ORCA: Add spacing between icons if there are multiple
             bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));
         if (is_volume_node)
             bmps.emplace_back(

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -558,8 +558,12 @@ void ObjectDataViewModel::UpdateBitmapForNode(ObjectDataViewModelNode *node)
         std::vector<wxBitmap> bmps;
         if (node->has_warning_icon())
             bmps.emplace_back(node->warning_icon_name() == WarningIcon ? m_warning_bmp : m_warning_manifold_bmp);
+        if (node->has_warning_icon() && node->has_lock()) // ORCA: Condition > Cut/Connector and Warning // Add spacing between icons if there are multiple
+            bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));	
         if (node->has_lock())
             bmps.emplace_back(m_lock_bmp);
+        if (node->has_lock() && is_volume_node || node->has_warning_icon() && is_volume_node) // ORCA: Condition > Cut/Connector and Volume or Warning and Volume // Add spacing between icons if there are multiple
+            bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));
         if (is_volume_node)
             bmps.emplace_back(
                 node->is_text_volume() ? m_text_volume_bmps[vol_type] :

--- a/src/slic3r/GUI/ObjectDataViewModel.cpp
+++ b/src/slic3r/GUI/ObjectDataViewModel.cpp
@@ -558,11 +558,13 @@ void ObjectDataViewModel::UpdateBitmapForNode(ObjectDataViewModelNode *node)
         std::vector<wxBitmap> bmps;
         if (node->has_warning_icon())
             bmps.emplace_back(node->warning_icon_name() == WarningIcon ? m_warning_bmp : m_warning_manifold_bmp);
-        if (node->has_warning_icon() && node->has_lock()) // ORCA: Condition > Cut/Connector and Warning // Add spacing between icons if there are multiple
-            bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));	
+        // ORCA: Add spacing between icons if there are multiple // Condition > Cut/Connector and Warning
+        if (node->has_warning_icon() && node->has_lock())
+            bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));
         if (node->has_lock())
             bmps.emplace_back(m_lock_bmp);
-        if (node->has_lock() && is_volume_node || node->has_warning_icon() && is_volume_node) // ORCA: Condition > Cut/Connector and Volume or Warning and Volume // Add spacing between icons if there are multiple
+        // ORCA: Add spacing between icons if there are multiple // Condition > (Cut/Connector and Volume) or (Warning and Volume)
+        if ((node->has_lock() && is_volume_node) || (node->has_warning_icon() && is_volume_node))
             bmps.emplace_back(create_scaled_bitmap("dot", nullptr, int(wxGetApp().em_unit() / 10) * 4));
         if (is_volume_node)
             bmps.emplace_back(


### PR DESCRIPTION
New vs Old
![Screenshot-20240510060352](https://github.com/SoftFever/OrcaSlicer/assets/28517890/baff49f8-4009-422e-a112-ef0dda272912)

• used font size for spacing width. this also gives better result for scaling

how to get all 3 icons for same list item
• Pick a step file or use a model with open mesh
• Use cut and add connector then perform cut. ignore dialog for fix

Another scenario for multiple icons
• Add a cube
• Add a modifier
• Cut with pins
![Screenshot-20240510192034](https://github.com/SoftFever/OrcaSlicer/assets/28517890/00688b1f-a012-44fd-9eab-23e0c6aebec7)

I'm sure there are many other combinations for multiple icons with / without cut

Also found this minor bug
• Scaling not works on that icons on original source if scaling changes while orca running