### PR TITLE
Update color palette for new filaments

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -3342,22 +3342,23 @@ wxColour Plater::get_next_color_for_filament()
     static int curr_color_filamenet = 0;
     // refs to https://www.ebaomonthly.com/window/photo/lesson/colorList.htm
     wxColour colors[FILAMENT_SYSTEM_COLORS_NUM] = {
-        *wxYELLOW,
-        * wxRED,
-        *wxBLUE,
-        *wxCYAN,
-        *wxLIGHT_GREY,
-        *wxWHITE,
-        *wxBLACK,
-        wxColour(0,127,255),
-        wxColour(139,0,255),
-        wxColour(102,255,0),
-        wxColour(255,215,0),
-        wxColour(0,35,100),
-        wxColour(255,0,255),
-        wxColour(8,37,103),
-        wxColour(127,255,212),
-        wxColour(255,191,0)
+        // ORCA updated all color palette
+        wxColour("#00C1AE"),
+        wxColour("#F4E2C1"),
+        wxColour("#ED1C24"),
+        wxColour("#00FF7F"),
+        wxColour("#F26722"),
+        wxColour("#FFEB31"),
+        wxColour("#7841CE"),
+        wxColour("#115877"),
+        wxColour("#ED1E79"),
+        wxColour("#2EBDEF"),
+        wxColour("#345B2F"),
+        wxColour("#800080"),
+        wxColour("#FA8173"),
+        wxColour("#800000"),
+        wxColour("#F7B763"),
+        wxColour("#A4C41E"),
     };
     return colors[curr_color_filamenet++ % FILAMENT_SYSTEM_COLORS_NUM];
 }


### PR DESCRIPTION
PROBLEM
• Current color palette has many repeating or very similar colors
• Colors looks came from 80s and all raw colors like rgb(0,255,255)
• Black and White colors shows less details on surfaces due to shadows and highlights
 
SOLUTION
• Picked more specific color tones. Tried to make every alternative to easily identifiable
• Didnt used black, white or gray

QUESTIONABLE
• New colors follows given order and i used orca color as first. Maybe orange one is better pick
• I can add, remove, or change order of colors

COMPARISON
before
![Screenshot-20250125041332](https://github.com/user-attachments/assets/68274b67-311d-47dc-a3b2-b4ceccbdcf9b)
after
![Screenshot-20250125042325](https://github.com/user-attachments/assets/fd2e1061-1075-4586-b5c6-d51311312766)

old color set
![Screenshot-20250125044859](https://github.com/user-attachments/assets/4ded5fd0-b514-47de-b09c-9fb24195020f)

new color set
![Screenshot-20250125043210](https://github.com/user-attachments/assets/137fa019-1f81-48bc-a6a2-578d0bed22cb)

as text if you want to experiment
`
        wxColour("#00C1AE"),
        wxColour("#F4E2C1"),
        wxColour("#ED1C24"),
        wxColour("#00FF7F"),
        wxColour("#F26722"),
        wxColour("#FFEB31"),
        wxColour("#7841CE"),
        wxColour("#115877"),
        wxColour("#ED1E79"),
        wxColour("#2EBDEF"),
        wxColour("#345B2F"),
        wxColour("#800080"),
        wxColour("#FA8173"),
        wxColour("#800000"),
        wxColour("#F7B763"),
        wxColour("#A4C41E"),
`