### PR TITLE
fixed a custom filament creation bug

### DIFF
--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -542,21 +542,24 @@ static char* read_json_file(const std::string &preset_path)
 }
 
 static std::string get_printer_nozzle_diameter(std::string printer_name) {
+    // Create a lowercase version of the printer_name for case-insensitive search
+    std::string printer_name_lower = printer_name;
+    std::transform(printer_name_lower.begin(), printer_name_lower.end(), printer_name_lower.begin(), ::tolower);
 
-    size_t index = printer_name.find(" nozzle)");
+    size_t index = printer_name_lower.find(" nozzle)");
     if (std::string::npos == index) {
-        size_t index = printer_name.find(" nozzle");
+        size_t index = printer_name_lower.find(" nozzle");
         if (std::string::npos == index) {
             return "";
         }
-        std::string nozzle           = printer_name.substr(0, index);
+        std::string nozzle = printer_name_lower.substr(0, index);
         size_t      last_space_index = nozzle.find_last_of(" ");
         if (std::string::npos == index) {
             return "";
         }
         return nozzle.substr(last_space_index + 1);
     } else {
-        std::string nozzle = printer_name.substr(0, index);
+        std::string nozzle = printer_name_lower.substr(0, index);
         size_t      last_bracket_index = nozzle.find_last_of("(");
         if (std::string::npos == index) {
             return "";


### PR DESCRIPTION
Orca doesnt recognize capitalized letter in 'Nozzle' in the printer name. Those printer profiles will not show up when creating custom filaments, which blocks users the ability to create custom filament profiles for those printers.

This fixes #7953 

# Screenshots/Recordings/Graphs
2.3.0-dev:
![image](https://github.com/user-attachments/assets/4ea2376f-7b2e-48ce-8b4b-28f7167b3fec)

after:
![image](https://github.com/user-attachments/assets/604b518b-6dd3-42bf-8749-a87927f45806)


## Tests

Tested locally on Windows11
