### PR TITLE
Reverse draft shield direction on even layers to reduce thermal stress.

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4557,6 +4557,8 @@ std::string GCode::extrude_loop(ExtrusionLoop loop, std::string description, dou
         // if spiral vase, we have to ensure that all contour are in the same orientation.
         loop.make_counter_clockwise();
     }
+    if (loop.loop_role() == elrSkirt && (this->m_layer->id() % 2 == 1))
+        loop.make_clockwise();
 
     // find the point of the loop that is closest to the current extruder position
     // or randomize if requested

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4558,7 +4558,7 @@ std::string GCode::extrude_loop(ExtrusionLoop loop, std::string description, dou
         loop.make_counter_clockwise();
     }
     if (loop.loop_role() == elrSkirt && (this->m_layer->id() % 2 == 1))
-        loop.make_clockwise();
+        loop.reverse();
 
     // find the point of the loop that is closest to the current extruder position
     // or randomize if requested


### PR DESCRIPTION
This PR will increase draft shield stability.

N.B. `layer_id % 2 == 1` is odd mathematically, but from user POV layer number starts from one, not zero.