### PR TITLE
Expose interface_shells option

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2328,6 +2328,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("flush_into_support", "reduce-wasting-during-filament-change#wipe-into-support-enabled-by-default");
         optgroup = page->new_optgroup(L("Advanced"), L"advanced");
         optgroup->append_single_option_line("interlocking_beam");
+        optgroup->append_single_option_line("interface_shells");
         optgroup->append_single_option_line("mmu_segmented_region_max_width");
         optgroup->append_single_option_line("mmu_segmented_region_interlocking_depth");
         optgroup->append_single_option_line("interlocking_beam_width");


### PR DESCRIPTION
# Description

`interface_shells` option exists in original PrusaSlicer, this PR just expose this option as this is a useful feature for people want to print multi color logo or sign.

# Screenshots/Recordings/Graphs

https://github.com/user-attachments/assets/449d6868-5791-4845-89d7-75e8d9f85826



Fixes #5106
