### PR TITLE
fix: the 'all' and 'clear all' btns do not make sense when choosing printers

### DIFF
--- a/resources/web/guide/21/21.js
+++ b/resources/web/guide/21/21.js
@@ -303,12 +303,18 @@ function FilterModelList(keyword) {
 function SelectPrinterAll( sVendor )
 {
 	$("input[vendor='"+sVendor+"']").prop("checked", true);
+	$("input[vendor='"+sVendor+"']").each(function() {
+		CheckBoxOnclick(this);
+	});
 }
 
 
 function SelectPrinterNone( sVendor )
 {
 	$("input[vendor='"+sVendor+"']").prop("checked", false);
+	$("input[vendor='"+sVendor+"']").each(function() {
+		CheckBoxOnclick(this);
+	});
 }
 
 

--- a/resources/web/guide/24/24.js
+++ b/resources/web/guide/24/24.js
@@ -303,12 +303,18 @@ function FilterModelList(keyword) {
 function SelectPrinterAll( sVendor )
 {
 	$("input[vendor='"+sVendor+"']").prop("checked", true);
+	$("input[vendor='"+sVendor+"']").each(function() {
+		CheckBoxOnclick(this);
+	});
 }
 
 
 function SelectPrinterNone( sVendor )
 {
 	$("input[vendor='"+sVendor+"']").prop("checked", false);
+	$("input[vendor='"+sVendor+"']").each(function() {
+		CheckBoxOnclick(this);
+	});
 }
 
 function OnExitFilter() {


### PR DESCRIPTION
when I choose the printer in wizard window by first wizard or user editting, the "all" and "clear all" btns do not make sense.
![img_v3_02gj_99e22c47-f99d-4052-8ee6-4e7a565b003g](https://github.com/user-attachments/assets/6865d043-63d4-4e88-9ed7-b86b5ecc138a)
The related code is in 21.js and 24.js
![image](https://github.com/user-attachments/assets/37bf1224-0d6a-4169-bcaf-26abc68c626d)
the btnclick function only change the 'checked' property but do nothing else, so that the printer is not chosen in fact (though it seams to be).

so is the 24.js.