### PR TITLE
Fix issue that thumbnail color not updated properly when AMS slot mapping changes

### DIFF
--- a/src/slic3r/GUI/3DScene.cpp
+++ b/src/slic3r/GUI/3DScene.cpp
@@ -84,7 +84,11 @@ std::vector<Slic3r::ColorRGBA> get_extruders_colors()
 
 float FullyTransparentMaterialThreshold  = 0.1f;
 float FullTransparentModdifiedToFixAlpha = 0.3f;
-float FULL_BLACK_THRESHOLD = 0.18f;
+// Be careful changing this value because it could break thumbnail color due to rounding error!
+// The color rendering on BambuLab's "send to printer" screen relies on the assumption that this color can be accurately rendered by OpenGL,
+// value like 0.18f could not because in C++ (int)(0.18f * 255) == 45 however in OpenGL it renders this as 46
+// which breaks the `SelectMachineDialog::record_edge_pixels_data()` function!
+float FULL_BLACK_THRESHOLD = 0.2f;
 
 Slic3r::ColorRGBA adjust_color_for_rendering(const Slic3r::ColorRGBA &colors)
 {

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -5939,7 +5939,7 @@ void GLCanvas3D::render_thumbnail_internal(ThumbnailData& thumbnail_data, const 
 
             ColorRGBA new_color = adjust_color_for_rendering(curr_color);
             if (ban_light) {
-                new_color[3] = (255 - vol->extruder_id) / 255.0f;
+                new_color[3] =(255 - (vol->extruder_id -1))/255.0f;
             }
             vol->model.set_color(new_color);
             shader->set_uniform("volume_world_matrix", vol->world_matrix());


### PR DESCRIPTION
Before:
![ams_color_before](https://github.com/user-attachments/assets/79789bb1-68aa-41d3-be6a-ab2df6caa4b4)

After:
![ams_color_after](https://github.com/user-attachments/assets/b8c6c2a3-1ec1-4c51-b3fa-753c49d38076)
