### PR TITLE
Fix one wall top surface incorrect spacing when precise wall is enabled

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -3019,7 +3019,7 @@ void PerimeterGenerator::process_arachne()
                 // Get final top ExPolygons.
                 top_expolygons = intersection_ex(top_expolygons, infill_contour);
 
-                const Polygons not_top_polygons = to_polygons(not_top_expolygons);
+                const Polygons not_top_polygons = to_polygons(offset_ex(not_top_expolygons,wall_0_inset));
                 Arachne::WallToolPaths inner_wall_tool_paths(not_top_polygons, perimeter_spacing, perimeter_spacing, coord_t(inner_loop_number + 1), 0, layer_height, input_params_tmp);
                 std::vector<Arachne::VariableWidthLines> inner_perimeters = inner_wall_tool_paths.getToolPaths();
 


### PR DESCRIPTION
# Description

When one wall top surface and precise wall is enabled with Arachne, the precise wall spacing is not observed in intermediate top surfaces.

See below spacing change between external perimeter and first internal when one wall is applied inside the model (the lettering on the right).

This issue can create external wall inconsistencies as on the one wall surface plane, the spacing between the first internal and external perimeter is different to all other layers. This can aggravate the so called benchy hull line issue.

https://github.com/user-attachments/assets/6c6d10a6-997b-48ad-8e7f-df4b8686b271

With this fix, we are resizing the internal polygons by the precise wall offset to align the first wall extrusions with the anticipated spacing.

https://github.com/user-attachments/assets/f6e72b10-c1dc-41f4-a075-26d0f9bafe10

