### PR TITLE
Limit variable layer height displaying precision to 3 digits

### DIFF
--- a/src/libslic3r/Slicing.cpp
+++ b/src/libslic3r/Slicing.cpp
@@ -314,6 +314,8 @@ std::vector<double> layer_height_profile_adaptive(const SlicingParameters& slici
         else if (layer_height_profile.back() > height && layer_height_profile.back() - height > LAYER_HEIGHT_CHANGE_STEP)
             height = layer_height_profile.back() - LAYER_HEIGHT_CHANGE_STEP;
 
+        height = std::round(height * 1000) / 1000.f;
+
         layer_height_profile.push_back(print_z);
         layer_height_profile.push_back(height);
         print_z += height;

--- a/src/libslic3r/Slicing.cpp
+++ b/src/libslic3r/Slicing.cpp
@@ -314,8 +314,6 @@ std::vector<double> layer_height_profile_adaptive(const SlicingParameters& slici
         else if (layer_height_profile.back() > height && layer_height_profile.back() - height > LAYER_HEIGHT_CHANGE_STEP)
             height = layer_height_profile.back() - LAYER_HEIGHT_CHANGE_STEP;
 
-        height = std::round(height * 1000) / 1000.f;
-
         layer_height_profile.push_back(print_z);
         layer_height_profile.push_back(height);
         print_z += height;

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -383,7 +383,7 @@ std::string GLCanvas3D::LayersEditing::get_tooltip(const GLCanvas3D& canvas) con
                 }
             }
             if (h > 0.0f)
-                ret = std::to_string(h);
+                ret = wxString::Format("%.3f",h).ToStdString();
         }
     }
     return ret;


### PR DESCRIPTION
Currently in variable layer height slider heights are shown with six digits precision:

![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/e74701b6-5011-41b5-a12a-97c291f0c468)

It has no meaning as Z height is rounded to three digits anyway (and to two digits in slider):

![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/c18b0206-8e49-4f51-b553-9bd327ee1706)

This PR rounds variable height calculation and displaying to three digits:

![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/505b1e5a-aef7-4e65-9ea2-33f9edb5e584)