### PR TITLE
FIX: CLI: fix an exception when parsing scale params

### DIFF
--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -3575,10 +3575,16 @@ int CLI::run(int argc, char **argv)
                     // this affects volumes:
                     o->rotate(Geometry::deg2rad(m_config.opt_float(opt_key)), Y);
         } else if (opt_key == "scale") {
+            float ratio = m_config.opt_float(opt_key);
+            if (ratio <= 0.f) {
+                BOOST_LOG_TRIVIAL(error) << boost::format("Invalid params:invalid scale ratio %1%")%ratio;
+                record_exit_reson(outfile_dir, CLI_INVALID_PARAMS, 0, cli_errors[CLI_INVALID_PARAMS], sliced_info);
+                flush_and_exit(CLI_INVALID_PARAMS);
+            }
             for (auto &model : m_models)
                 for (auto &o : model.objects)
                     // this affects volumes:
-                    o->scale(m_config.get_abs_value(opt_key, 1));
+                    o->scale(ratio));
         } else if (opt_key == "scale_to_fit") {
             const Vec3d &opt = m_config.opt<ConfigOptionPoint3>(opt_key)->value;
             if (opt.x() <= 0 || opt.y() <= 0 || opt.z() <= 0) {


### PR DESCRIPTION
# Description

This PR aims to solve an exception when using OrcaSlicer in CLI which caused the --scale option to not work. 
All credits to @lanewei120 from BambuStudio for pushing it on BS repo.

Related commit on BS:
https://github.com/bambulab/BambuStudio/commit/2d4655e780e85e84445bb0b1987445e9e8d66b95#diff-2fa194122e892282ec589e51d5f7da65da83ec0488ced4b63930345d1273a353R3797
Related issue on BS:
https://github.com/bambulab/BambuStudio/issues/4628
Related issue on Orca:
https://github.com/SoftFever/OrcaSlicer/issues/6454
fixes #6454
## Tests

```
./orca-slicer.exe --scale 2 --slice 1 --allow-newer-file test_model.stl --debug 5
```
The command above works again and scale the model then slice the scaled model. Before, the scale would not complete.
