### PR TITLE
Fixed not get port when obtaining the host.

### DIFF
--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -50,8 +50,15 @@ std::string get_host_from_url(const std::string& url_in)
             char* host;
             rc = curl_url_get(hurl, CURLUPART_HOST, &host, 0);
             if (rc == CURLUE_OK) {
-                out = host;
-                curl_free(host);
+                char* port;
+                rc = curl_url_get(hurl, CURLUPART_PORT, &port, 0);
+                if (rc == CURLUE_OK && port != nullptr) {
+                    out = std::string(host) + ":" + port;
+                    curl_free(port);
+                } else {
+                    out = host;
+                    curl_free(host);
+                }
             }
             else
                 BOOST_LOG_TRIVIAL(error) << "OctoPrint get_host_from_url: failed to get host form URL " << url;


### PR DESCRIPTION
# Description
Fixed the issue where the port was not being obtained when retrieving the Host, because according to the specification ([https://www.rfc-editor.org/rfc/rfc7230#section-5.4](https://chatgptnw.s2time.com:4443/url)), the host for this request needs to include the port.

This issue can be reproduced in v2.0.0. If your device address is a domain name with a port (e.g., [https://example.com:8080](https://chatgptnw.s2time.com:4443/url)), uploading gcode will fail.

## Tests
Tested in v2.0.0
