### PR TITLE
Fix/crashing when generating walls

### DIFF
--- a/src/libslic3r/Geometry/VoronoiOffset.cpp
+++ b/src/libslic3r/Geometry/VoronoiOffset.cpp
@@ -797,7 +797,7 @@ void annotate_inside_outside(VD &vd, const Lines &lines)
             // Opposite edge of an infinite edge is certainly not active.
             annotate_edge(edge.twin(), edge.is_secondary() ? EdgeCategory::PointsToContour : EdgeCategory::PointsOutside);
             if (edge.vertex0() != nullptr) {
-                //annotate_vertex(edge.vertex0(), edge.is_secondary() ? VertexCategory::OnContour : VertexCategory::Outside);
+                annotate_vertex(edge.vertex0(), edge.is_secondary() ? VertexCategory::OnContour : VertexCategory::Outside);
             } 
             // edge.vertex1() is null, it is implicitely outside.
             if (cell->contains_segment())


### PR DESCRIPTION
# Description
Added a nullptr check. It fixes #6279.

When slicing the file in #6279, there is a ACCESS_VIOLATION exception thrown by `annotate_vertex(edge.vertex0(), edge.is_secondary() ? VertexCategory::OnContour : VertexCategory::Outside)`;. `edge.vertex0()` appears to be null in some cases. The root cause is still unknown, but adding a nullptr check to skip this line `edge.vertex0()` seems to be working.

# Screenshots/Recordings/Graphs


## Tests
OrcaSlicer can now slice the 3mf file user provided in the bug report.
[Side.Entry.Housing.1.zip](https://github.com/user-attachments/files/16418264/Side.Entry.Housing.1.zip)
I found these two lines in the debug log:
```
[warning]	2024-07-29
16:57:42.821800[Thread 0x00006a90]:Detected finite Voronoi vertex with non finite vertex, input polygons will be rotated back and forth.
[error]	2024-07-29 16:57:42.823801[Thread 0x00006a90]:Detected missing Voronoi vertex even after the rotation of input.
```
