### PR TITLE
Fix: Switching between multi-extruder printers using tabs can cause t…

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -5096,8 +5096,14 @@ bool Tab::select_preset(std::string preset_name, bool delete_current /*=false*/,
 
         // Orca: update presets for the selected printer
         if (m_type == Preset::TYPE_PRINTER && wxGetApp().app_config->get_bool("remember_printer_config")) {
-          m_preset_bundle->update_selections(*wxGetApp().app_config);
-          wxGetApp().plater()->sidebar().on_filaments_change(m_preset_bundle->filament_presets.size());
+            m_preset_bundle->update_selections(*wxGetApp().app_config);
+            int extruders_count = m_preset_bundle->printers.get_edited_preset().config.opt<ConfigOptionFloats>("nozzle_diameter")->values.size();
+            if (extruders_count > 1) {
+                // multi tool
+                wxGetApp().plater()->sidebar().on_filaments_change(extruders_count);
+            } else {
+                wxGetApp().plater()->sidebar().on_filaments_change(m_preset_bundle->filament_presets.size());
+            }
         }
         load_current_preset();
 
@@ -6079,8 +6085,9 @@ void Page::update_visibility(ConfigOptionMode mode, bool update_contolls_visibil
 #ifdef __WXMSW__
     if (!m_show) return;
     // BBS: fix field control position
-    wxTheApp->CallAfter([this]() {
-        for (auto group : m_optgroups) {
+    auto groups = this->m_optgroups;
+    wxTheApp->CallAfter([groups]() {
+        for (auto group : groups) {
             if (group->custom_ctrl) group->custom_ctrl->fixup_items_positions();
         }
     });

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -1664,17 +1664,19 @@ void UnsavedChangesDialog::update_tree(Preset::Type type, PresetCollection* pres
 
         // process changes of extruders count
         if (type == Preset::TYPE_PRINTER && old_pt == ptFFF &&
-            old_config.opt<ConfigOptionStrings>("extruder_colour")->values.size() != new_config.opt<ConfigOptionStrings>("extruder_colour")->values.size()) {
+            old_config.opt<ConfigOptionFloats>("nozzle_diameter")->values.size() != new_config.opt<ConfigOptionFloats>("nozzle_diameter")->values.size()) {
             wxString local_label = _L("Extruders count");
-            wxString old_val = from_u8((boost::format("%1%") % old_config.opt<ConfigOptionStrings>("extruder_colour")->values.size()).str());
-            wxString new_val = from_u8((boost::format("%1%") % new_config.opt<ConfigOptionStrings>("extruder_colour")->values.size()).str());
+            wxString old_val = from_u8((boost::format("%1%") % old_config.opt<ConfigOptionFloats>("nozzle_diameter")->values.size()).str());
+            wxString new_val = from_u8((boost::format("%1%") % new_config.opt<ConfigOptionFloats>("nozzle_diameter")->values.size()).str());
 
             //BBS: the page "General" changed to "Basic information" instead
             //m_tree->Append("extruders_count", type, _L("General"), _L("Capabilities"), local_label, old_val, new_val, category_icon_map.at("Basic information"));
             //m_tree->Append("extruders_count", type, _L("General"), _L("Capabilities"), local_label, old_val, new_val, category_icon_map.at("General"));
 
-            PresetItem pi = {type, "extruders_count", _L("General"), _L("Capabilities"), local_label, old_val, new_val};
-            m_presetitems.push_back(pi);
+            if (old_val != new_val) {
+                PresetItem pi = {type, "extruders_count", _L("General"), _L("Capabilities"), local_label, old_val, new_val};
+                m_presetitems.push_back(pi);
+            }
         }
 
         for (const std::string& opt_key : dirty_options) {


### PR DESCRIPTION
# Reproduction steps for the issue:
1. Select multiple multi-tool printers at once. （eg: prusa x5l /  Snapmaker j1/Artisan）
![image](https://github.com/user-attachments/assets/1e9ef4ce-76ad-4dc6-bffe-0bbe0749c062)
2. Switch to another multi-tool printer using the tab.
![image](https://github.com/user-attachments/assets/9feaa2ff-0e54-4803-905d-8853ff031581)

you can observe that only one tool remains. Moreover, for multi-tool machines, Orca no longer allows the addition or removal of filament buttons (default). This can be very confusing for users.

# Analysis：
1. In Orca, there is an inconsistency in how the extruder_count is determined for multi-tool printers. Some parts of the code use nozzle_diameter to determine the number of extruders, while others use extruder_colour 
. This inconsistency can lead to confusion and errors in the user interface, such as the addition or removal of filament buttons not being available for multi-tool machines, which will be perplexing.

To address this issue and align with the characteristics of printers like Prusa and Snapmaker, it is recommended to standardize the determination of extruder_count by using nozzle_diameter for parsing across the software. This approach would ensure a unified method for identifying the number of extruders, thereby reducing confusion and improving the user experience.

2. In multi-tool scenarios, modify the parameters passed to on_filaments_change.

3. prevent crashing


