### PR TITLE
fix url protocol integration under linux

### DIFF
--- a/src/slic3r/GUI/DesktopIntegrationDialog.hpp
+++ b/src/slic3r/GUI/DesktopIntegrationDialog.hpp
@@ -30,7 +30,7 @@ public:
 	// Deletes Desktop files and icons for both PrusaSlicer and GcodeViewer at paths stored in App Config.
 	static void undo_desktop_intgration();
 	
-	static void perform_downloader_desktop_integration();
+	static void perform_downloader_desktop_integration(std::string url_prefix);
 	static void undo_downloader_registration();
 private:
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -6601,8 +6601,8 @@ void GUI_App::associate_url(std::wstring url_prefix)
         key_full.Create(false);
     }
     key_full = key_string;
-#elif defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION) 
-    DesktopIntegrationDialog::perform_downloader_desktop_integration();
+#elif defined(__linux__) && defined(SLIC3R_DESKTOP_INTEGRATION)
+    DesktopIntegrationDialog::perform_downloader_desktop_integration(boost::nowide::narrow(url_prefix));
 #endif // WIN32
 }
 


### PR DESCRIPTION
# Description

Fix URL protocol integration under Linux:
- fix desktop file creation
- create separate desktop entry per protocol

## Known limitations

Placing OrcaSlicer into directory containing special characters ($, space, /, ^, some others) will break desktop integrations (at least for Ubuntu) due to xdg-open 1.1.3 being not fully compatible with the specifications: it does not comply specifications cannot properly handle quoted ("") paths

## Tests

Manual tests for [thingverse](https://www.thingiverse.com/) (cura://) and https://www.printables.com/ (prusaslicer://) under next environments:
- Ubuntu 24.04 Gnome: Google Chrome 125.0.6422.141, Firefox 126.0.2
- Ubuntu 24.04 i3wm: Google Chrome 125.0.6422.141, Firefox 126.0.2

I'm using locally built OrcaSlicer, without AppImage so community testing are welcome.