### PR TITLE
pa calib: print flow value and acceleration

### DIFF
--- a/src/libslic3r/calib.hpp
+++ b/src/libslic3r/calib.hpp
@@ -255,6 +255,7 @@ public:
     double print_size_x() const { return object_size_x() + pattern_shift(); };
     double print_size_y() const { return object_size_y(); };
     double max_layer_z() const { return height_first_layer() + ((m_num_layers - 1) * height_layer()); };
+    double flow_val() const;
 
     void generate_custom_gcodes(const DynamicPrintConfig &config, bool is_bbl_machine, Model &model, const Vec3d &origin);
 


### PR DESCRIPTION
Print flow value and acceleration for PA pattern calibration. This should help keep track during adaptive PA calibration.

# Description

Modify Pattern PA calibration to print current Flow Rate and Acceleration values which should help following Adaptive PA calibration guidelines.

Those values printed below PA values:
- last line is Acceleration
- second to last line is Flow Rate

# Screenshots/Recordings/Graphs

![Screenshot from 2024-10-21 17-09-01](https://github.com/user-attachments/assets/33aa4c40-0bae-411f-81a2-be0cd97f0968)


## Tests

Manual tests with several speed ratios: checked printed flow rate matches one reported by gcode preview.