### PR TITLE
Added multithread building deps and orcaslicer sources on Linux

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -129,13 +129,13 @@ then
         # have to build deps with debug & release or the cmake won't find everything it needs
         mkdir deps/build/release
         cmake -S deps -B deps/build/release -G Ninja -DDESTDIR="../destdir" ${BUILD_ARGS}
-        cmake --build deps/build/release
+        cmake --build deps/build/release -j $(nproc --all)
         BUILD_ARGS="${BUILD_ARGS} -DCMAKE_BUILD_TYPE=Debug"
     fi
 
     echo "cmake -S deps -B deps/build -G Ninja ${BUILD_ARGS}"
     cmake -S deps -B deps/build -G Ninja ${BUILD_ARGS}
-    cmake --build deps/build
+    cmake --build deps/build -j $(nproc --all)
 fi
 
 
@@ -165,9 +165,9 @@ then
         ${BUILD_ARGS}
     echo "done"
     echo "Building OrcaSlicer ..."
-    cmake --build build --target OrcaSlicer
+    cmake --build build -j $(nproc --all) --target OrcaSlicer
     echo "Building OrcaSlicer_profile_validator .."
-    cmake --build build --target OrcaSlicer_profile_validator
+    cmake --build build -j $(nproc --all) --target OrcaSlicer_profile_validator
     ./run_gettext.sh
     echo "done"
 fi


### PR DESCRIPTION
# Description

By default, not all system threads are used, which greatly affects build speed in multicore/multicpu systems with low frequency CPU.
