### PR TITLE
Disabled arc fitting for Qidi X3/Q1 series

### DIFF
--- a/resources/profiles/Qidi/process/fdm_process_qidi_x3_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_qidi_x3_common.json
@@ -21,7 +21,7 @@
     "bridge_no_support": "1",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "outer_wall_line_width": "0.42",
     "outer_wall_speed": "120",
     "outer_wall_acceleration": "5000",


### PR DESCRIPTION
# Description

This commit is a consequence of this PR https://github.com/SoftFever/OrcaSlicer/pull/5352 so I disabled Arc Fitting option for all Qidi models that had it enabled.
This improve surface finish on stock printers.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
