### PR TITLE
Fix: Decouple the default material selection from the nozzle size on the machine.

### DIFF
--- a/resources/web/guide/22/22.js
+++ b/resources/web/guide/22/22.js
@@ -469,7 +469,7 @@ function ChooseDefaultFilament()
 		let OneFF=OneNode.getElementsByTagName("input")[0];
 		$(OneFF).prop("checked",false);
 		
-	    let filamentList=OneFF.getAttribute("filalist"); 
+	    let filamentList=GetFilamentShortname(OneFF.getAttribute("filalist")); 
 		//alert(filamentList);
 		let filamentArray=filamentList.split(';')
 		


### PR DESCRIPTION
fix the problem that the filament's selection varied depending  on the  different nozzles chosen in the Wizard.
- If choose Bambu 0.4mm nozzles, the ABS filament will be chosen.
![image](https://github.com/user-attachments/assets/6f85e786-c8b5-419e-b2cd-0df67b91efcd)
![image](https://github.com/user-attachments/assets/53762cb4-77f2-4c8a-998f-7b4d77357c2e)
- but If choose Bambu 0.2mm nozzles, the ABS filament will not be chosen
![image](https://github.com/user-attachments/assets/6599dc4c-1647-4ea9-b687-0225776da05c)
![image](https://github.com/user-attachments/assets/c355b24a-7f65-4ba1-9cd5-54084cef6b1a)

In configuration file，we only set that the machine's default filament is Bambu ABS for example. we don't distinguish the BambuABS and BambuABS 0.2mm and so is the wizard do. The wizard doesn't also show the BambuABS 0.2mm but BambuABS.
