### PR TITLE
optimize cross hatch infill to enchance strength

### DIFF
--- a/src/libslic3r/Fill/FillCrossHatch.cpp
+++ b/src/libslic3r/Fill/FillCrossHatch.cpp
@@ -194,10 +194,10 @@ void FillCrossHatch ::_fill_surface_single(
     bb.merge(align_to_grid(bb.min, Point(line_spacing * 4, line_spacing * 4)));
 
     // generate pattern
-    //Orca: optimize for low density
+    //Orca: optimize the cross-hatch infill pattern to improve strength when low infill density is used.
     double repeat_ratio = 1.0;
-    if(params.density < 0.3) 
-        repeat_ratio = std::clamp(1.0-std::exp(-5*params.density),0.2,1.0);
+    if (params.density < 0.3)
+        repeat_ratio = std::clamp(1.0 - std::exp(-5 * params.density), 0.2, 1.0);
 
     Polylines polylines = generate_infill_layers(scale_(this->z), repeat_ratio, line_spacing, bb.size()(0), bb.size()(1));
 

--- a/src/libslic3r/Fill/FillCrossHatch.cpp
+++ b/src/libslic3r/Fill/FillCrossHatch.cpp
@@ -193,7 +193,7 @@ void FillCrossHatch ::_fill_surface_single(
     bb.merge(align_to_grid(bb.min, Point(line_spacing * 4, line_spacing * 4)));
 
     // generate pattern
-    Polylines polylines = generate_infill_layers(scale_(this->z), 1, line_spacing, bb.size()(0), bb.size()(1));
+    Polylines polylines = generate_infill_layers(scale_(this->z), 0.4, line_spacing, bb.size()(0), bb.size()(1));
 
     // shift the pattern to the actual space
     for (Polyline &pl : polylines) { pl.translate(bb.min); }

--- a/src/libslic3r/Fill/FillCrossHatch.cpp
+++ b/src/libslic3r/Fill/FillCrossHatch.cpp
@@ -1,6 +1,7 @@
 #include "../ClipperUtils.hpp"
 #include "../ShortestPath.hpp"
 #include "../Surface.hpp"
+#include <cmath>
 
 #include "FillCrossHatch.hpp"
 
@@ -193,7 +194,12 @@ void FillCrossHatch ::_fill_surface_single(
     bb.merge(align_to_grid(bb.min, Point(line_spacing * 4, line_spacing * 4)));
 
     // generate pattern
-    Polylines polylines = generate_infill_layers(scale_(this->z), 0.4, line_spacing, bb.size()(0), bb.size()(1));
+    //Orca: optimize for low density
+    double repeat_ratio = 1.0;
+    if(params.density < 0.3) 
+        repeat_ratio = std::clamp(1.0-std::exp(-5*params.density),0.2,1.0);
+
+    Polylines polylines = generate_infill_layers(scale_(this->z), repeat_ratio, line_spacing, bb.size()(0), bb.size()(1));
 
     // shift the pattern to the actual space
     for (Polyline &pl : polylines) { pl.translate(bb.min); }


### PR DESCRIPTION
# Description
Optimize the cross-hatch infill pattern to improve strength when low infill density is used.
The cross-hatch pattern increases the printing speed, but it does not perform well when the infill density is low.
This PR improves the strength when density is low.

# Screenshots/Recordings/Graphs

Before:
![image](https://github.com/SoftFever/OrcaSlicer/assets/103989404/4a26aed1-684e-4912-bc4e-5fa0eff2d716)
After:
![image](https://github.com/SoftFever/OrcaSlicer/assets/103989404/b101af6b-3dd8-4c20-899c-d15b4aa6d8bd)



<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
