### PR TITLE
Add support for textured cool plate

### DIFF
--- a/resources/images/orca_bed_pct_left.svg
+++ b/resources/images/orca_bed_pct_left.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="302"
+   viewBox="0 0 24 302"
+   fill="none"
+   version="1.1"
+   id="svg14"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs14" />
+  <path
+     d="M 0.36895847,8.2161586 H 20.495973 V 1.5286532 H 20.6431 l 2.53059,1.265626 V 18.028666 H 23.026563 L 20.495973,16.76304 V 11.341161 H 1.6931042 L 0.36895847,8.3724087 Z"
+     id="text18"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="T" />
+  <path
+     d="m 0.95746767,22.325545 q 0,-4.687504 4.41381913,-4.687504 h 7.3563652 q 4.413819,0 4.413819,4.687504 v 3.593752 q 0,4.687505 -4.413819,4.687505 H 11.947877 L 4.812203,20.809918 q -1.2064438,0.218751 -1.2064438,1.515627 v 3.593752 q 0,1.562501 1.7655276,1.562501 h 0.7797747 l 1.3241457,2.968754 v 0.15625 H 5.3712868 q -4.41381913,0 -4.41381913,-4.687505 z m 6.92969593,-1.562502 5.0906044,6.70313 q 1.515411,-0.09375 1.515411,-1.546876 v -3.593752 q 0,-1.562502 -1.765527,-1.562502 z"
+     id="text17"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="e" />
+  <path
+     d="m 0.36895847,36.606806 v -0.156251 l 1.20644393,-2.718752 7.474067,4.843754 7.4593546,-4.843754 1.221156,2.734377 v 0.156251 l -6.282336,3.796877 6.282336,3.781253 v 0.15625 l -1.221156,2.734377 -7.4593546,-4.843753 -7.474067,4.843753 -1.20644393,-2.718752 v -0.15625 L 6.666007,40.419308 Z"
+     id="text16"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="x" />
+  <path
+     d="M 0.36895847,52.747446 H 14.463754 v -4.015628 h 0.147128 l 2.530589,1.265626 v 2.750002 h 5.296583 l 1.324146,2.968752 v 0.15625 h -6.620729 v 4.015628 H 16.994343 L 14.463754,58.62245 V 55.872448 H 1.6931042 L 0.36895847,52.903696 Z"
+     id="text15"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="t" />
+  <path
+     d="m 0.95746767,67.309956 q 0,-4.687505 4.41381913,-4.687505 H 16.405834 l 1.324146,2.968752 v 0.15625 H 5.3712868 q -1.7655276,0 -1.7655276,1.562503 v 3.593752 q 0,1.562501 1.7655276,1.562501 H 16.405834 l 1.324146,2.968753 v 0.15625 H 5.3712868 q -4.41381913,0 -4.41381913,-4.687504 z"
+     id="text14"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="u" />
+  <path
+     d="M 0.36895847,80.278718 H 12.727652 q 4.413819,0 4.413819,4.687504 v 3.906253 h -0.147128 l -2.501164,-1.250001 v -2.656252 q 0,-1.562501 -1.765527,-1.562501 H 1.6931042 L 0.36895847,80.434968 Z"
+     id="text13"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="r" />
+  <path
+     d="m 0.95746767,96.216231 q 0,-4.687503 4.41381913,-4.687503 h 7.3563652 q 4.413819,0 4.413819,4.687503 v 3.593753 q 0,4.687506 -4.413819,4.687506 H 11.947877 L 4.812203,94.700605 q -1.2064438,0.21875 -1.2064438,1.515626 v 3.593753 q 0,1.562506 1.7655276,1.562506 h 0.7797747 l 1.3241457,2.96875 v 0.15625 H 5.3712868 q -4.41381913,0 -4.41381913,-4.687506 z m 6.92969593,-1.562501 5.0906044,6.70313 q 1.515411,-0.0937 1.515411,-1.546876 v -3.593753 q 0,-1.562501 -1.765527,-1.562501 z"
+     id="text12"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="e" />
+  <path
+     d="m 0.95746767,113.87248 q 0,-4.6875 4.41381913,-4.6875 h 7.3563652 q 4.413819,0 4.413819,4.6875 v 3.59376 q 0,1.0625 -0.456095,1.5625 h 5.752678 l 1.324146,2.96875 v 0.15625 H 5.3712868 q -4.41381913,0 -4.41381913,-4.6875 z m 2.64829153,0 v 3.59376 q 0,1.5625 1.7655276,1.5625 h 7.3563652 q 1.765527,0 1.765527,-1.5625 v -3.59376 q 0,-1.5625 -1.765527,-1.5625 H 5.3712868 q -1.7655276,0 -1.7655276,1.5625 z"
+     id="text11"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="d" />
+  <path
+     d="m 0.95746767,146.37253 q 0,-5.46876 5.14945553,-5.46876 H 18.024235 q 5.149455,0 5.149455,5.46876 v 4.84376 q 0,5.46875 -5.149455,5.46875 h -1.618401 l -1.324145,-2.96875 v -0.15625 h 2.942546 q 2.501164,0 2.501164,-2.34375 v -4.84376 q 0,-2.34376 -2.501164,-2.34376 H 6.1069232 q -2.501164,0 -2.501164,2.34376 v 4.84376 q 0,2.34375 2.501164,2.34375 h 1.6184004 l 1.3241458,2.96875 v 0.15625 H 6.1069232 q -5.14945553,0 -5.14945553,-5.46875 z"
+     id="text10"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="C" />
+  <path
+     d="m 3.6057592,166.84129 v 3.59376 q 0,1.5625 1.7655276,1.5625 h 7.3563652 q 1.765527,0 1.765527,-1.5625 v -3.59376 q 0,-1.5625 -1.765527,-1.5625 H 5.3712868 q -1.7655276,0 -1.7655276,1.5625 z m -2.64829153,0 q 0,-4.6875 4.41381913,-4.6875 h 7.3563652 q 4.413819,0 4.413819,4.6875 v 3.59376 q 0,4.6875 -4.413819,4.6875 H 5.3712868 q -4.41381913,0 -4.41381913,-4.6875 z"
+     id="text9"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="o" />
+  <path
+     d="m 3.6057592,184.49756 v 3.59375 q 0,1.5625 1.7655276,1.5625 h 7.3563652 q 1.765527,0 1.765527,-1.5625 v -3.59375 q 0,-1.5625 -1.765527,-1.5625 H 5.3712868 q -1.7655276,0 -1.7655276,1.5625 z m -2.64829153,0 q 0,-4.68751 4.41381913,-4.68751 h 7.3563652 q 4.413819,0 4.413819,4.68751 v 3.59375 q 0,4.6875 -4.413819,4.6875 H 5.3712868 q -4.41381913,0 -4.41381913,-4.6875 z"
+     id="text8"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="o" />
+  <path
+     d="M 0.36895847,198.24757 H 22.438054 l 1.324146,2.96875 v 0.15625 H 1.6931042 l -1.32414573,-2.96875 z"
+     id="text7"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="l" />
+  <path
+     d="M 0.36895847,220.12259 H 22.438054 l 0.735636,1.65625 v 8.34375 q 0,5.46876 -5.149455,5.46876 h -4.413819 q -5.1494559,0 -5.1494559,-5.46876 v -6.875 H 1.6931042 l -1.32414573,-2.96875 z m 20.15644053,3.125 h -9.416147 v 6.875 q 0,2.34376 2.501164,2.34376 h 4.413819 q 2.501164,0 2.501164,-2.34376 z"
+     id="text6"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="P" />
+  <path
+     d="M 0.36895847,241.0601 H 22.438054 l 1.324146,2.96875 v 0.15625 H 1.6931042 l -1.32414573,-2.96875 z"
+     id="text5"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="l" />
+  <path
+     d="m 3.6057592,253.5601 v 3.28125 q 0,1.5625 1.7655276,1.5625 h 2.0156441 q 1.7655275,0 1.7655275,-1.5625 v -3.28125 q 0,-1.5625 -1.7655275,-1.5625 H 5.3712868 q -1.7655276,0 -1.7655276,1.5625 z m -2.64829153,0 q 0,-4.6875 4.41381913,-4.6875 h 2.0156441 q 4.4138191,0 4.4138191,4.6875 v 3.28125 q 0,0.81251 -0.441382,1.5625 h 1.368284 q 1.765527,0 1.765527,-1.5625 v -5.59375 h 0.147128 l 2.501164,1.25 v 4.34375 q 0,4.68751 -4.413819,4.68751 H 1.6931042 L 0.36895847,258.5601 v -0.15625 H 1.3988496 q -0.44138193,-0.59374 -0.44138193,-1.5625 z"
+     id="text4"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="a" />
+  <path
+     d="M 0.36895847,268.27887 H 14.463754 v -4.01563 h 0.147128 l 2.530589,1.26562 v 2.75001 h 5.296583 l 1.324146,2.96875 v 0.15625 h -6.620729 v 4.01562 h -0.147128 l -2.530589,-1.26562 v -2.75 H 1.6931042 l -1.32414573,-2.96875 z"
+     id="text3"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="t" />
+  <path
+     d="m 0.95746767,282.84136 q 0,-4.6875 4.41381913,-4.6875 h 7.3563652 q 4.413819,0 4.413819,4.6875 v 3.59376 q 0,4.6875 -4.413819,4.6875 h -0.779775 l -7.135674,-9.79688 q -1.2064438,0.21875 -1.2064438,1.51562 v 3.59376 q 0,1.5625 1.7655276,1.5625 h 0.7797747 l 1.3241457,2.96875 v 0.15625 H 5.3712868 q -4.41381913,0 -4.41381913,-4.6875 z m 6.92969593,-1.5625 5.0906044,6.70314 q 1.515411,-0.0938 1.515411,-1.54688 v -3.59376 q 0,-1.5625 -1.765527,-1.5625 z"
+     id="text2"
+     style="font-weight:bold;font-size:31.0518px;font-family:'Nova Square';-inkscape-font-specification:'Nova Square Bold';writing-mode:tb-rl;fill:#b3b3b3;fill-rule:evenodd;stroke-width:13.8763;stroke-miterlimit:3.6"
+     aria-label="e" />
+</svg>

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1803,6 +1803,8 @@ static BambuBedType to_bambu_bed_type(BedType type)
         bambu_bed_type = bbtHighTemperaturePlate;
     else if (type == btPTE)
         bambu_bed_type = bbtTexturedPEIPlate;
+    else if (type == btPCT)
+        bambu_bed_type = bbtCoolPlate;
 
     return bambu_bed_type;
 }

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -823,7 +823,7 @@ static std::vector<std::string> s_Preset_filament_options {
     "filament_flow_ratio", "filament_density", "filament_cost", "filament_minimal_purge_on_wipe_tower",
     "nozzle_temperature", "nozzle_temperature_initial_layer",
     // BBS
-    "cool_plate_temp", "eng_plate_temp", "hot_plate_temp", "textured_plate_temp", "cool_plate_temp_initial_layer", "eng_plate_temp_initial_layer", "hot_plate_temp_initial_layer","textured_plate_temp_initial_layer",
+    "cool_plate_temp", "textured_cool_plate_temp", "eng_plate_temp", "hot_plate_temp", "textured_plate_temp", "cool_plate_temp_initial_layer", "textured_cool_plate_temp_initial_layer", "eng_plate_temp_initial_layer", "hot_plate_temp_initial_layer","textured_plate_temp_initial_layer",
     // "bed_type",
     //BBS:temperature_vitrification
     "temperature_vitrification", "reduce_fan_stop_start_freq","dont_slow_down_outer_wall", "slow_down_for_layer_cooling", "fan_min_speed",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -128,9 +128,10 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "bridge_acceleration",
         "travel_acceleration",
         "sparse_infill_acceleration",
-        "internal_solid_infill_acceleration"
+        "internal_solid_infill_acceleration",
         // BBS
         "cool_plate_temp_initial_layer",
+        "textured_cool_plate_temp_initial_layer",
         "eng_plate_temp_initial_layer",
         "hot_plate_temp_initial_layer",
         "textured_plate_temp_initial_layer",
@@ -270,6 +271,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "single_extruder_multi_material"
             || opt_key == "nozzle_temperature"
             || opt_key == "cool_plate_temp"
+            || opt_key == "textured_cool_plate_temp"
             || opt_key == "eng_plate_temp"
             || opt_key == "hot_plate_temp"
             || opt_key == "textured_plate_temp"

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -352,7 +352,8 @@ static const t_config_enum_values s_keys_map_BedType = {
     { "Cool Plate",         btPC },
     { "Engineering Plate",  btEP  },
     { "High Temp Plate",    btPEI  },
-    { "Textured PEI Plate", btPTE }
+    { "Textured PEI Plate", btPTE },
+    { "Textured Cool Plate", btPCT }
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(BedType)
 
@@ -665,6 +666,16 @@ void PrintConfigDef::init_fff_params()
     def->max = 300;
     def->set_default_value(new ConfigOptionInts{ 35 });
 
+    def = this->add("textured_cool_plate_temp", coInts);
+    def->label = L("Other layers");
+    def->tooltip = L("Bed temperature for layers except the initial one. "
+        "Value 0 means the filament does not support to print on the Textured Cool Plate");
+    def->sidetext = L("°C");
+    def->full_label = L("Bed temperature");
+    def->min = 0;
+    def->max = 300;
+    def->set_default_value(new ConfigOptionInts{ 40 });
+
     def = this->add("eng_plate_temp", coInts);
     def->label = L("Other layers");
     def->tooltip = L("Bed temperature for layers except the initial one. "
@@ -705,6 +716,16 @@ void PrintConfigDef::init_fff_params()
     def->max = 120;
     def->set_default_value(new ConfigOptionInts{ 35 });
 
+    def = this->add("textured_cool_plate_temp_initial_layer", coInts);
+    def->label = L("Initial layer");
+    def->full_label = L("Initial layer bed temperature");
+    def->tooltip = L("Bed temperature of the initial layer. "
+        "Value 0 means the filament does not support to print on the Textured Cool Plate");
+    def->sidetext = L("°C");
+    def->min = 0;
+    def->max = 120;
+    def->set_default_value(new ConfigOptionInts{ 40 });
+
     def = this->add("eng_plate_temp_initial_layer", coInts);
     def->label = L("Initial layer");
     def->full_label = L("Initial layer bed temperature");
@@ -740,10 +761,12 @@ void PrintConfigDef::init_fff_params()
     def->mode = comSimple;
     def->enum_keys_map = &s_keys_map_BedType;
     def->enum_values.emplace_back("Cool Plate");
+    def->enum_values.emplace_back("Textured Cool Plate");
     def->enum_values.emplace_back("Engineering Plate");
     def->enum_values.emplace_back("High Temp Plate");
     def->enum_values.emplace_back("Textured PEI Plate");
     def->enum_labels.emplace_back(L("Cool Plate"));
+    def->enum_labels.emplace_back(L("Textured Cool Plate"));
     def->enum_labels.emplace_back(L("Engineering Plate"));
     def->enum_labels.emplace_back(L("Smooth PEI Plate / High Temp Plate"));
     def->enum_labels.emplace_back(L("Textured PEI Plate"));

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -258,6 +258,7 @@ enum BedType {
     btEP,
     btPEI,
     btPTE,
+    btPCT,
     btCount
 };
 
@@ -324,6 +325,9 @@ static std::string bed_type_to_gcode_string(const BedType type)
     case btPC:
         type_str = "cool_plate";
         break;
+    case btPCT:
+        type_str = "textured_cool_plate";
+        break;
     case btEP:
         type_str = "eng_plate";
         break;
@@ -346,6 +350,9 @@ static std::string get_bed_temp_key(const BedType type)
     if (type == btPC)
         return "cool_plate_temp";
 
+    if (type == btPCT)
+        return "textured_cool_plate_temp";
+
     if (type == btEP)
         return "eng_plate_temp";
 
@@ -362,6 +369,9 @@ static std::string get_bed_temp_1st_layer_key(const BedType type)
 {
     if (type == btPC)
         return "cool_plate_temp_initial_layer";
+
+    if (type == btPCT)
+        return "textured_cool_plate_temp_initial_layer";
 
     if (type == btEP)
         return "eng_plate_temp_initial_layer";
@@ -1172,10 +1182,12 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionString,             bed_custom_model))
     ((ConfigOptionEnum<BedType>,      curr_bed_type))
     ((ConfigOptionInts,               cool_plate_temp))
+    ((ConfigOptionInts,               textured_cool_plate_temp))
     ((ConfigOptionInts,               eng_plate_temp))
     ((ConfigOptionInts,               hot_plate_temp)) // hot is short for high temperature
     ((ConfigOptionInts,               textured_plate_temp))
     ((ConfigOptionInts,               cool_plate_temp_initial_layer))
+    ((ConfigOptionInts,               textured_cool_plate_temp_initial_layer))
     ((ConfigOptionInts,               eng_plate_temp_initial_layer))
     ((ConfigOptionInts,               hot_plate_temp_initial_layer)) // hot is short for high temperature
     ((ConfigOptionInts,               textured_plate_temp_initial_layer))

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -5513,6 +5513,7 @@ void PartPlateList::BedTextureInfo::reset()
 
 void PartPlateList::init_bed_type_info()
 {
+	BedTextureInfo::TexturePart pct_part_left(10, 130,  10, 110, "orca_bed_pct_left.svg");
 	BedTextureInfo::TexturePart pc_part1(10, 130,  10, 110, "bbl_bed_pc_left.svg");
 	BedTextureInfo::TexturePart pc_part2(74, -10, 148, 12, "bbl_bed_pc_bottom.svg");
 	BedTextureInfo::TexturePart ep_part1(7.5, 90, 12.5, 150, "bbl_bed_ep_left.svg");
@@ -5527,6 +5528,8 @@ void PartPlateList::init_bed_type_info()
 	}
 	bed_texture_info[btPC].parts.push_back(pc_part1);
 	bed_texture_info[btPC].parts.push_back(pc_part2);
+	bed_texture_info[btPCT].parts.push_back(pct_part_left);
+	bed_texture_info[btPCT].parts.push_back(pc_part2);
 	bed_texture_info[btEP].parts.push_back(ep_part1);
 	bed_texture_info[btEP].parts.push_back(ep_part2);
 	bed_texture_info[btPEI].parts.push_back(pei_part1);

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3315,6 +3315,11 @@ void TabFilament::build()
         line.append_option(optgroup->get_option("cool_plate_temp"));
         optgroup->append_line(line);
 
+        line = { L("Textured Cool plate"), L("Bed temperature when cool plate is installed. Value 0 means the filament does not support to print on the Textured Cool Plate") };
+        line.append_option(optgroup->get_option("textured_cool_plate_temp_initial_layer"));
+        line.append_option(optgroup->get_option("textured_cool_plate_temp"));
+        optgroup->append_line(line);
+
         line = { L("Engineering plate"), L("Bed temperature when engineering plate is installed. Value 0 means the filament does not support to print on the Engineering Plate") };
         line.append_option(optgroup->get_option("eng_plate_temp_initial_layer"));
         line.append_option(optgroup->get_option("eng_plate_temp"));
@@ -3578,6 +3583,7 @@ void TabFilament::toggle_options()
         toggle_option("pressure_advance", pa);
         auto support_multi_bed_types = is_BBL_printer || cfg.opt_bool("support_multi_bed_types");
         toggle_line("cool_plate_temp_initial_layer", support_multi_bed_types );
+        toggle_line("textured_cool_plate_temp_initial_layer", support_multi_bed_types);
         toggle_line("eng_plate_temp_initial_layer", support_multi_bed_types);
         toggle_line("textured_plate_temp_initial_layer", support_multi_bed_types);
         


### PR DESCRIPTION
# Description

Support textured cool plates like BigTree's CryoGrip Textured Coating Steel Sheet. 
This allows users to adjust z offset for textured plates.

<img width="1096" alt="Screenshot 2024-09-22 at 1 30 32 AM" src="https://github.com/user-attachments/assets/7e8ec944-8a32-430b-a4e7-8833cebe34b9">

<img width="1097" alt="Screenshot 2024-09-22 at 10 34 59 AM" src="https://github.com/user-attachments/assets/7d3edae2-b3e7-4579-b831-4c5cca6798bd">
