### PR TITLE
Fix compilation with gcc14

### DIFF
--- a/src/clipper2/Clipper2Lib/include/clipper2/clipper.core.h
+++ b/src/clipper2/Clipper2Lib/include/clipper2/clipper.core.h
@@ -114,7 +114,7 @@ struct Point {
 	Point(const T2 x_, const T2 y_) { Init(x_, y_); }
 
 	template <typename T2>
-	explicit Point<T>(const Point<T2>& p) { Init(p.x, p.y); }
+	explicit Point(const Point<T2>& p) { Init(p.x, p.y); }
 
 	Point operator * (const double scale) const
 	{


### PR DESCRIPTION
# Description

Compilation using GCC-14 on Ubuntu 24.10 yelds warning (turned into the error by -Werror):

```
src/clipper2/Clipper2Lib/include/clipper2/clipper.core.h:117:26: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
  117 |         explicit Point<T>(const Point<T2>& p) { Init(p.x, p.y); }
      |                          ^

```

Some details why C++ behaves this way could be found at https://eel.is/c++draft/diff.cpp17.class#2

## Tests

Local compilation 