### PR TITLE
Fix crash when first layer is empty

### DIFF
--- a/src/libslic3r/GCode/ToolOrdering.cpp
+++ b/src/libslic3r/GCode/ToolOrdering.cpp
@@ -887,7 +887,7 @@ void ToolOrdering::reorder_extruders_for_minimum_flush_volume()
         return false;
     };
 
-    std::optional<unsigned int>current_extruder_id(-1);
+    std::optional<unsigned int>current_extruder_id;
     for (int i = 0; i < m_layer_tools.size(); ++i) {
         LayerTools& lt = m_layer_tools[i];
         if (lt.extruders.empty())


### PR DESCRIPTION
Fix #6807

All places that use `current_extruder_id` will first do a `if(current_extruder_id)` check, which will only be false if this optional is not set. But when it's initialized with `-1` all the checks will become useless which causes this crash.