### PR TITLE
fix: ImageGrid download button would delete instead

### DIFF
--- a/src/slic3r/GUI/ImageGrid.cpp
+++ b/src/slic3r/GUI/ImageGrid.cpp
@@ -652,7 +652,8 @@ void Slic3r::GUI::ImageGrid::renderContent1(wxDC &dc, wxPoint const &pt, int ind
         if (hit) {
             texts.Add(_L("Delete"));
             texts.Add(secondAction);
-            texts.Add(thirdAction);
+            if (!thirdAction.IsEmpty())
+                texts.Add(thirdAction);
             renderButtons(dc, texts, rect, m_hit_type == HIT_ACTION ? m_hit_item & 3 : -1, states);
         } else if (!nonHoverText.IsEmpty()) {
             texts.Add(nonHoverText);


### PR DESCRIPTION
# Description

I was trying to download a file when it deleted instead, oops!

`HitTest()` expects only two buttons at this point, however `renderContent1` would always show 3. See images for demonstration.

I double checked Bambu Studio for the intended behavior, they show 2 buttons in this state. 

### Issue:
![before](https://github.com/user-attachments/assets/437fdfec-56d5-4ff1-a7fe-886773faa110)

Applied the code changes in the PR and got the expected fix:

### The fix:
![after](https://github.com/user-attachments/assets/d305fc91-b453-43c8-9e03-71645e277bc8)
