### PR TITLE
Jerk - per axis maximum limit

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -262,9 +262,6 @@ std::string GCodeWriter::set_jerk_xy(double jerk)
 
 std::string GCodeWriter::set_accel_and_jerk(unsigned int acceleration, double jerk)
 {
-    double jerk_x = jerk;
-    double jerk_y = jerk;
-    
     // Only Klipper supports setting acceleration and jerk at the same time. Throw an error if we try to do this on other flavours.
     if(FLAVOR_IS_NOT(gcfKlipper))
         throw std::runtime_error("set_accel_and_jerk() is only supported by Klipper");

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -20,7 +20,7 @@ public:
         multiple_extruders(false), m_extruder(nullptr),
         m_single_extruder_multi_material(false),
         m_last_acceleration(0), m_max_acceleration(0),m_last_travel_acceleration(0), m_max_travel_acceleration(0),
-        m_last_jerk(0), m_max_jerk(0),
+        m_last_jerk(0), m_max_jerk_x(0), m_max_jerk_y(0),
         m_last_bed_temperature(0), m_last_bed_temperature_reached(true),
         m_lifted(0),
         m_to_lift(0),
@@ -128,7 +128,8 @@ public:
     // Limit for setting the acceleration, to respect the machine limits set for the Marlin firmware.
     // If set to zero, the limit is not in action.
     unsigned int    m_max_acceleration;
-    double          m_max_jerk;
+    double          m_max_jerk_x;
+    double          m_max_jerk_y;
     double          m_last_jerk;
     double          m_max_jerk_z;
     double          m_max_jerk_e;


### PR DESCRIPTION
Currently both X/Y jerks are limited by lower jerk value from **Jerk limitation** settings. But for large bedslingers Y axis could have much less jerk then X due to weight. This PR set each axis jerk according to corresponding limit.

![image](https://github.com/user-attachments/assets/b971aa01-ba85-4f37-9add-3dcc803ce619)

![image](https://github.com/user-attachments/assets/5ff88622-20db-4e41-a19f-2f0f641bca47)

![image](https://github.com/user-attachments/assets/34a35a1e-f7f5-4a0c-bf78-49de022ef444)
