### PR TITLE
fix: allow build on Fedora >= 40

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,10 @@ if (NOT MSVC AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMP
         add_compile_options(-gz=zstd)
     endif()
 
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=template-id-cdtor" )
+    endif()
+
 endif()
 
 if (SLIC3R_ASAN)

--- a/linux.d/fedora
+++ b/linux.d/fedora
@@ -16,6 +16,7 @@ REQUIRED_DEV_PACKAGES=(
     gstreamermm-devel
     gtk3-devel
     libmspack-devel
+    libquadmath-devel
     libsecret-devel
     libtool
     m4


### PR DESCRIPTION
# Description

Fedora 40 and 41 use GNU c++ version 14.2.1 which throws an error compiling OrcaSlicer:

`error: template-id not allowed for constructor in C++20`

To ignore this error `-Wno-error=template-id-cdtor` can be added to the compiler flags.

Furthermore Fedora 40 and 41 need an additional package to be installed: `libquadmath-devel`. On Fedora 39 this package is not needed, but it exists and does no harm.

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

## Tests

A full compile run was carried out on these OS:

OS | Version | c++ -v | -Wno-error=template-id-cdtor needed? | libquadmath-devel needed? | Compile test passed?
-- | -- | -- | -- | -- | --
Fedora | 41 | 14.2.1 20240912 (Red Hat 14.2.1-3) | yes | yes | ✅
Fedora | 40 | 14.2.1 20240912 (Red Hat 14.2.1-3) | yes | yes | ✅
Fedora | 39 | 13.3.1 20240913 (Red Hat 13.3.1-3) | no | no | ✅
Ubuntu | 24.04 | 13.2.0 (Ubuntu 13.2.0-23ubuntu4) | no | N/A | ✅
Ubuntu | 20.04 | 9.4.0 (Ubuntu 9.4.0-1ubuntu1~20.04.2) | no | N/A | ✅
