### PR TITLE
Multi zone implementation

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -4967,7 +4967,7 @@ void GCodeProcessor::run_post_process()
                     } else {
                         std::string comment = "preheat T" + std::to_string(tool_number) +
                                               " time: " + std::to_string((int) std::round(time_diffs[0])) + "s";
-                        return GCodeWriter::set_temperature(temperature, this->m_flavor, false, tool_number, comment);
+                        return GCodeWriter::set_temperature(temperature, this->m_flavor, false, tool_number, -1, comment);
                     }
                 },
                 // line replacer

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -92,7 +92,7 @@ std::string GCodeWriter::postamble() const
     return gcode.str();
 }
 
-std::string GCodeWriter::set_temperature(unsigned int temperature, GCodeFlavor flavor, bool wait, int tool, std::string comment){
+std::string GCodeWriter::set_temperature(unsigned int temperature, GCodeFlavor flavor, bool wait, int tool, int zone, std::string comment){
     if (wait && (flavor == gcfMakerWare || flavor == gcfSailfish))
         return "";
 
@@ -107,12 +107,23 @@ std::string GCodeWriter::set_temperature(unsigned int temperature, GCodeFlavor f
         } else {
             code = "M104";
         }
-        if(comment.empty())
-            comment = "set nozzle temperature";
+        if (comment.empty()) {
+            if (zone != -1) {
+                comment = "set zone" + std::to_string(zone) + " temperature";
+            } else {
+                comment = "set nozzle temperature";
+            }
+        }
     }
 
     std::ostringstream gcode;
     gcode << code << " ";
+
+    //add zone if present 
+    if (zone != -1) {
+        gcode << "Z" << zone << " ";
+    }
+
     if (flavor == gcfMach3 || flavor == gcfMachinekit) {
         gcode << "P";
     } else {
@@ -134,12 +145,12 @@ std::string GCodeWriter::set_temperature(unsigned int temperature, GCodeFlavor f
     return gcode.str();
 }
 
-std::string GCodeWriter::set_temperature(unsigned int temperature, bool wait, int tool) const
+std::string GCodeWriter::set_temperature(unsigned int temperature, bool wait, int tool, int zone) const
 {
     // set tool to -1 to make sure we won't emit T parameter for single extruder or SEMM
     if (!this->multiple_extruders || m_single_extruder_multi_material)
         tool = -1;
-    return set_temperature(temperature, this->config.gcode_flavor, wait, tool);
+    return set_temperature(temperature, this->config.gcode_flavor, wait, tool, zone);
 }
 
 // BBS

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -43,9 +43,9 @@ public:
     }
     std::string preamble();
     std::string postamble() const;
-    static std::string set_temperature(unsigned int temperature, GCodeFlavor flavor, bool wait = false, int tool = -1, std::string comment = std::string());
+    static std::string set_temperature(unsigned int temperature, GCodeFlavor flavor, bool wait = false, int tool = -1, int zone = -1, std::string comment = std::string());
 
-    std::string set_temperature(unsigned int temperature, bool wait = false, int tool = -1) const;
+    std::string set_temperature(unsigned int temperature, bool wait = false, int tool = -1, int zone = -1) const;
     std::string set_bed_temperature(int temperature, bool wait = false);
     std::string set_chamber_temperature(int temperature, bool wait = false);
     std::string set_print_acceleration(unsigned int acceleration)   { return set_acceleration_internal(Acceleration::Print, acceleration); }

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -822,6 +822,11 @@ static std::vector<std::string> s_Preset_filament_options {
     "filament_max_volumetric_speed",
     "filament_flow_ratio", "filament_density", "filament_cost", "filament_minimal_purge_on_wipe_tower",
     "nozzle_temperature", "nozzle_temperature_initial_layer",
+    "multi_zone_1_initial_layer", "multi_zone_1_temperature", "multi_zone_2_initial_layer", "multi_zone_2_temperature",
+    "multi_zone_3_initial_layer", "multi_zone_3_temperature", "multi_zone_4_initial_layer", "multi_zone_4_temperature",
+    "multi_zone_5_initial_layer", "multi_zone_5_temperature", "multi_zone_6_initial_layer", "multi_zone_6_temperature",
+    "multi_zone_7_initial_layer", "multi_zone_7_temperature", "multi_zone_8_initial_layer", "multi_zone_8_temperature",
+    "multi_zone_9_initial_layer", "multi_zone_9_temperature", "multi_zone_10_initial_layer", "multi_zone_10_temperature",
     // BBS
     "cool_plate_temp", "textured_cool_plate_temp", "eng_plate_temp", "hot_plate_temp", "textured_plate_temp", "cool_plate_temp_initial_layer", "textured_cool_plate_temp_initial_layer", "eng_plate_temp_initial_layer", "hot_plate_temp_initial_layer","textured_plate_temp_initial_layer",
     // "bed_type",
@@ -876,7 +881,7 @@ static std::vector<std::string> s_Preset_printer_options {
     "cooling_tube_retraction",
     "cooling_tube_length", "high_current_on_filament_swap", "parking_pos_retraction", "extra_loading_move", "purge_in_prime_tower", "enable_filament_ramming",
     "z_offset",
-    "disable_m73", "preferred_orientation", "emit_machine_limits_to_gcode", "pellet_modded_printer", "support_multi_bed_types","bed_mesh_min","bed_mesh_max","bed_mesh_probe_distance", "adaptive_bed_mesh_margin", "enable_long_retraction_when_cut","long_retractions_when_cut","retraction_distances_when_cut"
+    "disable_m73", "preferred_orientation", "emit_machine_limits_to_gcode", "pellet_modded_printer", "multi_zone", "multi_zone_number", "support_multi_bed_types","bed_mesh_min","bed_mesh_max","bed_mesh_probe_distance", "adaptive_bed_mesh_margin", "enable_long_retraction_when_cut","long_retractions_when_cut","retraction_distances_when_cut"
     };
 
 static std::vector<std::string> s_Preset_sla_print_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2537,6 +2537,28 @@ void PrintConfigDef::init_fff_params()
     def->min = 0;
     def->max = max_temp;
     def->set_default_value(new ConfigOptionInts { 200 });
+    
+    for (int zone = 1; zone <= 10; zone++) {
+        std::string zone_str = std::to_string(zone);
+
+        def             = this->add("multi_zone_" + zone_str + "_initial_layer", coInts);
+        def->label      = L("Initial layer");
+        def->full_label = L("Initial layer Zone " + zone_str + " temperature");
+        def->tooltip    = L("Zone " + zone_str + " temperature to print initial layer when using this filament");
+        def->sidetext   = L("°C");
+        def->min        = 0;
+        def->max        = max_temp;
+        def->set_default_value(new ConfigOptionInts{200});
+
+        def             = this->add("multi_zone_" + zone_str + "_temperature", coInts);
+        def->label      = L("Other layers");
+        def->tooltip    = L("Zone " + zone_str + " temperature for layers after the initial one");
+        def->sidetext   = L("°C");
+        def->full_label = L("Zone " + zone_str + " temperature");
+        def->min        = 0;
+        def->max        = max_temp;
+        def->set_default_value(new ConfigOptionInts{200});
+    }
 
     def = this->add("full_fan_speed_layer", coInts);
     def->label = L("Full fan speed at layer");
@@ -2813,6 +2835,20 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Enable this option if your printer uses pellets instead of filaments");
     def->mode    = comSimple;
     def->set_default_value(new ConfigOptionBool(false));
+    
+    def          = this->add("multi_zone", coBool);
+    def->label   = L("Multi heating zone");
+    def->tooltip = L("Enable this option if your printer uses multi heating zone");
+    def->mode    = comSimple;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def          = this->add("multi_zone_number", coInt);
+    def->label   = L("Zones");
+    def->tooltip = L("Number of heating zones");
+    def->mode    = comSimple;
+    def->min     = 1;
+    def->max     = 10;  
+    def->set_default_value(new ConfigOptionInt(1));	
 
     def = this->add("support_multi_bed_types", coBool);
     def->label = L("Support multi bed types");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1317,7 +1317,29 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionPoint,               bed_mesh_probe_distance))
     ((ConfigOptionFloat,               adaptive_bed_mesh_margin))
 
-
+    //Multi zone temps
+    ((ConfigOptionBool,                multi_zone))
+    ((ConfigOptionInt,                 multi_zone_number))
+    ((ConfigOptionInts,                multi_zone_1_temperature))
+    ((ConfigOptionInts,                multi_zone_1_initial_layer))
+    ((ConfigOptionInts,                multi_zone_2_temperature))
+    ((ConfigOptionInts,                multi_zone_2_initial_layer))
+    ((ConfigOptionInts,                multi_zone_3_temperature))
+    ((ConfigOptionInts,                multi_zone_3_initial_layer))
+    ((ConfigOptionInts,                multi_zone_4_temperature))
+    ((ConfigOptionInts,                multi_zone_4_initial_layer))
+    ((ConfigOptionInts,                multi_zone_5_temperature))
+    ((ConfigOptionInts,                multi_zone_5_initial_layer))
+    ((ConfigOptionInts,                multi_zone_6_temperature))
+    ((ConfigOptionInts,                multi_zone_6_initial_layer))
+    ((ConfigOptionInts,                multi_zone_7_temperature))
+    ((ConfigOptionInts,                multi_zone_7_initial_layer))
+    ((ConfigOptionInts,                multi_zone_8_temperature))
+    ((ConfigOptionInts,                multi_zone_8_initial_layer))
+    ((ConfigOptionInts,                multi_zone_9_temperature))
+    ((ConfigOptionInts,                multi_zone_9_initial_layer))
+    ((ConfigOptionInts,                multi_zone_10_temperature))
+    ((ConfigOptionInts,                multi_zone_10_initial_layer))
 )
 
 // This object is mapped to Perl as Slic3r::Config::Full.

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3632,14 +3632,15 @@ void TabFilament::toggle_options()
         toggle_line("filament_diameter", !is_pellet_printer);
 
         bool is_multi_zone = cfg.opt_bool("multi_zone");
-        if (is_multi_zone) {
-            int zone_count = cfg.opt_int("multi_zone_number");
-            for (int zone = 10; zone > 0; zone--) {
-                std::string zone_str = std::to_string(zone);
-                toggle_line("multi_zone_" + zone_str + "_initial_layer", zone <= zone_count);
-                toggle_line("multi_zone_" + zone_str + "_temperature", zone <= zone_count);
-            }
+        int  zone_count    = is_multi_zone ? cfg.opt_int("multi_zone_number") : 0;
+
+        for (int zone = 10; zone > 0; zone--) {
+            std::string zone_str = std::to_string(zone);
+            bool        toggle   = is_multi_zone && zone <= zone_count;
+            toggle_line("multi_zone_" + zone_str + "_initial_layer", toggle);
+            toggle_line("multi_zone_" + zone_str + "_temperature", toggle);
         }
+
         toggle_line("nozzle_temperature_initial_layer", !is_multi_zone);
         toggle_line("nozzle_temperature", !is_multi_zone);
     }


### PR DESCRIPTION
# Description

This PR implements the logic to manage a multi-heating zone configuration for the nozzle, specifically for the `modded_printer_pellet` models. 

### Changes introduced:
- **Multi Heating Zone Feature**: When enabled, users can independently set the temperature for each zone, rather than setting a single temperature for the nozzle.
- **Updated G-code Command (M104)**: The M104 command now supports a new parameter `Z{zone_number}`, allowing targeted zone heating. This feature is compatible with multi-extruder printers.
- The previous behavior of the M104 command remains unchanged when the multi-heating zone option is disabled.

### Impact:
This update enhances flexibility and precision in temperature control, particularly for advanced multi-zone setups.

### Breaking Changes:
No breaking changes are introduced. The existing functionality remains intact when the multi-heating zone feature is disabled.

# Screenshots/Recordings/Graphs

[TBD]

## Tests

The following tests were conducted to verify the changes:
1. Generated a G-code file with correctly modified M104 commands, including the new `Z{zone_number}` parameter.
2. Verified that disabling the multi-heating zone option preserves the previous behavior without any regressions.