### PR TITLE
Fix crash when dragging text in WebViews on macOS

### DIFF
--- a/src/slic3r/Utils/MacDarkMode.mm
+++ b/src/slic3r/Utils/MacDarkMode.mm
@@ -151,6 +151,9 @@ void openFolderForFile(wxString const & file)
 - (BOOL)performDragOperation2:(id<NSDraggingInfo>)info
 {
     NSURL* url = [NSURL URLFromPasteboard:[info draggingPasteboard]];
+    if (!url) {
+        return FALSE;
+    }
     NSString * path = [url path];
     url = [NSURL fileURLWithPath: path];
     [self loadFileURL:url allowingReadAccessToURL:url];


### PR DESCRIPTION
Fix #6608