### PR TITLE
Fix: URL-encode password in Duet::get_connect_url

### DIFF
--- a/src/slic3r/Utils/Duet.cpp
+++ b/src/slic3r/Utils/Duet.cpp
@@ -205,7 +205,7 @@ std::string Duet::get_connect_url(const bool dsfUrl) const
 	} else {
 		return (boost::format("%1%rr_connect?password=%2%&%3%")
 				% get_base_url()
-				% (password.empty() ? "reprap" : password)
+				% Http::url_encode(password.empty() ? "reprap" : password) // url_encode is needed because password can contain special characters like `&`, "#", etc.
 				% timestamp_str()).str();
 	}
 }


### PR DESCRIPTION
# Description
This pull request includes a change to the `src/slic3r/Utils/Duet.cpp` file. The change ensures that passwords containing special characters are properly encoded in the URL.

* [`src/slic3r/Utils/Duet.cpp`](diffhunk://#diff-8fdf65478dafba9670beac4c1402b9031ad24c5dce09348d7773138b89735c99L208-R208): Modified the `get_connect_url` method to use `Http::url_encode` for encoding the password, ensuring special characters like `&` and `#` are handled correctly.

This is a very simple fix if there is a better approach, I am open to learn.


<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs
![duet_connect_dialog](https://github.com/user-attachments/assets/9d55e7cc-e7be-4de3-ab44-8edabe1301ab)
![duet_connect_dialog_error_message](https://github.com/user-attachments/assets/f408a697-085b-48e1-b18e-5ee2c7c77e45)

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

1.  Set the password on the controller to something like `password1`
2.  Inside the Orca physical printer dialog select Duet as the host type.
3.  Provide the simple password `password1`, this should result in a passing connection test.
4.  Set the password on the controller (printer) to something like `password!@#1`
5.  Now inside the Orca physical printer dialog change the password from `password1` --> `password!@#1`
6.  Test the connection again it will fail with `Could not connect to Duet: Wrong password`

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
