### PR TITLE
Enable filament buttons on the multi-extruder

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -1280,7 +1280,8 @@ void Sidebar::update_all_preset_comboboxes()
         p->m_filament_icon->SetBitmap_("filament");
     }
 
-    show_SEMM_buttons(cfg.opt_bool("single_extruder_multi_material"));
+    // show_SEMM_buttons(cfg.opt_bool("single_extruder_multi_material"));
+    show_SEMM_buttons(true);
 
     //p->m_staticText_filament_settings->Update();
 


### PR DESCRIPTION
With the number of extruder configured, I still want to enable these buttons, especially `flush_multiplier`, without which the wipe tower will waste material.

For filament that exceed the number (for example, the number of extruder is 2, and the filament number is 4) the printer will not execute it, so this error should be handled by the user himself.

Or maybe there's a better way to do it? [like this](https://github.com/macdylan/sm2uploader/releases/tag/v2.8)
> ....
T[0,2,4,6...] will be modified to T0
T[1,3,5,7...] will be modified to T1
...