### PR TITLE
Reduce one top perimeter offset

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1099,7 +1099,7 @@ void PerimeterGenerator::split_top_surfaces(const ExPolygons &orig_polygons, ExP
     // split the polygons with top/not_top
     // get the offset from solid surface anchor
     coord_t offset_top_surface =
-        scale_(1.5 * (config->wall_loops.value == 0
+        scale_(0.7 * (config->wall_loops.value == 0
                           ? 0.
                           : unscaled(double(ext_perimeter_width +
                                             perimeter_spacing * int(int(config->wall_loops.value) - int(1))))));


### PR DESCRIPTION
Reduce offset of internal perimeters inward for one top perimeter. Current value seems to be too large causing excessive shift and artifacts. Fixes  #6000 **One wall on top causes wrong wall generation in Arachne ** and  fixes #3313 **Perimeters offset too much for one wall on top surfaces ** 

Current value:
![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/8df9cb21-a066-498c-b8a0-b421d16c039f)
![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/8c50e05d-36c9-4a64-a38f-392c0dea8ae9)

New value:
![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/8bacbb3e-8d5f-4e56-b775-325eea688bea)
![image](https://github.com/SoftFever/OrcaSlicer/assets/8691781/3a38b1e4-ac3b-4e1a-bb66-5cf15b670266)

Both Arache and Classib are affected.

Obviously this  value could be configurable, though it seems this value is good enough.