### PR TITLE
CI: Avoid Linux Asset Name Collision

### DIFF
--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -282,7 +282,7 @@ jobs:
           upload_url: https://uploads.github.com/repos/SoftFever/OrcaSlicer/releases/137995723/assets{?name,label}
           release_id: 137995723
           asset_path: ./build/OrcaSlicer_Linux${{ env.ubuntu-ver-str }}_${{ env.ver }}.AppImage
-          asset_name: OrcaSlicer_Linux_${{ env.ver }}.AppImage
+          asset_name: OrcaSlicer_Linux${{ env.ubuntu-ver-str }}_${{ env.ver }}.AppImage
           asset_content_type: application/octet-stream
           max_releases: 1 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
 


### PR DESCRIPTION
This PR fixes the issue that only one of the two Linux builds gets published due to a naming collision (a small oversight from #5919).