### PR TITLE
Fix Prime volume field missing on BBL printers

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -681,7 +681,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
 
     toggle_line("single_extruder_multi_material_priming", !bSEMM && have_prime_tower && !is_BBL_Printer);
 
-    toggle_line("prime_volume",have_prime_tower && (!purge_in_primetower || !bSEMM));
+    toggle_line("prime_volume",have_prime_tower && (!purge_in_primetower || !bSEMM || is_BBL_Printer));
     
     for (auto el : {"flush_into_infill", "flush_into_support", "flush_into_objects"})
         toggle_field(el, have_prime_tower);


### PR DESCRIPTION
# Description

Fixes #7751 where prime volume was missing for BBL printers

## Tests

Tested with BBL printer - value is showing
BBL printer with prime tower disabled - value not showing as expected 
Tested with SEMM printer - value showing