### PR TITLE
RatRig machines which use Klipper don't use M601 but "PAUSE" for paus…

### DIFF
--- a/resources/profiles/Ratrig/machine/fdm_klipper_common.json
+++ b/resources/profiles/Ratrig/machine/fdm_klipper_common.json
@@ -45,7 +45,7 @@
   "silent_mode": "0",
   "single_extruder_multi_material": "1",
   "change_filament_gcode": "M600",
-  "machine_pause_gcode": "M601",
+  "machine_pause_gcode": "PAUSE",
   "wipe": ["1"],
   "default_filament_profile": ["RatRig Generic ABS"],
   "default_print_profile": "0.20mm Standard @RatRig",


### PR DESCRIPTION
…e command

RatRig machines which use Klipper don't use M601 but "PAUSE" for pause command

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
