### PR TITLE
Correct FBG6 extruder clearance radius

### DIFF
--- a/resources/profiles/FlyingBear/machine/FlyingBear Ghost 6 0.4 nozzle.json
+++ b/resources/profiles/FlyingBear/machine/FlyingBear Ghost 6 0.4 nozzle.json
@@ -110,7 +110,7 @@
     ],
     "extruder_clearance_height_to_lid": "80",
     "extruder_clearance_height_to_rod": "64",
-    "extruder_clearance_radius": "40",
+    "extruder_clearance_radius": "55",
     "z_hop": [
         "0.2"
     ],


### PR DESCRIPTION
# Description

The value 40 mm is too low and can cause the head to hit printed models in "By object" print mode.
I've just discovered this when I heard wrong noises from the 3D printer.
The correct value is about 53 mm, I propose using 55 mm in order to play it safe.

# Screenshots/Recordings/Graphs

![IMG_8610](https://github.com/user-attachments/assets/f12688e2-c202-40dd-b91e-f8292e7f557b)
