### PR TITLE
Added additional filament vendors.

### DIFF
--- a/scripts/generate_presets_vendors.py
+++ b/scripts/generate_presets_vendors.py
@@ -1,0 +1,150 @@
+# helps manage the static list of vendor names in src/slic3r/GUI/CreatePresetsDialog.cpp
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+scripts_dir = Path(__file__).resolve().parent
+print(f'Scripts dir: {scripts_dir}')
+root_dir = scripts_dir.parent
+profiles_dir = root_dir / 'resources' / 'profiles'
+
+printers: Dict[str, List[str]] = {}
+
+# generates the printer vendor list
+print(f'Looking in {profiles_dir.resolve()}')
+for entry in profiles_dir.glob('*.json'):
+    if entry.is_file():
+        entry_info = json.loads(entry.read_text())
+        vendor_name = entry_info.get('name', None)
+        if vendor_name:
+            models = [machine.get('name', None) for machine in entry_info.get('machine_model_list', []) if machine.get('name', None)]
+            printers[vendor_name] = models
+
+vendor_names = [f'"{vendor_name}",' for vendor_name in sorted(printers.keys(), key=str.casefold)]
+vend_col_width = len(max(vendor_names, key=len))
+vendors_formatted = '    {' + '\n     '.join(' '.join(f"{vendor_name:{vend_col_width}}" for vendor_name in vendor_names[i:i+5]) for i in range(0, len(vendor_names), 5)).rstrip()[:-1] + '}'
+print(vendors_formatted)
+
+# generates the printer model map
+models_formatted = '    {'
+models_indent = len(models_formatted) + vend_col_width + 2
+for vendor_name in sorted(printers.keys(), key=str.casefold):
+    vendor_formatted = f'"{vendor_name}",'
+    models_formatted += f'{{{vendor_formatted:{vend_col_width}}{{'
+
+    model_names = printers[vendor_name]
+    model_names_formatted = [f'"{model_name}",' for model_name in model_names]
+    model_col_width = len(max(model_names_formatted, key=len))
+    model_names_str = ('\n' + ' ' * models_indent).join(' '.join(f"{model_name:{model_col_width}}" for model_name in model_names_formatted[i:i+5]) for i in range(0, len(model_names), 5)).rstrip()[:-1] + '}'
+
+    models_formatted += model_names_str
+    
+    models_formatted += '},\n     '
+
+models_formatted = models_formatted.rstrip()[:-1]
+print(models_formatted)
+
+
+# Generate Filament Vendors
+filament_vendors = [
+    '3Dgenius',
+    '3DJake',
+    '3DXTECH',
+    '3D BEST-Q',
+    '3D Hero',
+    '3D-Fuel',
+    'Aceaddity',
+    'AddNorth',
+    'Amazon Basics',
+    'AMOLEN',
+    'Ankermake',
+    'Anycubic',
+    'Atomic',
+    'AzureFilm',
+    'BASF',
+    'Bblife',
+    'BCN3D',
+    'Beyond Plastic',
+    'California Filament',
+    'Capricorn',
+    'CC3D',
+    'colorFabb',
+    'Comgrow',
+    'Cookiecad',
+    'Creality',
+    'Das Filament',
+    'DO3D',
+    'DOW',
+    'DSM',
+    'Duramic',
+    'ELEGOO',
+    'Eryone',
+    'Essentium',
+    'eSUN',
+    'Extrudr',
+    'Fiberforce',
+    'Fiberlogy',
+    'FilaCube',
+    'Filamentive',
+    'Fillamentum',
+    'FLASHFORGE',
+    'Formfortura',
+    'Francofil',
+    'GEEETECH',
+    'Giantarm',
+    'Gizmo Dorks',
+    'GreenGate3D',
+    'HATCHBOX',
+    'Hello3D',
+    'IC3D',
+    'IEMAI',
+    'IIID Max',
+    'INLAND',
+    'iProspect',
+    'iSANMATE',
+    'Justmaker',
+    'Keene Village Plastics',
+    'Kexcelled',
+    'MakerBot',
+    'MatterHackers',
+    'MIKA3D',
+    'NinjaTek',
+    'Nobufil',
+    'Novamaker',
+    'OVERTURE',
+    'OVVNYXE',
+    'Polymaker',
+    'Priline',
+    'Printed Solid',
+    'Protopasta',
+    'Prusament',
+    'Push Plastic',
+    'R3D',
+    'Re-pet3D',
+    'Recreus',
+    'Regen',
+    'Sain SMART',
+    'SliceWorx',
+    'Snapmaker',
+    'SnoLabs',
+    'Spectrum',
+    'SUNLU',
+    'TTYT3D',
+    'UltiMaker',
+    'Verbatim',
+    'VO3D',
+    'Voxelab',
+    'YOOPAI',
+    'Yousu',
+    'Ziro',
+    'Zyltech',
+    ]
+
+filament_vendors_formatted = [f'"{vendor_name}",' for vendor_name in filament_vendors]
+fil_col_width = len(max(filament_vendors_formatted, key=len))
+filaments_formatted = '    {'
+filament_indent = len(filaments_formatted)
+filaments_formatted += ('\n' + ' ' * filament_indent).join(' '.join(f'{vendor_name:{fil_col_width}}' for vendor_name in filament_vendors_formatted[i:i+5]) for i in range(0, len(filament_vendors), 5)).rstrip()[:-1] + '};'
+print(filaments_formatted)

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -37,22 +37,44 @@
 namespace Slic3r { 
 namespace GUI {
 
-static const std::vector<std::string> filament_vendors = {"Polymaker", "OVERTURE", "Kexcelled", "HATCHBOX",  "eSUN",       "SUNLU",    "Prusament", "Creality", "Protopasta",
-                                                          "Anycubic",  "Basf",     "ELEGOO",    "INLAND",    "FLASHFORGE", "AMOLEN",   "MIKA3D",    "3DXTECH",  "Duramic",
-                                                          "Priline",   "Eryone",   "3Dgunius",  "Novamaker", "Justmaker",  "Giantarm", "iProspect"};
-
-static const std::vector<std::string> filament_types = {"PLA",    "PLA+",  "PLA Tough", "PETG",  "ABS",    "ASA",    "FLEX",        "HIPS",   "PA",     "PACF",
-                                                        "NYLON",  "PVA",   "PC",        "PCABS", "PCTG",   "PCCF",   "PP",          "PEI",    "PET",    "PETG",
-                                                        "PETGCF", "PTBA",  "PTBA90A",   "PEEK",  "TPU93A", "TPU75D", "TPU",         "TPU92A", "TPU98A", "Misc",
+static const std::vector<std::string> filament_vendors = 
+    {"3Dgenius",               "3DJake",                 "3DXTECH",                "3D BEST-Q",              "3D Hero",
+     "3D-Fuel",                "Aceaddity",              "AddNorth",               "Amazon Basics",          "AMOLEN",
+     "Ankermake",              "Anycubic",               "Atomic",                 "AzureFilm",              "BASF",
+     "Bblife",                 "BCN3D",                  "Beyond Plastic",         "California Filament",    "Capricorn",
+     "CC3D",                   "colorFabb",              "Comgrow",                "Cookiecad",              "Creality",
+     "Das Filament",           "DO3D",                   "DOW",                    "DSM",                    "Duramic",
+     "ELEGOO",                 "Eryone",                 "Essentium",              "eSUN",                   "Extrudr",
+     "Fiberforce",             "Fiberlogy",              "FilaCube",               "Filamentive",            "Fillamentum",
+     "FLASHFORGE",             "Formfortura",            "Francofil",              "GEEETECH",               "Giantarm",
+     "Gizmo Dorks",            "GreenGate3D",            "HATCHBOX",               "Hello3D",                "IC3D",
+     "IEMAI",                  "IIID Max",               "INLAND",                 "iProspect",              "iSANMATE",
+     "Justmaker",              "Keene Village Plastics", "Kexcelled",              "MakerBot",               "MatterHackers",
+     "MIKA3D",                 "NinjaTek",               "Nobufil",                "Novamaker",              "OVERTURE",
+     "OVVNYXE",                "Polymaker",              "Priline",                "Printed Solid",          "Protopasta",
+     "Prusament",              "Push Plastic",           "R3D",                    "Re-pet3D",               "Recreus",
+     "Regen",                  "Sain SMART",             "SliceWorx",              "Snapmaker",              "SnoLabs",
+     "Spectrum",               "SUNLU",                  "TTYT3D",                 "UltiMaker",              "Verbatim",
+     "VO3D",                   "Voxelab",                "YOOPAI",                 "Yousu",                  "Ziro",
+     "Zyltech"};
+     
+static const std::vector<std::string> filament_types = {"PLA",    "PLA+",  "PLA Tough", "PETG",  "ABS",    "ASA",    "FLEX",         "HIPS",   "PA",     "PACF",
+                                                        "NYLON",  "PVA",   "PC",        "PCABS", "PCTG",   "PCCF",   "PHA",          "PP",     "PEI",    "PET",    "PETG",
+                                                        "PETGCF", "PTBA",  "PTBA90A",   "PEEK",  "TPU93A", "TPU75D", "TPU",          "TPU92A", "TPU98A", "Misc",
                                                         "TPE",    "GLAZE", "Nylon",     "CPE",   "METAL",  "ABST",   "Carbon Fiber"};
 
-static const std::vector<std::string> printer_vendors = {"Anycubic",  "Artillery", "BIBO",           "BIQU",     "Creality ENDER", "Creality CR", "Creality SERMOON",
-                                                         "FLSun",     "gCreate",   "Geeetech",       "INAT",     "Infinity3D",     "Jubilee",     "LNL3D",
-                                                         "LulzBot",   "MakerGear", "Original Prusa", "Papapiu",  "Print4Taste",    "RatRig",      "Rigid3D",
-                                                         "Snapmaker", "Sovol",     "TriLAB",         "Trimaker", "Ultimaker",      "Voron",       "Zonestar"};
+static const std::vector<std::string> printer_vendors = 
+    {"Anker",              "Anycubic",           "Artillery",          "Bambulab",           "BIQU",
+     "Comgrow",            "Creality",           "Custom Printer",     "Elegoo",             "Flashforge",
+     "FLSun",              "FlyingBear",         "Folgertech",         "InfiMech",           "Kingroon",
+     "Orca Arena Printer", "Peopoly",            "Prusa",              "Qidi",               "Raise3D",
+     "RatRig",             "SecKit",             "Snapmaker",          "Sovol",              "Tronxy",
+     "TwoTrees",           "UltiMaker",          "Vivedino",           "Voron",              "Voxelab",
+     "Vzbot",              "Wanhao"};
 
 static const std::unordered_map<std::string, std::vector<std::string>> printer_model_map =
-    {{"Anycubic",       {"Kossel Linear Plus", "Kossel Pulley(Linear)", "Mega Zero", "i3 Mega", "Predator"}},
+    {{"Anker",          {"Anker M5", "Anker M5 All-Metal Hot End", "Anker M5C"}},
+     {"Anycubic",       {"Kossel Linear Plus", "Kossel Pulley(Linear)", "Mega Zero", "i3 Mega", "Predator"}},
      {"Artillery",      {"sidewinder X1",   "Genius", "Hornet"}},
      {"BIBO",           {"BIBO2 Touch"}},
      {"BIQU",           {"BX"}},
@@ -93,10 +115,10 @@ static const std::unordered_map<std::string, std::vector<std::string>> printer_m
                         "Zero 120mm3",      "Switchwire"}},
      {"Zonestar",       {"Z5",              "Z6",               "Z5x",              "Z8",               "Z9"}}};
 
-static std::vector<std::string>               nozzle_diameter_vec = {"0.4", "0.2", "0.25", "0.3", "0.35", "0.5", "0.6", "0.75", "0.8", "1.0", "1.2"};
-static std::unordered_map<std::string, float> nozzle_diameter_map = {{"0.2", 0.2}, {"0.25", 0.25}, {"0.3", 0.3}, {"0.35", 0.35},
-                                                                     {"0.4", 0.4}, {"0.5", 0.5},   {"0.6", 0.6}, {"0.75", 0.75},
-                                                                     {"0.8", 0.8}, {"1.0", 1.0},   {"1.2", 1.2}};
+static std::vector<std::string>               nozzle_diameter_vec = {"0.4", "0.15", "0.2", "0.25", "0.3", "0.35", "0.5", "0.6", "0.75", "0.8", "1.0", "1.2"};
+static std::unordered_map<std::string, float> nozzle_diameter_map = {{"0.15", 0.15}, {"0.2", 0.2},   {"0.25", 0.25}, {"0.3", 0.3},
+                                                                     {"0.35", 0.35}, {"0.4", 0.4},   {"0.5", 0.5},   {"0.6", 0.6},
+                                                                     {"0.75", 0.75}, {"0.8", 0.8},   {"1.0", 1.0},   {"1.2", 1.2}};
 
 static std::set<int> cannot_input_key = {9, 10, 13, 33, 35, 36, 37, 38, 40, 41, 42, 44, 46, 47, 59, 60, 62, 63, 64, 92, 94, 95, 124, 126};
 
@@ -673,6 +695,7 @@ wxBoxSizer *CreateFilamentPresetDialog::create_vendor_item()
     for (const wxString &vendor : filament_vendors) {
         choices.push_back(vendor);
     }
+    choices.Sort();
 
     wxBoxSizer *vendor_sizer   = new wxBoxSizer(wxHORIZONTAL);
     m_filament_vendor_combobox = new ComboBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, NAME_OPTION_COMBOBOX_SIZE, 0, nullptr, wxCB_READONLY);
@@ -754,6 +777,7 @@ wxBoxSizer *CreateFilamentPresetDialog::create_type_item()
     for (const wxString &filament : m_system_filament_types_set) {
         filament_type.Add(filament);
     }
+    filament_type.Sort();
 
     wxBoxSizer *comboBoxSizer = new wxBoxSizer(wxVERTICAL);
     m_filament_type_combobox  = new ComboBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, NAME_OPTION_COMBOBOX_SIZE, 0, nullptr, wxCB_READONLY);


### PR DESCRIPTION
Added Anker printers to filament presets dialog.
Added helper to generate formatted hard-coded strings in the dialog from the available profile JSON files.

# Description

Many popular/common filament vendors are now pre-populated in the custom filament vendor list. 
Now entries are sorted alphabetically rather than randomly.


# Screenshots/Recordings/Graphs

![image](https://github.com/SoftFever/OrcaSlicer/assets/17968842/e3ba1911-1f1f-43ba-90ed-cb0db93b8eaa)
![image](https://github.com/SoftFever/OrcaSlicer/assets/17968842/db194c67-390a-400e-aab9-2cc1be9e7638)

Output from the helper script:
```
Scripts dir: /home/anselor/source/OrcaSlicer/scripts
Looking in /home/anselor/source/OrcaSlicer/resources/profiles
    {"Anker",              "Anycubic",           "Artillery",          "Bambulab",           "BIQU",
     "Comgrow",            "CONSTRUCT3D",        "Creality",           "Custom Printer",     "Dremel",
     "Elegoo",             "Flashforge",         "FLSun",              "FlyingBear",         "Folgertech",
     "InfiMech",           "Kingroon",           "MagicMaker",         "Orca Arena Printer", "Peopoly",
     "Prusa",              "Qidi",               "Raise3D",            "RatRig",             "SecKit",
     "Snapmaker",          "Sovol",              "Tronxy",             "TwoTrees",           "UltiMaker",
     "Vivedino",           "Voron",              "Voxelab",            "Vzbot",              "Wanhao"}
    {{"Anker",             {"Anker M5",                   "Anker M5 All-Metal Hot End", "Anker M5C"}},
     {"Anycubic",          {"Anycubic i3 Mega S",  "Anycubic Chiron",     "Anycubic Vyper",      "Anycubic Kobra Max",  "Anycubic Kobra Plus",
                            "Anycubic 4Max Pro",   "Anycubic 4Max Pro 2", "Anycubic Kobra 2"}},
     {"Artillery",         {"Artillery Sidewinder X1", "Artillery Genius",        "Artillery Genius Pro",    "Artillery Sidewinder X2", "Artillery Hornet"}},
     {"Bambulab",          {"Bambu Lab X1 Carbon", "Bambu Lab X1",        "Bambu Lab X1E",       "Bambu Lab P1P",       "Bambu Lab P1S",
                            "Bambu Lab A1 mini",   "Bambu Lab A1"}},
     {"BIQU",              {"BIQU B1",      "BIQU BX",      "BIQU Hurakan"}},
     {"Comgrow",           {"Comgrow T500"}},
     {"CONSTRUCT3D",       {"Construct 1 XL", "Construct 1"}},
     {"Creality",          {"Creality CR-10 V2",           "Creality CR-10 Max",          "Creality CR-10 SE",           "Creality CR-6 SE",            "Creality CR-6 Max",
                            "Creality Ender-3 V2",         "Creality Ender-3 V2 Neo",     "Creality Ender-3 S1",         "Creality Ender-3",            "Creality Ender-3 Pro",
                            "Creality Ender-3 S1 Pro",     "Creality Ender-3 S1 Plus",    "Creality Ender-3 V3 SE",      "Creality Ender-3 V3 KE",      "Creality Ender-3 V3",
                            "Creality Ender-5",            "Creality Ender-5 Plus",       "Creality Ender-5 Pro (2019)", "Creality Ender-5S",           "Creality Ender-5 S1",
                            "Creality Ender-6",            "Creality Sermoon V1",         "Creality K1",                 "Creality K1C",                "Creality K1 Max"}},
     {"Custom Printer",    {"Generic Klipper Printer", "Generic Marlin Printer",  "Generic RRF Printer"}},
     {"Dremel",            {"Dremel 3D20", "Dremel 3D40", "Dremel 3D45"}},
     {"Elegoo",            {"Elegoo Neptune",        "Elegoo Neptune X",      "Elegoo Neptune 2",      "Elegoo Neptune 2S",     "Elegoo Neptune 2D",
                            "Elegoo Neptune 3",      "Elegoo Neptune 3 Pro",  "Elegoo Neptune 3 Plus", "Elegoo Neptune 3 Max",  "Elegoo Neptune 4 Pro",
                            "Elegoo Neptune 4",      "Elegoo Neptune 4 Max",  "Elegoo Neptune 4 Plus"}},
     {"Flashforge",        {"Flashforge Adventurer 5M",       "Flashforge Adventurer 5M Pro",   "Flashforge Adventurer 3 Series", "Flashforge Guider 3 Ultra"}},
     {"FLSun",             {"FLSun Q5",       "FLSun QQ-S Pro", "FLSun V400"}},
     {"FlyingBear",        {"FlyingBear Reborn3", "FlyingBear S1"}},
     {"Folgertech",        {"Folgertech i3",   "Folgertech FT-5", "Folgertech FT-6"}},
     {"InfiMech",          {"InfiMech TX"}},
     {"Kingroon",          {"Kingroon KP3S PRO S1", "Kingroon KP3S PRO V2", "Kingroon KP3S 3.0"}},
     {"MagicMaker",        {"MM hqs hj",   "MM hqs SF",   "MM hj SK",    "MM BoneKing", "MM slb"}},
     {"Orca Arena Printer",{"Orca Arena X1 Carbon"}},
     {"Peopoly",           {"Peopoly Magneto X"}},
     {"Prusa",             {"MK4IS",  "MINIIS", "MK3S",   "MINI"}},
     {"Qidi",              {"Qidi Q1 Pro",    "Qidi X-Max 3",   "Qidi X-Plus 3",  "Qidi X-Smart 3", "Qidi X-Plus",
                            "Qidi X-Max",     "Qidi X-CF Pro"}},
     {"Raise3D",           {"Raise3D Pro3",      "Raise3D Pro3 Plus"}},
     {"RatRig",            {"RatRig V-Core 3 200", "RatRig V-Core 3 300", "RatRig V-Core 3 400", "RatRig V-Core 3 500", "RatRig V-Minion",
                            "RatRig V-Cast"}},
     {"SecKit",            {"SecKit SK-Tank", "Seckit Go3"}},
     {"Snapmaker",         {"Snapmaker J1",                 "Snapmaker A250",               "Snapmaker A350",               "Snapmaker A250 Dual",          "Snapmaker A350 Dual",
                            "Snapmaker A250 QSKit",         "Snapmaker A350 QSKit",         "Snapmaker A250 BKit",          "Snapmaker A350 BKit",          "Snapmaker A250 QS+B Kit",
                            "Snapmaker A350 QS+B Kit",      "Snapmaker A250 Dual QSKit",    "Snapmaker A350 Dual QSKit",    "Snapmaker A250 Dual BKit",     "Snapmaker A350 Dual BKit",
                            "Snapmaker A250 Dual QS+B Kit", "Snapmaker A350 Dual QS+B Kit", "Snapmaker Artisan"}},
     {"Sovol",             {"Sovol SV01 Pro",  "Sovol SV02",      "Sovol SV05",      "Sovol SV06",      "Sovol SV06 Plus",
                            "Sovol SV07",      "Sovol SV07 Plus"}},
     {"Tronxy",            {"Tronxy X5SA 400 Marlin Firmware"}},
     {"TwoTrees",          {"TwoTrees SP-5 Klipper", "TwoTrees SK1"}},
     {"UltiMaker",         {"UltiMaker 2"}},
     {"Vivedino",          {"Troodon 2.0 - RRF",     "Troodon 2.0 - Klipper"}},
     {"Voron",             {"Voron 2.4 250",        "Voron 2.4 300",        "Voron 2.4 350",        "Voron Trident 250",    "Voron Trident 300",
                            "Voron Trident 350",    "Voron 0.1",            "Voron Switchwire 250"}},
     {"Voxelab",           {"Voxelab Aquila X2"}},
     {"Vzbot",             {"Vzbot 235 AWD", "Vzbot 330 AWD"}},
     {"Wanhao",            {"Wanhao D12-300"}}
    {"3Dgenius",               "3DJake",                 "3DXTECH",                "3D BEST-Q",              "3D Hero",
     "3D-Fuel",                "Aceaddity",              "AddNorth",               "Amazon Basics",          "AMOLEN",
     "Ankermake",              "Anycubic",               "Atomic",                 "AzureFilm",              "BASF",
     "Bblife",                 "BCN3D",                  "Beyond Plastic",         "California Filament",    "Capricorn",
     "CC3D",                   "colorFabb",              "Comgrow",                "Cookiecad",              "Creality",
     "Das Filament",           "DO3D",                   "DOW",                    "DSM",                    "Duramic",
     "ELEGOO",                 "Eryone",                 "Essentium",              "eSUN",                   "Extrudr",
     "Fiberforce",             "Fiberlogy",              "FilaCube",               "Filamentive",            "Fillamentum",
     "FLASHFORGE",             "Formfortura",            "Francofil",              "GEEETECH",               "Giantarm",
     "Gizmo Dorks",            "GreenGate3D",            "HATCHBOX",               "Hello3D",                "IC3D",
     "IEMAI",                  "IIID Max",               "INLAND",                 "iProspect",              "iSANMATE",
     "Justmaker",              "Keene Village Plastics", "Kexcelled",              "MakerBot",               "MatterHackers",
     "MIKA3D",                 "NinjaTek",               "Nobufil",                "Novamaker",              "OVERTURE",
     "OVVNYXE",                "Polymaker",              "Priline",                "Printed Solid",          "Protopasta",
     "Prusament",              "Push Plastic",           "R3D",                    "Re-pet3D",               "Recreus",
     "Regen",                  "Sain SMART",             "SliceWorx",              "Snapmaker",              "SnoLabs",
     "Spectrum",               "SUNLU",                  "TTYT3D",                 "UltiMaker",              "Verbatim",
     "VO3D",                   "Voxelab",                "YOOPAI",                 "Yousu",                  "Ziro",
     "Zyltech"};
```

## Tests

Loaded the dialog and verified the names are present. Created a new filament type using a preset. Verified custom filaments are still present after a restart.