### PR TITLE
Adaptive layers - respect layer height range modifiers.

### DIFF
--- a/src/libslic3r/Slicing.cpp
+++ b/src/libslic3r/Slicing.cpp
@@ -319,6 +319,13 @@ std::vector<double> layer_height_profile_adaptive(const SlicingParameters& slici
         else if (layer_height_profile.back() > height && layer_height_profile.back() - height > LAYER_HEIGHT_CHANGE_STEP)
             height = layer_height_profile.back() - LAYER_HEIGHT_CHANGE_STEP;
 
+        for (auto const& [range,options] : object.layer_config_ranges) {
+            if ( print_z >= range.first && print_z <= range.second) {
+                    height = options.opt_float("layer_height");
+                    break;
+            };
+        };
+
         layer_height_profile.push_back(print_z);
         layer_height_profile.push_back(height);
         print_z += height;
@@ -444,6 +451,7 @@ std::vector<double> smooth_height_profile(const std::vector<double>& profile, co
 }
 
 void adjust_layer_height_profile(
+    const ModelObject           &model_object,
     const SlicingParameters     &slicing_params,
     std::vector<coordf_t> 		&layer_height_profile,
     coordf_t 					 z,
@@ -477,6 +485,11 @@ void adjust_layer_height_profile(
 			break;
         }
     }
+
+    for (auto const& [range,options] : model_object.layer_config_ranges) {
+        if (z >= range.first - current_layer_height && z <= range.second + current_layer_height)
+            return;
+    };
 
     // 2) Is it possible to apply the delta?
     switch (action) {

--- a/src/libslic3r/Slicing.hpp
+++ b/src/libslic3r/Slicing.hpp
@@ -176,6 +176,7 @@ enum LayerHeightEditActionType : unsigned int {
 };
 
 void adjust_layer_height_profile(
+    const ModelObject           &model_object,
     const SlicingParameters     &slicing_params,
     std::vector<coordf_t>       &layer_height_profile,
     coordf_t                     z,

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -77,8 +77,6 @@
 
 #include <imguizmo/ImGuizmo.h>
 
-#pragma optimize("", off)
-
 static constexpr const float TRACKBALLSIZE = 0.8f;
 
 static Slic3r::ColorRGBA DEFAULT_BG_LIGHT_COLOR      = { 0.906f, 0.906f, 0.906f, 1.0f };

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -77,6 +77,8 @@
 
 #include <imguizmo/ImGuizmo.h>
 
+#pragma optimize("", off)
+
 static constexpr const float TRACKBALLSIZE = 0.8f;
 
 static Slic3r::ColorRGBA DEFAULT_BG_LIGHT_COLOR      = { 0.906f, 0.906f, 0.906f, 1.0f };
@@ -590,7 +592,7 @@ void GLCanvas3D::LayersEditing::adjust_layer_height_profile()
 {
     this->update_slicing_parameters();
     PrintObject::update_layer_height_profile(*m_model_object, *m_slicing_parameters, m_layer_height_profile);
-    Slic3r::adjust_layer_height_profile(*m_slicing_parameters, m_layer_height_profile, this->last_z, this->strength, this->band_width, this->last_action);
+    Slic3r::adjust_layer_height_profile(*m_model_object, *m_slicing_parameters, m_layer_height_profile, this->last_z, this->strength, this->band_width, this->last_action);
     m_layers_texture.valid = false;
 }
 


### PR DESCRIPTION
This PR enforces Height Range Modifiers for Adaptive Layers. If object has such modifiers they layer height will be used and not be affected by Adaptive/Smooth/Editing:
 
![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/305e5e56-a63a-4999-ac9b-30a4ecf7031c)
