### PR TITLE
Fix arrange when print-by-object and have object off-plate

### DIFF
--- a/src/libslic3r/Arrange.cpp
+++ b/src/libslic3r/Arrange.cpp
@@ -103,8 +103,10 @@ void update_selected_items_inflation(ArrangePolygons& selected, const DynamicPri
     BoundingBox bedbb = Polygon(bedpts).bounding_box();
     // set obj distance for auto seq_print
     if (params.is_seq_print) {
-        if (params.all_objects_are_short)
+        bool all_objects_are_short = std::all_of(selected.begin(), selected.end(), [&](ArrangePolygon& ap) { return ap.height < params.nozzle_height; });
+        if (all_objects_are_short) {
             params.min_obj_distance = std::max(params.min_obj_distance, scaled(std::max(MAX_OUTER_NOZZLE_DIAMETER/2.f, params.object_skirt_offset*2)+0.001));
+        }
         else
             params.min_obj_distance = std::max(params.min_obj_distance, scaled(params.clearance_radius + 0.001)); // +0.001mm to avoid clearance check fail due to rounding error
     }

--- a/src/libslic3r/Arrange.hpp
+++ b/src/libslic3r/Arrange.hpp
@@ -135,7 +135,6 @@ struct ArrangeParams {
     float clearance_radius = 0;
     float object_skirt_offset = 0;
     float nozzle_height = 0;
-    bool  all_objects_are_short = false;
     float printable_height = 256.0;
     Vec2d align_center{ 0.5,0.5 };
 

--- a/src/slic3r/GUI/Jobs/ArrangeJob.cpp
+++ b/src/slic3r/GUI/Jobs/ArrangeJob.cpp
@@ -775,7 +775,6 @@ arrangement::ArrangeParams init_arrange_params(Plater *p)
     params.printable_height                    = print_config.printable_height.value;
     params.allow_rotations                     = settings.enable_rotation;
     params.nozzle_height                       = print_config.nozzle_height.value;
-    params.all_objects_are_short               = print.is_all_objects_are_short();
     params.align_center                        = print_config.best_object_pos.value;
     params.allow_multi_materials_on_same_plate = settings.allow_multi_materials_on_same_plate;
     params.avoid_extrusion_cali_region         = settings.avoid_extrusion_cali_region;

--- a/src/slic3r/GUI/Jobs/FillBedJob.cpp
+++ b/src/slic3r/GUI/Jobs/FillBedJob.cpp
@@ -56,7 +56,6 @@ void FillBedJob::prepare()
 
             ArrangePolygon ap = get_instance_arrange_poly(mo->instances[inst_idx], global_config);
             BoundingBox ap_bb = ap.transformed_poly().contour.bounding_box();
-            ap.height = 1;
             ap.name = mo->name;
 
             if (selected)
@@ -173,7 +172,6 @@ void FillBedJob::prepare()
         ArrangePolygon ap = template_ap;
         ap.poly = m_selected.front().poly;
         ap.bed_idx = PartPlateList::MAX_PLATES_COUNT;
-        ap.height = 1;
         ap.itemid = -1;
         ap.setter = [this, mi](const ArrangePolygon &p) {
             ModelObject *mo = m_plater->model().objects[m_object_idx];


### PR DESCRIPTION
Fix #5153
Fix #7745

Partly revert 0b6a1d36360448c5e6818001b9d8ea99a57567a7
