### PR TITLE
Fix flow dynamics calib crash when last bed type is selected

### DIFF
--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -24,12 +24,14 @@ static const std::string temp_gcode_path = temp_dir + "/temp.gcode";
 static const std::string path            = temp_dir + "/test.3mf";
 static const std::string config_3mf_path = temp_dir + "/test_config.3mf";
 
-static std::string MachineBedTypeString[5] = {
+static std::string MachineBedTypeString[7] = {
     "auto",
+    "suprtack",
     "pc",
     "ep",
     "pei",
-    "pte"
+    "pte",
+    "pct",
 };
 
 


### PR DESCRIPTION
Fix #7857