### PR TITLE
QOL fix : Removed filament_density: 0 from Kobra 3 profiles (fixes #7367)

### DIFF
--- a/resources/profiles/Anycubic/filament/Anycubic PETG @Anycubic Kobra 3 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/filament/Anycubic PETG @Anycubic Kobra 3 0.4 nozzle.json
@@ -91,9 +91,6 @@
     "filament_cost": [
         "0"
     ],
-    "filament_density": [
-        "0"
-    ],
     "filament_deretraction_speed": [
         "80"
     ],

--- a/resources/profiles/Anycubic/filament/Generic ABS @Anycubic Kobra 3 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/filament/Generic ABS @Anycubic Kobra 3 0.4 nozzle.json
@@ -91,9 +91,6 @@
     "filament_cost": [
         "0"
     ],
-    "filament_density": [
-        "0"
-    ],
     "filament_deretraction_speed": [
         "80"
     ],

--- a/resources/profiles/Anycubic/filament/Generic TPU @Anycubic Kobra 3 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/filament/Generic TPU @Anycubic Kobra 3 0.4 nozzle.json
@@ -91,9 +91,6 @@
     "filament_cost": [
         "0"
     ],
-    "filament_density": [
-        "0"
-    ],
     "filament_deretraction_speed": [
         "25"
     ],


### PR DESCRIPTION
# Description

This removes filament_density: 0 setting from Kobra 3 profiles (fixes #7367)
