### PR TITLE
Reset SV06 (Plus) ACE wall_sequence to default

### DIFF
--- a/resources/profiles/Sovol/process/0.08mm High Quality @Sovol SV06 ACE 0.4 nozzle.json
+++ b/resources/profiles/Sovol/process/0.08mm High Quality @Sovol SV06 ACE 0.4 nozzle.json
@@ -30,7 +30,6 @@
 	"precise_outer_wall": "1",
 	"outer_wall_line_width": "0.4",
 	"wall_infill_order": "inner wall/outer wall/infill",
-	"wall_sequence": "inner-outer-inner wall",
 	"line_width": "0.4",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",

--- a/resources/profiles/Sovol/process/0.12mm Quality @Sovol SV06 ACE 0.4 nozzle.json
+++ b/resources/profiles/Sovol/process/0.12mm Quality @Sovol SV06 ACE 0.4 nozzle.json
@@ -30,7 +30,6 @@
 	"precise_outer_wall": "1",
 	"outer_wall_line_width": "0.4",
 	"wall_infill_order": "inner wall/outer wall/infill",
-	"wall_sequence": "inner-outer-inner wall",
 	"line_width": "0.4",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",

--- a/resources/profiles/Sovol/process/0.12mm Standard @Sovol SV06 ACE 0.2 nozzle.json
+++ b/resources/profiles/Sovol/process/0.12mm Standard @Sovol SV06 ACE 0.2 nozzle.json
@@ -30,7 +30,6 @@
 	"precise_outer_wall": "1",
 	"outer_wall_line_width": "0.2",
 	"wall_infill_order": "inner wall/outer wall/infill",
-	"wall_sequence": "inner-outer-inner wall",
 	"line_width": "0.2",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",

--- a/resources/profiles/Sovol/process/0.20mm Standard @Sovol SV06 Plus ACE.json
+++ b/resources/profiles/Sovol/process/0.20mm Standard @Sovol SV06 Plus ACE.json
@@ -30,7 +30,6 @@
 	"precise_outer_wall": "1",
 	"outer_wall_line_width": "0.4",
 	"wall_infill_order": "inner wall/outer wall/infill",
-	"wall_sequence": "inner-outer-inner wall",
 	"line_width": "0.4",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",

--- a/resources/profiles/Sovol/process/0.28mm Fast @Sovol SV06 ACE 0.4 nozzle.json
+++ b/resources/profiles/Sovol/process/0.28mm Fast @Sovol SV06 ACE 0.4 nozzle.json
@@ -30,7 +30,6 @@
 	"precise_outer_wall": "1",
 	"outer_wall_line_width": "0.4",
 	"wall_infill_order": "inner wall/outer wall/infill",
-	"wall_sequence": "inner-outer-inner wall",
 	"line_width": "0.4",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",

--- a/resources/profiles/Sovol/process/0.30mm Standard @Sovol SV06 ACE 0.6 nozzle.json
+++ b/resources/profiles/Sovol/process/0.30mm Standard @Sovol SV06 ACE 0.6 nozzle.json
@@ -30,7 +30,6 @@
 	"precise_outer_wall": "1",
 	"outer_wall_line_width": "0.6",
 	"wall_infill_order": "inner wall/outer wall/infill",
-	"wall_sequence": "inner-outer-inner wall",
 	"line_width": "0.6",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",

--- a/resources/profiles/Sovol/process/0.40mm Standard @Sovol SV06 ACE 0.8 nozzle.json
+++ b/resources/profiles/Sovol/process/0.40mm Standard @Sovol SV06 ACE 0.8 nozzle.json
@@ -30,7 +30,6 @@
 	"precise_outer_wall": "1",
 	"outer_wall_line_width": "0.8",
 	"wall_infill_order": "inner wall/outer wall/infill",
-	"wall_sequence": "inner-outer-inner wall",
 	"line_width": "0.8",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",


### PR DESCRIPTION
@liberodark FYI in case you have thoughts on this

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

The SV06 ACE profile Sovol originally supplied set "Wall printing order" to "Inner/Outer/Inner", and this got copied to the other layer height variants. But these profiles set "Wall loops" to 2, so "Inner/Outer/Inner" effectively becomes "Outer/Inner". This results in messy, quite noticeable Z seams.

It seems that "Inner/Outer" wall sequence is Orca's default, and IMO it results in better visual surface quality.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

I'm not the best at photographing this, but here's the result of the current SV06 ACE profile behavior. Notice how jagged and gappy the seams on the left side of the print look:

![Z seams with Inner/Outer/Inner wall order](https://github.com/user-attachments/assets/647e7338-325f-4bc3-beb7-7f6f4e42e02d)

And here's the same model printed with Inner/Outer wall sequence. The Z seams are still visible, but smoother and less eye catching:

![s with Inner/Outer](https://github.com/user-attachments/assets/b87c9e63-983b-432e-b81a-e31ec4d90743)

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

Verified effects via some calibration prints.
