### PR TITLE
Fix small top/bottom solid infill filtering

### DIFF
--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -528,13 +528,13 @@ void LayerRegion::process_external_surfaces(const Layer *lower_layer, const Poly
         // scaling an area requires two calls!
         double min_area = scale_(scale_(this->region().config().minimum_sparse_infill_area.value));
         ExPolygons small_regions{};
-        sparse.erase(std::remove_if(sparse.begin(), sparse.end(), [min_area, &small_regions](ExPolygon& ex_polygon) {
+        expansion_zones[1].expolygons.erase(std::remove_if(expansion_zones[1].expolygons.begin(), expansion_zones[1].expolygons.end(), [min_area, &small_regions](ExPolygon& ex_polygon) {
             if (ex_polygon.area() <= min_area) {
                 small_regions.push_back(ex_polygon);
                 return true;
             }
             return false;
-        }), sparse.end());
+        }), expansion_zones[1].expolygons.end());
 
         if (!small_regions.empty()) {
             expansion_zones[0].expolygons = union_ex(expansion_zones[0].expolygons, small_regions);

--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -523,6 +523,21 @@ void LayerRegion::process_external_surfaces(const Layer *lower_layer, const Poly
 #endif
     }
 
+    this->fill_surfaces.remove_types({stTop});
+    {
+        Surface top_templ(stTop, {});
+        top_templ.thickness = layer_thickness;
+        this->fill_surfaces.append(std::move(expansion_zones.back().expolygons), top_templ);
+    }
+
+    expansion_zones.pop_back();
+
+    expansion_zones.at(0).parameters = RegionExpansionParameters::build(expansion_bottom, expansion_step, max_nr_expansion_steps);
+    Surfaces bottoms = expand_merge_surfaces(this->fill_surfaces.surfaces, stBottom, expansion_zones, closing_radius);
+
+    expansion_zones.at(0).parameters = RegionExpansionParameters::build(expansion_top, expansion_step, max_nr_expansion_steps);
+    Surfaces tops = expand_merge_surfaces(this->fill_surfaces.surfaces, stTop, expansion_zones, closing_radius);
+
     // turn too small internal regions into solid regions according to the user setting
     if (!this->layer()->object()->print()->config().spiral_mode && this->region().config().sparse_infill_density.value > 0) {
         // scaling an area requires two calls!
@@ -540,21 +555,6 @@ void LayerRegion::process_external_surfaces(const Layer *lower_layer, const Poly
             expansion_zones[0].expolygons = union_ex(expansion_zones[0].expolygons, small_regions);
         }
     }
-
-    this->fill_surfaces.remove_types({stTop});
-    {
-        Surface top_templ(stTop, {});
-        top_templ.thickness = layer_thickness;
-        this->fill_surfaces.append(std::move(expansion_zones.back().expolygons), top_templ);
-    }
-
-    expansion_zones.pop_back();
-
-    expansion_zones.at(0).parameters = RegionExpansionParameters::build(expansion_bottom, expansion_step, max_nr_expansion_steps);
-    Surfaces bottoms = expand_merge_surfaces(this->fill_surfaces.surfaces, stBottom, expansion_zones, closing_radius);
-
-    expansion_zones.at(0).parameters = RegionExpansionParameters::build(expansion_top, expansion_step, max_nr_expansion_steps);
-    Surfaces tops = expand_merge_surfaces(this->fill_surfaces.surfaces, stTop, expansion_zones, closing_radius);
 
 //    this->fill_surfaces.remove_types({ stBottomBridge, stBottom, stTop, stInternal, stInternalSolid });
     this->fill_surfaces.clear();


### PR DESCRIPTION
Fix two issues introduced in PR #6654
- Use the variable `sparse` after been `std::move`-d
- The order of `expand_merge_surfaces()` call and the small region filtering block are reversed

This fixes the following bug:
![d3bd0367861c18224a90475aac640727](https://github.com/user-attachments/assets/906e89e4-482f-4cf8-9cfe-053bb1851195)
