### PR TITLE
capitalize support names in the UI for consistency

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4406,17 +4406,17 @@ void PrintConfigDef::init_fff_params()
     def = this->add("support_type", coEnum);
     def->label = L("Type");
     def->category = L("Support");
-    def->tooltip = L("normal(auto) and tree(auto) is used to generate support automatically. "
-                     "If normal(manual) or tree(manual) is selected, only support enforcers are generated");
+    def->tooltip = L("Normal (auto) and Tree (auto) is used to generate support automatically. "
+                     "If Normal (manual) or Tree (manual) is selected, only support enforcers are generated");
     def->enum_keys_map = &ConfigOptionEnum<SupportType>::get_enum_values();
     def->enum_values.push_back("normal(auto)");
     def->enum_values.push_back("tree(auto)");
     def->enum_values.push_back("normal(manual)");
     def->enum_values.push_back("tree(manual)");
-    def->enum_labels.push_back(L("normal(auto)"));
-    def->enum_labels.push_back(L("tree(auto)"));
-    def->enum_labels.push_back(L("normal(manual)"));
-    def->enum_labels.push_back(L("tree(manual)"));
+    def->enum_labels.push_back(L("Normal (auto)"));
+    def->enum_labels.push_back(L("Tree (auto)"));
+    def->enum_labels.push_back(L("Normal (manual)"));
+    def->enum_labels.push_back(L("Tree (manual)"));
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionEnum<SupportType>(stNormalAuto));
 


### PR DESCRIPTION
# Description

Just capitalized Tree and Normal plus added a space before (auto) for UI consistency.

# Screenshots/Recordings/Graphs

![image](https://github.com/user-attachments/assets/87d63909-59d6-461a-a6e1-c6f3cc8d18fa)

## Tests

I manually verified slicing still works and selects the correct support type
