### PR TITLE
Allow clicking the toolbar icon multiple times without moving the cursor

### DIFF
--- a/src/slic3r/GUI/GLToolbar.cpp
+++ b/src/slic3r/GUI/GLToolbar.cpp
@@ -792,8 +792,8 @@ void GLToolbar::do_action(GLToolbarItem::EActionType type, int item_id, GLCanvas
                     }
 
                     if (m_type == Normal && item->get_state() != GLToolbarItem::Disabled) {
-                        // the item may get disabled during the action, if not, set it back to normal state
-                        item->set_state(GLToolbarItem::Normal);
+                        // the item may get disabled during the action, if not, set it back to hover state
+                        item->set_state(GLToolbarItem::Hover);
                         parent.render();
                     }
                 }


### PR DESCRIPTION
This reverts commit a26c573b1b13867ce50a16f0ae924be9aa05f26c.

Currently some of the toolbar icon is not hovered after mouse click (such as the add plate icon), and you have to move the cursor a little bit to highlight the icon again then you're able to click the icon again. Not a big deal in noremal use cases, however in sutuations like adding a lot of empty plates at once this could be annoying.

Not sure why BambuLab did this.

And not sure why I care about this and created this PR... (