### PR TITLE
Fix cmake warning on policy CMP0135

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -30,6 +30,10 @@ if (APPLE)
 
 endif ()
 
+if(POLICY CMP0135) # DOWNLOAD_EXTRACT_TIMESTAMP
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
 project(OrcaSlicer-deps)
 
 include(ExternalProject)
@@ -56,10 +60,6 @@ endif ()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     option(DEP_WX_GTK3 "Build wxWidgets against GTK3" OFF)
-else() 
-    if(POLICY CMP0135) # DOWNLOAD_EXTRACT_TIMESTAMP
-        cmake_policy(SET CMP0135 NEW)
-    endif()
 endif()
 
 set(IS_CROSS_COMPILE FALSE)


### PR DESCRIPTION
# Description

A bunch of warnings printed at dependencies build:
```
CMake Warning (dev) at /usr/share/cmake-3.30/Modules/ExternalProject/shared_internal_commands.cmake:1282 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  /usr/share/cmake-3.30/Modules/ExternalProject.cmake:3035 (_ep_add_download_command)
  CMakeLists.txt:124 (ExternalProject_Add)
  OCCT/OCCT.cmake:11 (orcaslicer_add_cmake_project)
  CMakeLists.txt:342 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

## Tests

Dependencies build on Linux machine.