### PR TITLE
Fix some filaments profiles for Anycubic Kobra S1

### DIFF
--- a/resources/profiles/Anycubic/filament/Anycubic ABS @Anycubic Kobra S1 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/filament/Anycubic ABS @Anycubic Kobra S1 0.4 nozzle.json
@@ -46,10 +46,10 @@
         "70"
     ],
     "cool_plate_temp": [
-        "35"
+        "90"
     ],
     "cool_plate_temp_initial_layer": [
-        "35"
+        "90"
     ],
     "default_filament_colour": [
         ""
@@ -247,6 +247,6 @@
         "100"
     ],
     "textured_plate_temp_initial_layer": [
-        "55"
+        "90"
     ]
 }

--- a/resources/profiles/Anycubic/filament/Anycubic ASA @Anycubic Kobra S1 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/filament/Anycubic ASA @Anycubic Kobra S1 0.4 nozzle.json
@@ -46,10 +46,10 @@
         "70"
     ],
     "cool_plate_temp": [
-        "35"
+        "100"
     ],
     "cool_plate_temp_initial_layer": [
-        "35"
+        "100"
     ],
     "default_filament_colour": [
         ""
@@ -247,9 +247,9 @@
         "100"
     ],
     "textured_plate_temp": [
-        "55"
+        "100"
     ],
     "textured_plate_temp_initial_layer": [
-        "55"
+        "100"
     ]
 }

--- a/resources/profiles/Anycubic/filament/Anycubic PETG @Anycubic Kobra S1 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/filament/Anycubic PETG @Anycubic Kobra S1 0.4 nozzle.json
@@ -16,7 +16,7 @@
         "12"
     ],
     "nozzle_temperature": [
-        "230"
+        "250"
     ],
     "compatible_printers": [
         "Anycubic Kobra S1 0.4 nozzle"
@@ -46,10 +46,10 @@
         "70"
     ],
     "cool_plate_temp": [
-        "35"
+        "55"
     ],
     "cool_plate_temp_initial_layer": [
-        "35"
+        "55"
     ],
     "default_filament_colour": [
         ""
@@ -202,13 +202,13 @@
         "0"
     ],
     "hot_plate_temp": [
-        "65"
+        "70"
     ],
     "hot_plate_temp_initial_layer": [
-        "65"
+        "70"
     ],
     "nozzle_temperature_initial_layer": [
-        "230"
+        "250"
     ],
     "nozzle_temperature_range_high": [
         "260"
@@ -247,9 +247,9 @@
         "70"
     ],
     "textured_plate_temp": [
-        "55"
+        "70"
     ],
     "textured_plate_temp_initial_layer": [
-        "55"
+        "70"
     ]
 }


### PR DESCRIPTION
# Description

The Anycubic Kobra S1 has a bad PETG profile by default, this PR aims to fix it.
So changes also for ABS and ASA but it's just in case other plate types are added later.