### PR TITLE
Fix crash when extruder 16 is used in color painting

### DIFF
--- a/src/libslic3r/PrintApply.cpp
+++ b/src/libslic3r/PrintApply.cpp
@@ -1506,7 +1506,7 @@ Print::ApplyStatus Print::apply(const Model &model, DynamicPrintConfig new_full_
             num_extruders > 1 &&
             std::find_if(volumes.begin(), volumes.end(), [](const ModelVolume *v) { return ! v->mmu_segmentation_facets.empty(); }) != volumes.end()) {
 
-            std::array<bool, static_cast<size_t>(EnforcerBlockerType::ExtruderMax)> used_facet_states{};
+            std::array<bool, static_cast<size_t>(EnforcerBlockerType::ExtruderMax) + 1> used_facet_states{};
             for (const ModelVolume *volume : volumes) {
                 const std::vector<bool> &volume_used_facet_states = volume->mmu_segmentation_facets.get_data().used_states;
 

--- a/src/libslic3r/TriangleSelector.cpp
+++ b/src/libslic3r/TriangleSelector.cpp
@@ -1665,7 +1665,7 @@ TriangleSelector::TriangleSplittingData TriangleSelector::serialize() const {
             } else {
                 // In case this is leaf, we better save information about its state.
                 int n = int(tr.get_state());
-                if (n < static_cast<size_t>(EnforcerBlockerType::ExtruderMax))
+                if (n <= static_cast<size_t>(EnforcerBlockerType::ExtruderMax))
                     data.used_states[n] = true;
 
                 if (n >= 3) {

--- a/src/libslic3r/TriangleSelector.hpp
+++ b/src/libslic3r/TriangleSelector.hpp
@@ -256,7 +256,7 @@ public:
         // Bit stream containing splitting information.
         std::vector<bool>                     bitstream;
         // Array indicating which triangle state types are used (encoded inside bitstream).
-        std::vector<bool>                     used_states { std::vector<bool>(static_cast<size_t>(EnforcerBlockerType::ExtruderMax), false) };
+        std::vector<bool>                     used_states { std::vector<bool>(static_cast<size_t>(EnforcerBlockerType::ExtruderMax) + 1, false) };
 
         TriangleSplittingData() = default;
 
@@ -270,7 +270,7 @@ public:
 
         // Reset all used states before they are recomputed based on the bitstream.
         void reset_used_states() {
-            used_states.resize(static_cast<size_t>(EnforcerBlockerType::ExtruderMax), false);
+            used_states.resize(static_cast<size_t>(EnforcerBlockerType::ExtruderMax) + 1, false);
             std::fill(used_states.begin(), used_states.end(), false);
         }
 


### PR DESCRIPTION
Fixes #7198

The issue can be easily reproduced on any platform by:
1. Add 16 filaments
2. Add a cube
3. Paint the cube using the 16th color
4. Slice & crash

Or simply slice the project from #7198.

![image](https://github.com/user-attachments/assets/1603a34a-990a-46c0-ad2e-33ff1e1bcb83)
