### PR TITLE
fix slow_down_layers

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5193,7 +5193,7 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             speed = m_config.get_abs_value("initial_layer_speed");
     }
     else if(m_config.slow_down_layers > 1){
-        const auto _layer = layer_id() + 1;
+        const auto _layer = layer_id();
         if (_layer > 0 && _layer < m_config.slow_down_layers) {
             const auto first_layer_speed =
                 is_perimeter(path.role())


### PR DESCRIPTION
# Description

Setting ```slow_down_layers``` to 2 or more results in wrong number of slowed down layers.

Do not increment layer_id since bottom layer (#0) handled separately.

At slow_down_layers=0 and slow_down_layers=1 acts the same slowing down first layer.
Values slow_down_layers >= 2 defines exact number of layers printed at slower speeds.

Addresses #4898 

## Tests

Manual tests. Test gcode with different ```slow_down_layers``` values attached: 
[slow_down_layers-test.zip](https://github.com/SoftFever/OrcaSlicer/files/15369200/slow_down_layers-test.zip)
