### PR TITLE
Improvements and fixes for Creality K2 Plus

### DIFF
--- a/resources/profiles/Creality/filament/Creality Generic ABS @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ABS @K2-all.json
@@ -17,6 +17,7 @@
     "slow_down_min_speed": [
         "20"
     ],
+	"filament_start_gcode": ["; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || position[2] > first_layer_height)}\n{if (position[2] +0.4  < printable_height) }\nG2 Z{position[2]  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{position[2] } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n"],
     "compatible_printers": [
         "Creality K2 Plus 0.2 nozzle",
         "Creality K2 Plus 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic ASA @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic ASA @K2-all.json
@@ -17,6 +17,7 @@
     "slow_down_min_speed": [
         "20"
     ],
+	"filament_start_gcode": ["; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || position[2] > first_layer_height)}\n{if (position[2] +0.4  < printable_height) }\nG2 Z{position[2]  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{position[2] } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n"],
     "compatible_printers": [
         "Creality K2 Plus 0.2 nozzle",
         "Creality K2 Plus 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PA-CF @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PA-CF @K2-all.json
@@ -14,6 +14,7 @@
     "fan_min_speed": [
         "30"
     ],
+	"filament_start_gcode": ["; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || position[2] > first_layer_height)}\n{if (position[2] +0.4  < printable_height) }\nG2 Z{position[2]  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{position[2] } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n"],
     "compatible_printers": [
 		"Creality K2 Plus 0.2 nozzle",
         "Creality K2 Plus 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PETG @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PETG @K2-all.json
@@ -50,6 +50,7 @@
     "reduce_fan_stop_start_freq": [
         "1"
     ],
+	"filament_start_gcode": ["; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || position[2] > first_layer_height)}\n{if (position[2] +0.4  < printable_height) }\nG2 Z{position[2]  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{position[2] } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n"],
     "compatible_printers": [
         "Creality K2 Plus 0.2 nozzle",
         "Creality K2 Plus 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic PLA @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic PLA @K2-all.json
@@ -44,6 +44,7 @@
     "reduce_fan_stop_start_freq": [
         "1"
     ],
+	"filament_start_gcode": ["; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || position[2] > first_layer_height)}\n{if (position[2] +0.4  < printable_height) }\nG2 Z{position[2]  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{position[2] } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n"],
     "compatible_printers": [
         "Creality K2 Plus 0.2 nozzle",
         "Creality K2 Plus 0.4 nozzle",

--- a/resources/profiles/Creality/filament/Creality Generic TPU @K2-all.json
+++ b/resources/profiles/Creality/filament/Creality Generic TPU @K2-all.json
@@ -32,6 +32,7 @@
     "reduce_fan_stop_start_freq": [
         "1"
     ],
+	"filament_start_gcode": ["; filament start gcode\n{if (position[2] > first_layer_height) }\nM104 S[nozzle_temperature]\n{else}\nM104 S[first_layer_temperature]\n{endif}\n\n{if(initial_extruder != current_extruder || position[2] > first_layer_height)}\n{if (position[2] +0.4  < printable_height) }\nG2 Z{position[2]  + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X205 Y345 F20000\nG1 Z{position[2] } F1200\n{else}\nG1 X205 Y345 F20000\n{endif}\n{endif}\n"],
     "compatible_printers": [
 		"Creality K2 Plus 0.2 nozzle",
         "Creality K2 Plus 0.4 nozzle",

--- a/resources/profiles/Creality/machine/Creality K2 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K2 Plus 0.2 nozzle.json
@@ -20,9 +20,10 @@
     ],
     "printable_height": "350",
     "nozzle_type": "hardened_steel",
+    "nozzle_volume": "183",
     "auxiliary_fan": "1",
     "support_air_filtration": "1",
-    "support_multi_bed_types": "0",
+    "support_multi_bed_types": "1",
     "machine_max_acceleration_e": [
         "5000",
         "5000"
@@ -91,7 +92,7 @@
     ],
     "printer_settings_id": "Creality",
     "retraction_minimum_travel": [
-        "2"
+        "1"
     ],
     "retract_before_wipe": [
         "70%"
@@ -108,7 +109,14 @@
     "deretraction_speed": [
         "40"
     ],
+    "retract_lift_above": [
+        "0"
+    ],
+    "retract_lift_below": [
+        "349"
+    ],
     "enable_filament_ramming": "0",
+    "purge_in_prime_tower": "0",
     "cooling_tube_length": "0",
     "cooling_tube_retraction": "0",
     "parking_pos_retraction": "0",
@@ -127,12 +135,12 @@
     "default_filament_profile": [
         "Creality Generic PLA @K2-all"
     ],
-    "machine_start_gcode":"M140 S0\nM104 S0 \nSTART_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nM204 S2000\nG1 Z3 F600\nM83\nG1 Y150 F12000\nG1 X0 F12000\nG1 Z0.2 F600\nG1 X0 Y150 F6000\nG1 X0 Y0 E15 F1500\nG1 X150 Y0 E15 F1500\nG92 E0\nG1 Z1 F600",
+    "machine_start_gcode": "M140 S0\nM104 S0 \nSTART_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nM109 S[nozzle_temperature_initial_layer]\nM204 S2000\nG1 Z3 F600\nM83\nG1 Y150 F12000\nG1 X0 F12000\nG1 Z0.2 F600\nG1 X0 Y150 F6000\nG1 X0 Y0 E15 F6000\nG1 X150 Y0 E15 F6000\nG92 E0\nG1 Z1 F600",
     "machine_end_gcode": "END_PRINT",
     "machine_pause_gcode": "PAUSE",
     "change_filament_gcode": "G2 Z{z_after_toolchange + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X0 Y245 F30000\nG1 Z{z_after_toolchange} F600",
     "scan_first_layer": "0",
-    "thumbnails_format":"PNG",
+    "thumbnails_format": "PNG",
     "thumbnails": [
         "300x300",
         "96x96"

--- a/resources/profiles/Creality/machine/Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K2 Plus 0.4 nozzle.json
@@ -20,9 +20,10 @@
     ],
     "printable_height": "350",
     "nozzle_type": "hardened_steel",
+    "nozzle_volume": "183",
     "auxiliary_fan": "1",
     "support_air_filtration": "1",
-    "support_multi_bed_types": "0",
+    "support_multi_bed_types": "1",
     "machine_max_acceleration_e": [
         "5000",
         "5000"
@@ -91,13 +92,13 @@
     ],
     "printer_settings_id": "Creality",
     "retraction_minimum_travel": [
-        "2"
+        "1"
     ],
     "retract_before_wipe": [
         "70%"
     ],
     "retraction_length": [
-        "0.5"
+        "0.8"
     ],
     "retract_length_toolchange": [
         "0"
@@ -108,7 +109,14 @@
     "deretraction_speed": [
         "40"
     ],
+    "retract_lift_above": [
+        "0"
+    ],
+    "retract_lift_below": [
+        "349"
+    ],
     "enable_filament_ramming": "0",
+    "purge_in_prime_tower": "0",
     "cooling_tube_length": "0",
     "cooling_tube_retraction": "0",
     "parking_pos_retraction": "0",
@@ -120,19 +128,19 @@
         "0.4"
     ],
     "wipe_distance": [
-        "1"
+        "2"
     ],
     "single_extruder_multi_material": "1",
     "manual_filament_change": "0",
     "default_filament_profile": [
         "Creality Generic PLA @K2-all"
     ],
-    "machine_start_gcode":"M140 S0\nM104 S0 \nSTART_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nM204 S2000\nG1 Z3 F600\nM83\nG1 Y150 F12000\nG1 X0 F12000\nG1 Z0.2 F600\nG1 X0 Y150 F6000\nG1 X0 Y0 E15 F1500\nG1 X150 Y0 E15 F1500\nG92 E0\nG1 Z1 F600",
+    "machine_start_gcode": "M140 S0\nM104 S0 \nSTART_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nM109 S[nozzle_temperature_initial_layer]\nM204 S2000\nG1 Z3 F600\nM83\nG1 Y150 F12000\nG1 X0 F12000\nG1 Z0.2 F600\nG1 X0 Y150 F6000\nG1 X0 Y0 E15 F6000\nG1 X150 Y0 E15 F6000\nG92 E0\nG1 Z1 F600",
     "machine_end_gcode": "END_PRINT",
     "machine_pause_gcode": "PAUSE",
     "change_filament_gcode": "G2 Z{z_after_toolchange + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X0 Y245 F30000\nG1 Z{z_after_toolchange} F600",
     "scan_first_layer": "0",
-    "thumbnails_format":"PNG",
+    "thumbnails_format": "PNG",
     "thumbnails": [
         "300x300",
         "96x96"

--- a/resources/profiles/Creality/machine/Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K2 Plus 0.6 nozzle.json
@@ -20,9 +20,10 @@
     ],
     "printable_height": "350",
     "nozzle_type": "hardened_steel",
+    "nozzle_volume": "183",
     "auxiliary_fan": "1",
     "support_air_filtration": "1",
-    "support_multi_bed_types": "0",
+    "support_multi_bed_types": "1",
     "machine_max_acceleration_e": [
         "5000",
         "5000"
@@ -91,7 +92,7 @@
     ],
     "printer_settings_id": "Creality",
     "retraction_minimum_travel": [
-        "2"
+        "1"
     ],
     "retract_before_wipe": [
         "70%"
@@ -108,7 +109,14 @@
     "deretraction_speed": [
         "40"
     ],
+    "retract_lift_above": [
+        "0"
+    ],
+    "retract_lift_below": [
+        "349"
+    ],
     "enable_filament_ramming": "0",
+    "purge_in_prime_tower": "0",
     "cooling_tube_length": "0",
     "cooling_tube_retraction": "0",
     "parking_pos_retraction": "0",
@@ -127,7 +135,7 @@
     "default_filament_profile": [
         "Creality Generic PLA @K2-all"
     ],
-    "machine_start_gcode":"M140 S0\nM104 S0 \nSTART_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nM204 S2000\nG1 Z3 F600\nM83\nG1 Y150 F12000\nG1 X0 F12000\nG1 Z0.2 F600\nG1 X0 Y150 F6000\nG1 X0 Y0 E15 F1500\nG1 X150 Y0 E15 F1500\nG92 E0\nG1 Z1 F600",
+    "machine_start_gcode": "M140 S0\nM104 S0 \nSTART_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nM109 S[nozzle_temperature_initial_layer]\nM204 S2000\nG1 Z3 F600\nM83\nG1 Y150 F12000\nG1 X0 F12000\nG1 Z0.2 F600\nG1 X0 Y150 F6000\nG1 X0 Y0 E15 F6000\nG1 X150 Y0 E15 F6000\nG92 E0\nG1 Z1 F600",
     "machine_end_gcode": "END_PRINT",
     "machine_pause_gcode": "PAUSE",
     "change_filament_gcode": "G2 Z{z_after_toolchange + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X0 Y245 F30000\nG1 Z{z_after_toolchange} F600",

--- a/resources/profiles/Creality/machine/Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality K2 Plus 0.8 nozzle.json
@@ -20,9 +20,10 @@
     ],
     "printable_height": "350",
     "nozzle_type": "hardened_steel",
+    "nozzle_volume": "183",
     "auxiliary_fan": "1",
     "support_air_filtration": "1",
-    "support_multi_bed_types": "0",
+    "support_multi_bed_types": "1",
     "machine_max_acceleration_e": [
         "5000",
         "5000"
@@ -91,7 +92,7 @@
     ],
     "printer_settings_id": "Creality",
     "retraction_minimum_travel": [
-        "2"
+        "1"
     ],
     "retract_before_wipe": [
         "70%"
@@ -108,7 +109,14 @@
     "deretraction_speed": [
         "40"
     ],
+    "retract_lift_above": [
+        "0"
+    ],
+    "retract_lift_below": [
+        "349"
+    ],
     "enable_filament_ramming": "0",
+    "purge_in_prime_tower": "0",
     "cooling_tube_length": "0",
     "cooling_tube_retraction": "0",
     "parking_pos_retraction": "0",
@@ -127,12 +135,12 @@
     "default_filament_profile": [
         "Creality Generic PLA @K2-all"
     ],
-    "machine_start_gcode":"M140 S0\nM104 S0 \nSTART_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nM204 S2000\nG1 Z3 F600\nM83\nG1 Y150 F12000\nG1 X0 F12000\nG1 Z0.2 F600\nG1 X0 Y150 F6000\nG1 X0 Y0 E15 F1500\nG1 X150 Y0 E15 F1500\nG92 E0\nG1 Z1 F600",
+    "machine_start_gcode": "M140 S0\nM104 S0 \nSTART_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]\nT[initial_no_support_extruder]\nM109 S[nozzle_temperature_initial_layer]\nM204 S2000\nG1 Z3 F600\nM83\nG1 Y150 F12000\nG1 X0 F12000\nG1 Z0.2 F600\nG1 X0 Y150 F6000\nG1 X0 Y0 E15 F6000\nG1 X150 Y0 E15 F6000\nG92 E0\nG1 Z1 F600",
     "machine_end_gcode": "END_PRINT",
     "machine_pause_gcode": "PAUSE",
     "change_filament_gcode": "G2 Z{z_after_toolchange + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X0 Y245 F30000\nG1 Z{z_after_toolchange} F600",
     "scan_first_layer": "0",
-    "thumbnails_format":"PNG",
+    "thumbnails_format": "PNG",
     "thumbnails": [
         "300x300",
         "96x96"

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Plus 0.2 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "30",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.25",
     "inner_wall_speed": "150",
     "wall_loops": "4",

--- a/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.08mm SuperDetail @Creality K2 Plus 0.4 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "30",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.45",
     "inner_wall_speed": "350",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.10mm HighDetail @Creality K2 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.10mm HighDetail @Creality K2 Plus 0.2 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "30",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.25",
     "inner_wall_speed": "150",
     "wall_loops": "4",

--- a/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Plus 0.2 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "30",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.25",
     "inner_wall_speed": "150",
     "wall_loops": "4",

--- a/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.12mm Detail @Creality K2 Plus 0.4 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "30",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.45",
     "inner_wall_speed": "300",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.14mm Optimal @Creality K2 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/process/0.14mm Optimal @Creality K2 Plus 0.2 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "30",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.25",
     "inner_wall_speed": "150",
     "wall_loops": "4",

--- a/resources/profiles/Creality/process/0.16mm Optimal @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.16mm Optimal @Creality K2 Plus 0.4 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "30",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.45",
     "inner_wall_speed": "300",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.18mm Detail @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.18mm Detail @Creality K2 Plus 0.6 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "20",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.65",
     "inner_wall_speed": "150",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.20mm Standard @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.20mm Standard @Creality K2 Plus 0.4 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "30",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.45",
     "inner_wall_speed": "300",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.24mm Detail @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Detail @Creality K2 Plus 0.8 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "20",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.82",
     "inner_wall_speed": "150",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.24mm Draft @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Draft @Creality K2 Plus 0.4 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "30",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.45",
     "inner_wall_speed": "300",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.24mm Optimal @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.24mm Optimal @Creality K2 Plus 0.6 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "20",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.65",
     "inner_wall_speed": "150",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.28mm SuperDraft @Creality K2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/process/0.28mm SuperDraft @Creality K2 Plus 0.4 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "30",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.45",
     "inner_wall_speed": "200",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.30mm Standard @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.30mm Standard @Creality K2 Plus 0.6 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "20",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.65",
     "inner_wall_speed": "150",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.32mm Optimal @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.32mm Optimal @Creality K2 Plus 0.8 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "20",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.82",
     "inner_wall_speed": "150",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.36mm Draft @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.36mm Draft @Creality K2 Plus 0.6 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "20",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.65",
     "inner_wall_speed": "150",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.40mm Standard @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.40mm Standard @Creality K2 Plus 0.8 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "20",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.82",
     "inner_wall_speed": "150",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.42mm SuperDraft @Creality K2 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/process/0.42mm SuperDraft @Creality K2 Plus 0.6 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "20",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.65",
     "inner_wall_speed": "150",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.48mm Draft @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.48mm Draft @Creality K2 Plus 0.8 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "20",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.82",
     "inner_wall_speed": "150",
     "wall_loops": "2",

--- a/resources/profiles/Creality/process/0.56mm SuperDraft @Creality K2 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/process/0.56mm SuperDraft @Creality K2 Plus 0.8 nozzle.json
@@ -54,6 +54,7 @@
     "overhang_3_4_speed": "20",
     "overhang_4_4_speed": "10",
     "only_one_wall_top": "1",
+    "precise_outer_wall": "1",
     "inner_wall_line_width": "0.82",
     "inner_wall_speed": "150",
     "wall_loops": "2",


### PR DESCRIPTION
# Description

Creality K2 Plus profile have some flaws, this is a first step in the right direction.
It fixes default parameters so filament is not flushed into the prime tower anymore, adds nozzle volume, fixes retraction travel moves, enables precise walls, ...

PS : I had to re-create this PR because of failing automated test related to untouched Prusa MK3S profiles.