### PR TITLE
Disable "cut to parts" when dovetail is selected.

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
@@ -2772,12 +2772,17 @@ void GLGizmoCut3D::render_cut_plane_input_window(CutConnectors &connectors, floa
         render_part_action_line(_L("Upper part"), "##upper", m_keep_upper, m_place_on_cut_upper, m_rotate_upper);
         render_part_action_line(_L("Lower part"), "##lower", m_keep_lower, m_place_on_cut_lower, m_rotate_lower);
 
-        m_imgui->disabled_begin(has_connectors);
-        m_imgui->bbl_checkbox(_L("Cut to parts"), m_keep_as_parts);
-        if (m_keep_as_parts) {
-            m_keep_upper = true;
-            m_keep_lower = true;
-        }
+        m_imgui->disabled_begin(has_connectors || m_part_selection.valid() || mode == CutMode::cutTongueAndGroove);
+
+            if (m_part_selection.valid())
+                m_keep_as_parts = false;
+
+            m_imgui->bbl_checkbox(_L("Cut to parts"), m_keep_as_parts);
+            if (m_keep_as_parts) {
+                m_keep_upper = m_keep_lower = true;
+                m_place_on_cut_upper = m_place_on_cut_lower = false;
+                m_rotate_upper = m_rotate_lower = false;
+            }
         m_imgui->disabled_end();
     }
 


### PR DESCRIPTION
Sync with latest PrusaSlicer code.

This option doesn't work when dovetail is used anyway so disable it to make it less confusing, and this matches the behavior as PrusaSlicer and BambuStudio.