### PR TITLE
Correction material settings for Ultimaker 2

### DIFF
--- a/resources/profiles/UltiMaker/filament/UltiMaker Generic ABS.json
+++ b/resources/profiles/UltiMaker/filament/UltiMaker Generic ABS.json
@@ -10,7 +10,7 @@
         "0.926"
     ],
     "filament_max_volumetric_speed": [
-        "2"
+        "4.5"
     ],
 	"compatible_printers": [
 		"UltiMaker 2 0.4 nozzle"

--- a/resources/profiles/UltiMaker/filament/UltiMaker Generic ABS.json
+++ b/resources/profiles/UltiMaker/filament/UltiMaker Generic ABS.json
@@ -7,7 +7,7 @@
     "instantiation": "true",
     "inherits": "fdm_filament_abs",
     "filament_flow_ratio": [
-        "0.926"
+        "0.94"
     ],
     "filament_max_volumetric_speed": [
         "4.5"

--- a/resources/profiles/UltiMaker/filament/UltiMaker Generic PLA.json
+++ b/resources/profiles/UltiMaker/filament/UltiMaker Generic PLA.json
@@ -10,7 +10,7 @@
         "0.987"
     ],
     "filament_max_volumetric_speed": [
-        "12"
+        "5"
     ],
     "slow_down_layer_time": [
         "8"

--- a/resources/profiles/UltiMaker/filament/fdm_filament_abs.json
+++ b/resources/profiles/UltiMaker/filament/fdm_filament_abs.json
@@ -5,28 +5,28 @@
     "instantiation": "false",
     "inherits": "fdm_filament_common",
     "cool_plate_temp" : [
-        "80"
+        "90"
     ],
     "eng_plate_temp" : [
-        "80"
+        "90"
     ],
     "hot_plate_temp" : [
-        "80"
+        "90"
     ],
     "textured_plate_temp" : [
-        "80"
+        "90"
     ],
     "cool_plate_temp_initial_layer" : [
-        "80"
+        "90"
     ],
     "eng_plate_temp_initial_layer" : [
-        "80"
+        "90"
     ],
     "hot_plate_temp_initial_layer" : [
-        "80"
+        "90"
     ],
     "textured_plate_temp_initial_layer" : [
-        "80"
+        "90"
     ],
     "slow_down_for_layer_cooling": [
         "1"


### PR DESCRIPTION
# Description

I found that the UM2, barely reaching 5 mm3/s, was set to 12 mm3/s for PLA, so I checked various settings and corrected them:

ABS from 2 to 4.5 mm3/s (tested myself on Cura, it's the standard settings)
PLA from 12 to 5 (tested myself)

I changed one flow multiplier for ABS because it was too low (my experience on multiple ABS on the UM2, using Cura).

And I increased the bed temperature for ABS from 80C to 90C.

## Tests

I used my experience with UM2 and Cura.