### PR TITLE
Gcode Statistics Panel Fixes

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1056,8 +1056,6 @@ void GCodeViewer::load(const GCodeProcessorResult& gcode_result, const Print& pr
         set_view_type(EViewType::ColorPrint);
     }
 
-    m_fold = false;
-
     bool only_gcode_3mf = false;
     PartPlate* current_plate = wxGetApp().plater()->get_partplate_list().get_curr_plate();
     bool current_has_print_instances = current_plate->has_printable_instances();

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -4642,15 +4642,15 @@ void GCodeViewer::render_legend(float &legend_height, int canvas_width, int canv
     ImGui::SameLine();
     std::wstring btn_name;
     if (m_fold)
-        btn_name = ImGui::UnfoldButtonIcon + boost::nowide::widen(std::string(""));
+        btn_name = ImGui::UnfoldButtonIcon;
     else
-        btn_name = ImGui::FoldButtonIcon + boost::nowide::widen(std::string(""));
+        btn_name = ImGui::FoldButtonIcon;
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.0f, 0.59f, 0.53f, 1.00f));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.0f, 0.59f, 0.53f, 0.78f));
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0.0f, 0.0f));
     //ImGui::PushItemWidth(
-    float button_width = ImGui::CalcTextSize(into_u8(btn_name).c_str()).x;
+    float button_width = 34.0f;
     if (ImGui::Button(into_u8(btn_name).c_str(), ImVec2(button_width, 0))) {
         m_fold = !m_fold;
     }


### PR DESCRIPTION
# Description

This PR fixes the following issues:

1. Gcode Statistics Panel: open/close state not persistent between slicing: https://github.com/SoftFever/OrcaSlicer/discussions/6021
2. open/close button width is too wide

# Screenshots/Recordings/Graphs
![Button_width_incorrect](https://github.com/user-attachments/assets/be8c0a09-8737-49e2-95ec-6abef6b15223)
![Button_width_correct](https://github.com/user-attachments/assets/719026ca-f85c-460a-b652-fad4c2a54fbd)