### PR TITLE
Fixed Clipper library (our own fork of it) when working with Z coordinate

### DIFF
--- a/src/clipper/clipper.cpp
+++ b/src/clipper/clipper.cpp
@@ -119,6 +119,10 @@ inline cInt Round(double val)
   return static_cast<cInt>((val < 0) ? (val - 0.5) : (val + 0.5));
 }
 
+// Overriding the Eigen operators because we don't want to compare Z coordinate if IntPoint is 3 dimensional.
+inline bool operator==(const IntPoint &l, const IntPoint &r) { return l.x() == r.x() && l.y() == r.y(); }
+inline bool operator!=(const IntPoint &l, const IntPoint &r) { return l.x() != r.x() || l.y() != r.y(); }
+
 //------------------------------------------------------------------------------
 // PolyTree methods ...
 //------------------------------------------------------------------------------
@@ -189,16 +193,22 @@ double Area(const Path &poly)
 }
 //------------------------------------------------------------------------------
 
-double Area(const OutRec &outRec)
+double Area(const OutPt *op)
 {
-  OutPt *op = outRec.Pts;
+  const OutPt *startOp = op;
   if (!op) return 0;
   double a = 0;
   do {
     a +=  (double)(op->Prev->Pt.x() + op->Pt.x()) * (double)(op->Prev->Pt.y() - op->Pt.y());
     op = op->Next;
-  } while (op != outRec.Pts);
+  } while (op != startOp);
   return a * 0.5;
+}
+//------------------------------------------------------------------------------
+
+double Area(const OutRec &outRec)
+{
+  return Area(outRec.Pts);
 }
 //------------------------------------------------------------------------------
 
@@ -536,27 +546,32 @@ bool FirstIsBottomPt(const OutPt* btmPt1, const OutPt* btmPt2)
   p = btmPt2->Next;
   while ((p->Pt == btmPt2->Pt) && (p != btmPt2)) p = p->Next;
   double dx2n = std::fabs(GetDx(btmPt2->Pt, p->Pt));
-  return (dx1p >= dx2p && dx1p >= dx2n) || (dx1n >= dx2p && dx1n >= dx2n);
+
+  if (std::max(dx1p, dx1n) == std::max(dx2p, dx2n) &&
+    std::min(dx1p, dx1n) == std::min(dx2p, dx2n))
+      return Area(btmPt1) > 0; //if otherwise identical use orientation
+  else
+    return (dx1p >= dx2p && dx1p >= dx2n) || (dx1n >= dx2p && dx1n >= dx2n);
 }
 //------------------------------------------------------------------------------
 
 // Called by GetLowermostRec()
 OutPt* GetBottomPt(OutPt *pp)
 {
-  OutPt* dups = 0;
+  OutPt* dups = nullptr;
   OutPt* p = pp->Next;
   while (p != pp)
   {
     if (p->Pt.y() > pp->Pt.y())
     {
       pp = p;
-      dups = 0;
+      dups = nullptr;
     }
     else if (p->Pt.y() == pp->Pt.y() && p->Pt.x() <= pp->Pt.x())
     {
       if (p->Pt.x() < pp->Pt.x())
       {
-        dups = 0;
+        dups = nullptr;
         pp = p;
       } else
       {
@@ -577,6 +592,7 @@ OutPt* GetBottomPt(OutPt *pp)
   }
   return pp;
 }
+
 //------------------------------------------------------------------------------
 
 bool Pt2IsBetweenPt1AndPt3(const IntPoint &pt1,


### PR DESCRIPTION
The Eigen vector type compares all components, while the ClipperLib own IntPoint type compared x and y only.
Fixed by overriding the ==/!= operators to compare just x and y components for Eigen types.

Cherry-picked from prusa3d/PrusaSlicer@0202eec4b715eaa28a79f8bb82b0330c1efce8c9

This fixes #7160

Before:
![image](https://github.com/user-attachments/assets/fe833996-8335-473c-bd65-ee93a25c3dce)

After:
![image](https://github.com/user-attachments/assets/72bc838d-0983-43f2-9bc4-5c7b32ee4604)
