### PR TITLE
Copy fan min/max from Bambu PETG to fix excessive cooling in Generic PETG

### DIFF
--- a/resources/profiles/BBL/filament/Generic PETG @base.json
+++ b/resources/profiles/BBL/filament/Generic PETG @base.json
@@ -21,10 +21,10 @@
         "30"
     ],
     "fan_max_speed": [
-        "90"
+        "40"
     ],
     "fan_min_speed": [
-        "40"
+        "10"
     ],
     "filament_flow_ratio": [
         "0.95"


### PR DESCRIPTION
# Description

The Generic PETG profile for Bambu machines had 40-90 cooling which is even more than PLA.  Copy more sane values from the Bambu PETG profile since PETG needs lower fan for better layer adhesion.
  
# Screenshots/Recordings/Graphs
n/a

## Tests
n/a