### PR TITLE
calib_dlg: fix checkbox styling

### DIFF
--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -18,8 +18,6 @@ wxBoxSizer* create_item_checkbox(wxString title, wxWindow* parent, bool* value, 
     m_sizer_checkbox->Add(0, 0, 0, wxEXPAND | wxLEFT, 8);
 
     auto checkbox_title = new wxStaticText(parent, wxID_ANY, title, wxDefaultPosition, wxSize(-1, -1), 0);
-    checkbox_title->SetForegroundColour(wxColour(144, 144, 144));
-    checkbox_title->SetFont(::Label::Body_13);
     checkbox_title->Wrap(-1);
     m_sizer_checkbox->Add(checkbox_title, 0, wxALIGN_CENTER | wxALL, 3);
 
@@ -28,7 +26,10 @@ wxBoxSizer* create_item_checkbox(wxString title, wxWindow* parent, bool* value, 
     checkbox->Bind(wxEVT_TOGGLEBUTTON, [parent, checkbox, value](wxCommandEvent& e) {
         (*value) = (*value) ? false : true;
         e.Skip();
-        });
+    });
+    checkbox_title->Bind(wxEVT_UPDATE_UI, [checkbox](wxUpdateUIEvent &evt) {
+        evt.Enable(checkbox->IsEnabled());
+    });
 
     return m_sizer_checkbox;
 }


### PR DESCRIPTION
# Description

Do not set custom font and colour for checkbox caption labels. Update checkbox caption labels visibility depending on checkbox enabled state

# Screenshots/Recordings/Graphs

Original behavior:
![Screenshot from 2024-10-29 18-01-54](https://github.com/user-attachments/assets/37436e75-cb0e-42d8-b4f6-aa78e06de90d) ![Screenshot from 2024-10-29 18-01-45](https://github.com/user-attachments/assets/a6781a11-f1c0-46ba-9076-9e757c5b80a7)  ![Screenshot from 2024-10-29 18-10-37](https://github.com/user-attachments/assets/e7a97c7c-21c5-49f6-b5e4-b67058f6905a)



Updated behavior:
![Screenshot from 2024-10-29 18-01-19](https://github.com/user-attachments/assets/83c50472-a771-468e-9d93-28f67fe98b51) ![Screenshot from 2024-10-29 18-01-10](https://github.com/user-attachments/assets/448bea57-a660-42ed-931d-1aea84319eab)  ![Screenshot from 2024-10-29 18-12-11](https://github.com/user-attachments/assets/5c3eb210-1756-4a4a-894f-4f8db9601a3a)


## Tests

Linux with light theme only.