### PR TITLE
Match text size of advanced toggle text

### DIFF
--- a/src/slic3r/GUI/ParamsPanel.cpp
+++ b/src/slic3r/GUI/ParamsPanel.cpp
@@ -225,7 +225,7 @@ ParamsPanel::ParamsPanel( wxWindow* parent, wxWindowID id, const wxPoint& pos, c
         m_tips_arrow = new ScalableButton(m_top_panel, wxID_ANY, "tips_arrow");
         m_tips_arrow->Hide();
 
-        m_title_view = new Label(m_top_panel, _L("Advance"));
+        m_title_view = new Label(m_top_panel, Label::Body_12, _L("Advance")); // ORCA match size with advanced toggle on tab.cpp m_static_title
         m_mode_view = new SwitchButton(m_top_panel, wxID_ABOUT);
 
         // BBS: new layout


### PR DESCRIPTION
Matches advanced text size on sidebar with toggle used on material/machine settings window

before - it uses same text size with title text. sub items should use smaller text size
![Screenshot-20250205045302](https://github.com/user-attachments/assets/a55ece84-2330-443a-a04f-ef1504334691)

after - Text size matched with Global/Objects toggle and Window version of Advanced toggle
![Screenshot-20250205040232](https://github.com/user-attachments/assets/a0501eba-7266-472a-96b3-ebbb0997e764)
