### PR TITLE
Fix wipe tower issues with SEMM and ramming turned off

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -766,15 +766,11 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
                 gcodegen.m_wipe.reset_path();                                           // We don't want wiping on the ramming lines.
             toolchange_gcode_str = gcodegen.set_extruder(new_extruder_id, tcr.print_z); // TODO: toolchange_z vs print_z
             if (gcodegen.config().enable_prime_tower) {
-                // ORCA: For SEMM, this move causes the nozzle to crash on the wipe tower for the final wipe layer.
-                // TODO: Requires validation whether this is an issue even with multi extruder printers
-                if(!this->m_single_extruder_multi_material){
-                    deretraction_str += gcodegen.writer().travel_to_z(z, "restore layer Z");
-                    Vec3d position{gcodegen.writer().get_position()};
-                    position.z() = z;
-                    gcodegen.writer().set_position(position);
-                }
-                deretraction_str += gcodegen.unretract();
+            deretraction_str += gcodegen.writer().travel_to_z(z, "restore layer Z");
+            Vec3d position{gcodegen.writer().get_position()};
+            position.z() = z;
+            gcodegen.writer().set_position(position);
+            deretraction_str += gcodegen.unretract();
             }
         }
 

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -766,11 +766,15 @@ static std::vector<Vec2d> get_path_of_change_filament(const Print& print)
                 gcodegen.m_wipe.reset_path();                                           // We don't want wiping on the ramming lines.
             toolchange_gcode_str = gcodegen.set_extruder(new_extruder_id, tcr.print_z); // TODO: toolchange_z vs print_z
             if (gcodegen.config().enable_prime_tower) {
-            deretraction_str += gcodegen.writer().travel_to_z(z, "restore layer Z");
-            Vec3d position{gcodegen.writer().get_position()};
-            position.z() = z;
-            gcodegen.writer().set_position(position);
-            deretraction_str += gcodegen.unretract();
+                // ORCA: For SEMM, this move causes the nozzle to crash on the wipe tower for the final wipe layer.
+                // TODO: Requires validation whether this is an issue even with multi extruder printers
+                if(!this->m_single_extruder_multi_material){
+                    deretraction_str += gcodegen.writer().travel_to_z(z, "restore layer Z");
+                    Vec3d position{gcodegen.writer().get_position()};
+                    position.z() = z;
+                    gcodegen.writer().set_position(position);
+                }
+                deretraction_str += gcodegen.unretract();
             }
         }
 

--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -893,7 +893,8 @@ void WipeTower2::toolchange_Unload(
 	float remaining = xr - xl ;							// keeps track of distance to the next turnaround
 	float e_done = 0;									// measures E move done from each segment   
 
-    const bool do_ramming = m_semm || m_filpar[m_current_tool].multitool_ramming;
+    // Orca: Do ramming when SEMM and ramming is enabled or when multi tool head when ramming is enabled on the multi tool.
+    const bool do_ramming = (m_semm && m_enable_filament_ramming) || m_filpar[m_current_tool].multitool_ramming;
     const bool cold_ramming = m_is_mk4mmu3;
 
     if (do_ramming) {
@@ -1544,7 +1545,8 @@ void WipeTower2::plan_toolchange(float z_par, float layer_height_par, unsigned i
 	float length_to_extrude = volume_to_length(0.25f * std::accumulate(m_filpar[old_tool].ramming_speed.begin(), m_filpar[old_tool].ramming_speed.end(), 0.f),
 										m_perimeter_width * m_filpar[old_tool].ramming_line_width_multiplicator,
 										layer_height_par);
-	float ramming_depth = (int(length_to_extrude / width) + 1) * (m_perimeter_width * m_filpar[old_tool].ramming_line_width_multiplicator * m_filpar[old_tool].ramming_step_multiplicator) * m_extra_spacing_ramming;
+    // Orca: Set ramming depth to 0 if ramming is disabled.
+    float ramming_depth = m_enable_filament_ramming ? ((int(length_to_extrude / width) + 1) * (m_perimeter_width * m_filpar[old_tool].ramming_line_width_multiplicator * m_filpar[old_tool].ramming_step_multiplicator) * m_extra_spacing_ramming) : 0;
     float first_wipe_line = - (width*((length_to_extrude / width)-int(length_to_extrude / width)) - width);
 
     float first_wipe_volume = length_to_volume(first_wipe_line, m_perimeter_width * m_extra_flow, layer_height_par);


### PR DESCRIPTION
# Description

Fixes issues discussed here: https://github.com/SoftFever/OrcaSlicer/pull/6894

**EDIT: Reverted changes for Z issues when next layer starts over the wipe tower.** Keeping the below commentary for reference only.

@SoftFever Would appreciate a review for the nozzle crash on the last wipe tower layer issue please. This was added here https://github.com/SoftFever/OrcaSlicer/commit/13ddb38119f7e86b2ff60916e73a80790649815c but with the model below I get a nozzle crash on the top layer as the nozzle is forced one layer down. For some reason this:
```
        double current_z = gcodegen.writer().get_position().z();
        if (z == -1.) // in case no specific z was provided, print at current_z pos
            z = current_z;
```
Returns the previous layer Z when on the final wipe tower layer, so it pushes the nozzle down to the wipe tower. 

Maybe that is expected as on the last layer of the wipe tower the nozzle finishes the layer, does the tool change and then immediately moves to the next layer while still over the wipe tower. See below:

Last layer where a toolchange is needed is printed - the grey line is the last print
![image](https://github.com/user-attachments/assets/3f376ad2-ba3b-45ef-b854-2bfdc7ef2fda)

The first move of the next layer is the purge tower (the fix is applied to the below screenshot so there is no z going to the prev layer):
![image](https://github.com/user-attachments/assets/e796ffe8-502e-45c5-8d62-7525a2818b93)

So technically Z hasn't changed over the model, so the gcode gen function doesnt know of this new height. So when setting it to current Z we are actually setting it to the previous Z from the model...

Just a theory on this as I am really not sure. In any case, this PR appears to have resolved it for SEMM by removing the specific code segment that causes this Z move on the wipe tower.

I have not tested this with a multi toolhead profile so please do before merging anything in :) 