### PR TITLE
A bunch of tab fixes

### DIFF
--- a/src/slic3r/GUI/OG_CustomCtrl.cpp
+++ b/src/slic3r/GUI/OG_CustomCtrl.cpp
@@ -492,13 +492,16 @@ bool OG_CustomCtrl::update_visibility(ConfigOptionMode mode)
     wxCoord    h_pos2 = get_title_width() * m_em_unit;
     wxCoord    v_pos = 0;
 
-    size_t invisible_lines = 0;
+    bool has_visible_lines = false;
     for (CtrlLine& line : ctrl_lines) {
         line.update_visibility(mode);
-        if (line.is_visible)
+        if (line.is_visible) {
             v_pos += (wxCoord)line.height;
-        else
-            invisible_lines++;
+
+            if (!line.is_separator()) { // Ignore separators
+                has_visible_lines = true;
+            }
+        }
     }
     // BBS: multi-line title
     SetFont(Label::Head_16);
@@ -513,7 +516,7 @@ bool OG_CustomCtrl::update_visibility(ConfigOptionMode mode)
 
     this->SetMinSize(wxSize(h_pos, v_pos));
 
-    return invisible_lines != ctrl_lines.size();
+    return has_visible_lines;
 }
 
 // BBS: call by Tab/Page

--- a/src/slic3r/GUI/PresetComboBoxes.cpp
+++ b/src/slic3r/GUI/PresetComboBoxes.cpp
@@ -799,8 +799,10 @@ bool PlaterPresetComboBox::switch_to_tab()
     //BBS  Select NoteBook Tab params
     if (tab->GetParent() == wxGetApp().params_panel())
         wxGetApp().mainframe->select_tab(MainFrame::tp3DEditor);
-    else
+    else {
         wxGetApp().params_dialog()->Popup();
+        tab->OnActivate();
+    }
     tab->restore_last_select_item();
 
     const Preset* selected_filament_preset = nullptr;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5282,10 +5282,10 @@ bool Tab::update_current_page_in_background(int& item)
 
         // clear pages from the controlls
         // BBS: fix after new layout, clear page in backgroud
-        if (m_parent->is_active_and_shown_tab((wxPanel*)this))
-            m_parent->clear_page();
         for (auto p : m_pages)
             p->clear();
+        if (m_parent->is_active_and_shown_tab((wxPanel*)this))
+            m_parent->clear_page();
 
         update_undo_buttons();
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -468,14 +468,7 @@ void Tab::create_preset_tab()
     // so that the cursor jumps to the last item.
     // BBS: bold selection
     m_tabctrl->Bind(wxEVT_TAB_SEL_CHANGING, [this](wxCommandEvent& event) {
-        if (m_disable_tree_sel_changed_event)
-            return;
         const auto sel_item = m_tabctrl->GetSelection();
-        //OutputDebugStringA("wxEVT_TAB_SEL_CHANGING ");
-        //OutputDebugStringA(m_title.c_str());
-        //const auto selection = sel_item >= 0 ? m_tabctrl->GetItemText(sel_item) : "";
-        //OutputDebugString(selection);
-        //OutputDebugStringA("\n");
         m_tabctrl->SetItemBold(sel_item, false);
         });
     m_tabctrl->Bind(wxEVT_TAB_SEL_CHANGED, [this](wxCommandEvent& event) {

--- a/src/slic3r/GUI/Widgets/TabCtrl.cpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.cpp
@@ -127,9 +127,13 @@ bool TabCtrl::DeleteItem(int item)
     sizer->Remove(item * 2);
     if (btns.size() > 1)
         sizer->GetItem(sizer->GetItemCount() - 1)->SetMinSize({0, 0});
+
+    const bool selection_changed = sel >= item;
+    if (selection_changed) {
+        sel--;  // `relayout()` uses `sel` so we need to update this before calling `relayout()`
+    }
     relayout();
-    if (sel >= item) {
-        sel--;
+    if (selection_changed) {
         sendTabCtrlEvent();
     }
 

--- a/src/slic3r/GUI/Widgets/TabCtrl.cpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.cpp
@@ -120,6 +120,11 @@ bool TabCtrl::DeleteItem(int item)
     if (item < 0 || item >= btns.size()) {
         return false;
     }
+    const bool selection_changed = sel >= item;
+
+    if (selection_changed) {
+        sendTabCtrlEvent(true);
+    }
 
     Button* btn = btns[item];
     btn->Destroy();
@@ -128,7 +133,6 @@ bool TabCtrl::DeleteItem(int item)
     if (btns.size() > 1)
         sizer->GetItem(sizer->GetItemCount() - 1)->SetMinSize({0, 0});
 
-    const bool selection_changed = sel >= item;
     if (selection_changed) {
         sel--;  // `relayout()` uses `sel` so we need to update this before calling `relayout()`
     }


### PR DESCRIPTION
Fixes a few tab related issues:
- The speed tab is not hidden properly when toggle off advance mode with speed tab currently selected:
![2e77a974fc2b4c7b856872fa9422bfe7](https://github.com/user-attachments/assets/5fdb2398-aae7-43ff-8d12-942513b65b56)
- Crash when toggling off advance mode if you switched tabs in the printer config (similar to #6519):
![b412bc21a3c8af4288320806ac25bf47](https://github.com/user-attachments/assets/275d156e-663b-40a4-a982-3cb01ceba586)
- Crash if current selected tab is positioned after the removed tab (introduced in #6537):
![crash_last_tab](https://github.com/user-attachments/assets/a8f678c3-0034-4f18-a57e-fe250368fead)
- Wrong text boldness when the number of tabs changed (also introduced in #6537)

Known issue:
- In some cases the tab highlight will off (again, introduced in #6537):
![tab_highlight_wrong](https://github.com/user-attachments/assets/a1bdace9-ac57-4290-8941-eb7a03ecba5f)
