### PR TITLE
Fixing high GPU usage when color scheme is set to "Filament" or "Speed"

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -4547,7 +4547,6 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
                 const auto preferred_offset = ImGui::GetWindowWidth() - ImGui::CalcTextSize(_u8L("Display").c_str()).x - ImGui::GetFrameHeight() / 2 - 2 * window_padding - ImGui::GetStyle().ScrollbarSize;
                 if (preferred_offset > offsets.back()) {
                     offsets.back() = preferred_offset;
-                    imgui.set_requires_extra_frame();
                 }
             }
 


### PR DESCRIPTION
First time contributing, I hope I'm doing this correctly.

# Description
Removed `imgui.set_requires_extra_frame()`, this line causes Slic3r::GUI::GLCanvas3D::render() to be called repeatedly when 'Filament' or 'Speed' is selected in the preview panel (even when OrcaSlicer is minimized)

This should fix #3594 

I see that this line was added in #3363. I don't fully understand the intention behind it, but removing this line does not seem to affect the legend window fix

# Screenshots/Recordings/Graphs
Now in "Filament" or "Speed" preview, GPU usage is 0% when OrcaSlicer is minimized or idle.

Before:
![Screenshot 2024-07-22 183641](https://github.com/user-attachments/assets/489c30f0-d3fb-4eb9-bdcb-137c732c481e)

After:
![Screenshot 2024-07-22 183917](https://github.com/user-attachments/assets/97166e7d-393d-45e9-8ec8-bafe6d73daab)

