### PR TITLE
fix profile assignment of Flashforge.json

### DIFF
--- a/resources/profiles/Flashforge.json
+++ b/resources/profiles/Flashforge.json
@@ -488,7 +488,7 @@
       "sub_path": "machine/Flashforge Adventurer 5M Pro 0.8 Nozzle.json"
     },
     {
-      "name": "fdm_flashforge_common",
+      "name": "fdm_adventurer3_common",
       "sub_path": "machine/fdm_adventurer3_common.json"
     },
     {


### PR DESCRIPTION
# Description

The machine list of  `resources/profiles/Flashforge.json` contains a doubled entry `fdm_flashforge_common`.

The second entry is associated with ` "sub_path": "machine/fdm_adventurer3_common.json"`. 

This appears to be incorrect. Entry name has been renamed to the apparently more correct `fdm_adventurer3_common`.
