### PR TITLE
Configure filament change and pause commands for SV06 (Plus) ACE

### DIFF
--- a/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.2 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.2 nozzle.json
@@ -120,8 +120,11 @@
     ],
 	"gcode_flavor": "klipper",
 	"before_layer_change_gcode": "TIMELAPSE_TAKE_FRAME\nG92 E0",
+    "change_filament_gcode": "M600",
+    "manual_filament_change": "1",
 	"machine_start_gcode": "M140 S[bed_temperature_initial_layer_single] ;set bed temp\nM190 S[bed_temperature_initial_layer_single] ;wait for bed temp\nSTART_PRINT\nG90\nG1 X0 F6000\nG1 Y20\nG1 Z0.200 F600\nG1 Y-4 F6000\nM400\nM104 S[nozzle_temperature_initial_layer] ;set extruder temp\nM109 S[nozzle_temperature_initial_layer];wait for extruder temp\nG91\nM83\nG1 E-0.100 Z5 F600\nG1 X{print_bed_max[1] / 3} F6000\nG1 Z-4.800 F600\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 Y1 E0.16 F3000\nG1 X-{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 X-{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 Y1 E0.24 F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 E-0.200 Z1 F600\nM400\n\n",
 	"machine_end_gcode": "END_PRINT\n",
+    "machine_pause_gcode": "PAUSE",
 	"default_filament_profile": [
 		"Sovol SV06 ACE PLA"
 	]

--- a/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.4 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.4 nozzle.json
@@ -120,8 +120,11 @@
     ],
 	"gcode_flavor": "klipper",
 	"before_layer_change_gcode": "TIMELAPSE_TAKE_FRAME\nG92 E0",
+    "change_filament_gcode": "M600",
+    "manual_filament_change": "1",
 	"machine_start_gcode": "M140 S[bed_temperature_initial_layer_single] ;set bed temp\nM190 S[bed_temperature_initial_layer_single] ;wait for bed temp\nSTART_PRINT\nG90\nG1 X0 F6000\nG1 Y20\nG1 Z0.400 F600\nG1 Y-4 F6000\nM400\nM104 S[nozzle_temperature_initial_layer] ;set extruder temp\nM109 S[nozzle_temperature_initial_layer];wait for extruder temp\nG91\nM83\nG1 E-0.200 Z5 F600\nG1 X{print_bed_max[1] / 3} F6000\nG1 Z-4.800 F600\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 Y1 E0.16 F3000\nG1 X-{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 X-{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 Y1 E0.24 F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 E-0.200 Z1 F600\nM400\n\n",
 	"machine_end_gcode": "END_PRINT\n",
+    "machine_pause_gcode": "PAUSE",
 	"default_filament_profile": [
 		"Sovol SV06 ACE PLA"
 	]

--- a/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.6 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.6 nozzle.json
@@ -120,8 +120,11 @@
     ],
 	"gcode_flavor": "klipper",
 	"before_layer_change_gcode": "TIMELAPSE_TAKE_FRAME\nG92 E0",
+    "change_filament_gcode": "M600",
+    "manual_filament_change": "1",
 	"machine_start_gcode": "M140 S[bed_temperature_initial_layer_single] ;set bed temp\nM190 S[bed_temperature_initial_layer_single] ;wait for bed temp\nSTART_PRINT\nG90\nG1 X0 F6000\nG1 Y20\nG1 Z0.600 F600\nG1 Y-4 F6000\nM400\nM104 S[nozzle_temperature_initial_layer] ;set extruder temp\nM109 S[nozzle_temperature_initial_layer];wait for extruder temp\nG91\nM83\nG1 E-0.300 Z5 F600\nG1 X{print_bed_max[1] / 3} F6000\nG1 Z-4.800 F600\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 Y1 E0.16 F3000\nG1 X-{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 X-{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 Y1 E0.24 F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 E-0.200 Z1 F600\nM400\n\n",
 	"machine_end_gcode": "END_PRINT\n",
+    "machine_pause_gcode": "PAUSE",
 	"default_filament_profile": [
 		"Sovol SV06 ACE PLA"
 	]

--- a/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.8 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 ACE 0.8 nozzle.json
@@ -120,8 +120,11 @@
     ],
 	"gcode_flavor": "klipper",
 	"before_layer_change_gcode": "TIMELAPSE_TAKE_FRAME\nG92 E0",
+    "change_filament_gcode": "M600",
+    "manual_filament_change": "1",
 	"machine_start_gcode": "M140 S[bed_temperature_initial_layer_single] ;set bed temp\nM190 S[bed_temperature_initial_layer_single] ;wait for bed temp\nSTART_PRINT\nG90\nG1 X0 F6000\nG1 Y20\nG1 Z0.800 F600\nG1 Y-4 F6000\nM400\nM104 S[nozzle_temperature_initial_layer] ;set extruder temp\nM109 S[nozzle_temperature_initial_layer];wait for extruder temp\nG91\nM83\nG1 E-0.300 Z5 F600\nG1 X{print_bed_max[1] / 3} F6000\nG1 Z-4.800 F600\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 Y1 E0.16 F3000\nG1 X-{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 X-{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 Y1 E0.24 F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 E-0.200 Z1 F600\nM400\n\n",
 	"machine_end_gcode": "END_PRINT\n",
+    "machine_pause_gcode": "PAUSE",
 	"default_filament_profile": [
 		"Sovol SV06 ACE PLA"
 	]

--- a/resources/profiles/Sovol/machine/Sovol SV06 Plus ACE 0.4 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 Plus ACE 0.4 nozzle.json
@@ -118,8 +118,11 @@
     ],
 	"gcode_flavor": "klipper",
 	"before_layer_change_gcode": "TIMELAPSE_TAKE_FRAME\nG92 E0",
+    "change_filament_gcode": "M600",
+    "manual_filament_change": "1",
 	"machine_start_gcode": "M140 S[bed_temperature_initial_layer_single] ;set bed temp\nM190 S[bed_temperature_initial_layer_single] ;wait for bed temp\nSTART_PRINT\nG28\nG90\nG1 X0 F6000\nG1 Y-4\nG1 Z0.200 F600\nM400\nM104 S[nozzle_temperature_initial_layer] ;set extruder temp\nM109 S[nozzle_temperature_initial_layer];wait for extruder temp\nG91\nM83\nG1 E-0.200 Z5 F600\nG1 X{print_bed_max[1] / 3} F6000\nG1 Z-5 F600\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 Y1 E0.16 F3000\nG1 X-{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 X-{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 Y1 E0.24 F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.24} F3000\nG1 X{print_bed_max[1] / 6} E{print_bed_max[1] / 6 * 0.16} F3000\nG1 E-0.200 Z1 F600\nM400\n\n",
 	"machine_end_gcode": "END_PRINT\n",
+    "machine_pause_gcode": "PAUSE",
 	"default_filament_profile": [
 		"Sovol SV06 Plus ACE PLA"
 	]


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

Sets up the filament change and pause print commands for these printers.

There's only one toolhead, so `manual_filament_change` is required to avoid generating tool swap G-code that the printer won't recognize.

Hat tip: Oliver on the Sovol forums for [pointing out how to do this](https://forum.sovol3d.com/t/multicolor-with-the-sv06-ace/6715). :)

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

![Example multi-filament print (green on black)](https://github.com/user-attachments/assets/bb737420-c11f-4e04-b190-ad0d78f2b4ab)

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

Ran a print with a pause and a filament change (see above).