### PR TITLE
Suppress some compiler warnings, fix few possible bugs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,11 @@ if (NOT MSVC AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMP
         add_compile_options(-gz=zstd)
     endif()
 
+    # Since some portions of code are just commented out or put under conditional compilation, there are
+    # a bunch of warning related to unused functions and variables. Suppress those warnings to not pollute
+    # compilers diagnostics output with warnings we not going to look at
+    add_compile_options(-Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-label -Wno-unused-local-typedefs)
+
 endif()
 
 if (SLIC3R_ASAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,8 +252,10 @@ if (NOT MSVC AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMP
     # On GCC and Clang, no return from a non-void function is a warning only. Here, we make it an error.
     add_compile_options(-Werror=return-type)
 
-    # Ignore unused functions warnings
-    add_compile_options(-Wno-unused-function)
+    # Since some portions of code are just commented out or put under conditional compilation, there are
+    # a bunch of warning related to unused functions and variables. Suppress those warnings to not pollute
+    # compilers diagnostics output with warnings we not going to look at
+    add_compile_options(-Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-label -Wno-unused-local-typedefs)
 
     # Ignore signed/unsigned comparison warnings
     add_compile_options(-Wno-sign-compare)
@@ -299,11 +301,6 @@ if (NOT MSVC AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMP
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13.0)
         add_compile_options(-gz=zstd)
     endif()
-
-    # Since some portions of code are just commented out or put under conditional compilation, there are
-    # a bunch of warning related to unused functions and variables. Suppress those warnings to not pollute
-    # compilers diagnostics output with warnings we not going to look at
-    add_compile_options(-Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-label -Wno-unused-local-typedefs)
 
 endif()
 

--- a/src/libslic3r/Extruder.cpp
+++ b/src/libslic3r/Extruder.cpp
@@ -9,7 +9,7 @@ double Extruder::m_share_retracted = 0.;
 Extruder::Extruder(unsigned int id, GCodeConfig *config, bool share_extruder) :
     m_id(id),
     m_config(config),
-    m_share_extruder(m_share_extruder)
+    m_share_extruder(share_extruder)
 {
     reset();
     

--- a/src/libslic3r/TreeSupport.cpp
+++ b/src/libslic3r/TreeSupport.cpp
@@ -873,7 +873,7 @@ void TreeSupport::detect_overhangs(bool detect_first_sharp_tail_only)
 
                 // normal overhang
                 ExPolygons lower_layer_offseted = offset_ex(lower_polys, support_offset_scaled, SUPPORT_SURFACES_OFFSET_PARAMETERS);
-                ExPolygons overhang_areas = std::move(diff_ex(curr_polys, lower_layer_offseted));
+                ExPolygons overhang_areas = diff_ex(curr_polys, lower_layer_offseted);
 
                 overhang_areas.erase(std::remove_if(overhang_areas.begin(), overhang_areas.end(),
                     [extrusion_width_scaled](ExPolygon& area) { return offset_ex(area, -0.1 * extrusion_width_scaled).empty(); }),
@@ -2303,7 +2303,7 @@ void TreeSupport::draw_circles(const std::vector<std::vector<Node*>>& contact_no
                         for (size_t i = 0; i <= bottom_gap_layers; i++)
                         {
                             const Layer* below_layer = m_object->get_layer(layer_nr - bottom_interface_layers - i);
-                            ExPolygons bottom_interface = std::move(intersection_ex(base_areas, below_layer->lslices));
+                            ExPolygons bottom_interface = intersection_ex(base_areas, below_layer->lslices);
                             floor_areas.insert(floor_areas.end(), bottom_interface.begin(), bottom_interface.end());
                         }
                     }
@@ -2315,7 +2315,7 @@ void TreeSupport::draw_circles(const std::vector<std::vector<Node*>>& contact_no
                 }
                 if (bottom_gap_layers > 0 && layer_nr > bottom_gap_layers) {
                     const Layer* below_layer = m_object->get_layer(layer_nr - bottom_gap_layers);
-                    ExPolygons bottom_gap_area = std::move(intersection_ex(floor_areas, below_layer->lslices));
+                    ExPolygons bottom_gap_area = intersection_ex(floor_areas, below_layer->lslices);
                     if (!bottom_gap_area.empty()) {
                         floor_areas = std::move(diff_ex(floor_areas, bottom_gap_area));
                     }
@@ -2659,7 +2659,7 @@ void TreeSupport::drop_nodes(std::vector<std::vector<Node*>>& contact_nodes)
 
         m_object->print()->set_status(60, (boost::format(_L("Support: propagate branches at layer %d")) % layer_nr).str());
 
-        Polygons layer_contours = std::move(m_ts_data->get_contours_with_holes(layer_nr));
+        Polygons layer_contours = m_ts_data->get_contours_with_holes(layer_nr);
         //std::unordered_map<Line, bool, LineHash>& mst_line_x_layer_contour_cache = m_mst_line_x_layer_contour_caches[layer_nr];
         std::unordered_map<Line, bool, LineHash> mst_line_x_layer_contour_cache;
         auto is_line_cut_by_contour = [&mst_line_x_layer_contour_cache,&layer_contours](Point a, Point b)
@@ -3645,7 +3645,7 @@ const ExPolygons& TreeSupportData::calculate_collision(const RadiusLayerPair& ke
 {
     assert(key.layer_nr < m_layer_outlines.size());
 
-    ExPolygons collision_areas = std::move(offset_ex(m_layer_outlines[key.layer_nr], scale_(key.radius)));
+    ExPolygons collision_areas = offset_ex(m_layer_outlines[key.layer_nr], scale_(key.radius));
     const auto ret = m_collision_cache.insert({ key, std::move(collision_areas) });
     return ret.first->second;
 }
@@ -3677,7 +3677,7 @@ const ExPolygons& TreeSupportData::calculate_avoidance(const RadiusLayerPair& ke
         }
 
         layer_nr_next   = layer_heights[layer_nr].next_layer_nr;
-        ExPolygons        avoidance_areas = std::move(offset_ex(get_avoidance(radius, layer_nr_next, key.recursions+1), scale_(-m_max_move)));
+        ExPolygons        avoidance_areas = offset_ex(get_avoidance(radius, layer_nr_next, key.recursions+1), scale_(-m_max_move));
         const ExPolygons &collision       = get_collision(radius, layer_nr);
         avoidance_areas.insert(avoidance_areas.end(), collision.begin(), collision.end());
         avoidance_areas = std::move(union_ex(avoidance_areas));
@@ -3685,7 +3685,7 @@ const ExPolygons& TreeSupportData::calculate_avoidance(const RadiusLayerPair& ke
         //assert(ret.second);
         return ret.first->second;
     } else {
-        ExPolygons avoidance_areas = std::move(offset_ex(m_layer_outlines_below[layer_nr], scale_(m_xy_distance + radius)));
+        ExPolygons avoidance_areas = offset_ex(m_layer_outlines_below[layer_nr], scale_(m_xy_distance + radius));
         auto ret = m_avoidance_cache.insert({ key, std::move(avoidance_areas) });
         assert(ret.second);
         return ret.first->second;

--- a/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoFdmSupports.cpp
@@ -101,7 +101,7 @@ bool GLGizmoFdmSupports::on_init()
     m_desc["smart_fill_angle"]      = _L("Smart fill angle");
     m_desc["on_overhangs_only"] = _L("On overhangs only");
 
-    memset(&m_print_instance, sizeof(m_print_instance), 0);
+    memset(&m_print_instance, 0, sizeof(m_print_instance));
     return true;
 }
 

--- a/src/slic3r/GUI/UnsavedChangesDialog.hpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.hpp
@@ -459,7 +459,7 @@ public:
     std::string get_left_preset_name(Preset::Type type);
     std::string get_right_preset_name(Preset::Type type);
 
-    std::vector<std::string> get_selected_options(Preset::Type type) const { return std::move(m_tree->options(type, true)); }
+    std::vector<std::string> get_selected_options(Preset::Type type) const { return m_tree->options(type, true); }
 
     std::array<Preset::Type, 3>         types_list() const;
 

--- a/src/slic3r/Utils/ESP3D.cpp
+++ b/src/slic3r/Utils/ESP3D.cpp
@@ -58,7 +58,7 @@ bool ESP3D::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn 
     std::string short_name = get_short_name(upload_data.upload_path.string());
     bool        res        = false;
 
-    auto http = Http::post(std::move((boost::format("http://%1%/upload_serial") % m_host).str()));
+    auto http = Http::post((boost::format("http://%1%/upload_serial") % m_host).str());
     http.header("Connection", "keep-alive")
         .form_add_file("file", upload_data.source_path, short_name)
         .on_complete([&](std::string body, unsigned status) {


### PR DESCRIPTION
# Description

Suppress compiler warnings we not going to fix. Fix few obvious errors.


While looking at issue #6137 I found suspicious code: 

https://github.com/SoftFever/OrcaSlicer/blob/5e4dd4d84792682accff3ae8c965444fcb5d242e/src/libslic3r/Extruder.cpp#L12

This led me to an idea that no one is looking at warnings produced by compilers.
Currently there are 3056 warnings emitted for OrcaSlicer build using GCC, nearly half of which are unused functions and variables. All that noise distracts developer making them completely ignore compiler output and because of this some obvious mistakes makes into the code base.

