### PR TITLE
AppImage: Fix env overrides that cause segfault and EGL initialization error for Mesa from GIT

### DIFF
--- a/src/platform/unix/BuildLinuxImage.sh.in
+++ b/src/platform/unix/BuildLinuxImage.sh.in
@@ -37,7 +37,7 @@ echo -n "[9/9] Generating Linux app..."
 cat << EOF >@SLIC3R_APP_CMD@
 #!/bin/bash
 DIR=\$(readlink -f "\$0" | xargs dirname)
-export LD_LIBRARY_PATH="\$DIR/bin"
+export LD_LIBRARY_PATH="\$DIR/bin:\$LD_LIBRARY_PATH"
 
 # FIXME: OrcaSlicer segfault workarounds
 # 1) OrcaSlicer will segfault on systems where locale info is not as expected (i.e. Holo-ISO arch-based distro)


### PR DESCRIPTION
# Description

## What issue does this PR address or fix?
When user built Mesa from GIT and load it using env variables `LD_LIBRARY_PATH` and `LIBGL_DRIVERS_PATH`
it overrides `LD_LIBRARY_PATH` inside AppImage but other variable `LIBGL_DRIVERS_PATH` does not override and it cause EGL init error (see screenshots).

Here I did paththrough `LD_LIBRARY_PATH` to application and Mesa loader

PS: I see that other guys works on Flatpak version - it use own Mesa containerized with application and should works perfectly without changes in such case.

## What new features or enhancements does this PR introduce?
Only bug fix for users that has Mesa from GIT

## Are there any breaking changes or dependencies that need to be considered?
Here should not be anything that can break something

# Screenshots/Recordings/Graphs

## Without changes 
![Screenshot from 2024-07-15 02-23-01](https://github.com/user-attachments/assets/e1a92e89-1651-41c7-8ebc-0043dddb7ab3)

## With changes
![Screenshot from 2024-07-15 02-24-19](https://github.com/user-attachments/assets/9b5f0a9b-43e4-48e4-82ca-4bebe8ea66a3)


## Tests

It should start successfully, otherwise it just segfault on startup not even shown UI
