### PR TITLE
Fix flush multiplier

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -1685,6 +1685,8 @@ void PresetBundle::load_selections(AppConfig &config, const PresetPreferences& p
     const Preset *preferred_printer = printers.find_system_preset_by_model_and_variant(preferred_selection.printer_model_id, preferred_selection.printer_variant);
     printers.select_preset_by_name(preferred_printer ? preferred_printer->name : initial_printer_profile_name, true);
 
+    CNumericLocalesSetter locales_setter;
+
     // Orca: load from orca_presets
     // const auto os_presets = config.get_machine_settings(initial_printer_profile_name);
     std::string initial_print_profile_name        = config.get_printer_setting(initial_printer_profile_name, PRESET_PRINT_NAME);

--- a/src/slic3r/GUI/WipeTowerDialog.cpp
+++ b/src/slic3r/GUI/WipeTowerDialog.cpp
@@ -581,21 +581,19 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
 
         auto on_apply_text_modify = [this](wxEvent& e) {
             wxString str = m_flush_multiplier_ebox->GetValue();
-            str.Replace(",", ".");
-            double  multiplier = 1.f;
-            if (str.ToDouble(&multiplier)) {
-                if (multiplier < g_min_flush_multiplier || multiplier > g_max_flush_multiplier) {
-                    str = wxString::Format(("%.2f"), multiplier < g_min_flush_multiplier ? g_min_flush_multiplier : g_max_flush_multiplier);
-                    m_flush_multiplier_ebox->SetValue(str);
-                    MessageDialog dlg(nullptr,
-                        wxString::Format(_L("The multiplier should be in range [%.2f, %.2f]."), g_min_flush_multiplier, g_max_flush_multiplier),
-                        _L("Warning"), wxICON_WARNING | wxOK);
-                    dlg.ShowModal();
-                }
-                for (unsigned int i = 0; i < m_number_of_extruders; ++i) {
-                    for (unsigned int j = 0; j < m_number_of_extruders; ++j) {
-                        edit_boxes[i][j]->SetValue(to_string(int(m_matrix[m_number_of_extruders * j + i] * multiplier)));
-                    }
+            str.Replace(".", ",");
+            float multiplier = wxAtof(str);
+            if (multiplier < g_min_flush_multiplier || multiplier > g_max_flush_multiplier) {
+                str = wxString::Format(("%.2f"), multiplier < g_min_flush_multiplier ? g_min_flush_multiplier : g_max_flush_multiplier);
+                m_flush_multiplier_ebox->SetValue(str);
+                MessageDialog dlg(nullptr,
+                    wxString::Format(_L("The multiplier should be in range [%.2f, %.2f]."), g_min_flush_multiplier, g_max_flush_multiplier),
+                    _L("Warning"), wxICON_WARNING | wxOK);
+                dlg.ShowModal();
+            }
+            for (unsigned int i = 0; i < m_number_of_extruders; ++i) {
+                for (unsigned int j = 0; j < m_number_of_extruders; ++j) {
+                    edit_boxes[i][j]->SetValue(to_string(int(m_matrix[m_number_of_extruders * j + i] * multiplier)));
                 }
             }
 
@@ -610,9 +608,7 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
         param_sizer->Add(flush_multiplier_title, 0, wxALIGN_CENTER | wxALL, 0);
         param_sizer->AddSpacer(FromDIP(5));
         m_flush_multiplier_ebox = new wxTextCtrl(m_page_advanced, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(50), -1), wxTE_PROCESS_ENTER);
-        char flush_multi_str[32] = { 0 };
-        snprintf(flush_multi_str, sizeof(flush_multi_str), "%.2f", flush_multiplier);
-        m_flush_multiplier_ebox->SetValue(flush_multi_str);
+        m_flush_multiplier_ebox->SetValue(wxString::Format(("%.2f"), flush_multiplier));
         m_flush_multiplier_ebox->SetValidator(wxTextValidator(wxFILTER_NUMERIC));
         param_sizer->Add(m_flush_multiplier_ebox, 0, wxALIGN_CENTER | wxALL, 0);
         param_sizer->AddStretchSpacer(1);
@@ -622,13 +618,11 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
         m_flush_multiplier_ebox->Bind(wxEVT_KILL_FOCUS, on_apply_text_modify);
         m_flush_multiplier_ebox->Bind(wxEVT_COMMAND_TEXT_UPDATED, [this](wxCommandEvent&) {
             wxString str = m_flush_multiplier_ebox->GetValue();
-            str.Replace(",", ".");
-            double multiplier = 1.f;
-            if (str.ToDouble(&multiplier)) {
-                if (multiplier < g_min_flush_multiplier || multiplier > g_max_flush_multiplier) {
-                    str = wxString::Format(("%.2f"), multiplier < g_min_flush_multiplier ? g_min_flush_multiplier : g_max_flush_multiplier);
-                    m_flush_multiplier_ebox->SetValue(str);
-                }
+            str.Replace(".", ",");
+            float multiplier = wxAtof(str);
+            if (multiplier < g_min_flush_multiplier || multiplier > g_max_flush_multiplier) {
+                str = wxString::Format(("%.2f"), multiplier < g_min_flush_multiplier ? g_min_flush_multiplier : g_max_flush_multiplier);
+                m_flush_multiplier_ebox->SetValue(str);
             }
             m_flush_multiplier_ebox->SetInsertionPointEnd();
         });

--- a/src/slic3r/GUI/WipeTowerDialog.cpp
+++ b/src/slic3r/GUI/WipeTowerDialog.cpp
@@ -581,7 +581,6 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
 
         auto on_apply_text_modify = [this](wxEvent& e) {
             wxString str = m_flush_multiplier_ebox->GetValue();
-            str.Replace(".", ",");
             float multiplier = wxAtof(str);
             if (multiplier < g_min_flush_multiplier || multiplier > g_max_flush_multiplier) {
                 str = wxString::Format(("%.2f"), multiplier < g_min_flush_multiplier ? g_min_flush_multiplier : g_max_flush_multiplier);
@@ -618,7 +617,6 @@ WipingPanel::WipingPanel(wxWindow* parent, const std::vector<float>& matrix, con
         m_flush_multiplier_ebox->Bind(wxEVT_KILL_FOCUS, on_apply_text_modify);
         m_flush_multiplier_ebox->Bind(wxEVT_COMMAND_TEXT_UPDATED, [this](wxCommandEvent&) {
             wxString str = m_flush_multiplier_ebox->GetValue();
-            str.Replace(".", ",");
             float multiplier = wxAtof(str);
             if (multiplier < g_min_flush_multiplier || multiplier > g_max_flush_multiplier) {
                 str = wxString::Format(("%.2f"), multiplier < g_min_flush_multiplier ? g_min_flush_multiplier : g_max_flush_multiplier);

--- a/src/slic3r/GUI/WipeTowerDialog.hpp
+++ b/src/slic3r/GUI/WipeTowerDialog.hpp
@@ -61,12 +61,7 @@ public:
         if (m_flush_multiplier_ebox == nullptr)
             return 1.f;
 
-        wxString str = m_flush_multiplier_ebox->GetValue();
-        str.Replace(",", ".");
-        double multiplier = 1.f;
-        str.ToDouble(&multiplier);
-
-        return multiplier;
+        return wxAtof(m_flush_multiplier_ebox->GetValue());
     }
 
 private:


### PR DESCRIPTION


# Description

Introducing the fix for the flush multiplier in non-English languages from Bambu Studio Github. Commit Link: https://github.com/bambulab/BambuStudio/commit/dbff3729a4ced8f60c710e162066672a4ffaf8aa

Additionally, I’ve maintained the Replace function, replacing the “.” (dot) with a “,” (comma).