### PR TITLE
Fix custom profiles added/removed each other run

### DIFF
--- a/src/slic3r/Utils/PresetUpdater.cpp
+++ b/src/slic3r/Utils/PresetUpdater.cpp
@@ -1111,12 +1111,9 @@ void PresetUpdater::priv::check_installed_vendor_profiles() const
                             fs::remove_all(path_of_vendor);
                     }
                 }
-                else if ((vendor_name == PresetBundle::BBL_BUNDLE) || (enabled_vendors.find(vendor_name) != enabled_vendors.end())) {//if vendor has no file, copy it from resource for BBL
+                else if (enabled_vendors.find(vendor_name) != enabled_vendors.end()) {//if vendor has no file, copy it from resource
                     bundles.push_back(vendor_name);
                 }
-            }
-            else if ((vendor_name == PresetBundle::BBL_BUNDLE) || (enabled_vendors.find(vendor_name) != enabled_vendors.end())) { //always update configs from resource to vendor for BBL
-                bundles.push_back(vendor_name);
             }
         }
     }


### PR DESCRIPTION
# Description

Addresses https://github.com/SoftFever/OrcaSlicer/issues/8094

Problem:
  Custom section of profiles disappeared each other run of OrcaSlicer.

Cause:
  Inconsistent behavior for BBL and rest of the machines.
  There are special case for BBL to update the profiles in next cases:
    - if no BBL profiles found in system dir
    - if no profiles update enabled at all The problem happened since BBL_BUNDLE = "Custom" which were adding Custom bundle into the system even if there no Custom bundle enabled by the user. On the next run this Custom bundle getting removed since it is not enabled by the user. This keep toggling each app run.

Fix:
  Remove special BBL_BUNDLE treatment.

Note:
  User may need to manually enable base printer config using 'Printer Selection' dialog for their profiles in order to make custom profiles visible.