### PR TITLE
Removed editor's label from Russian translation file

### DIFF
--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -2,7 +2,6 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# EDITOR <helldar@dragon-code.pro>, YEAR.
 #
 msgid ""
 msgstr ""


### PR DESCRIPTION
I figured I didn't contribute as many translations, and also in some places the context wasn't taken into account, as there were some controversial translation situations. So I decided to remove the editor's label from the file, otherwise someone else will think I did it (no, I didn't) 🙂