### PR TITLE
Extrusion Rate Smoothing: Round speed values to prevent needless & trivial speed fluctuations

### DIFF
--- a/src/libslic3r/GCode/PressureEqualizer.cpp
+++ b/src/libslic3r/GCode/PressureEqualizer.cpp
@@ -769,6 +769,7 @@ void PressureEqualizer::push_line_to_output(const size_t line_idx, float new_fee
     // Orca: sanity check, 1 mm/s is the minimum feedrate.
     if (new_feedrate < 60)
         new_feedrate = 60;
+    new_feedrate = std::round(new_feedrate);
     const GCodeLine &line = m_gcode_lines[line_idx];
     if (line_idx > 0 && output_buffer_length > 0) {
         const std::string prev_line_str = std::string(output_buffer.begin() + int(this->output_buffer_prev_length),


### PR DESCRIPTION
# Description

Currently extrusion rate smoothing outputs a float to the set speed command. However this results on occasion in trivial speed fluctuations midway through continuous speed segments like seen below. This may or may not have an effect on print output; however it should be addressed to eliminate redundant gcode commands.

![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/fdf5c26d-f712-451e-ac48-a39f2c5c5543)

By rounding the speed to whole numbers this issue is eliminated, while also allowing speed adjustments to continue to be emitted where the speed delta is more than 1mm/sec

![image](https://github.com/SoftFever/OrcaSlicer/assets/59056762/320a58e9-b16e-41f4-9aa1-a8aac4b12518)
