### PR TITLE
remove duplicate key "printer_structure" from Ankermake machine files

### DIFF
--- a/resources/profiles/Anker/machine/Anker M5 0.2 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5 0.2 nozzle.json
@@ -15,7 +15,6 @@
     "printer_variant": "0.2",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5 0.25 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5 0.25 nozzle.json
@@ -15,7 +15,6 @@
     "printer_variant": "0.25",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5 0.4 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5 0.4 nozzle.json
@@ -12,7 +12,6 @@
     "printer_variant": "0.4",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5 0.6 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5 0.6 nozzle.json
@@ -18,7 +18,6 @@
     "printer_variant": "0.6",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5 All-Metal 0.2 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5 All-Metal 0.2 nozzle.json
@@ -15,7 +15,6 @@
     "printer_variant": "0.2",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5 All-Metal 0.25 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5 All-Metal 0.25 nozzle.json
@@ -15,7 +15,6 @@
     "printer_variant": "0.25",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5 All-Metal 0.4 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5 All-Metal 0.4 nozzle.json
@@ -12,7 +12,6 @@
     "printer_variant": "0.4",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5 All-Metal 0.6 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5 All-Metal 0.6 nozzle.json
@@ -18,7 +18,6 @@
     "printer_variant": "0.6",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5C 0.2 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5C 0.2 nozzle.json
@@ -15,7 +15,6 @@
     "printer_variant": "0.2",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5C 0.25 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5C 0.25 nozzle.json
@@ -15,7 +15,6 @@
     "printer_variant": "0.25",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5C 0.4 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5C 0.4 nozzle.json
@@ -12,7 +12,6 @@
     "printer_variant": "0.4",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],

--- a/resources/profiles/Anker/machine/Anker M5C 0.6 nozzle.json
+++ b/resources/profiles/Anker/machine/Anker M5C 0.6 nozzle.json
@@ -18,7 +18,6 @@
     "printer_variant": "0.6",
     "auxiliary_fan": "0",
     "bed_exclude_area": [],
-    "printer_structure": "i3",
     "default_filament_profile": [
         "Anker Generic PLA+"
     ],


### PR DESCRIPTION
# Description

There was duplicate JSON keys in the Ankermake M5 and M5C json files. This just removes the useless duplicate keys.

# Screenshots/Recordings/Graphs

NA

## Tests

NA
