### PR TITLE
Fixes a configuration issue with the Sovol SV06 ACE profile

### DIFF
--- a/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.4 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.4 nozzle.json
@@ -6,7 +6,7 @@
 	"instantiation": "true",
 	"inherits": "fdm_machine_common",
 	"printer_model": "Sovol SV06 ACE",
-	"default_print_profile": "0.20mm Standard @Sovol SV06 ACE",
+	"default_print_profile": "0.20mm Standard @Sovol SV06 ACE - official",
 	"nozzle_diameter": [
 		"0.4"
 	],

--- a/resources/profiles/Sovol/machine/Sovol SV06 Plus ACE 0.4 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 Plus ACE 0.4 nozzle.json
@@ -6,7 +6,7 @@
 	"instantiation": "true",
 	"inherits": "fdm_machine_common",
 	"printer_model": "Sovol SV06 Plus ACE",
-	"default_print_profile": "0.20mm Standard @Sovol SV06 Plus ACE",
+	"default_print_profile": "0.20mm Standard @Sovol SV06 Plus ACE - official",
 	"nozzle_diameter": [
 		"0.4"
 	],


### PR DESCRIPTION
# Description

I have been struggling to get the new SV06 Ace profiles to show up and be usable.  Looking in the code I see that the new process config files have " - official" at the end of the filename and in the name.  I personally don't know if that should be the case since it deviates from other profiles, but the underlying issue (I believe) was that the default print profile was set to:
"default_print_profile": "0.20mm Standard @Sovol SV06 ACE"
not what the print profile had: 
"default_print_profile": "0.20mm Standard @Sovol SV06 ACE - official"

This patch changes the machine config so it points to the correct print profile.  After changing the machine showed up in my install.

# Screenshots/Recordings/Graphs

No UI changes

## Tests

I made these changes in the config, copied them into my resources folder, removed preferences and tried to add the printer.  I verified I could see the printer in the printer selection and drop down.
