### PR TITLE
fixed typo in english i18n - 'advanced' instead of 'advance'

### DIFF
--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -5725,7 +5725,7 @@ msgstr "Global"
 msgid "Objects"
 msgstr "Objects"
 
-msgid "Advance"
+msgid "Advanced"
 msgstr "Advanced"
 
 msgid "Compare presets"


### PR DESCRIPTION
with msgstr being advanced and msgid advanced i think its right this way. it shows up on the main view as the slider for advanced options and bugs me so much.

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
