### PR TITLE
UseElegoo Neptune 4 retraction from Np4 Pro profile

### DIFF
--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.2 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.2 nozzle).json
@@ -36,7 +36,10 @@
 		"85%"
 	],
 	"retraction_length": [
-		"5"
+		"0.8"
+	],
+	"retraction_speed": [
+		"60"
 	],
 	"retract_length_toolchange": [
 		"2"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.4 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.4 nozzle).json
@@ -36,7 +36,10 @@
 		"85%"
 	],
 	"retraction_length": [
-		"5"
+		"0.8"
+	],
+	"retraction_speed": [
+		"60"
 	],
 	"retract_length_toolchange": [
 		"2"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.6 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.6 nozzle).json
@@ -36,7 +36,10 @@
 		"85%"
 	],
 	"retraction_length": [
-		"5"
+		"2.5"
+	],
+	"retraction_speed": [
+		"60"
 	],
 	"retract_length_toolchange": [
 		"2"

--- a/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.8 nozzle).json
+++ b/resources/profiles/Elegoo/machine/Elegoo Neptune 4 (0.8 nozzle).json
@@ -36,8 +36,11 @@
 		"85%"
 	],
 	"retraction_length": [
-		"5"
-	],
+		"0.8"
+	  ],
+	  "retraction_speed": [
+		"60"
+	  ],
 	"retract_length_toolchange": [
 		"2"
 	],


### PR DESCRIPTION
# Description

Default printer profile for Elegoo Neptune 4 sets inexplicable retraction length of 5mm, which way too much for 
machine with direct extruder. It causes fusible filament like PLA slip between gears during deretractions, which leads to significant defects in model.

I copied profile settings from Neptune 5 Pro, because its settings have been fixed long time ago and both printers have exactly the same extruder. Also it is often recommended online to use Np4Pro profile for regular Neptune 4.

# Screenshots/Recordings/Graphs

Default retraction settings of 5mm on the left VS 0.8mm retraction length on the right
⚙️ Eryone PLA 0.4 nozzle / 205°C / flow 1.05
![photo_2024-08-26_09-37-16](https://github.com/user-attachments/assets/18e837ab-92db-4398-b7dc-7f4fc600e563)

## Tests

You can see the difference on the photo above.