### PR TITLE
FlashForge Adventurer 3 machine start gcode second fix #6282

### DIFF
--- a/resources/profiles/Flashforge/machine/fdm_adventurer3_common.json
+++ b/resources/profiles/Flashforge/machine/fdm_adventurer3_common.json
@@ -41,7 +41,7 @@
 	"change_filament_gcode": "M600",
 	"machine_pause_gcode": "M25",
 	"default_filament_profile": [ "Flashforge PLA" ],
-	"machine_start_gcode": "M140 S[bed_temperature_initial_layer] T0\nM104 S[nozzle_temperature_initial_layer] T0\nM104 S0 T1\nM107\nM900 K[pressure_advance] T0\nG90\nG28\nM132 X Y Z A B\nG1 Z50.000 F420\nG161 X Y F3300\nM7 T0\nM6 T0\nM651 S255",
+	"machine_start_gcode": "M140 S[bed_temperature_initial_layer] T0\nM104 S[nozzle_temperature_initial_layer] T0\nM104 S0 T1\nM107\nM900 K[pressure_advance] T0\nG90\nG28\nM132 X Y Z A B\nG1 Z50.000 F420\nG161 X Y F3300\nM7 T0\nM6 T0\nM651 S255\n;pre-extrude\nM108 T0\nG1 X-37.50 Y-75.00 F6000\nM106\nG1 Z0.200 F420\nG1 X-37.50 Y-74.50 F6000\nG1 X37.50 Y-74.50 E9.5 F1200\n",
 	"machine_end_gcode": "G1 E-3 F3600\nG0 X50 Y50 F9000\nM104 S0 T0\nM140 S0 T0\nG162 Z F1800\nG28 X Y\nM132 X Y A B\nM652\nG91\nM18",
 	"before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\n;[layer_z]",
 	"layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]",


### PR DESCRIPTION
# Description

After conversation with original author of machine start g-code that causes problem with latest FlashPrint version bringing back pre-extrusion line but with slitly different position. With new value g-code exported from OrcaSlicer works as demand.

# Screenshots/Recordings/Graphs

![Screenshot from 2024-09-12 22-30-44](https://github.com/user-attachments/assets/71b9ebe0-292d-4610-ade7-851c4be78787)

## Tests
Flow rate calibration sliced, exported and loaded to FlashPrint without errors.
