### PR TITLE
Feature: set different colors to tools on devices with multitools

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -1851,6 +1851,26 @@ void PresetBundle::export_selections(AppConfig &config)
 }
 
 // BBS
+void PresetBundle::set_num_filaments(unsigned int n, std::vector<std::string> new_colors) {
+    int old_filament_count = this->filament_presets.size();
+    if (n > old_filament_count && old_filament_count != 0)
+        filament_presets.resize(n, filament_presets.back());
+    else {
+        filament_presets.resize(n);
+    }
+    ConfigOptionStrings* filament_color = project_config.option<ConfigOptionStrings>("filament_colour");
+    filament_color->resize(n);
+    ams_multi_color_filment.resize(n);
+    // BBS set new filament color to new_color
+    if (old_filament_count < n) {
+        if (!new_colors.empty()) {
+            for (int i = old_filament_count; i < n; i++) {
+                filament_color->values[i] = new_colors[i - old_filament_count];
+            }
+        }
+    }
+    update_multi_material_filament_presets();
+}
 void PresetBundle::set_num_filaments(unsigned int n, std::string new_color)
 {
     int old_filament_count = this->filament_presets.size();

--- a/src/libslic3r/PresetBundle.hpp
+++ b/src/libslic3r/PresetBundle.hpp
@@ -111,6 +111,7 @@ public:
     void            export_selections(AppConfig &config);
 
     // BBS
+    void            set_num_filaments(unsigned int n, std::vector<std::string> new_colors);
     void            set_num_filaments(unsigned int n, std::string new_col = "");
     unsigned int sync_ams_list(unsigned int & unknowns);
     //BBS: check whether this is the only edited filament

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -1649,7 +1649,14 @@ void Tab::on_value_change(const std::string& opt_key, const boost::any& value)
     //Orca: sync filament num if it's a multi tool printer
     if (opt_key == "extruders_count" && !m_config->opt_bool("single_extruder_multi_material")){
         auto num_extruder = boost::any_cast<size_t>(value);
-        wxGetApp().preset_bundle->set_num_filaments(num_extruder);
+        int         old_filament_size = wxGetApp().preset_bundle->filament_presets.size();
+        std::vector<std::string> new_colors;
+        for (int i = old_filament_size; i < num_extruder; ++i) {
+            wxColour    new_col   = Plater::get_next_color_for_filament();
+            std::string new_color = new_col.GetAsString(wxC2S_HTML_SYNTAX).ToStdString();
+            new_colors.push_back(new_color);
+        }
+        wxGetApp().preset_bundle->set_num_filaments(num_extruder, new_colors);
         wxGetApp().plater()->on_filaments_change(num_extruder);
         wxGetApp().get_tab(Preset::TYPE_PRINT)->update();
         wxGetApp().preset_bundle->export_selections(*wxGetApp().app_config);


### PR DESCRIPTION
The core advantage of multi-tools devices lies in multi-color printing. For machines with multi-tools, it is more reasonable to set different default colors for each extruders.
- original effect:
![image](https://github.com/user-attachments/assets/8d0c97f1-9db5-42c1-8fa9-913dfd263b66)
![image](https://github.com/user-attachments/assets/ee36f7a6-f733-44fb-bd58-80126dfa4b7f)

- current effect:
![image](https://github.com/user-attachments/assets/0bacc180-530a-4e7b-8e5a-a7e1fa116c0a)
![image](https://github.com/user-attachments/assets/6fc85e1f-3890-49ae-9c5d-423bc123cea4)
