### PR TITLE
Fix missing "%" on Sovol profiles fixes #8207

### DIFF
--- a/resources/profiles/Sovol/process/fdm_process_common.json
+++ b/resources/profiles/Sovol/process/fdm_process_common.json
@@ -7,7 +7,7 @@
     "reduce_crossing_wall": "0",
     "bridge_flow": "0.95",
     "bridge_speed": "25",
-    "internal_bridge_speed" : "150",
+    "internal_bridge_speed" : "150%",
     "brim_width": "5",
     "compatible_printers": [],
     "print_sequence": "by layer",


### PR DESCRIPTION
# Description

This PR fixes a missing "%" in the internal_bridge_speed setting for Sovol.
