### PR TITLE
Fix issue that the support contact layer is printed in wrong filament

### DIFF
--- a/src/libslic3r/Support/SupportMaterial.cpp
+++ b/src/libslic3r/Support/SupportMaterial.cpp
@@ -4706,7 +4706,7 @@ void PrintObjectSupportMaterial::generate_toolpaths(
                     // Filler and its parameters
                     filler_interface.get(), fill_params,
                     // Extrusion parameters
-                    erSupportMaterialInterface, interface_flow);
+                    interface_as_base ? erSupportMaterial : erSupportMaterialInterface, interface_flow);
             }
 
             // Base interface layers under soluble interfaces


### PR DESCRIPTION
 when interface layer number is set to 0

Cherry-picked from prusa3d/PrusaSlicer@ca5f6da08d38c75e0e00ea2604de9709b9caa8aa

Fix #7900

![141efe159392d6c21662950bc82620e7](https://github.com/user-attachments/assets/54701fa9-a9f8-4422-b1d9-83515d091d9e)
