### PR TITLE
rename flow rate calibration to flow ratio

### DIFF
--- a/src/slic3r/GUI/CalibrationPanel.cpp
+++ b/src/slic3r/GUI/CalibrationPanel.cpp
@@ -21,7 +21,7 @@ wxString get_calibration_type_name(CalibMode cali_mode)
     case CalibMode::Calib_PA_Line:
         return _L("Flow Dynamics");
     case CalibMode::Calib_Flow_Rate:
-        return _L("Flow Rate");
+        return _L("Flow Ratio");
     case CalibMode::Calib_Vol_speed_Tower:
         return _L("Max Volumetric Speed");
     case CalibMode::Calib_Temp_Tower:

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2858,7 +2858,7 @@ void MainFrame::init_menubar_as_editor()
     append_menu_item(flowrate_menu, wxID_ANY, _L("YOLO (perfectionist version)"), _L("Orca YOLO flowrate calibration, 0.005 step"),
         [this](wxCommandEvent&) { if (m_plater) m_plater->calib_flowrate(true, 2); }, "", nullptr,
         [this]() {return m_plater->is_view3D_shown();; }, this);
-    m_topbar->GetCalibMenu()->AppendSubMenu(flowrate_menu, _L("Flow rate"));
+    m_topbar->GetCalibMenu()->AppendSubMenu(flowrate_menu, _L("Flow ratio"));
     append_menu_item(m_topbar->GetCalibMenu(), wxID_ANY, _L("Pressure advance"), _L("Pressure advance"),
         [this](wxCommandEvent&) {
             if (!m_pa_calib_dlg)
@@ -2945,7 +2945,7 @@ void MainFrame::init_menubar_as_editor()
     append_menu_item(flowrate_menu, wxID_ANY, _L("Pass 2"), _L("Flow rate test - Pass 2"),
         [this](wxCommandEvent&) { if (m_plater) m_plater->calib_flowrate(false, 2); }, "", nullptr,
         [this]() {return m_plater->is_view3D_shown();; }, this);
-    append_submenu(calib_menu,flowrate_menu,wxID_ANY,_L("Flow rate"),_L("Flow rate"),"",
+    append_submenu(calib_menu,flowrate_menu,wxID_ANY,_L("Flow ratio"),_L("Flow ratio"),"",
                    [this]() {return m_plater->is_view3D_shown();; });
     flowrate_menu->AppendSeparator();
     append_menu_item(flowrate_menu, wxID_ANY, _L("YOLO (Recommended)"), _L("Orca YOLO flowrate calibration, 0.01 step"),


### PR DESCRIPTION


# Description

A simple rename of the flow rate calibration to flow ratio to make the terminology consistent throughout the app.  It has caused confusion with a few users on the OrcaSlicer discord.

# Screenshots/Recordings/Graphs

![image](https://github.com/user-attachments/assets/df1d1fec-86c5-457f-8962-fa7b72bc585f)

## Tests

I manually ran the flow ratio calibration test to ensure it still functioned.