### PR TITLE
Integrate external purge estimates (eg Blobifier) to the filament consumption UI

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -272,6 +272,7 @@ class Print;
         static const std::vector<std::string> Reserved_Tags_compatible;
         static const std::string Flush_Start_Tag;
         static const std::string Flush_End_Tag;
+        static const std::string External_Purge_Tag;
     public:
         enum class ETags : unsigned char
         {


### PR DESCRIPTION
# Description
With external purging solutions becoming more common, I’ve come across a limitation when assembling mine - it is impossible to estimate the amount of filament purged during slicing!

For example, when using Happy Hare together with the blobifier, it is not possible currently to estimate the volume of filament purged, because there are no G1 Ex commands issued by the slicer, but rather the purge volumes are calculated and executed by the printer/ happy hare and blobifier software and macros themselves.

**This PR aims to address this limitation by tagging the purge commands as specially formatted comments and use that to calculate the projected flushed filament volume.** This is particularly useful in combination with Spoolman as you can actually compare now the projected filament use vs your available filament in the spool man UI.

This should be fairly accurate as the flush/purge volume matrix is read by Happy Hare and is used by the blobifier to execute the purge. Also this approach allows the user to apply the same correction variable to the volumes (variable_purge_length_modifier), if other than 0.

![image](https://github.com/user-attachments/assets/0f5a51d6-c57a-4e68-8e73-a238d3524f13)

![image](https://github.com/user-attachments/assets/35e72159-a004-4115-b2f4-8752df33aa48)

This also allows the user to include the combined filament consumption between external purge (in the blobifier) and any prime tower that the user may have enabled (eg. to ensure the nozzle is primed before printing).

![image](https://github.com/user-attachments/assets/bdb8b329-5142-4878-95e6-8b5e36f9a7a3)

To set it up, set the below in your Change Filament g-code:
```
T[next_extruder]
; FLUSH_START
; EXTERNAL_PURGE {flush_length_1+flush_length_2+flush_length_3+flush_length_4}
; FLUSH_END 
```

If your variable_purge_length_modifier is not 1.0, then you can adjust the calculated purge volume like so (eg. if the value is 0.6).

```
T[next_extruder]
; FLUSH_START
; EXTERNAL_PURGE {0.6*(flush_length_1+flush_length_2+flush_length_3+flush_length_4)}
; FLUSH_END 
```

Make sure purge in the prime tower is disabled:
![image](https://github.com/user-attachments/assets/25e02855-c035-4ec9-a265-714dd3519404)


## Tests

Tested with Bambu and Voron printers. As this is a comment in the Gcode and the code is only invoked when the external purge tag is present, there are no side effects.
