### PR TITLE
Fix profiles with missing compatible printers

### DIFF
--- a/resources/profiles/Elegoo/filament/Elegoo Generic ASA.json
+++ b/resources/profiles/Elegoo/filament/Elegoo Generic ASA.json
@@ -14,5 +14,32 @@
     ],
     "filament_max_volumetric_speed": [
         "12"
-    ]
+    ],
+	"compatible_printers": [
+		"Elegoo Neptune 0.4 nozzle",
+		"Elegoo Neptune X 0.4 nozzle",
+		"Elegoo Neptune 2 0.4 nozzle",
+		"Elegoo Neptune 2S 0.4 nozzle",
+		"Elegoo Neptune 2D 0.4 nozzle",
+		"Elegoo Neptune 3 0.4 nozzle",
+		"Elegoo Neptune 3 Pro 0.4 nozzle",
+		"Elegoo Neptune 3 Plus 0.4 nozzle",
+		"Elegoo Neptune 3 Max 0.4 nozzle",
+		"Elegoo Neptune 4 (0.2 nozzle)",
+		"Elegoo Neptune 4 (0.4 nozzle)",
+		"Elegoo Neptune 4 (0.6 nozzle)",
+		"Elegoo Neptune 4 (0.8 nozzle)",
+		"Elegoo Neptune 4 Max (0.2 nozzle)",
+		"Elegoo Neptune 4 Max (0.4 nozzle)",
+		"Elegoo Neptune 4 Max (0.6 nozzle)",
+		"Elegoo Neptune 4 Max (0.8 nozzle)",
+		"Elegoo Neptune 4 Plus (0.2 nozzle)",
+		"Elegoo Neptune 4 Plus (0.4 nozzle)",
+		"Elegoo Neptune 4 Plus (0.6 nozzle)",
+		"Elegoo Neptune 4 Plus (0.8 nozzle)",
+		"Elegoo Neptune 4 Pro (0.2 nozzle)",
+		"Elegoo Neptune 4 Pro (0.4 nozzle)",
+		"Elegoo Neptune 4 Pro (0.6 nozzle)",
+		"Elegoo Neptune 4 Pro (0.8 nozzle)"
+	]
 }

--- a/resources/profiles/Elegoo/filament/Elegoo Generic PETG PRO.json
+++ b/resources/profiles/Elegoo/filament/Elegoo Generic PETG PRO.json
@@ -77,5 +77,32 @@
     ],
     "filament_end_gcode": [
         "; filament end gcode \n"
+    ],
+    "compatible_printers": [
+      "Elegoo Neptune 0.4 nozzle",
+      "Elegoo Neptune X 0.4 nozzle",
+      "Elegoo Neptune 2 0.4 nozzle",
+      "Elegoo Neptune 2S 0.4 nozzle",
+      "Elegoo Neptune 2D 0.4 nozzle",
+      "Elegoo Neptune 3 0.4 nozzle",
+      "Elegoo Neptune 3 Pro 0.4 nozzle",
+      "Elegoo Neptune 3 Plus 0.4 nozzle",
+      "Elegoo Neptune 3 Max 0.4 nozzle",
+      "Elegoo Neptune 4 (0.2 nozzle)",
+      "Elegoo Neptune 4 (0.4 nozzle)",
+      "Elegoo Neptune 4 (0.6 nozzle)",
+      "Elegoo Neptune 4 (0.8 nozzle)",
+      "Elegoo Neptune 4 Max (0.2 nozzle)",
+      "Elegoo Neptune 4 Max (0.4 nozzle)",
+      "Elegoo Neptune 4 Max (0.6 nozzle)",
+      "Elegoo Neptune 4 Max (0.8 nozzle)",
+      "Elegoo Neptune 4 Plus (0.2 nozzle)",
+      "Elegoo Neptune 4 Plus (0.4 nozzle)",
+      "Elegoo Neptune 4 Plus (0.6 nozzle)",
+      "Elegoo Neptune 4 Plus (0.8 nozzle)",
+      "Elegoo Neptune 4 Pro (0.2 nozzle)",
+      "Elegoo Neptune 4 Pro (0.4 nozzle)",
+      "Elegoo Neptune 4 Pro (0.6 nozzle)",
+      "Elegoo Neptune 4 Pro (0.8 nozzle)"
     ]
 }

--- a/resources/profiles/Elegoo/filament/Elegoo Generic PLA Matte.json
+++ b/resources/profiles/Elegoo/filament/Elegoo Generic PLA Matte.json
@@ -17,5 +17,32 @@
     ],
     "filament_start_gcode": [
         "; filament start gcode\n"
-    ]
+    ],
+	"compatible_printers": [
+		"Elegoo Neptune 0.4 nozzle",
+		"Elegoo Neptune X 0.4 nozzle",
+		"Elegoo Neptune 2 0.4 nozzle",
+		"Elegoo Neptune 2S 0.4 nozzle",
+		"Elegoo Neptune 2D 0.4 nozzle",
+		"Elegoo Neptune 3 0.4 nozzle",
+		"Elegoo Neptune 3 Pro 0.4 nozzle",
+		"Elegoo Neptune 3 Plus 0.4 nozzle",
+		"Elegoo Neptune 3 Max 0.4 nozzle",
+		"Elegoo Neptune 4 (0.2 nozzle)",
+		"Elegoo Neptune 4 (0.4 nozzle)",
+		"Elegoo Neptune 4 (0.6 nozzle)",
+		"Elegoo Neptune 4 (0.8 nozzle)",
+		"Elegoo Neptune 4 Max (0.2 nozzle)",
+		"Elegoo Neptune 4 Max (0.4 nozzle)",
+		"Elegoo Neptune 4 Max (0.6 nozzle)",
+		"Elegoo Neptune 4 Max (0.8 nozzle)",
+		"Elegoo Neptune 4 Plus (0.2 nozzle)",
+		"Elegoo Neptune 4 Plus (0.4 nozzle)",
+		"Elegoo Neptune 4 Plus (0.6 nozzle)",
+		"Elegoo Neptune 4 Plus (0.8 nozzle)",
+		"Elegoo Neptune 4 Pro (0.2 nozzle)",
+		"Elegoo Neptune 4 Pro (0.4 nozzle)",
+		"Elegoo Neptune 4 Pro (0.6 nozzle)",
+		"Elegoo Neptune 4 Pro (0.8 nozzle)"
+	]
 }

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle ABS.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle ABS.json
@@ -50,5 +50,32 @@
     ],
     "overhang_fan_speed": [
         "30"
+    ],
+    "compatible_printers": [
+      "RatRig V-Core 3 200 0.4 nozzle",
+      "RatRig V-Core 3 300 0.4 nozzle",
+      "RatRig V-Core 3 400 0.4 nozzle",
+      "RatRig V-Core 3 500 0.4 nozzle",
+      "RatRig V-Minion 0.4 nozzle",
+      "RatRig V-Cast 0.4 nozzle",
+      "RatRig V-Cast 0.6 nozzle",
+      "RatRig V-Core 4 300 0.4 nozzle",
+      "RatRig V-Core 4 300 0.5 nozzle",
+      "RatRig V-Core 4 300 0.6 nozzle",
+      "RatRig V-Core 4 400 0.4 nozzle",
+      "RatRig V-Core 4 400 0.5 nozzle",
+      "RatRig V-Core 4 400 0.6 nozzle",
+      "RatRig V-Core 4 500 0.4 nozzle",
+      "RatRig V-Core 4 500 0.5 nozzle",
+      "RatRig V-Core 4 500 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.6 nozzle"
     ]
 }

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle ASA.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle ASA.json
@@ -50,5 +50,32 @@
     ],
     "overhang_fan_speed": [
         "28"
+    ],
+    "compatible_printers": [
+      "RatRig V-Core 3 200 0.4 nozzle",
+      "RatRig V-Core 3 300 0.4 nozzle",
+      "RatRig V-Core 3 400 0.4 nozzle",
+      "RatRig V-Core 3 500 0.4 nozzle",
+      "RatRig V-Minion 0.4 nozzle",
+      "RatRig V-Cast 0.4 nozzle",
+      "RatRig V-Cast 0.6 nozzle",
+      "RatRig V-Core 4 300 0.4 nozzle",
+      "RatRig V-Core 4 300 0.5 nozzle",
+      "RatRig V-Core 4 300 0.6 nozzle",
+      "RatRig V-Core 4 400 0.4 nozzle",
+      "RatRig V-Core 4 400 0.5 nozzle",
+      "RatRig V-Core 4 400 0.6 nozzle",
+      "RatRig V-Core 4 500 0.4 nozzle",
+      "RatRig V-Core 4 500 0.5 nozzle",
+      "RatRig V-Core 4 500 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.6 nozzle"
     ]
 }

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle PCTG.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle PCTG.json
@@ -65,5 +65,32 @@
     ],
 	"temperature_vitrification": [
         "90"
+    ],
+    "compatible_printers": [
+      "RatRig V-Core 3 200 0.4 nozzle",
+      "RatRig V-Core 3 300 0.4 nozzle",
+      "RatRig V-Core 3 400 0.4 nozzle",
+      "RatRig V-Core 3 500 0.4 nozzle",
+      "RatRig V-Minion 0.4 nozzle",
+      "RatRig V-Cast 0.4 nozzle",
+      "RatRig V-Cast 0.6 nozzle",
+      "RatRig V-Core 4 300 0.4 nozzle",
+      "RatRig V-Core 4 300 0.5 nozzle",
+      "RatRig V-Core 4 300 0.6 nozzle",
+      "RatRig V-Core 4 400 0.4 nozzle",
+      "RatRig V-Core 4 400 0.5 nozzle",
+      "RatRig V-Core 4 400 0.6 nozzle",
+      "RatRig V-Core 4 500 0.4 nozzle",
+      "RatRig V-Core 4 500 0.5 nozzle",
+      "RatRig V-Core 4 500 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.6 nozzle"
     ]
 }

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle PETG.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle PETG.json
@@ -59,5 +59,32 @@
     ],
     "nozzle_temperature_range_low": [
         "230"
+    ],
+    "compatible_printers": [
+      "RatRig V-Core 3 200 0.4 nozzle",
+      "RatRig V-Core 3 300 0.4 nozzle",
+      "RatRig V-Core 3 400 0.4 nozzle",
+      "RatRig V-Core 3 500 0.4 nozzle",
+      "RatRig V-Minion 0.4 nozzle",
+      "RatRig V-Cast 0.4 nozzle",
+      "RatRig V-Cast 0.6 nozzle",
+      "RatRig V-Core 4 300 0.4 nozzle",
+      "RatRig V-Core 4 300 0.5 nozzle",
+      "RatRig V-Core 4 300 0.6 nozzle",
+      "RatRig V-Core 4 400 0.4 nozzle",
+      "RatRig V-Core 4 400 0.5 nozzle",
+      "RatRig V-Core 4 400 0.6 nozzle",
+      "RatRig V-Core 4 500 0.4 nozzle",
+      "RatRig V-Core 4 500 0.5 nozzle",
+      "RatRig V-Core 4 500 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.6 nozzle"
     ]
 }

--- a/resources/profiles/Ratrig/filament/RatRig BigNozzle PLA.json
+++ b/resources/profiles/Ratrig/filament/RatRig BigNozzle PLA.json
@@ -35,5 +35,32 @@
     ],
     "nozzle_temperature_range_low": [
         "210"
+    ],
+    "compatible_printers": [
+      "RatRig V-Core 3 200 0.4 nozzle",
+      "RatRig V-Core 3 300 0.4 nozzle",
+      "RatRig V-Core 3 400 0.4 nozzle",
+      "RatRig V-Core 3 500 0.4 nozzle",
+      "RatRig V-Minion 0.4 nozzle",
+      "RatRig V-Cast 0.4 nozzle",
+      "RatRig V-Cast 0.6 nozzle",
+      "RatRig V-Core 4 300 0.4 nozzle",
+      "RatRig V-Core 4 300 0.5 nozzle",
+      "RatRig V-Core 4 300 0.6 nozzle",
+      "RatRig V-Core 4 400 0.4 nozzle",
+      "RatRig V-Core 4 400 0.5 nozzle",
+      "RatRig V-Core 4 400 0.6 nozzle",
+      "RatRig V-Core 4 500 0.4 nozzle",
+      "RatRig V-Core 4 500 0.5 nozzle",
+      "RatRig V-Core 4 500 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.6 nozzle"
     ]
 }

--- a/resources/profiles/Ratrig/filament/RatRig Generic PCTG.json
+++ b/resources/profiles/Ratrig/filament/RatRig Generic PCTG.json
@@ -62,5 +62,32 @@
     ],
 	"temperature_vitrification": [
         "90"
+    ],
+    "compatible_printers": [
+      "RatRig V-Core 3 200 0.4 nozzle",
+      "RatRig V-Core 3 300 0.4 nozzle",
+      "RatRig V-Core 3 400 0.4 nozzle",
+      "RatRig V-Core 3 500 0.4 nozzle",
+      "RatRig V-Minion 0.4 nozzle",
+      "RatRig V-Cast 0.4 nozzle",
+      "RatRig V-Cast 0.6 nozzle",
+      "RatRig V-Core 4 300 0.4 nozzle",
+      "RatRig V-Core 4 300 0.5 nozzle",
+      "RatRig V-Core 4 300 0.6 nozzle",
+      "RatRig V-Core 4 400 0.4 nozzle",
+      "RatRig V-Core 4 400 0.5 nozzle",
+      "RatRig V-Core 4 400 0.6 nozzle",
+      "RatRig V-Core 4 500 0.4 nozzle",
+      "RatRig V-Core 4 500 0.5 nozzle",
+      "RatRig V-Core 4 500 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 300 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 400 0.6 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.4 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.5 nozzle",
+      "RatRig V-Core 4 HYBRID 500 0.6 nozzle"
     ]
 }

--- a/resources/web/guide/22/22.js
+++ b/resources/web/guide/22/22.js
@@ -138,7 +138,8 @@ function SortUI()
 		//let bCheck=$("#MachineList input:first").prop("checked");
 		if( fModel=='')
 		{
-			bFind=true;
+			// Orca: hide
+			bFind=false;
 		}
 		else
 		{


### PR DESCRIPTION
# Description
Filaments that don't have compatible printers defined will invalidate filter in filament selection UI
This PR:
1. Fix profiles with missing compatible printers attributes
2. Change code logic so that we don't show such filaments 

# Screenshots/Recordings/Graphs

![Screenshot 2025-01-01 000512](https://github.com/user-attachments/assets/ccfd99f0-fe7b-4420-a808-d3f8d85e4aca)


## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
