### PR TITLE
Revert "Tsmith35 per BS PR4631 (#6709)"

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -602,34 +602,16 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
             toolchange_gcode_str = toolchange_retract_str + toolchange_gcode_str;
             // BBS
             {
+                // BBS: current position and fan_speed is unclear after interting change_filament_gcode
                 check_add_eol(toolchange_gcode_str);
-                // BBS: gcode writer doesn't know fan speed after inserting tool change gcode
                 toolchange_gcode_str += ";_FORCE_RESUME_FAN_SPEED\n";
-                
-                // BBS: check whether custom gcode changes the axis positions. Update if changed.
-                bool position_changed = false;
-                Vec3d new_pos = gcodegen.writer().get_position();
-
-                double temp_x_after_toolchange_gcode;
-                if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_str, 0, temp_x_after_toolchange_gcode)) {
-                    new_pos(0) = temp_x_after_toolchange_gcode;
-                    position_changed = true;
-                }
-                
-                double temp_y_after_toolchange_gcode;
-                if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_str, 1, temp_y_after_toolchange_gcode)) {
-                    new_pos(1) = temp_y_after_toolchange_gcode;
-                    position_changed = true;
-                }
-                
-                double temp_z_after_toolchange_gcode;
-                if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_str, 2, temp_z_after_toolchange_gcode)) {
-                    new_pos(2) = temp_z_after_toolchange_gcode;
-                    position_changed = true;
-                }
-                
-                if (position_changed) {
-                    gcodegen.writer().set_position(new_pos);
+                gcodegen.writer().set_current_position_clear(false);
+                // BBS: check whether custom gcode changes the z position. Update if changed
+                double temp_z_after_tool_change;
+                if (GCodeProcessor::get_last_z_from_gcode(toolchange_gcode_str, temp_z_after_tool_change)) {
+                    Vec3d pos = gcodegen.writer().get_position();
+                    pos(2)    = temp_z_after_tool_change;
+                    gcodegen.writer().set_position(pos);
                 }
             }
 
@@ -3396,7 +3378,7 @@ namespace Skirt {
 
     static std::map<unsigned int, std::pair<size_t, size_t>> make_skirt_loops_per_extruder_1st_layer(
         const Print             				&print,
-	const ExtrusionEntityCollection &skirt,
+        const ExtrusionEntityCollection &skirt,
         const LayerTools                		&layer_tools,
         // Heights (print_z) at which the skirt has already been extruded.
         std::vector<coordf_t>  			    	&skirt_done)
@@ -3687,37 +3669,17 @@ LayerResult GCode::process_layer(
     gcode += this->change_layer(print_z);  // this will increase m_layer_index
     m_layer = &layer;
     m_object_layer_over_raft = false;
-    // insert timelapse_gcode when traditional mode is not used (smooth mode)
     if(is_BBL_Printer()){
         if (printer_structure == PrinterStructure::psI3 && !need_insert_timelapse_gcode_for_traditional && !m_spiral_vase && print.config().print_sequence == PrintSequence::ByLayer) {
-
-		        std::string timelapse_gcode = insert_timelapse_gcode();
-		        gcode += timelapse_gcode;
-		        
-		        //BBS: check whether custom gcode changes the axis positions. Update if changed.
-		        bool position_changed = false;
-		        Vec3d new_pos = m_writer.get_position();
-		        
-		        double temp_x_after_timelapse_gcode;
-		        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 0, temp_x_after_timelapse_gcode)) {
-		            new_pos(0) = temp_x_after_timelapse_gcode;
-		            position_changed = true;
-		        }
-		        
-		        double temp_y_after_timelapse_gcode;
-		        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 1, temp_y_after_timelapse_gcode)) {
-		            new_pos(1) = temp_y_after_timelapse_gcode;
-		            position_changed = true;
-		        }
-		        
-		        double temp_z_after_timelapse_gcode;
-		        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 2, temp_z_after_timelapse_gcode)) {
-		            new_pos(2) = temp_z_after_timelapse_gcode;
-		            position_changed = true;
-		        }
-		        
-		        if (position_changed) {
-		            m_writer.set_position(new_pos);
+            std::string timepals_gcode = insert_timelapse_gcode();
+            gcode += timepals_gcode;
+            m_writer.set_current_position_clear(false);
+            //BBS: check whether custom gcode changes the z position. Update if changed
+            double temp_z_after_timepals_gcode;
+            if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
+                Vec3d pos = m_writer.get_position();
+                pos(2) = temp_z_after_timepals_gcode;
+                m_writer.set_position(pos);
             }
         }
     } else {
@@ -4065,40 +4027,21 @@ LayerResult GCode::process_layer(
     // Extrude the skirt, brim, support, perimeters, infill ordered by the extruders.
     for (unsigned int extruder_id : layer_tools.extruders)
     {
-        // insert timelapse_gcode when wipe tower is enabled and traditional mode is used
         if (has_wipe_tower) {
             if (!m_wipe_tower->is_empty_wipe_tower_gcode(*this, extruder_id, extruder_id == layer_tools.extruders.back())) {
                 if (need_insert_timelapse_gcode_for_traditional && !has_insert_timelapse_gcode) {
-                    gcode += this->retract(false, false, LiftType::SpiralLift);
+                    gcode += this->retract(false, false, LiftType::NormalLift);
                     m_writer.add_object_change_labels(gcode);
 
-                    std::string timelapse_gcode = insert_timelapse_gcode();
-                    gcode += timelapse_gcode;
-                    
-                    //BBS: check whether custom gcode changes the axis positions. Update if changed.
-                    bool position_changed = false;
-                    Vec3d new_pos = m_writer.get_position();
-                    
-                    double temp_x_after_timelapse_gcode;
-                    if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 0, temp_x_after_timelapse_gcode)) {
-                        new_pos(0) = temp_x_after_timelapse_gcode;
-                        position_changed = true;
-                    }
-                    
-                    double temp_y_after_timelapse_gcode;
-                    if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 1, temp_y_after_timelapse_gcode)) {
-                        new_pos(1) = temp_y_after_timelapse_gcode;
-                        position_changed = true;
-                    }
-                    
-                    double temp_z_after_timelapse_gcode;
-                    if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 2, temp_z_after_timelapse_gcode)) {
-                        new_pos(2) = temp_z_after_timelapse_gcode;
-                        position_changed = true;
-                    }
-                    
-                    if (position_changed) {
-                        m_writer.set_position(new_pos);
+                    std::string timepals_gcode = insert_timelapse_gcode();
+                    gcode += timepals_gcode;
+                    m_writer.set_current_position_clear(false);
+                    //BBS: check whether custom gcode changes the z position. Update if changed
+                    double temp_z_after_timepals_gcode;
+                    if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
+                        Vec3d pos = m_writer.get_position();
+                        pos(2) = temp_z_after_timepals_gcode;
+                        m_writer.set_position(pos);
                     }
                     has_insert_timelapse_gcode = true;
                 }
@@ -4111,7 +4054,7 @@ LayerResult GCode::process_layer(
         // let analyzer tag generator aware of a role type change
         if (layer_tools.has_wipe_tower && m_wipe_tower)
             m_last_processor_extrusion_role = erWipeTower;
-
+        
         if (print.config().skirt_type == stCombined && !print.skirt().empty())
             gcode += generate_skirt(print, print.skirt(), Point(0,0), layer_tools, layer, extruder_id);
 
@@ -4209,22 +4152,18 @@ LayerResult GCode::process_layer(
                 if (m_config.reduce_crossing_wall)
                     m_avoid_crossing_perimeters.init_layer(*m_layer);
 
-                std::string start_str;
-                std::string start_str_a;
-                std::string temp_start_str;
                 if (this->config().gcode_label_objects) {
-                    start_str_a = std::string("; printing object ") + instance_to_print.print_object.model_object()->name +
+                    gcode += std::string("; printing object ") + instance_to_print.print_object.model_object()->name +
                              " id:" + std::to_string(instance_to_print.print_object.get_id()) + " copy " +
                              std::to_string(inst.id) + "\n";
                 }
                 // exclude objects
                 if (m_enable_exclude_object) {
                     if (is_BBL_Printer()) {
-                        start_str =
+                        m_writer.set_object_start_str(
                             std::string("; start printing object, unique label id: ") +
                             std::to_string(instance_to_print.label_object_id) + "\n" + "M624 " +
-                            _encode_label_ids_to_base64({instance_to_print.label_object_id}) + "\n";
-                            m_writer.set_object_start_str(start_str);
+                            _encode_label_ids_to_base64({instance_to_print.label_object_id}) + "\n");
                     } else {
                         const auto gflavor = print.config().gcode_flavor.value;
                         if (gflavor == gcfKlipper) {
@@ -4237,8 +4176,6 @@ LayerResult GCode::process_layer(
                         }
                     }
                 }
-                temp_start_str = start_str + start_str_a;
-                gcode += start_str_a;
 
                 if (m_config.enable_overhang_speed && !m_config.overhang_speed_classic)
                     m_extrusion_quality_estimator.set_current_object(&instance_to_print.print_object);
@@ -4325,39 +4262,20 @@ LayerResult GCode::process_layer(
                     };
 
                     //BBS: for first layer, we always print wall firstly to get better bed adhesive force
-
-                    // insert timelapse_gcode when no wipe tower, has infill and not first layer
+                    //This behaviour is same with cura
                     if (is_infill_first && !first_layer) {
                         if (!has_wipe_tower && need_insert_timelapse_gcode_for_traditional && !has_insert_timelapse_gcode && has_infill(by_region_specific)) {
-                            gcode += this->retract(false, false, LiftType::SpiralLift);
+                            gcode += this->retract(false, false, LiftType::NormalLift);
 
-                            std::string timelapse_gcode = insert_timelapse_gcode();
-                            gcode += timelapse_gcode;
-
-                            //BBS: check whether custom gcode changes the axis positions. Update if changed.
-                            bool position_changed = false;
-                            Vec3d new_pos = m_writer.get_position();
-                            
-                            double temp_x_after_timelapse_gcode;
-                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 0, temp_x_after_timelapse_gcode)) {
-                                new_pos(0) = temp_x_after_timelapse_gcode;
-                                position_changed = true;
-                            }
-                            
-                            double temp_y_after_timelapse_gcode;
-                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 1, temp_y_after_timelapse_gcode)) {
-                                new_pos(1) = temp_y_after_timelapse_gcode;
-                                position_changed = true;
-                            }
-                            
-                            double temp_z_after_timelapse_gcode;
-                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 2, temp_z_after_timelapse_gcode)) {
-                                new_pos(2) = temp_z_after_timelapse_gcode;
-                                position_changed = true;
-                            }
-                            
-                            if (position_changed) {
-                                m_writer.set_position(new_pos);
+                            std::string timepals_gcode = insert_timelapse_gcode();
+                            gcode += timepals_gcode;
+                            m_writer.set_current_position_clear(false);
+                            //BBS: check whether custom gcode changes the z position. Update if changed
+                            double temp_z_after_timepals_gcode;
+                            if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
+                                Vec3d pos = m_writer.get_position();
+                                pos(2) = temp_z_after_timepals_gcode;
+                                m_writer.set_position(pos);
                             }
 
                             has_insert_timelapse_gcode = true;
@@ -4366,37 +4284,18 @@ LayerResult GCode::process_layer(
                         gcode += this->extrude_perimeters(print, by_region_specific);
                     } else {
                         gcode += this->extrude_perimeters(print, by_region_specific);
-
-                        // insert timelapse_gcode when no wipe tower, no infill and is first layer
                         if (!has_wipe_tower && need_insert_timelapse_gcode_for_traditional && !has_insert_timelapse_gcode && has_infill(by_region_specific)) {
-                            gcode += this->retract(false, false, LiftType::SpiralLift);
-                            std::string timelapse_gcode = insert_timelapse_gcode();
-                            gcode += timelapse_gcode;
+                            gcode += this->retract(false, false, LiftType::NormalLift);
 
-                            //BBS: check whether custom gcode changes the axis positions. Update if changed.
-                            bool position_changed = false;
-                            Vec3d new_pos = m_writer.get_position();
-                            
-                            double temp_x_after_timelapse_gcode;
-                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 0, temp_x_after_timelapse_gcode)) {
-                                new_pos(0) = temp_x_after_timelapse_gcode;
-                                position_changed = true;
-                            }
-                            
-                            double temp_y_after_timelapse_gcode;
-                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 1, temp_y_after_timelapse_gcode)) {
-                                new_pos(1) = temp_y_after_timelapse_gcode;
-                                position_changed = true;
-                            }
-                            
-                            double temp_z_after_timelapse_gcode;
-                            if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 2, temp_z_after_timelapse_gcode)) {
-                                new_pos(2) = temp_z_after_timelapse_gcode;
-                                position_changed = true;
-                            }
-                            
-                            if (position_changed) {
-                                m_writer.set_position(new_pos);
+                            std::string timepals_gcode = insert_timelapse_gcode();
+                            gcode += timepals_gcode;
+                            m_writer.set_current_position_clear(false);
+                            //BBS: check whether custom gcode changes the z position. Update if changed
+                            double temp_z_after_timepals_gcode;
+                            if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
+                                Vec3d pos = m_writer.get_position();
+                                pos(2) = temp_z_after_timepals_gcode;
+                                m_writer.set_position(pos);
                             }
 
                             has_insert_timelapse_gcode = true;
@@ -4463,41 +4362,22 @@ LayerResult GCode::process_layer(
     BOOST_LOG_TRIVIAL(trace) << "Exported layer " << layer.id() << " print_z " << print_z <<
     log_memory_info();
 
-    // insert timelapse_gcode when no wipe tower and no infill
     if (!has_wipe_tower && need_insert_timelapse_gcode_for_traditional && !has_insert_timelapse_gcode) {
         if (m_support_traditional_timelapse)
             m_support_traditional_timelapse = false;
 
-        gcode += this->retract(false, false, LiftType::SpiralLift);
+        gcode += this->retract(false, false, LiftType::NormalLift);
         m_writer.add_object_change_labels(gcode);
 
-        std::string timelapse_gcode = insert_timelapse_gcode();
-        gcode += timelapse_gcode;
-
-        //BBS: check whether custom gcode changes the axis positions. Update if changed.
-        bool position_changed = false;
-        Vec3d new_pos = m_writer.get_position();
-        
-        double temp_x_after_timelapse_gcode;
-        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 0, temp_x_after_timelapse_gcode)) {
-            new_pos(0) = temp_x_after_timelapse_gcode;
-            position_changed = true;
-        }
-        
-        double temp_y_after_timelapse_gcode;
-        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 1, temp_y_after_timelapse_gcode)) {
-            new_pos(1) = temp_y_after_timelapse_gcode;
-            position_changed = true;
-        }
-        
-        double temp_z_after_timelapse_gcode;
-        if (GCodeProcessor::get_last_pos_from_gcode(timelapse_gcode, 2, temp_z_after_timelapse_gcode)) {
-            new_pos(2) = temp_z_after_timelapse_gcode;
-            position_changed = true;
-        }
-        
-        if (position_changed) {
-            m_writer.set_position(new_pos);
+        std::string timepals_gcode = insert_timelapse_gcode();
+        gcode += timepals_gcode;
+        m_writer.set_current_position_clear(false);
+        //BBS: check whether custom gcode changes the z position. Update if changed
+        double temp_z_after_timepals_gcode;
+        if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
+            Vec3d pos = m_writer.get_position();
+            pos(2) = temp_z_after_timepals_gcode;
+            m_writer.set_position(pos);
         }
     }
 
@@ -6530,33 +6410,16 @@ std::string GCode::set_extruder(unsigned int extruder_id, double print_z, bool b
 
         //BBS
         {
-            //BBS: gcode writer doesn't know fan speed after inserting tool change gcode
+            //BBS: gcode writer doesn't know where the extruder is and whether fan speed is changed after inserting tool change gcode
+            //Set this flag so that normal lift will be used the first time after tool change.
             gcode += ";_FORCE_RESUME_FAN_SPEED\n";
-
-            //BBS: check whether custom gcode changes the axis positions. Update if changed.
-            bool position_changed = false;
-            Vec3d new_pos = m_writer.get_position();
-            
-            double temp_x_after_toolchange_gcode;
-            if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_parsed, 0, temp_x_after_toolchange_gcode)) {
-                new_pos(0) = temp_x_after_toolchange_gcode;
-                position_changed = true;
-            }
-            
-            double temp_y_after_toolchange_gcode;
-            if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_parsed, 1, temp_y_after_toolchange_gcode)) {
-                new_pos(1) = temp_y_after_toolchange_gcode;
-                position_changed = true;
-            }
-            
-            double temp_z_after_toolchange_gcode;
-            if (GCodeProcessor::get_last_pos_from_gcode(toolchange_gcode_parsed, 2, temp_z_after_toolchange_gcode)) {
-                new_pos(2) = temp_z_after_toolchange_gcode;
-                position_changed = true;
-            }
-            
-            if (position_changed) {
-                m_writer.set_position(new_pos);
+            m_writer.set_current_position_clear(false);
+            //BBS: check whether custom gcode changes the z position. Update if changed
+            double temp_z_after_tool_change;
+            if (GCodeProcessor::get_last_z_from_gcode(toolchange_gcode_parsed, temp_z_after_tool_change)) {
+                Vec3d pos = m_writer.get_position();
+                pos(2) = temp_z_after_tool_change;
+                m_writer.set_position(pos);
             }
         }
     }
@@ -6804,4 +6667,4 @@ void GCode::ObjectByExtruder::Island::Region::append(const Type type, const Extr
 // a single object, or for possibly multiple objects with multiple instances.
 
 
-} /* slic3r_GCode_cpp_ */
+} // namespace Slic3r

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -2185,14 +2185,13 @@ int GCodeProcessor::get_gcode_last_filament(const std::string& gcode_str)
     return out_filament;
 }
 
-//BBS: get last position from gcode for specified axis
-//axis index is the same as Vec3d (X=0, Y=1, Z=2)
-bool GCodeProcessor::get_last_pos_from_gcode(const std::string& gcode_str, int axis, double& pos)
+//BBS: get last z position from gcode
+bool GCodeProcessor::get_last_z_from_gcode(const std::string& gcode_str, double& z)
 {
     int str_size = gcode_str.size();
     int start_index = 0;
     int end_index = 0;
-    bool is_axis_changed = false;
+    bool is_z_changed = false;
     while (end_index < str_size) {
         //find a full line
         if (gcode_str[end_index] != '\n') {
@@ -2212,32 +2211,24 @@ bool GCodeProcessor::get_last_pos_from_gcode(const std::string& gcode_str, int a
                                        || line_str.find("G2 ") == 0
                                        || line_str.find("G3 ") == 0))
             {
-                std::string axis_str;
-                if (axis == 0) {
-                    axis_str = "X";
-                } else if (axis == 1) {
-                    axis_str = "Y";
-                } else if (axis == 2) {
-                    axis_str = "Z";
-                }
-                auto axis_pos = line_str.find(" " + axis_str);
-                double temp_axis_pos = 0;
-                if (axis_pos != line_str.npos
-                    && axis_pos + 2 < line_str.size()) {
+                auto z_pos = line_str.find(" Z");
+                double temp_z = 0;
+                if (z_pos != line_str.npos
+                    && z_pos + 2 < line_str.size()) {
                     // Try to parse the numeric value.
-                    std::string axis_substr = line_str.substr(axis_pos + 2);
-                    char* start_ptr = &axis_substr[0];
-                    char* end_ptr = start_ptr + sizeof(axis_substr.c_str());
+                    std::string z_sub = line_str.substr(z_pos + 2);
+                    char* c = &z_sub[0];
+                    char* end = c + sizeof(z_sub.c_str());
 
                     auto is_end_of_word = [](char c) {
                         return c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == 0 || c == ';';
                     };
 
-                    auto [parsed_ptr, error_code] = fast_float::from_chars(start_ptr, end_ptr, temp_axis_pos);
-                    if (parsed_ptr != start_ptr && is_end_of_word(*parsed_ptr)) {
+                    auto [pend, ec] = fast_float::from_chars(c, end, temp_z);
+                    if (pend != c && is_end_of_word(*pend)) {
                         // The axis value has been parsed correctly.
-                        pos = temp_axis_pos;
-                        is_axis_changed = true;
+                        z = temp_z;
+                        is_z_changed = true;
                     }
                 }
             }
@@ -2246,7 +2237,7 @@ bool GCodeProcessor::get_last_pos_from_gcode(const std::string& gcode_str, int a
         start_index = end_index + 1;
         end_index = start_index;
     }
-    return is_axis_changed;
+    return is_z_changed;
 }
 
 void GCodeProcessor::process_tags(const std::string_view comment, bool producers_enabled)
@@ -5410,4 +5401,4 @@ void GCodeProcessor::update_slice_warnings()
     m_result.warnings.shrink_to_fit();
 }
 
-} /* slic3r_GCodeProcessor_cpp_ */
+} /* namespace Slic3r */

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -303,7 +303,7 @@ class Print;
         static bool contains_reserved_tags(const std::string& gcode, unsigned int max_count, std::vector<std::string>& found_tag);
 
         static int get_gcode_last_filament(const std::string &gcode_str);
-        static bool get_last_pos_from_gcode(const std::string& gcode_str, int axis, double& pos);
+        static bool get_last_z_from_gcode(const std::string& gcode_str, double& z);
 
         static const float Wipe_Width;
         static const float Wipe_Height;
@@ -984,3 +984,5 @@ class Print;
 } /* namespace Slic3r */
 
 #endif /* slic3r_GCodeProcessor_hpp_ */
+
+


### PR DESCRIPTION
Reverts SoftFever/OrcaSlicer#6709

This reverts the spiral lift modifications by @ziehmon for this reason:

> unfortunately we need to revert this MR. There is a bug when AMS is used, since the position after changing filaments will be at X asis boundary and a spiral Z hop will move the axis out of physical boundaries. Details here: https://github.com/bambulab/BambuStudio/issues/4841#issuecomment-2362988198
> 
> I am working on fixing this and will provide the fix here too. Sorry, I should've bought an AMS...

and additionally:

> New PR: https://github.com/bambulab/BambuStudio/pull/4848
> Let's wait for review and testing. Will surely take some time, but at least that's fixed again...for now

The corrected spiral lift modification will be resubmitted once Bambu has completed testing their PR#4848.