### PR TITLE
use orca color for "can't find device" link

### DIFF
--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -642,6 +642,7 @@ void SelectMachinePopup::update_other_devices()
     wxBoxSizer* placeholder_sizer = new wxBoxSizer(wxVERTICAL);
 
     m_hyperlink = new wxHyperlinkCtrl(m_placeholder_panel, wxID_ANY, _L("Can't find my devices?"), wxT("https://wiki.bambulab.com/en/software/bambu-studio/failed-to-connect-printer"), wxDefaultPosition, wxDefaultSize, wxHL_DEFAULT_STYLE);
+    m_hyperlink->SetNormalColour(StateColor::darkModeColorFor("#009789"));
     placeholder_sizer->Add(m_hyperlink, 0, wxALIGN_CENTER | wxALL, 5);
 
 


### PR DESCRIPTION
# Description

Fix text color for "Can't find device?" link in dark mode

# Screenshots/Recordings/Graphs

### Before
<img width="216" alt="Screenshot 2025-02-03 at 1 37 36 AM" src="https://github.com/user-attachments/assets/fcad98e7-8104-42de-9101-87f76a7b6c97" />


### After


<img width="216" alt="Screenshot 2025-02-03 at 11 54 43 AM" src="https://github.com/user-attachments/assets/e8932f05-5d9c-460e-8b13-3b9ab4aa745d" />


<img width="216" alt="Screenshot 2025-02-03 at 11 55 07 AM" src="https://github.com/user-attachments/assets/22fbb6d7-7680-4956-97a9-635c32dd8421" />

