### PR TITLE
Fix: global-level infill settings were ineffective;

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -2896,10 +2896,12 @@ static void apply_to_print_region_config(PrintRegionConfig &out, const DynamicPr
     auto *opt_extruder = in.opt<ConfigOptionInt>(key_extruder);
     if (opt_extruder)
         if (int extruder = opt_extruder->value; extruder != 0) {
-            // Not a default extruder.
-            out.sparse_infill_filament.value = extruder;
-            out.solid_infill_filament.value  = extruder;
-            out.wall_filament.value          = extruder;
+            if (out.sparse_infill_filament.value == 0) 
+                out.sparse_infill_filament.value = extruder;
+            if (out.solid_infill_filament.value == 0)
+                out.solid_infill_filament.value  = extruder;
+            if (out.wall_filament.value == 0)
+                out.wall_filament.value          = extruder;
         }
     // 2) Copy the rest of the values.
     for (auto it = in.cbegin(); it != in.cend(); ++ it)

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -918,6 +918,23 @@ void ObjectList::update_filament_in_config(const wxDataViewItem& item)
     const int extruder = m_objects_model->GetExtruderNumber(item);
     m_config->set_key_value("extruder", new ConfigOptionInt(extruder));
 
+    if (m_config->has("sparse_infill_filament")) {
+        m_config->set("sparse_infill_filament", m_config->option("extruder")->getInt());
+    }
+    else {
+        m_config->set_key_value("sparse_infill_filament", new ConfigOptionInt(m_config->option("extruder")->getInt()));
+    }
+    if (m_config->has("solid_infill_filament")) {
+        m_config->set("solid_infill_filament", m_config->option("extruder")->getInt());
+    } else {
+        m_config->set_key_value("solid_infill_filament", new ConfigOptionInt(m_config->option("extruder")->getInt()));
+    }
+    if (m_config->has("wall_filament")) {
+        m_config->set("wall_filament", m_config->option("extruder")->getInt());
+    } else {
+        m_config->set_key_value("wall_filament", new ConfigOptionInt(m_config->option("extruder")->getInt()));
+    }
+
     // BBS
     if (item_type & itObject) {
         const int obj_idx = m_objects_model->GetIdByItem(item);
@@ -5673,6 +5690,10 @@ void ObjectList::set_extruder_for_selected_items(const int extruder)
         else
             config.set_key_value("extruder", new ConfigOptionInt(new_extruder));
 
+        config.set("sparse_infill_filament", new_extruder);
+        config.set("solid_infill_filament", new_extruder);
+        config.set("wall_filament", new_extruder);
+        wxGetApp().obj_list()->update_selections();
         // for object, clear all its part volume's extruder config
         if (type & itObject) {
             ObjectDataViewModelNode* node = (ObjectDataViewModelNode*)item.GetID();


### PR DESCRIPTION
# Reproduction steps for the issue:
1. change the infill/walls/solid infill of the object
![image](https://github.com/user-attachments/assets/49fd6ba9-479d-448f-9ff1-2485a08ac75c)
2. slice plate
![image](https://github.com/user-attachments/assets/1d1c062d-d9b2-4c0e-9f22-3c09ae74a4b1)

it cant't be effective.

extra:
when user change the filament of the object, the walls, infill, solid infill should be changed as well but not now
![image](https://github.com/user-attachments/assets/f2cfe95a-3815-4cc8-a434-0574abda3887)
