### PR TITLE
Limit the max speed on the wipe tower

### DIFF
--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -1345,7 +1345,7 @@ WipeTower::ToolChangeResult WipeTower2::finish_layer()
         return poly;
     };
 
-    feedrate = first_layer ? m_first_layer_speed * 60.f : m_perimeter_speed * 60.f;
+    feedrate = first_layer ? m_first_layer_speed * 60.f : std::min(m_wipe_tower_max_purge_speed * 60.f, m_perimeter_speed * 60.f);
 
     // outer contour (always)
     bool infill_cone = first_layer && m_wipe_tower_width > 2*spacing && m_wipe_tower_depth > 2*spacing;


### PR DESCRIPTION
The speed of the outer wall may exceed the max speed on the wipe tower, which may lead to insufficient adhesion between different materials, such as PETG and PLA.