### PR TITLE
Fix: The "Unsaved Changes Dialog" pops up, but the content display section is empty.

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -5647,7 +5647,8 @@ bool GUI_App::check_and_keep_current_preset_changes(const wxString& caption, con
         bool is_called_from_configwizard = postponed_apply_of_keeped_changes != nullptr;
 
         UnsavedChangesDialog dlg(caption, header, "", action_buttons);
-        if (dlg.ShowModal() == wxID_CANCEL)
+        bool no_need_change = dlg.getUpdateItemCount() == 0 ? true : false;
+        if (!no_need_change && dlg.ShowModal() == wxID_CANCEL)
             return false;
 
         auto reset_modifications = [this, is_called_from_configwizard]() {
@@ -5662,7 +5663,7 @@ bool GUI_App::check_and_keep_current_preset_changes(const wxString& caption, con
             load_current_presets(false);
         };
 
-        if (dlg.discard())
+        if (dlg.discard() || no_need_change)
             reset_modifications();
         else  // save selected changes
         {

--- a/src/slic3r/GUI/UnsavedChangesDialog.hpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.hpp
@@ -312,6 +312,8 @@ public:
         {
         }
     };
+public:
+    int getUpdateItemCount() { return m_presetitems.size(); }  
 
 private:
     std::vector<PresetItem> m_presetitems;


### PR DESCRIPTION
    When I switch printers from the left tab bar, Orca checks if there have been any modifications relative to the system presets. If there are changes, it pops up the Unsaved Changes Dialog.
    But sometimes I find that the change content display section in the dialog is empty. This is undoubtedly very confusing for users.
    Upon investigation, it was found that this confusion arises because when comparing the initial preset with the current preset, there are some attributes that have not been changed, but the comparison still shows them as different. However, these attributes cannot be displayed in the dialog box (for example, the attribute long_retraction_when_cut).
    So, I've made the size of m_presetitems the criterion for whether to pop up the dialog box or not, because what is actually displayed in the table is the content of m_presetitems. If the size of m_presetitems is 0, then the dialog box is skipped directly, and it is treated as if the changes were discarded.