### PR TITLE
Fix random crash when opening 3mf files that have bed size different than current

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -6767,7 +6767,7 @@ void GLCanvas3D::_picking_pass()
         case SceneRaycaster::EType::Bed:
         {
             // BBS: add plate picking logic
-            int plate_hover_id = PartPlate::PLATE_BASE_ID - hit.raycaster_id;
+            int plate_hover_id = hit.raycaster_id;
             if (plate_hover_id >= 0 && plate_hover_id < PartPlateList::MAX_PLATES_COUNT * PartPlate::GRABBER_COUNT) {
                 wxGetApp().plater()->get_partplate_list().set_hover_id(plate_hover_id);
                 m_hover_plate_idxs.emplace_back(plate_hover_id);

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -1348,8 +1348,7 @@ void PartPlate::register_raycasters_for_picking(GLCanvas3D &canvas)
 
 int PartPlate::picking_id_component(int idx) const
 {
-	unsigned int id = PLATE_BASE_ID - this->m_plate_index * GRABBER_COUNT - idx;
-	return id;
+    return this->m_plate_index * GRABBER_COUNT + idx;
 }
 
 std::vector<int> PartPlate::get_extruders(bool conside_custom_gcode) const

--- a/src/slic3r/GUI/PartPlate.hpp
+++ b/src/slic3r/GUI/PartPlate.hpp
@@ -198,7 +198,6 @@ private:
     int picking_id_component(int idx) const;
 
 public:
-    static const unsigned int PLATE_BASE_ID = 255 * 255 * 253;
     static const unsigned int PLATE_NAME_HOVER_ID = 6;
     static const unsigned int GRABBER_COUNT = 8;
 

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -4396,7 +4396,9 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
 
             cur_plate->translate_all_instance(new_origin - cur_origin);
         }
+        view3D->get_canvas3d()->remove_raycasters_for_picking(SceneRaycaster::EType::Bed);
         partplate_list.reset_size(current_width, current_depth, current_height, true, true);
+        partplate_list.register_raycasters_for_picking(*view3D->get_canvas3d());
     }
 
     //BBS: add gcode loading logic in the end

--- a/src/slic3r/GUI/SceneRaycaster.hpp
+++ b/src/slic3r/GUI/SceneRaycaster.hpp
@@ -52,7 +52,7 @@ public:
     enum class EIdBase
     {
         Bed    = 0,
-        Volume = 1000,
+        Volume = 1000, // Must be smaller than PartPlateList::MAX_PLATES_COUNT * PartPlate::GRABBER_COUNT
         Gizmo  = 1000000,
         FallbackGizmo = 2000000
     };


### PR DESCRIPTION
This was caused by not unregistering the previous bed raycasters before resetting the bed polygons (which are used by the raycaster).

Also fixing the raycaster IDs for beds.