### PR TITLE
add missing includes

### DIFF
--- a/src/libslic3r/GCode/Thumbnails.cpp
+++ b/src/libslic3r/GCode/Thumbnails.cpp
@@ -4,11 +4,13 @@
 ///|/
 #include "Thumbnails.hpp"
 #include "../miniz_extension.hpp"
+#include "format.hpp"
 
 #include <qoi/qoi.h>
 #include <jpeglib.h>
 #include <jerror.h>
 #include <vector>
+#include <boost/algorithm/string.hpp>
 
 namespace Slic3r::GCodeThumbnails {
 

--- a/src/libslic3r/GCode/Thumbnails.hpp
+++ b/src/libslic3r/GCode/Thumbnails.hpp
@@ -8,6 +8,7 @@
 #include "../Point.hpp"
 #include "../PrintConfig.hpp"
 #include "ThumbnailData.hpp"
+#include "../enum_bitmask.hpp"
 
 #include <vector>
 #include <memory>

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -23,6 +23,7 @@
 #include "ClipperUtils.hpp"
 #include "Config.hpp"
 #include "I18N.hpp"
+#include "format.hpp"
 
 #include "GCode/Thumbnails.hpp"
 #include <set>


### PR DESCRIPTION
Building without precompiled header support revealed some missing includes that are added with this change for code health purposes. Those missing includes were hidden by precompiled header support due to the fact that the precompiled header file provides some definitions despite not being defined in directly or indirectly included header files.
