### PR TITLE
Bug fix: Inner Outer Inner failed to reorder in certain edge cases

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -3114,10 +3114,10 @@ void PerimeterGenerator::process_arachne()
                 std::vector<PerimeterGeneratorArachneExtrusion> reordered_extrusions;
                 
                 // Get searching thresholds. For an external perimeter we take the middle of the external perimeter width, split it in two, add the spacing to the internal perimeter and add half the internal perimeter width.
-                // This should get us to the middle of the internal perimeter. We then scale by 10% up for safety margin.
-                coord_t threshold_external = (this->ext_perimeter_flow.scaled_width()/2+this->ext_perimeter_flow.scaled_spacing()+this->perimeter_flow.scaled_width()/2) * 1.1;
-                // For the intenal perimeter threshold, the distance is the perimeter width plus the spacing, scaled by 10% for safety margin.
-                coord_t threshold_internal = (this->perimeter_flow.scaled_width()+this->perimeter_flow.scaled_spacing()) * 1.1;
+                // This should get us to the middle of the internal perimeter. We then scale by 2% up for safety margin.
+                coord_t threshold_external = (this->ext_perimeter_flow.scaled_width()/2+this->ext_perimeter_flow.scaled_spacing()+this->perimeter_flow.scaled_width()/2)*1.02;
+                // For the intenal perimeter threshold, the distance is the perimeter width plus the spacing, scaled by 2% for safety margin.
+                coord_t threshold_internal = (this->perimeter_flow.scaled_width()+this->perimeter_flow.scaled_spacing()) * 1.02;
                 
                 // Re-order extrusions based on distance
                 // Alorithm will aggresively optimise for the appearance of the outermost perimeter


### PR DESCRIPTION
# Description

In certain cases where the internal perimeter line width was significantly larger than the external perimeter line width, IOI mode failed to re order the external perimeters correctly. This was due to the safety margin for perimeter overlap (10%) that was introduced in the previous IOI rework PR. 

Reducing this to 2% just to cover edge cases caused due to numerical precision. This fixes these edge cases while also retaining correct wall ordering.

# Screenshots/Recordings/Graphs

**Before**
![image](https://github.com/user-attachments/assets/1aba94e6-c31e-4cee-a246-c788aa8de5b1)

The middle bridge was incorrectly "attached" to the previous island due to proximity calculation being tripped up due to the artificially increased overlap.