### PR TITLE
Fix Prime volume missing on BBL printers

### DIFF
--- a/resources/profiles/BBL/machine/fdm_machine_common.json
+++ b/resources/profiles/BBL/machine/fdm_machine_common.json
@@ -79,10 +79,9 @@
         "0.08"
     ],
     "printable_height": "250",
+    "extruder_clearance_radius": "65",
     "extruder_clearance_height_to_rod": "34",
     "extruder_clearance_height_to_lid": "140",
-    "extruder_clearance_max_radius": "65",
-    "extruder_clearance_dist_to_rod": "33",
     "printer_settings_id": "",
     "retraction_minimum_travel": [
         "2"

--- a/resources/profiles/BBL/machine/fdm_machine_common.json
+++ b/resources/profiles/BBL/machine/fdm_machine_common.json
@@ -124,5 +124,7 @@
     "upward_compatible_machine": [],
     "machine_start_gcode": "G0 Z20 F9000\nG92 E0; G1 E-10 F1200\nG28\nM970 Q1 A10 B10 C130 K0\nM970 Q1 A10 B131 C250 K1\nM974 Q1 S1 P0\nM970 Q0 A10 B10 C130 H20 K0\nM970 Q0 A10 B131 C250 K1\nM974 Q0 S1 P0\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG29 ;Home\nG90;\nG92 E0 ;Reset Extruder \nG1 Z2.0 F3000 ;Move Z Axis up \nG1 X10.1 Y20 Z0.28 F5000.0 ;Move to start position\nM109 S205;\nG1 X10.1 Y200.0 Z0.28 F1500.0 E15 ;Draw the first line\nG1 X10.4 Y200.0 Z0.28 F5000.0 ;Move to side a little\nG1 X10.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line\nG92 E0 ;Reset Extruder \nG1 X110 Y110 Z2.0 F3000 ;Move Z Axis up",
     "machine_end_gcode": "M400 ; wait for buffer to clear\nG92 E0 ; zero the extruder\nG1 E-4.0 F3600; retract \nG91\nG1 Z3;\nM104 S0 ; turn off hotend\nM140 S0 ; turn off bed\nM106 S0 ; turn off fan\nG90 \nG0 X110 Y200 F3600 \nprint_end",
-    "change_filament_gcode": ""
+    "change_filament_gcode": "",
+    "purge_in_prime_tower": "0",
+    "enable_filament_ramming": "0"
 }


### PR DESCRIPTION
Issue is caused by #7629, which overwriten the profile with BBL's, which has some our unique properties missing. This PR brings them back.

Fixes #7751