### PR TITLE
Turn on exclude object for Prusa MK4S

### DIFF
--- a/resources/profiles/Prusa/process/process_common_mk4s.json
+++ b/resources/profiles/Prusa/process/process_common_mk4s.json
@@ -9,6 +9,7 @@
     "enable_overhang_speed": "1",
     "enable_prime_tower": "1",
     "enforce_support_layers": "0",
+    "exclude_object": "1",
     "filename_format": "{input_filename_base}_{nozzle_diameter[0]}n_{layer_height}mm_{filament_type[0]}_{printer_model}_{print_time}.gcode",
     "from": "system",
     "gap_infill_speed": "120",


### PR DESCRIPTION
# Description

Simply sets "exclude_object" to "1" in the base MK4S profile, which was missed in the initial translation from Prusa Slicer.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
