### PR TITLE
Fix Line sparse infill

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -498,7 +498,7 @@ std::vector<SurfaceFill> group_fills(const Layer &layer)
                 params.bridge_angle = float(surface.bridge_angle);
                 if (params.extrusion_role == erInternalInfill) {
                     params.angle = float(Geometry::deg2rad(region_config.infill_direction.value));
-                    params.rotate_angle = (params.pattern == ipRectilinear);
+                    params.rotate_angle = (params.pattern == ipRectilinear || params.pattern == ipLine);
                 } else {
                     params.angle = float(Geometry::deg2rad(region_config.solid_infill_direction.value));
                     params.rotate_angle = region_config.rotate_solid_infill_direction;


### PR DESCRIPTION
# Description

This PR fixes the "Line" sparse infill bug, it was lined up instead of interlaced.

# Screenshots/Recordings/Graphs

#### Before:

![Before](https://github.com/SoftFever/OrcaSlicer/assets/50251547/d889d917-5e26-4b1a-a8e0-83d3f1a775ed)

#### After:

![After](https://github.com/SoftFever/OrcaSlicer/assets/50251547/caf0e036-0309-47a7-b1c2-69a92ca5b998)

## Tests

Compiled and tested in Windows11.

## What does it fix

Fixes #5655
