### PR TITLE
Flashforge-06-12: gcode and filament mapping

### DIFF
--- a/resources/profiles/Flashforge/filament/FusRock Generic NexPA-CF25.json
+++ b/resources/profiles/Flashforge/filament/FusRock Generic NexPA-CF25.json
@@ -20,12 +20,6 @@
     "1"
   ],
   "compatible_printers": [
-    "Flashforge Adventurer 5M 0.4 Nozzle",
-    "Flashforge Adventurer 5M 0.6 Nozzle",
-	"Flashforge Adventurer 5M 0.8 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.4 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.6 Nozzle",
-	"Flashforge Adventurer 5M Pro 0.8 Nozzle",
     "Flashforge Guider 3 Ultra 0.4 Nozzle"
   ],
   "compatible_printers_condition": "",

--- a/resources/profiles/Flashforge/filament/FusRock Generic PAHT-CF.json
+++ b/resources/profiles/Flashforge/filament/FusRock Generic PAHT-CF.json
@@ -20,12 +20,6 @@
     "1"
   ],
   "compatible_printers": [
-    "Flashforge Adventurer 5M 0.4 Nozzle",
-    "Flashforge Adventurer 5M 0.6 Nozzle",
-	  "Flashforge Adventurer 5M 0.8 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.4 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.6 Nozzle",
-	  "Flashforge Adventurer 5M Pro 0.8 Nozzle",
     "Flashforge Guider 3 Ultra 0.4 Nozzle",
     "Flashforge Guider 2s 0.4 nozzle"
   ],

--- a/resources/profiles/Flashforge/filament/FusRock Generic PET-CF.json
+++ b/resources/profiles/Flashforge/filament/FusRock Generic PET-CF.json
@@ -20,12 +20,6 @@
     "1"
   ],
   "compatible_printers": [
-    "Flashforge Adventurer 5M 0.4 Nozzle",
-    "Flashforge Adventurer 5M 0.6 Nozzle",
-	  "Flashforge Adventurer 5M 0.8 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.4 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.6 Nozzle",
-	  "Flashforge Adventurer 5M Pro 0.8 Nozzle",
     "Flashforge Guider 3 Ultra 0.4 Nozzle",
     "Flashforge Guider 2s 0.4 nozzle"
   ],

--- a/resources/profiles/Flashforge/filament/FusRock Generic S-Multi.json
+++ b/resources/profiles/Flashforge/filament/FusRock Generic S-Multi.json
@@ -20,12 +20,6 @@
     "1"
   ],
   "compatible_printers": [
-    "Flashforge Adventurer 5M 0.4 Nozzle",
-    "Flashforge Adventurer 5M 0.6 Nozzle",
-	"Flashforge Adventurer 5M 0.8 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.4 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.6 Nozzle",
-	"Flashforge Adventurer 5M Pro 0.8 Nozzle",
     "Flashforge Guider 3 Ultra 0.4 Nozzle"
   ],
   "compatible_printers_condition": "",
@@ -170,7 +164,7 @@
     "0"
   ],
   "filament_type": [
-    "PET-CF"
+    "S-Multi"
   ],
   "filament_unload_time": [
     "0"

--- a/resources/profiles/Flashforge/filament/FusRock Generic S-PAHT.json
+++ b/resources/profiles/Flashforge/filament/FusRock Generic S-PAHT.json
@@ -20,12 +20,6 @@
     "1"
   ],
   "compatible_printers": [
-    "Flashforge Adventurer 5M 0.4 Nozzle",
-    "Flashforge Adventurer 5M 0.6 Nozzle",
-	"Flashforge Adventurer 5M 0.8 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.4 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.6 Nozzle",
-	"Flashforge Adventurer 5M Pro 0.8 Nozzle",
     "Flashforge Guider 3 Ultra 0.4 Nozzle"
   ],
   "compatible_printers_condition": "",
@@ -170,7 +164,7 @@
     "0"
   ],
   "filament_type": [
-    "PA-CF"
+    "S-PAHT"
   ],
   "filament_unload_time": [
     "0"

--- a/resources/profiles/Flashforge/filament/Polymaker Generic CoPA.json
+++ b/resources/profiles/Flashforge/filament/Polymaker Generic CoPA.json
@@ -20,12 +20,6 @@
         "1"
     ],
   "compatible_printers": [
-    "Flashforge Adventurer 5M 0.4 Nozzle",
-    "Flashforge Adventurer 5M 0.6 Nozzle",
-	"Flashforge Adventurer 5M 0.8 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.4 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.6 Nozzle",
-	"Flashforge Adventurer 5M Pro 0.8 Nozzle",
     "Flashforge Guider 3 Ultra 0.4 Nozzle"
   ],
     "compatible_printers_condition": "",

--- a/resources/profiles/Flashforge/filament/Polymaker Generic S1.json
+++ b/resources/profiles/Flashforge/filament/Polymaker Generic S1.json
@@ -20,12 +20,6 @@
         "1"
     ],
   "compatible_printers": [
-    "Flashforge Adventurer 5M 0.4 Nozzle",
-    "Flashforge Adventurer 5M 0.6 Nozzle",
-	"Flashforge Adventurer 5M 0.8 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.4 Nozzle",
-    "Flashforge Adventurer 5M Pro 0.6 Nozzle",
-	"Flashforge Adventurer 5M Pro 0.8 Nozzle",
     "Flashforge Guider 3 Ultra 0.4 Nozzle"
   ],
     "compatible_printers_condition": "",

--- a/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json
+++ b/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json
@@ -38,7 +38,7 @@
 	"change_filament_gcode": "",
 	"machine_pause_gcode": "M25",
 	"default_filament_profile": [ "Flashforge Generic PLA" ],
-	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F800\nG1 X110 Y-110 F6000\nG1 E2 F800\nG1 Y-110 X55 Z0.25 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG1 Y-110 X55 Z0.45 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG92 E0",
+	"machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-0.2 F800\nG1 X110 Y-110 F6000\nG1 E2 F800\nG1 Y-110 X55 Z0.25 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG1 Y-110 X55 Z0.45 F4800\nG1 X-55 E8 F2400\nG1 Y-109.6 F2400\nG1 X55 E5 F2400\nG92 E0",
 	"machine_end_gcode": "G1 E-3 F3600\nG0 X50 Y50 F30000\nM104 S0 ; turn off temperature",
 	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]",
 	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",


### PR DESCRIPTION
# Description

1. Update AD5M series gcode: E-0.2;
2. Correct the filament mapping for those filaments specifically used on G3U;
3. Fix the filament type for S-Multi and S-PAHT.

# Screenshots/Recordings/Graphs
![1](https://github.com/SoftFever/OrcaSlicer/assets/58339623/e5420d6b-afa3-4ef2-a50f-6b59cce57e28)
![2](https://github.com/SoftFever/OrcaSlicer/assets/58339623/ca8cfb63-95db-4ed2-82e3-b3b9ae55efdf)


## Tests

Looks good on local test.

Hi @SoftFever ,  for your review. I kept the file-naming as usual this time. 
