### PR TITLE
Remove unused slow down proportionally code

### DIFF
--- a/src/libslic3r/GCode/CoolingBuffer.hpp
+++ b/src/libslic3r/GCode/CoolingBuffer.hpp
@@ -54,9 +54,6 @@ private:
     // the PrintConfig slice of FullPrintConfig is constant, thus no thread synchronization is required.
     const PrintConfig          &m_config;
     unsigned int                m_current_extruder;
-
-    // Old logic: proportional.
-    bool                        m_cooling_logic_proportional = false;
     //BBS: current fan speed
     int                         m_current_fan_speed;
 };


### PR DESCRIPTION
Slow down proportionally code was removed in Prusa more than six year ago https://github.com/prusa3d/PrusaSlicer/commit/cbaf0ccc51133db07b47e1de0177b5db4fae2a02.

Let's cleanup code base.