### PR TITLE
Refactor stagger concentric seams

### DIFF
--- a/src/libslic3r/Fill/FillConcentric.cpp
+++ b/src/libslic3r/Fill/FillConcentric.cpp
@@ -10,18 +10,23 @@
 namespace Slic3r {
 
 template<typename LINE_T>
-int stagger_seam_index(int ind, LINE_T line)
+int stagger_seam_index(int ind, LINE_T line, double shift, bool dir)
 {
     Point const *point = &line.points[ind];
     double dist = 0;
-    while (dist < 0.5 / SCALING_FACTOR) {
-        ind = (ind + 1) % line.points.size();
+    while (dist < shift / SCALING_FACTOR) {
+        if (dir)
+            ind = (ind + 1) % line.points.size();
+        else
+            ind = ind > 0 ? --ind : line.points.size() - 1;
         Point const &next = line.points[ind];
         dist += point->distance_to(next);
         point = &next;
     };
     return ind;
 }
+
+#define STAGGER_SEAM_THRESHOLD 0.9
 
 void FillConcentric::_fill_surface_single(
     const FillParams                &params, 
@@ -55,8 +60,20 @@ void FillConcentric::_fill_surface_single(
     // split paths using a nearest neighbor search
     size_t iPathFirst = polylines_out.size();
     Point last_pos(0, 0);
+    
+    double min_nozzle_diameter;
+    bool dir;
+    if (this->print_config != nullptr && params.density >= STAGGER_SEAM_THRESHOLD) {
+        min_nozzle_diameter = *std::min_element(print_config->nozzle_diameter.values.begin(), print_config->nozzle_diameter.values.end());
+        dir = rand() % 2;
+    }
+    
     for (const Polygon &loop : loops) {
-        polylines_out.emplace_back(loop.split_at_index(stagger_seam_index(last_pos.nearest_point_index(loop.points), loop)));
+        int ind = (this->print_config != nullptr && params.density > STAGGER_SEAM_THRESHOLD) ?
+                    stagger_seam_index(last_pos.nearest_point_index(loop.points), loop, min_nozzle_diameter / 2, dir) :
+                    last_pos.nearest_point_index(loop.points);
+
+        polylines_out.emplace_back(loop.split_at_index(ind));
         last_pos = polylines_out.back().last_point();
     }
 
@@ -118,13 +135,18 @@ void FillConcentric::_fill_surface_single(const FillParams& params,
         // Split paths using a nearest neighbor search.
         size_t firts_poly_idx = thick_polylines_out.size();
         Point  last_pos(0, 0);
+        bool dir = rand() % 2;
         for (const Arachne::ExtrusionLine* extrusion : all_extrusions) {
             if (extrusion->empty())
                 continue;
-
             ThickPolyline thick_polyline = Arachne::to_thick_polyline(*extrusion);
-            if (extrusion->is_closed)
-                thick_polyline.start_at_index(stagger_seam_index(last_pos.nearest_point_index(thick_polyline.points), thick_polyline));
+            
+            if (extrusion->is_closed) {
+                int ind = (params.density >= STAGGER_SEAM_THRESHOLD) ?
+                            stagger_seam_index(last_pos.nearest_point_index(thick_polyline.points), thick_polyline, min_nozzle_diameter / 2, dir) :
+                            last_pos.nearest_point_index(thick_polyline.points);
+                thick_polyline.start_at_index(ind);
+            }
             thick_polylines_out.emplace_back(std::move(thick_polyline));
             last_pos = thick_polylines_out.back().last_point();
         }


### PR DESCRIPTION
Followup to **Stagger concentric infill seams. #6184** 

1. Use `min_nozzle_diameter / 2` for shift.
2. Use if density >= 90%
3. Random spiral direction for not seams overlap:

![image](https://github.com/user-attachments/assets/d3c144ae-6080-4bf8-bff4-c9ca8793f17d)

![image](https://github.com/user-attachments/assets/a9e13ab6-1df2-4af0-8dc4-e683c6a01828)
