### PR TITLE
Localization: Change Python executable name for Windows

### DIFF
--- a/run_gettext.bat
+++ b/run_gettext.bat
@@ -10,7 +10,7 @@ for %%a in (%*) do (
 
 if %FULL_MODE%==1 (
     .\tools\xgettext.exe --keyword=L --keyword=_L --keyword=_u8L --keyword=L_CONTEXT:1,2c --keyword=_L_PLURAL:1,2 --add-comments=TRN --from-code=UTF-8 --no-location --debug --boost -f ./localization/i18n/list.txt -o ./localization/i18n/OrcaSlicer.pot
-    python3 scripts/HintsToPot.py ./resources ./localization/i18n
+    python scripts/HintsToPot.py ./resources ./localization/i18n
 )
 REM Print the current directory
 echo %cd%


### PR DESCRIPTION
A small follow-up for #5959

This PR changes the name of Python executable called in `run_gettext.bat` from `python3` to `python`. This is because the name of the Python interpreter (provided by [python/cpython](https://github.com/python/cpython)) in Windows is `python`, not `python3`.