### PR TITLE
Fix building errors when precompiled header support is disabled

### DIFF
--- a/src/libslic3r/ClipperZUtils.hpp
+++ b/src/libslic3r/ClipperZUtils.hpp
@@ -6,6 +6,7 @@
 
 #include <clipper/clipper_z.hpp>
 #include <libslic3r/Point.hpp>
+#include <libslic3r/ExPolygon.hpp>
 
 namespace Slic3r {
 

--- a/src/libslic3r/Slicing.hpp
+++ b/src/libslic3r/Slicing.hpp
@@ -11,6 +11,7 @@
 
 #include "libslic3r.h"
 #include "Utils.hpp"
+#include "Point.hpp"
 
 namespace Slic3r
 {


### PR DESCRIPTION
Here are more missing header files recently identified by building without precompiled header support.