### PR TITLE
Suggest  firmware retraction time

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -693,7 +693,9 @@ void GCodeProcessor::TimeProcessor::post_process(const std::string& filename, st
                     if (!disable_m73 && !processed &&!is_temporary_decoration(gcode_line) &&
                         (GCodeReader::GCodeLine::cmd_is(gcode_line, "G1") || 
                             GCodeReader::GCodeLine::cmd_is(gcode_line, "G2") ||
-                            GCodeReader::GCodeLine::cmd_is(gcode_line, "G3"))) {
+                            GCodeReader::GCodeLine::cmd_is(gcode_line, "G3") ||
+                            GCodeReader::GCodeLine::cmd_is(gcode_line, "G10")||
+                            GCodeReader::GCodeLine::cmd_is(gcode_line, "G11"))) {
                         // remove temporary lines, add lines M73 where needed
                         unsigned int extra_lines_count = process_line_move(g1_lines_counter ++);
                         if (extra_lines_count > 0)
@@ -3811,14 +3813,18 @@ void GCodeProcessor::process_G29(const GCodeReader::GCodeLine& line)
 
 void GCodeProcessor::process_G10(const GCodeReader::GCodeLine& line)
 {
-    // stores retract move
-    store_move_vertex(EMoveType::Retract);
+    GCodeReader::GCodeLine g10;
+    g10.set(Axis::E, -this->m_parser.config().retraction_length.get_at(m_extruder_id));
+    g10.set(Axis::F,  this->m_parser.config().retraction_speed.get_at(m_extruder_id) * 60);
+    process_G1(g10);
 }
 
 void GCodeProcessor::process_G11(const GCodeReader::GCodeLine& line)
 {
-    // stores unretract move
-    store_move_vertex(EMoveType::Unretract);
+    GCodeReader::GCodeLine g11;
+    g11.set(Axis::E, this->m_parser.config().retraction_length.get_at(m_extruder_id) + this->m_parser.config().retract_restart_extra.get_at(m_extruder_id));
+    g11.set(Axis::F, this->m_parser.config().deretraction_speed.get_at(m_extruder_id) * 60);
+    process_G1(g11);
 }
 
 void GCodeProcessor::process_G20(const GCodeReader::GCodeLine& line)

--- a/src/libslic3r/GCode/SpiralVase.cpp
+++ b/src/libslic3r/GCode/SpiralVase.cpp
@@ -131,7 +131,7 @@ std::string SpiralVase::process_layer(const std::string &gcode, bool last_layer)
             if (line.has_z() && !line.retracting(reader)) {
                 // If this is the initial Z move of the layer, replace it with a
                 // (redundant) move to the last Z of previous layer.
-                line.set(reader, Z, z);
+                line.set(Z, z);
                 new_gcode += line.raw() + '\n';
                 return;
             } else {
@@ -142,17 +142,17 @@ std::string SpiralVase::process_layer(const std::string &gcode, bool last_layer)
                         float factor = len / total_layer_length;
                         if (transition_in)
                             // Transition layer, interpolate the amount of extrusion from zero to the final value.
-                            line.set(reader, E, line.e() * factor, 5 /*decimal_digits*/);
+                            line.set(E, line.e() * factor, 5 /*decimal_digits*/);
                         else if (transition_out) {
                             // We want the last layer to ramp down extrusion, but without changing z height!
                             // So clone the line before we mess with its Z and duplicate it into a new layer that ramps down E
                             // We add this new layer at the very end
                             GCodeReader::GCodeLine transitionLine(line);
-                            transitionLine.set(reader, E, line.e() * (1 - factor), 5 /*decimal_digits*/);
+                            transitionLine.set(E, line.e() * (1 - factor), 5 /*decimal_digits*/);
                             transition_gcode += transitionLine.raw() + '\n';
                         }
                         // This line is the core of Spiral Vase mode, ramp up the Z smoothly
-                        line.set(reader, Z, z + factor * layer_height);
+                        line.set(Z, z + factor * layer_height);
                         if (smooth_spiral) {
                             // Now we also need to try to interpolate X and Y
                             SpiralVase::SpiralPoint p(line.x(), line.y()); // Get current x/y coordinates
@@ -171,10 +171,10 @@ std::string SpiralVase::process_layer(const std::string &gcode, bool last_layer)
                                     if (modified_dist_XY < 0.001)
                                         line.clear();
                                     else {
-                                        line.set(reader, X, target.x);
-                                        line.set(reader, Y, target.y);
+                                        line.set(X, target.x);
+                                        line.set(Y, target.y);
                                         // Scale the extrusion amount according to change in length
-                                        line.set(reader, E, line.e() * modified_dist_XY / dist_XY, 5 /*decimal_digits*/);
+                                        line.set(E, line.e() * modified_dist_XY / dist_XY, 5 /*decimal_digits*/);
                                         last_point = target;
                                     }
                                 } else {

--- a/src/libslic3r/GCodeReader.cpp
+++ b/src/libslic3r/GCodeReader.cpp
@@ -275,7 +275,7 @@ bool GCodeReader::GCodeLine::has_value(char axis, float &value) const
     return false;
 }
 
-void GCodeReader::GCodeLine::set(const GCodeReader &reader, const Axis axis, const float new_value, const int decimal_digits)
+void GCodeReader::GCodeLine::set(const Axis axis, const float new_value, const int decimal_digits)
 {
     std::ostringstream ss;
     ss << std::fixed << std::setprecision(decimal_digits) << new_value;

--- a/src/libslic3r/GCodeReader.hpp
+++ b/src/libslic3r/GCodeReader.hpp
@@ -50,7 +50,7 @@ public:
         bool extruding(const GCodeReader &reader)  const { return (this->cmd_is("G1") || this->cmd_is("G2") || this->cmd_is("G3")) && this->dist_E(reader) > 0; }
         bool retracting(const GCodeReader &reader) const { return (this->cmd_is("G1") || this->cmd_is("G2") || this->cmd_is("G3")) && this->dist_E(reader) < 0; }
         bool travel()     const { return (this->cmd_is("G1") || this->cmd_is("G2") || this->cmd_is("G3")) && ! this->has(E); }
-        void set(const GCodeReader &reader, const Axis axis, const float new_value, const int decimal_digits = 3);
+        void set(const Axis axis, const float new_value, const int decimal_digits = 3);
 
         bool  has_x() const { return this->has(X); }
         bool  has_y() const { return this->has(Y); }
@@ -93,6 +93,7 @@ public:
     void reset() { memset(m_position, 0, sizeof(m_position)); }
     void apply_config(const GCodeConfig &config);
     void apply_config(const DynamicPrintConfig &config);
+    const GCodeConfig& config() { return m_config; };
 
     template<typename Callback>
     void parse_buffer(const std::string &buffer, Callback callback)


### PR DESCRIPTION
Currently firmware retraction time is not taking into account while calculating print time. This PR uses retraction settings for time calculation as if they were set in firmware parameters. Though real parameters could be different, but nevertheless it provides more realistic printing time, especially for bowden extructors and long prints.

Software 3mm retraction:
![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/717273ea-e182-4f50-86dc-9327d3984e31)

Firmware w/o correction (current behavior):
![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/c64f2aac-2d59-4501-aae1-0ddbae1e212e)

With firmware and correction:
![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/ac567367-50fe-4fc8-9c33-b8adae4d75af)
