### PR TITLE
Disabled Arc fitting for all Creality models that had it enabled

### DIFF
--- a/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3 0.4 nozzle.json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3KE.json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality Ender3V3KE.json
@@ -24,7 +24,6 @@
 	"bridge_no_support": "0",
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.1",
-	"enable_arc_fitting": "1",
 	"outer_wall_line_width": "0.42",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.42",

--- a/resources/profiles/Creality/process/0.12mm Fine @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality K1 (0.4 nozzle).json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.12mm Fine @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality K1C 0.4 nozzle.json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.12mm Fine @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.12mm Fine @Creality K1Max (0.4 nozzle).json
@@ -22,7 +22,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3 0.4 nozzle.json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3KE.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality Ender3V3KE.json
@@ -24,7 +24,6 @@
 	"bridge_no_support": "0",
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.1",
-	"enable_arc_fitting": "1",
 	"outer_wall_line_width": "0.42",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.42",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1 (0.4 nozzle).json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1C 0.4 nozzle.json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K1Max (0.4 nozzle).json
@@ -22,7 +22,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3 0.4 nozzle.json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3KE.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality Ender3V3KE.json
@@ -24,7 +24,6 @@
 	"bridge_no_support": "0",
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.1",
-	"enable_arc_fitting": "1",
 	"outer_wall_line_width": "0.42",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.42",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1 (0.4 nozzle).json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1C 0.4 nozzle.json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K1Max (0.4 nozzle).json
@@ -22,7 +22,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3 0.4 nozzle.json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3KE.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality Ender3V3KE.json
@@ -24,7 +24,6 @@
 	"bridge_no_support": "0",
 	"draft_shield": "disabled",
 	"elefant_foot_compensation": "0.1",
-	"enable_arc_fitting": "1",
 	"outer_wall_line_width": "0.42",
 	"wall_infill_order": "inner wall/outer wall/infill",
 	"line_width": "0.42",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1 (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1 (0.4 nozzle).json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1C 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1C 0.4 nozzle.json
@@ -25,7 +25,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K1Max (0.4 nozzle).json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K1Max (0.4 nozzle).json
@@ -22,7 +22,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "200",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.24mm Optimal @Creality K1 (0.6 nozzle).json
+++ b/resources/profiles/Creality/process/0.24mm Optimal @Creality K1 (0.6 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.24mm Optimal @Creality K1C 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Optimal @Creality K1C 0.6 nozzle.json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.24mm Optimal @Creality K1Max (0.6 nozzle).json
+++ b/resources/profiles/Creality/process/0.24mm Optimal @Creality K1Max (0.6 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality Ender3V3 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality Ender3V3 0.6 nozzle.json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1 (0.6 nozzle).json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1 (0.6 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1C 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1C 0.6 nozzle.json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K1Max (0.6 nozzle).json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K1Max (0.6 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.32mm Optimal @Creality K1 (0.8 nozzle).json
+++ b/resources/profiles/Creality/process/0.32mm Optimal @Creality K1 (0.8 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.82",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.32mm Optimal @Creality K1C 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.32mm Optimal @Creality K1C 0.8 nozzle.json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.82",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.32mm Optimal @Creality K1Max (0.8 nozzle).json
+++ b/resources/profiles/Creality/process/0.32mm Optimal @Creality K1Max (0.8 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.82",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.36mm Draft @Creality Ender3V3 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.36mm Draft @Creality Ender3V3 0.6 nozzle.json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.36mm Draft @Creality K1 (0.6 nozzle).json
+++ b/resources/profiles/Creality/process/0.36mm Draft @Creality K1 (0.6 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.36mm Draft @Creality K1C 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.36mm Draft @Creality K1C 0.6 nozzle.json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.36mm Draft @Creality K1Max (0.6 nozzle).json
+++ b/resources/profiles/Creality/process/0.36mm Draft @Creality K1Max (0.6 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.62",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1 (0.8 nozzle).json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1 (0.8 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.82",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1C 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1C 0.8 nozzle.json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.82",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K1Max (0.8 nozzle).json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K1Max (0.8 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.82",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.48mm Draft @Creality K1 (0.8 nozzle).json
+++ b/resources/profiles/Creality/process/0.48mm Draft @Creality K1 (0.8 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.82",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.48mm Draft @Creality K1C 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.48mm Draft @Creality K1C 0.8 nozzle.json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.82",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",

--- a/resources/profiles/Creality/process/0.48mm Draft @Creality K1Max (0.8 nozzle).json
+++ b/resources/profiles/Creality/process/0.48mm Draft @Creality K1Max (0.8 nozzle).json
@@ -21,7 +21,6 @@
     "bridge_no_support": "0",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
     "outer_wall_line_width": "0.82",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",


### PR DESCRIPTION
# Description

This commit is a consequence of this PR #5352 so I disabled Arc Fitting option for all Creality models that had it enabled.
This should fix "Timer too close" issues caused by the weak CPU used by Creality while improving surface finish on stock printers that use a resolution of 1mm.
