### PR TITLE
Fix loading 3d mouse params from config

### DIFF
--- a/src/slic3r/GUI/Mouse3DController.cpp
+++ b/src/slic3r/GUI/Mouse3DController.cpp
@@ -406,8 +406,8 @@ void Mouse3DController::load_config(const AppConfig &appconfig)
 	    params.zoom.scale = Params::DefaultZoomScale * std::clamp(zoom_speed, 0.1, 10.0);
         params.swap_yz = swap_yz;
         params.invert_x = invert_x;
-        params.invert_y = invert_x;
-        params.invert_z = invert_x;
+        params.invert_y = invert_y;
+        params.invert_z = invert_z;
         params.invert_yaw = invert_yaw;
         params.invert_pitch = invert_pitch;
         params.invert_roll = invert_roll;


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->
When loading 3d mouse parameters from the config file, the x-axis inversion setting was incorrectly assigned to the y and z as well, which is remedied by this PR.

## Tests

Since this seems a trivial enough change, I haven't done any local building/testing. Let me know if you need anything like that from me anyways.
