### PR TITLE
Fix invalid START_PRINT in unofficial Rat Rig profiles.

### DIFF
--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 300 0.4 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 300 0.4 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 300 0.5 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 300 0.5 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 300 0.6 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 300 0.6 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 400 0.4 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 400 0.4 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 400 0.5 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 400 0.5 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 400 0.6 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 400 0.6 nozzle.json
@@ -39,7 +39,7 @@
   "retraction_minimum_travel": ["2"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 500 0.4 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 500 0.4 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 500 0.5 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 500 0.5 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 500 0.6 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 500 0.6 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 300 0.4 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 300 0.4 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 300 0.5 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 300 0.5 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 300 0.6 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 300 0.6 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 400 0.4 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 400 0.4 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 400 0.5 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 400 0.5 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 400 0.6 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 400 0.6 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 500 0.4 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 500 0.4 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 500 0.5 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 500 0.5 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",

--- a/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 500 0.6 nozzle.json
+++ b/resources/profiles/Ratrig/machine/RatRig V-Core 4 HYBRID 500 0.6 nozzle.json
@@ -38,7 +38,7 @@
   "deretraction_speed": ["120"],
   "wipe": ["0"],
   "retract_before_wipe": ["0%"],
-  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nTOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
+  "machine_start_gcode": "START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single] TOTAL_LAYER_COUNT={total_layer_count} X0={first_layer_print_min[0]} Y0={first_layer_print_min[1]} X1={first_layer_print_max[0]} Y1={first_layer_print_max[1]}",
   "layer_change_gcode": ";AFTER_LAYER_CHANGE\n;[layer_z]\nG92 E0\n_ON_LAYER_CHANGE LAYER={layer_num + 1}",
   "before_layer_change_gcode": ";[layer_z]",
   "change_filament_gcode": "M600",


### PR DESCRIPTION
# Description

This PR fixes a pretty major bug in the current Rat Rig V-Core 4 profiles shipped in OrcaSlicer, where the START_PRINT arguments where broken up by a linebreak, resulting in non functional g-code files.

