### PR TITLE
Mark unsaved project title with *

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -1999,6 +1999,9 @@ void MainFrame::update_slice_print_status(SlicePrintEventType event, bool can_sl
     m_slice_btn->Enable(enable_slice);
     m_slice_enable = enable_slice;
     m_print_enable = enable_print;
+
+    if (wxGetApp().mainframe)
+        wxGetApp().plater()->update_title_dirty_status();
 }
 
 

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -654,6 +654,7 @@ public:
 
     bool need_update() const;
     void set_need_update(bool need_update);
+    void update_title_dirty_status();
 
     // ROII wrapper for suppressing the Undo / Redo snapshot to be taken.
 	class SuppressSnapshots

--- a/src/slic3r/GUI/ProjectDirtyStateManager.cpp
+++ b/src/slic3r/GUI/ProjectDirtyStateManager.cpp
@@ -17,8 +17,7 @@ namespace GUI {
 
 void ProjectDirtyStateManager::update_from_undo_redo_stack(bool dirty)
 {
-    if (!m_plater_dirty)
-        m_plater_dirty = dirty;
+    m_plater_dirty = dirty;
     if (const Plater *plater = wxGetApp().plater(); plater && wxGetApp().initialized())
         wxGetApp().mainframe->update_title();
 }


### PR DESCRIPTION
Unsaved (changed) project is marked with asterisk like in many other applications:

Clean (saved):
![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/9e6694fa-bad0-4c66-add6-e3e0e7ae1149)

Modified:
![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/107835e7-07e2-424d-8848-6c906e22a7bd)

Handled config changes, objects moves, Undo/Redo commands.


Tested on Windows only.