### PR TITLE
Fix access violation when slicing project with print-by-object mode

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -219,10 +219,14 @@ ToolOrdering::ToolOrdering(const PrintObject &object, unsigned int first_extrude
 
     // BBS
     // Reorder the extruders to minimize tool switches.
-    if (first_extruder == (unsigned int)-1) {
-        this->reorder_extruders(generate_first_layer_tool_order(object));
+    std::vector<unsigned int> first_layer_tool_order;
+    if (first_extruder == (unsigned int) -1) {
+        first_layer_tool_order = generate_first_layer_tool_order(object);
     }
-    else {
+
+    if (!first_layer_tool_order.empty()) {
+        this->reorder_extruders(first_layer_tool_order);
+    } else {
         this->reorder_extruders(first_extruder);
     }
 


### PR DESCRIPTION
Slice will fail if:
1. support is enabled
2. object is floating (by having a very sharp edge touching the build plate)
3. print-by-object
4. Only a single filament is used

This project demonstrate this issue:
[toolorderissue.3mf.txt](https://github.com/user-attachments/files/16064973/toolorderissue.3mf.txt)

The same issue was presented in by-layer mode and was patched by this commit before: 612204b443ca716b9a9936386327b1e45120d06b
And this PR applies this same patch to by-object mode.