### PR TITLE
Fix a bug that wipe tower has missing extrusions when ramming is disabled

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -676,9 +676,10 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     for (auto el : {"wipe_tower_rotation_angle", "wipe_tower_cone_angle",
                     "wipe_tower_extra_spacing", "wipe_tower_max_purge_speed",
                     "wipe_tower_bridging", "wipe_tower_extra_flow",
-                    "wipe_tower_no_sparse_layers",
-                    "single_extruder_multi_material_priming"})
+                    "wipe_tower_no_sparse_layers"})
       toggle_line(el, have_prime_tower && !is_BBL_Printer);
+
+    toggle_line("single_extruder_multi_material_priming", !bSEMM && have_prime_tower && !is_BBL_Printer);
 
     toggle_line("prime_volume",have_prime_tower && (!purge_in_primetower || !bSEMM));
     


### PR DESCRIPTION
# Description

Fix a bug where the wipe tower has missing extrusions when ramming is disabled.

Additionally, this update improves the logic for the 'Enable Filament Ramming' feature. We no longer need to set the cooling parameters to 0 to completely disable ramming.

<img width="446" alt="Screenshot 2024-09-25 at 12 03 12 AM" src="https://github.com/user-attachments/assets/770f241f-a600-48c1-9fe6-d886b7e35d13">


# Screenshots/Recordings/Graphs
Before:  
![image](https://github.com/user-attachments/assets/8dfa4d01-1576-4dee-820e-a1f6059fba09)

After fix:  

<img width="857" alt="Screenshot 2024-09-25 at 12 01 48 AM" src="https://github.com/user-attachments/assets/47f586a0-1cea-4a9e-a46c-559f7db51c89">



## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
