### PR TITLE
Include libspnav in flatpak builds

### DIFF
--- a/flatpak/io.github.softfever.OrcaSlicer.yml
+++ b/flatpak/io.github.softfever.OrcaSlicer.yml
@@ -14,9 +14,11 @@ finish-args:
   - --filesystem=xdg-run/gvfs
   - --filesystem=/run/media
   - --filesystem=/media
+  - --filesystem=/run/spnav.sock:ro
   # Allow OrcaSlicer to talk to other instances
   - --talk-name=io.github.softfever.OrcaSlicer.InstanceCheck.*
   - --system-talk-name=org.freedesktop.UDisks2
+  - --env=SPNAV_SOCKET=/run/spnav.sock
 
 modules:
 
@@ -78,6 +80,12 @@ modules:
         tag: v5.249.0
     cleanup:
       - / 
+
+  - name: libspnav
+    sources:
+      - type: archive
+        url: https://github.com/FreeSpacenav/libspnav/releases/download/v1.1/libspnav-1.1.tar.gz
+        sha256: 04b297f68a10db4fa40edf68d7f823ba7b9d0442f2b665181889abe2cea42759
  
   - name: orca_wxwidgets
     buildsystem: simple


### PR DESCRIPTION
# Description
This PR includes libspnav in the flatpak builds. Allowing usage of 3Dconnexion devices on linux systems with spacenavd is installed.

This partially fixes #5204 . However I'm only including my patch for flatpak, as I didn't confirm that the additional patches by @buzzhuzz ([commit](https://github.com/buzzhuzz/OrcaSlicer/commit/141b7c8154abe1bebac99478598c07ba9b45afd0)) are working.

## Tests
Built and verified working on my system. 