### PR TITLE
Sovol SV06 ACE Enable Multi Bed

### DIFF
--- a/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.2 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.2 nozzle.json
@@ -29,6 +29,7 @@
 	"retraction_minimum_travel": [
 		"0.5"
 	],
+	"support_multi_bed_types": "1",
 	"machine_max_acceleration_e": [
 		"5000",
 		"5000"

--- a/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.4 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.4 nozzle.json
@@ -29,6 +29,7 @@
 	"retraction_minimum_travel": [
 		"1"
 	],
+	"support_multi_bed_types": "1",
 	"machine_max_acceleration_e": [
 		"5000",
 		"5000"

--- a/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.6 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.6 nozzle.json
@@ -29,6 +29,7 @@
 	"retraction_minimum_travel": [
 		"1.5"
 	],
+	"support_multi_bed_types": "1",
 	"machine_max_acceleration_e": [
 		"5000",
 		"5000"

--- a/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.8 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.8 nozzle.json
@@ -29,6 +29,7 @@
 	"retraction_minimum_travel": [
 		"2"
 	],
+	"support_multi_bed_types": "1",
 	"machine_max_acceleration_e": [
 		"5000",
 		"5000"


### PR DESCRIPTION
# Description

SV06 ACE is compatible with some Bed from Bambu/Biqu/Elegoo.

# Screenshots/Recordings/Graphs



## Tests

Some print have been success more easily than the official bed.
