### PR TITLE
Differentiates beta releases. Always shows release notes as text.

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4280,7 +4280,6 @@ void GUI_App::check_new_version_sf(bool show_tips, int by_user)
                         best_pre         = tag_version;
                         best_pre_url     = root.get<std::string>("html_url");
                         best_pre_content = root.get<std::string>("body");
-                        best_pre.set_prerelease("Preview");
                     }
                 } else {
                     if (best_release < tag_version) {
@@ -4302,7 +4301,6 @@ void GUI_App::check_new_version_sf(bool show_tips, int by_user)
                             best_pre         = tag_version;
                             best_pre_url     = json_version.second.get<std::string>("html_url");
                             best_pre_content = json_version.second.get<std::string>("body");
-                            best_pre.set_prerelease("Preview");
                         }
                     } else {
                         if (best_release < tag_version) {

--- a/src/slic3r/GUI/ReleaseNote.cpp
+++ b/src/slic3r/GUI/ReleaseNote.cpp
@@ -502,21 +502,20 @@ std::vector<std::string> UpdateVersionDialog::splitWithStl(std::string str,std::
 void UpdateVersionDialog::update_version_info(wxString release_note, wxString version)
 {
     //bbs check whether the web display is used
-    bool use_web_link       = false;
-    url_line                = "";
-    auto split_array        =  splitWithStl(release_note.ToStdString(), "###");
-
-    if (split_array.size() >= 3) {
-        for (auto i = 0; i < split_array.size(); i++) {
-            std::string url = split_array[i];
-            if (std::strstr(url.c_str(), "http://") != NULL || std::strstr(url.c_str(), "https://") != NULL) {
-                use_web_link = true;
-                url_line = url;
-                break;
-            }
-        }
-    }
-   
+    bool use_web_link = false;
+    url_line          = "";
+    // Orca: not used in Orca Slicer
+    // auto split_array = splitWithStl(release_note.ToStdString(), "###");
+    // if (split_array.size() >= 3) {
+    //     for (auto i = 0; i < split_array.size(); i++) {
+    //         std::string url = split_array[i];
+    //         if (std::strstr(url.c_str(), "http://") != NULL || std::strstr(url.c_str(), "https://") != NULL) {
+    //             use_web_link = true;
+    //             url_line     = url;
+    //             break;
+    //         }
+    //     }
+    // }
 
     if (use_web_link) {
         m_brand->Hide();


### PR DESCRIPTION
# Description
* Removes `Preview` overwrite for pre-releases so that Semver can differentiate/compare the versions better. 
* Also removes the logic that tries to find a URL to load in the release notes. This used to cause blank release notes for releases that had 3x `###` followed by a URL in the description. v2.2.0-rc is a good example of this.

# Screenshots/Recordings/Graphs/Tests
Applied this change to versions 2.1.0 and 2.2.0 beta so I could test both stable and unstable functionality.
## 2.1.0 Before
Stable finds 2.1.1
![image](https://github.com/user-attachments/assets/06cb21ae-e63a-4f62-a1b0-555292d54767)
Unstable finds 2.2.0 beta (Even though beta2 and rc are already released)
![image](https://github.com/user-attachments/assets/11e2038c-2707-469a-ab81-272153e4e60b)

## 2.1.0 After
Stable finds 2.1.1
![image](https://github.com/user-attachments/assets/3100b256-176e-4c1b-9847-c83881dda9e1)
Unstable finds 2.0.0 rc
![image](https://github.com/user-attachments/assets/7c7bf389-3a1e-4ca0-a55c-1fc51f40d781)

## 2.2.0-beta Before
Stable finds nothing newer
![image](https://github.com/user-attachments/assets/61eb546b-7ede-4d55-aeae-a68fa423da81)
Unstable finds nothing newer
![image](https://github.com/user-attachments/assets/3fa86110-e716-48aa-8de2-a0dd2f7983cd)

## 2.2.0-beta After
Stable finds nothing newer
![image](https://github.com/user-attachments/assets/b04f19a8-5d0a-4e6f-a0c5-682fc80579f8)
Unstable finds 2.2.0 rc
![image](https://github.com/user-attachments/assets/6426354e-6227-4145-91f7-40cd9cef1274)
Unstable finds 2.2.0 beta2 when I manually remove 2.2.0 rc from the api response.
![image](https://github.com/user-attachments/assets/20531679-488d-4cc4-96d9-e0ca6dda4488)

