### PR TITLE
Enable Air Filtration Support for BBL P1S, X1, X1C

### DIFF
--- a/resources/profiles/BBL/machine/Bambu Lab P1S 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab P1S 0.4 nozzle.json
@@ -29,6 +29,7 @@
     "nozzle_height": "4.2",
     "nozzle_type": "stainless_steel",
     "scan_first_layer": "0",
+    "support_air_filtration": "1",
     "upward_compatible_machine": [
         "Bambu Lab P1P 0.4 nozzle",
         "Bambu Lab X1 0.4 nozzle",

--- a/resources/profiles/BBL/machine/Bambu Lab X1 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab X1 0.4 nozzle.json
@@ -30,6 +30,7 @@
     "nozzle_height": "4.2",
     "nozzle_type": "stainless_steel",
     "scan_first_layer": "1",
+    "support_air_filtration": "1",
     "upward_compatible_machine": [
         "Bambu Lab P1S 0.4 nozzle",
         "Bambu Lab P1P 0.4 nozzle",

--- a/resources/profiles/BBL/machine/Bambu Lab X1 Carbon 0.4 nozzle.json
+++ b/resources/profiles/BBL/machine/Bambu Lab X1 Carbon 0.4 nozzle.json
@@ -28,6 +28,7 @@
     "machine_unload_filament_time": "28",
     "nozzle_height": "4.2",
     "scan_first_layer": "1",
+    "support_air_filtration": "1",
     "upward_compatible_machine": [
         "Bambu Lab P1S 0.4 nozzle",
         "Bambu Lab P1P 0.4 nozzle",


### PR DESCRIPTION
# Description
Re-Creation of Pull Request #6964 with X1E changes pulled. 

OrcaSlicer includes exhaust fan settings for each filaments, however these settings do not take effect on Bambu Labs machines that include chamber temperature regulation fans. 
![image](https://github.com/user-attachments/assets/6bb79d56-9940-46cf-b998-7d29c49bc928)

Further investigation into the g-code files produced reveals that the filament start g-code is responsible for using the air filtration setting and sending the appropriate `M106 P3 S{during_print_exhaust_fan_speed_num[current_extruder]}` command to the printer.  However, this command, even with the setting enabled, is never written to the final g-code file. 

By default, Bambu Lab's filament profiles wrap this command up in` {if activate_air_filtration[current_extruder] && support_air_filtration}` clause, which always evaluates to false. As it turns out, the printer's have the `support_air_filtration` flag set to `0` in the  `fdm_machine_common.json` file. 

This change updates that value to `1` in the .json files for the X1, X1C, X1E, and P1S 0.4mm nozzles. This is then inherited to other nozzle sizes and user generated profiles. This is done by simply adding a line `    "support_air_filtration": "1",` to the .json to override the inherited setting. 
<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

Fixes #6066 
# Screenshots/Recordings/Graphs

N/A 

## Tests

Updated this flag in a custom user config for the printer than tried generating the code file with Air Filtration enabled and set to 70% 

The appropriate `M106 P3 S178 ` appears in the filament start gcode section of the file.  
<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

Updated this flag in a custom user config for the printer than tried generating the code file with Air Filtration enabled and set to 70% 

The appropriate `M106 P3 S178 ` appears in the filament start gcode section of the file.  

