### PR TITLE
fix: Don't exit if libgtk is not found

### DIFF
--- a/linux.d/debian
+++ b/linux.d/debian
@@ -1,4 +1,4 @@
-FOUND_GTK3=$(dpkg -l libgtk* | grep gtk-3)
+FOUND_GTK3=$(dpkg -l libgtk* | grep gtk-3 || echo '')
 
 REQUIRED_DEV_PACKAGES=(
     autoconf


### PR DESCRIPTION
# Description

When trying to compile OrcaSlicer on a minimal Ubuntu 20.04 and 24.04 (e. g. a container) `./BuildLinux.sh -u` exits silently:

```bash
root@6ababa89c422:/OrcaSlicer# ./BuildLinux.sh -u ; echo $? 
1
```

`./linux.d/debian` exits on the [first line](https://github.com/SoftFever/OrcaSlicer/blob/3caca2215db3eaf00ae97073763ab10579f900dd/linux.d/debian#L1) due to `set -e` in [`BuildLinux.sh`](https://github.com/SoftFever/OrcaSlicer/blob/3caca2215db3eaf00ae97073763ab10579f900dd/BuildLinux.sh#L5)

## Tests

Tested compiling on Ubuntu 20.04 and 24.04
