### PR TITLE
gui: improve RichMessageDialog

### DIFF
--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -383,25 +383,26 @@ RichMessageDialog::RichMessageDialog(wxWindow* parent,
     : MsgDialog(parent, caption.IsEmpty() ? wxString::Format(_L("%s info"), SLIC3R_APP_FULL_NAME) : caption, wxEmptyString, style)
 {
     add_msg_content(this, content_sizer, message);
-
-    m_checkBox = new wxCheckBox(this, wxID_ANY, m_checkBoxText);
-    wxGetApp().UpdateDarkUI(m_checkBox);
-    m_checkBox->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent&) { m_checkBoxValue = m_checkBox->GetValue(); });
-
-    btn_sizer->Insert(0, m_checkBox, wxALIGN_CENTER_VERTICAL);
-
     finalize();
 }
 
 int RichMessageDialog::ShowModal()
 {
-    if (m_checkBoxText.IsEmpty())
-        m_checkBox->Hide();
-    else
-        m_checkBox->SetLabelText(m_checkBoxText);
+    if (!m_checkBoxText.IsEmpty()) {
+        show_dsa_button(m_checkBoxText);
+        m_checkbox_dsa->SetValue(m_checkBoxValue);
+    }
     Layout();
 
     return wxDialog::ShowModal();
+}
+
+bool RichMessageDialog::IsCheckBoxChecked() const
+{
+    if (m_checkbox_dsa)
+        return m_checkbox_dsa->GetValue();
+
+    return m_checkBoxValue;
 }
 #endif
 

--- a/src/slic3r/GUI/MsgDialog.hpp
+++ b/src/slic3r/GUI/MsgDialog.hpp
@@ -193,7 +193,7 @@ public:
 	}
 
 	wxString	GetCheckBoxText()	const { return m_checkBoxText; }
-	bool		IsCheckBoxChecked() const { return m_checkBoxValue; }
+	bool		IsCheckBoxChecked() const;
 
 // This part o fcode isported from the "wx\msgdlg.h"
 	using wxMD = wxMessageDialogBase;


### PR DESCRIPTION
# Description

Current implementation of RichMessageDialog creates and pushes extra checkbox widget into button button sizer which already filled in with wxEXPAND items. That pushes position of newly added checkbox to the left-most position which makes it invisibe for some users.

Optimize implementation of RichMessageDialog using m_checkbox_dsa of MessageDialog instead of creating a new one. As a result, position of the checkbox is right below the main text section.

Adresses #5333

# Screenshots/Recordings/Graphs

Original dialog:
![Screenshot from 2024-05-15 17-37-11](https://github.com/SoftFever/OrcaSlicer/assets/46728448/d2dac54d-278b-42c5-b31c-2ce3b8039fe8)


Updated dialog:
![Screenshot from 2024-05-12 15-39-57](https://github.com/SoftFever/OrcaSlicer/assets/46728448/ee5ac348-9abd-4c7f-8df3-74094187039c)
