### PR TITLE
Bug fix: Avoid crossing walls feature removes some retraction wipes

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5891,8 +5891,10 @@ std::string GCode::travel_to(const Point& point, ExtrusionRole role, std::string
 
     // generate G-code for the travel move
     if (needs_retraction) {
-        if (m_config.reduce_crossing_wall && could_be_wipe_disabled)
-            m_wipe.reset_path();
+        // ORCA: Fix scenario where wipe is disabled when avoid crossing perimeters was enabled even though a retraction move was performed.
+        // This replicates the existing behaviour of always wiping when retracting
+        /*if (m_config.reduce_crossing_wall && could_be_wipe_disabled)
+            m_wipe.reset_path();*/
 
         Point last_post_before_retract = this->last_pos();
         gcode += this->retract(false, false, lift_type);


### PR DESCRIPTION
# Description

Avoid crossing walls specifically was erasing the wipe paths even though a retraction was performed as part of the travel move, which is inconsistent with the existing approach when avoid crossing walls is disabled.

Fixes #6266

# Screenshots/Recordings/Graphs

**Before:**
![image](https://github.com/user-attachments/assets/f832f77b-a719-492c-9f2d-e46a3a9fb65c)

**After:**
![image](https://github.com/user-attachments/assets/55cdc274-0584-4c8d-a314-cb3df102d502)

**Avoid crossing walls disabled:**
![image](https://github.com/user-attachments/assets/e2743bbd-11c1-4694-ab73-e83d1a31c491)

## Tests

N/A, minor change.