### PR TITLE
Disable Arc Fitting for FlashForge

### DIFF
--- a/resources/profiles/Flashforge/process/fdm_process_flashforge_common.json
+++ b/resources/profiles/Flashforge/process/fdm_process_flashforge_common.json
@@ -13,7 +13,7 @@
     "compatible_printers_condition": "",
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0.15",
-    "enable_arc_fitting": "1",
+    "enable_arc_fitting": "0",
     "outer_wall_acceleration": "5000",
     "wall_infill_order": "inner wall/outer wall/infill",
     "line_width": "0.42",


### PR DESCRIPTION
# Description

Some printers (FlashForge Adventurer 5M and FlashForge Adventurer 5M Pro) have issues related to Arc Fitting, this patch disables that feature.

# Screenshots/Recordings/Graphs

No UI change was done.

## Tests

Disabling Arc Fitting fixes the issue on my printer, and that is also known to cause issues, as publicly publish on many Reddit threads:
https://www.reddit.com/r/FlashForge/comments/1cu1rnq/psa_disable_arc_fitting_in_orcaslicer_on_ad5m/ https://www.reddit.com/r/FlashForge/comments/1dw99d5/ad5m_pro_move_que_overflow/ https://www.reddit.com/r/FlashForge/comments/1ct0uck/my_a5m_stopped_mid_print/