### PR TITLE
Fix crash caused by wrong pointer used after VtxBuffer resized during 3d navigator rendering

### DIFF
--- a/src/imguizmo/ImGuizmo.cpp
+++ b/src/imguizmo/ImGuizmo.cpp
@@ -2941,7 +2941,7 @@ namespace IMGUIZMO_NAMESPACE
              if (iPass) {
                 // Draw face label
                 ImDrawList* drawList        = gContext.mDrawList;
-                ImDrawVert* vtx_write_start = drawList->_VtxWritePtr;
+                int         vtx_write_start = drawList->VtxBuffer.Size;
 
                 const auto label       = gContext.mStyle.FaceLabels[iFace];
                 ImVec2     labelSize   = ImGui::CalcTextSize(label);
@@ -2978,7 +2978,7 @@ namespace IMGUIZMO_NAMESPACE
                     break;
                 }
 
-                for (auto v = vtx_write_start; v < vtx_write_end; v++) {
+                for (auto v = (drawList->VtxBuffer.Data + vtx_write_start); v < vtx_write_end; v++) {
                     auto  pp = ((v->pos - labelOrigin) * scaleFactor * invert2 + ImVec2{0.5, 0.5}) * 2.f;
                     vec_t pt = tdx * pp.x + tdy * pp.y;
                     v->pos   = worldToPos((pt + origin) * 0.5 * invert, res, position, size);


### PR DESCRIPTION
The old `drawList->_VtxWritePtr` will be invalid if the VtxBuffer get resized during text rendering, which caused this crash. Use the vtx index instead of the raw printer.