### PR TITLE
Fix issue that "total filament used [g]" is missing from gcode

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1720,6 +1720,7 @@ namespace DoExport {
                 filament_stats_string_out += "\n" + out_filament_used_g.first;
             if (out_filament_cost.second)
                filament_stats_string_out += "\n" + out_filament_cost.first;
+            filament_stats_string_out += "\n";
         }
         return filament_stats_string_out;
     }


### PR DESCRIPTION
# Description
Without the trailing `\n` the internal gcode will look like this:
![image](https://github.com/user-attachments/assets/de968d7a-7029-470b-8d10-bc3b5591a125)
Then during the gcode export the gcode processor will remove it from file as it failed to parse this line,
which causes the missing of "total filament used [g]" in the final file

## Tests

1. Select non-bbl printer
2. Slice anything and export the gcode
3. Check the gcode and see if "total filament used [g]" presents
