### PR TITLE
ENH: modify the start pos of wall for wipe tower[affects BBL machines only]

### DIFF
--- a/src/libslic3r/GCode/WipeTower.hpp
+++ b/src/libslic3r/GCode/WipeTower.hpp
@@ -304,7 +304,7 @@ private:
     float  m_travel_speed       = 0.f;
     float  m_first_layer_speed  = 0.f;
     size_t m_first_layer_idx    = size_t(-1);
-
+    size_t m_cur_layer_id;
 	// G-code generator parameters.
     float           m_cooling_tube_retraction   = 0.f;
     float           m_cooling_tube_length       = 0.f;


### PR DESCRIPTION
and modify the overlap of wall and infill for wipe tower jira:none

cherry picked from commit bambulab/BambuStudio@4db196b11f052d6a7a7c7a8aafe0d2b34a7d2d80

Thanks BambuLab!

- Optimize the starting position of the printing wiper tower after material change, the initial print on the wipe tower sometimes had under-extrusion issues, and all layers of wipe tower have the same starting position, increasing the risk of collision. This optimization distributes the initial extrusion over four corners, reducing the accumulation of defects.
- Reducing the rivet length between the wipe tower's outer wall and infill to 0mm minimizes the risk of collision when switching between printing infill and outer walls.

![image](https://github.com/user-attachments/assets/7cd4daf2-4df4-4bfc-b447-99099e73631b)
