### PR TITLE
Update plate list > plate number position

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -8044,7 +8044,7 @@ void GLCanvas3D::_render_imgui_select_plate_toolbar()
         }
 
         // draw text
-        ImVec2 text_start_pos = ImVec2(start_pos.x + 10.0f, start_pos.y + 8.0f);
+        ImVec2 text_start_pos = ImVec2(start_pos.x + 4.0f, start_pos.y + 2.0f); // ORCA move close to corner to prevent overlapping with preview
         ImGui::RenderText(text_start_pos, std::to_string(i + 1).c_str());
 
         ImGui::PopID();


### PR DESCRIPTION
Moved number to a bit more close to corner. Fixes number overlaps with thumbnails on some models
Didnt tested on high resolution monitors. if there is a problem it can be fixed with using dpi ratio

before - after
![Screenshot-20240721133926](https://github.com/user-attachments/assets/35c1b735-c530-4ead-90ef-4719f25627fc)
