### PR TITLE
Fix the incorrect translation of 'Bottom' into Ukrainian

### DIFF
--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -4625,7 +4625,7 @@ msgstr "Вигляд зверху"
 
 #. TRN To be shown in the main menu View->Bottom
 msgid "Bottom"
-msgstr "Ніз"
+msgstr "Низ"
 
 msgid "Bottom View"
 msgstr "Вигляд знизу"


### PR DESCRIPTION
Currently on Ukrainian language word "Bottom" is misspelled. Currently it is "Hіз", but correct is "Низ". This word is displayed on coordinate system widget and it is pretty disturbing to see it written all the time incorrectly