### PR TITLE
feat: add model_name and plate_number placeholders

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2399,6 +2399,8 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         this->placeholder_parser().set("first_layer_temperature", new ConfigOptionInts(m_config.nozzle_temperature_initial_layer));
         this->placeholder_parser().set("max_print_height",new ConfigOptionInt(m_config.printable_height));
         this->placeholder_parser().set("z_offset", new ConfigOptionFloat(m_config.z_offset));
+        this->placeholder_parser().set("model_name", new ConfigOptionString(print.get_model_name()));
+        this->placeholder_parser().set("plate_number", new ConfigOptionString(print.get_plate_number_formatted()));
         this->placeholder_parser().set("plate_name", new ConfigOptionString(print.get_plate_name()));
         this->placeholder_parser().set("first_layer_height", new ConfigOptionFloat(m_config.initial_layer_print_height.value));
 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -2841,8 +2841,28 @@ std::string Print::output_filename(const std::string &filename_base) const
     DynamicConfig config = this->finished() ? this->print_statistics().config() : this->print_statistics().placeholders();
     config.set_key_value("num_filaments", new ConfigOptionInt((int)m_config.nozzle_diameter.size()));
     config.set_key_value("plate_name", new ConfigOptionString(get_plate_name()));
+    config.set_key_value("plate_number", new ConfigOptionString(get_plate_number_formatted()));
+    config.set_key_value("model_name", new ConfigOptionString(get_model_name()));
 
     return this->PrintBase::output_filename(m_config.filename_format.value, ".gcode", filename_base, &config);
+}
+
+std::string Print::get_model_name() const
+{
+    if (model().model_info != nullptr)
+    {
+        return model().model_info->model_name;
+    } else {
+        return "";
+    }
+}
+
+std::string Print::get_plate_number_formatted() const
+{
+    std::string plate_number = std::to_string(get_plate_index() + 1);
+    static const size_t n_zero = 2;
+
+    return std::string(n_zero - std::min(n_zero, plate_number.length()), '0') + plate_number;
 }
 
 //BBS: add gcode file preload logic

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -903,6 +903,9 @@ public:
 
 	std::string                 output_filename(const std::string &filename_base = std::string()) const override;
 
+	std::string                 get_model_name() const;
+	std::string                 get_plate_number_formatted() const;
+
     size_t                      num_print_regions() const throw() { return m_print_regions.size(); }
     const PrintRegion&          get_print_region(size_t idx) const  { return *m_print_regions[idx]; }
     const ToolOrdering&         get_tool_ordering() const { return m_wipe_tower_data.tool_ordering; }


### PR DESCRIPTION
# Description

This uses the BBS project name from the `Project` tab which could be susceptible to upstream changes removing this feature.

The project_name template only works when you open a 3MF file. If you create a new project and set the project name `Model.model_info` is always null whether you save the project or not. If you save the current project, switch to a new project/different project, then re-load it then the template works as expected.

I'm not sure if it's an issue with this implementation or something else upstream.

This is distinct from the project file name in that it can be used to group multiple 3MF files under the same project. For example if you are printing parts for a Voron printer on a Voron 2.4 and Trident, you would have a 3MF file per printer but you may not want the different 3MF file names in the G-Code filename.

The plate number is assumed to always be <100 which matches the formatting of the plate number in the UI.

Relates-To: https://github.com/SoftFever/OrcaSlicer/issues/3816

# Screenshots/Recordings/Graphs

![Screenshot_20240520_135328](https://github.com/SoftFever/OrcaSlicer/assets/7258613/f24fd1c5-7244-4c1b-bbac-652dcb044e8e)
![Screenshot_20240524_170909](https://github.com/SoftFever/OrcaSlicer/assets/7258613/6ba307ad-2725-4536-ad6a-e2f1f77fa923)


## Tests

- When opening a 3MF file
  - When the project has no project name configured
    - Adding the project name updates the G-Code file name :heavy_check_mark: 
    - Updating the project name updates the G-Code file name :heavy_check_mark: 
  - When the 3MF file has a non-empty project name configured
    - Updating the project name updates the G-Code file name :heavy_check_mark: 
    - Clearing the project name updates the G-Code file name :heavy_check_mark: 
- When starting a new project
  - Adding the project name updates the G-Code file name :heavy_multiplication_x: 
  - When saving a new project
    - Adding the project name updates the G-Code file name :heavy_multiplication_x: 