### PR TITLE
fix filename encode issue when download chinese filename

### DIFF
--- a/src/slic3r/GUI/Downloader.cpp
+++ b/src/slic3r/GUI/Downloader.cpp
@@ -159,7 +159,7 @@ void Downloader::start_download(const std::string& full_url)
     size_t id = get_next_id();
     std::string escaped_url = FileGet::escape_url(full_url.substr(results.length()));
     if (is_bambustudio_open(full_url) || (is_orca_open(full_url) && is_makerworld_link(full_url)))
-        plater->request_model_download(escaped_url);
+        plater->request_model_download(wxString::FromUTF8(escaped_url));
     else {
         std::string text(escaped_url);
         m_downloads.emplace_back(std::make_unique<Download>(id, std::move(escaped_url), this, m_dest_folder));


### PR DESCRIPTION
# Description
OrcaSlicer: 2.2.0
Operator: Win10/11 Simplified Chinese 

when download from makerworld.com.cn, if filename contain chinese, the downloaded filename is in wrong encode. if the invalid encode contain character not allowed in windows path, the download will failed.

check the wxwidget docs: https://docs.wxwidgets.org/3.2.6/overview_unicode.html

> Notice that the narrow strings used with wxWidgets are always assumed to be in the current locale encoding

So, this code `wxString(escaped_url)`, wxWidgets will think the string is in current locale(gbk in chinese windows).

test file: https://makerworld.com.cn/zh/models/648200?designId=648200#profileId-589194
<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs
before: 
![图片](https://github.com/user-attachments/assets/34502132-d496-45fe-b895-f12e8ec09204)

after:
![图片](https://github.com/user-attachments/assets/d897c0a0-79af-40ea-8703-867a8dd7c2b4)

this is also can use python to check:
```python
'拉面套装分盘'.encode().decode("gbk", errors='replace')
```
![图片](https://github.com/user-attachments/assets/12aa7d6f-3646-4e40-bebf-9e63022db0ee)

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
