### PR TITLE
gcode: keep line endins in post processing

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -5018,9 +5018,18 @@ void GCodeProcessor::run_post_process()
                 // End of line is indicated also if end of file was reached.
                 eol |= eof && it_end == it_bufend;
                 gcode_line.insert(gcode_line.end(), it, it_end);
+
+                it = it_end;
+                // append EOL.
+                if (it != it_bufend && *it == '\r') {
+                    gcode_line += *it++;
+                }
+                if (it != it_bufend && *it == '\n') {
+                    gcode_line += *it++;
+                }
+
                 if (eol) {
                     ++line_id;
-                    gcode_line += "\n";
                     const unsigned int internal_g1_lines_counter = export_lines.update(gcode_line, line_id, g1_lines_counter);
                     // replace placeholder lines
                     bool processed = process_placeholders(gcode_line);
@@ -5057,12 +5066,6 @@ void GCodeProcessor::run_post_process()
                     export_lines.write(out, 1.1f * max_backtrace_time, m_result, out_path);
                     gcode_line.clear();
                 }
-                // Skip EOL.
-                it = it_end;
-                if (it != it_bufend && *it == '\r')
-                    ++it;
-                if (it != it_bufend && *it == '\n')
-                    ++it;
             }
             if (eof)
                 break;


### PR DESCRIPTION
# Description

Some portions of GCode (like BTT_TFT thumbnails)  has to be CRLF in order to work correctly. However, gcode post processor was ignoring input line endings style emitting '\n' (LF) into post-processed output.

## Tests

Modified printer config to have 32x32/BTT_TFT thumbnails. Sliced and exported test model.
Thumbnail lines has CRLF line endings while actual gcode has LF line endings.

Test file:  [post-cap-Cap_PETG_40m55s-btt.gcode.zip](https://github.com/user-attachments/files/18466845/post-cap-Cap_PETG_40m55s-btt.gcode.zip)

