### PR TITLE
Fix Preferences dialog sizing on multi monitor setups

### DIFF
--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -1004,7 +1004,7 @@ void PreferencesDialog::create()
     SetSizer(main_sizer);
     Layout();
     Fit();
-    int screen_height = wxGetDisplaySize().GetY();
+    int screen_height = wxDisplay(m_parent).GetClientArea().GetHeight();
     if (this->GetSize().GetY() > screen_height)
         this->SetSize(this->GetSize().GetX() + FromDIP(40), screen_height * 4 / 5);
 


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

Update the way the preferences dialog size is set. Currently, on multi monitor setups, only the resolution of the main display is used, even if the window is on a different monitor with a different resolution. Now, the resolution of the monitor displaying the window is used in the sizing calculation. Also, rather than getting the total vertical resolution of the monitor, it gets the usable (or as wxWidgets calls it, the client resolution). This gets the area of the screen that does not include the task bar.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->
Before:
![image](https://github.com/SoftFever/OrcaSlicer/assets/24759591/fb39e853-ef51-479b-8e1b-599a523bb0e2)

After:
![image](https://github.com/SoftFever/OrcaSlicer/assets/24759591/e05c6d58-b65f-4432-a292-09b72f82ce96)


## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
Tested on Windows 11

fixes #5782 