### PR TITLE
Fix issue `Preset name "0.20mm Speed @MK3S 0.4" was marked as renamed…

### DIFF
--- a/resources/profiles/Prusa/process/0.20mm Detail @MK3S 0.6.json
+++ b/resources/profiles/Prusa/process/0.20mm Detail @MK3S 0.6.json
@@ -3,7 +3,6 @@
   "print_settings_id": "0.20mm Detail @MK3S 0.6",
   "name": "0.20mm Detail @MK3S 0.6",
   "from": "system",
-  "renamed_from":"0.20mm Standard @MK3S",
   "instantiation": "true",
   "inherits": "process_common_mk3",
   "bottom_shell_layers": "4",

--- a/resources/profiles/Prusa/process/0.20mm Speed @MK3S 0.4.json
+++ b/resources/profiles/Prusa/process/0.20mm Speed @MK3S 0.4.json
@@ -3,7 +3,6 @@
   "print_settings_id": "0.20mm Speed @MK3S 0.4",
   "name": "0.20mm Speed @MK3S 0.4",
   "from": "system",
-  "renamed_from":"0.20mm Standard @MK3S",
   "instantiation": "true",
   "inherits": "process_common_mk3",
   "bottom_shell_layers": "4",

--- a/resources/profiles/Prusa/process/0.20mm Speed @MK3S.json
+++ b/resources/profiles/Prusa/process/0.20mm Speed @MK3S.json
@@ -3,7 +3,6 @@
   "print_settings_id": "0.20mm Speed @MK3S",
   "name": "0.20mm Speed @MK3S",
   "from": "system",
-  "renamed_from":"0.20mm Standard @MK3S",
   "instantiation": "true",
   "inherits": "process_common_mk3",
   "bottom_shell_layers": "4",


### PR DESCRIPTION
… from "0.20mm Standard @MK3S", though preset name "0.20mm Detail @MK3S 0.6" was marked as renamed from "0.20mm Standard @MK3S" as well.`

