### PR TITLE
Fix shaky close button on notification

### DIFF
--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -304,10 +304,10 @@ void NotificationManager::PopNotification::render(GLCanvas3D& canvas, float init
 		bbl_render_left_sign(imgui, win_size.x, win_size.y, win_pos.x, win_pos.y);
 		render_left_sign(imgui);
 		render_text(imgui, win_size.x, win_size.y, win_pos.x, win_pos.y);
-		render_close_button(imgui, win_size.x, win_size.y, win_pos.x, win_pos.y);
         m_minimize_b_visible = false;
         if (m_multiline && m_lines_count > 3)
 			render_minimize_button(imgui, win_pos.x, win_pos.y);
+        render_close_button(imgui, win_size.x, win_size.y, win_pos.x, win_pos.y); // ORCA draw it after minimize button since its position related to minimize button
 	}
 	imgui.end();
 


### PR DESCRIPTION
### Problem
position of close button changes existence of minimize button. rendering close button before minimize button causing issue.

### Solution
just changed order to fix it

before

https://github.com/user-attachments/assets/b48de02c-a66d-4e1f-a465-b2e8a3dd6347



after

https://github.com/user-attachments/assets/d31223b4-ba3d-465b-9d3f-4e6256836da6


