### PR TITLE
Update Creality Generic TPU.json

### DIFF
--- a/resources/profiles/Creality/filament/Creality Generic TPU.json
+++ b/resources/profiles/Creality/filament/Creality Generic TPU.json
@@ -16,10 +16,12 @@
         "Creality K1 Max (0.4 nozzle)",
         "Creality K1 Max (0.6 nozzle)",
         "Creality K1 Max (0.8 nozzle)",
-	    "Creality Sermoon V1 0.4 nozzle",
+	"Creality Sermoon V1 0.4 nozzle",
         "Creality CR-10 SE 0.2 nozzle",
-		"Creality CR-10 SE 0.4 nozzle",
-		"Creality CR-10 SE 0.6 nozzle",
-		"Creality CR-10 SE 0.8 nozzle"
+	"Creality CR-10 SE 0.4 nozzle",
+	"Creality CR-10 SE 0.6 nozzle",
+	"Creality CR-10 SE 0.8 nozzle",
+        "Creality Ender-3 S1 Pro 0.4 nozzle",
+	"Creality Ender-3 S1 0.4 nozzle"
     ]
 }


### PR DESCRIPTION
Added Ender 3 S1 series to compatible printers

# Description

Ender 3 S1 Series are direct drive printers, they can print TPU without any issues

