### PR TITLE
Add some AliZ filament profiles as example

### DIFF
--- a/resources/profiles/BBL.json
+++ b/resources/profiles/BBL.json
@@ -606,20 +606,28 @@
             "sub_path": "filament/fdm_filament_common.json"
         },
         {
-            "name": "fdm_filament_pla",
-            "sub_path": "filament/fdm_filament_pla.json"
-        },
-        {
-            "name": "fdm_filament_tpu",
-            "sub_path": "filament/fdm_filament_tpu.json"
-        },
-        {
-            "name": "fdm_filament_pet",
-            "sub_path": "filament/fdm_filament_pet.json"
-        },
-        {
             "name": "fdm_filament_abs",
             "sub_path": "filament/fdm_filament_abs.json"
+        },
+        {
+            "name": "fdm_filament_asa",
+            "sub_path": "filament/fdm_filament_asa.json"
+        },
+        {
+            "name": "fdm_filament_bvoh",
+            "sub_path": "filament/fdm_filament_bvoh.json"
+        },
+        {
+            "name": "fdm_filament_eva",
+            "sub_path": "filament/fdm_filament_eva.json"
+        },
+        {
+            "name": "fdm_filament_hips",
+            "sub_path": "filament/fdm_filament_hips.json"
+        },
+        {
+            "name": "fdm_filament_pa",
+            "sub_path": "filament/fdm_filament_pa.json"
         },
         {
             "name": "fdm_filament_pc",
@@ -630,280 +638,48 @@
             "sub_path": "filament/fdm_filament_pctg.json"
         },
         {
-            "name": "fdm_filament_asa",
-            "sub_path": "filament/fdm_filament_asa.json"
-        },
-        {
-            "name": "fdm_filament_pva",
-            "sub_path": "filament/fdm_filament_pva.json"
-        },
-        {
-            "name": "fdm_filament_pa",
-            "sub_path": "filament/fdm_filament_pa.json"
-        },
-        {
-            "name": "fdm_filament_hips",
-            "sub_path": "filament/fdm_filament_hips.json"
-        },
-        {
-            "name": "fdm_filament_pps",
-            "sub_path": "filament/fdm_filament_pps.json"
-        },
-        {
-            "name": "fdm_filament_ppa",
-            "sub_path": "filament/fdm_filament_ppa.json"
-        },
-        {
             "name": "fdm_filament_pe",
             "sub_path": "filament/fdm_filament_pe.json"
         },
         {
-            "name": "fdm_filament_pp",
-            "sub_path": "filament/fdm_filament_pp.json"
-        },
-        {
-            "name": "fdm_filament_eva",
-            "sub_path": "filament/fdm_filament_eva.json"
+            "name": "fdm_filament_pet",
+            "sub_path": "filament/fdm_filament_pet.json"
         },
         {
             "name": "fdm_filament_pha",
             "sub_path": "filament/fdm_filament_pha.json"
         },
         {
-            "name": "fdm_filament_bvoh",
-            "sub_path": "filament/fdm_filament_bvoh.json"
+            "name": "fdm_filament_pla",
+            "sub_path": "filament/fdm_filament_pla.json"
+        },
+        {
+            "name": "fdm_filament_pp",
+            "sub_path": "filament/fdm_filament_pp.json"
+        },
+        {
+            "name": "fdm_filament_ppa",
+            "sub_path": "filament/fdm_filament_ppa.json"
+        },
+        {
+            "name": "fdm_filament_pps",
+            "sub_path": "filament/fdm_filament_pps.json"
+        },
+        {
+            "name": "fdm_filament_pva",
+            "sub_path": "filament/fdm_filament_pva.json"
         },
         {
             "name": "fdm_filament_sbs",
             "sub_path": "filament/fdm_filament_sbs.json"
         },
         {
-            "name": "Bambu PLA Matte @base",
-            "sub_path": "filament/Bambu PLA Matte @base.json"
-        },
-        {
-            "name": "Bambu PLA Basic @base",
-            "sub_path": "filament/Bambu PLA Basic @base.json"
-        },
-        {
-            "name": "Bambu PLA Tough @base",
-            "sub_path": "filament/Bambu PLA Tough @base.json"
-        },
-        {
-            "name": "Bambu PLA Marble @base",
-            "sub_path": "filament/Bambu PLA Marble @base.json"
-        },
-        {
-            "name": "Bambu PLA Sparkle @base",
-            "sub_path": "filament/Bambu PLA Sparkle @base.json"
-        },
-        {
-            "name": "Bambu PLA Impact @base",
-            "sub_path": "filament/Bambu PLA Impact @base.json"
-        },
-        {
-            "name": "Bambu PLA Metal @base",
-            "sub_path": "filament/Bambu PLA Metal @base.json"
-        },
-        {
-            "name": "Bambu PLA Silk @base",
-            "sub_path": "filament/Bambu PLA Silk @base.json"
-        },
-        {
-            "name": "Bambu Support W @base",
-            "sub_path": "filament/Bambu Support W @base.json"
-        },
-        {
-            "name": "SUNLU PLA Matte @base",
-            "sub_path": "filament/SUNLU/SUNLU PLA Matte @base.json"
-        },
-        {
-            "name": "SUNLU PLA+ @base",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ @base.json"
-        },
-        {
-            "name": "SUNLU PLA+ 2.0 @base",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @base.json"
-        },
-        {
-            "name": "SUNLU Silk PLA+ @base",
-            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @base.json"
-        },
-        {
-            "name": "SUNLU PLA Marble @base",
-            "sub_path": "filament/SUNLU/SUNLU Marble PLA @base.json"
-        },
-        {
-            "name": "SUNLU Wood PLA @base",
-            "sub_path": "filament/SUNLU/SUNLU Wood PLA @base.json"
-        },
-        {
-            "name": "SUNLU PETG @base",
-            "sub_path": "filament/SUNLU/SUNLU PETG @base.json"
-        },
-        {
-            "name": "eSUN PLA+ @base",
-            "sub_path": "filament/eSUN PLA+ @base.json"
-        },
-        {
-            "name": "PolyTerra PLA @base",
-            "sub_path": "filament/PolyTerra PLA @base.json"
-        },
-        {
-            "name": "PolyLite PLA @base",
-            "sub_path": "filament/PolyLite PLA @base.json"
-        },
-        {
-            "name": "Generic PLA @base",
-            "sub_path": "filament/Generic PLA @base.json"
-        },
-        {
-            "name": "Generic PLA Silk @base",
-            "sub_path": "filament/Generic PLA Silk @base.json"
-        },
-        {
-            "name": "Generic PLA-CF @base",
-            "sub_path": "filament/Generic PLA-CF @base.json"
-        },
-        {
-            "name": "Generic SBS @base",
-            "sub_path": "filament/Generic SBS @base.json"
-        },
-        {
-            "name": "Bambu PLA-CF @base",
-            "sub_path": "filament/Bambu PLA-CF @base.json"
-        },
-        {
-            "name": "Bambu Support For PLA @base",
-            "sub_path": "filament/Bambu Support For PLA @base.json"
-        },
-        {
-            "name": "Bambu PLA Aero @base",
-            "sub_path": "filament/Bambu PLA Aero @base.json"
-        },
-        {
-            "name": "Overture PLA @base",
-            "sub_path": "filament/Overture PLA @base.json"
-        },
-        {
-            "name": "Overture Matte PLA @base",
-            "sub_path": "filament/Overture Matte PLA @base.json"
-        },
-        {
-            "name": "Generic PLA High Speed @base",
-            "sub_path": "filament/Generic PLA High Speed @base.json"
-        },
-        {
-            "name": "Bambu PLA Glow @base",
-            "sub_path": "filament/Bambu PLA Glow @base.json"
-        },
-        {
-            "name": "Bambu PLA Dynamic @base",
-            "sub_path": "filament/Bambu PLA Dynamic @base.json"
-        },
-        {
-            "name": "Bambu PLA Galaxy @base",
-            "sub_path": "filament/Bambu PLA Galaxy @base.json"
-        },
-        {
-            "name": "Bambu Support For PLA/PETG @base",
-            "sub_path": "filament/Bambu Support For PLA-PETG @base.json"
-        },
-        {
-            "name": "Bambu PLA Wood @base",
-            "sub_path": "filament/Bambu PLA Wood @base.json"
-        },
-        {
-            "name": "Bambu PLA Silk+ @base",
-            "sub_path": "filament/Bambu PLA Silk+ @base.json"
-        },
-        {
-            "name": "Bambu TPU 95A @base",
-            "sub_path": "filament/Bambu TPU 95A @base.json"
-        },
-        {
-            "name": "Generic TPU",
-            "sub_path": "filament/Generic TPU.json"
-        },
-        {
-            "name": "Generic TPU @BBL P1P",
-            "sub_path": "filament/P1P/Generic TPU @BBL P1P.json"
-        },
-        {
-            "name": "Bambu TPU 95A HF @base",
-            "sub_path": "filament/Bambu TPU 95A HF @base.json"
-        },
-        {
-            "name": "Generic TPU for AMS @base",
-            "sub_path": "filament/Generic TPU for AMS @base.json"
-        },
-        {
-            "name": "Bambu TPU for AMS @base",
-            "sub_path": "filament/Bambu TPU for AMS @base.json"
-        },
-        {
-            "name": "Bambu PETG Basic @base",
-            "sub_path": "filament/Bambu PETG Basic @base.json"
-        },
-        {
-            "name": "Bambu PET-CF @base",
-            "sub_path": "filament/Bambu PET-CF @base.json"
-        },
-        {
-            "name": "Generic PETG @base",
-            "sub_path": "filament/Generic PETG @base.json"
-        },
-        {
-            "name": "Generic PETG-CF @base",
-            "sub_path": "filament/Generic PETG-CF @base.json"
-        },
-        {
-            "name": "Bambu PETG-CF @base",
-            "sub_path": "filament/Bambu PETG-CF @base.json"
-        },
-        {
-            "name": "PolyLite PETG @base",
-            "sub_path": "filament/PolyLite PETG @base.json"
-        },
-        {
-            "name": "Bambu PETG Translucent @base",
-            "sub_path": "filament/Bambu PETG Translucent @base.json"
-        },
-        {
-            "name": "Generic PCTG @base",
-            "sub_path": "filament/Generic PCTG @base.json"
-        },
-        {
-            "name": "Bambu PETG HF @base",
-            "sub_path": "filament/Bambu PETG HF @base.json"
-        },
-        {
-            "name": "Fiberon PETG-ESD @base",
-            "sub_path": "filament/Fiberon PETG-ESD @base.json"
-        },
-        {
-            "name": "Fiberon PETG-rCF @base",
-            "sub_path": "filament/Fiberon PETG-rCF @base.json"
-        },
-        {
-            "name": "Fiberon PET-CF @base",
-            "sub_path": "filament/Fiberon PET-CF @base.json"
-        },
-        {
-            "name": "Generic PETG HF @base",
-            "sub_path": "filament/Generic PETG HF @base.json"
+            "name": "fdm_filament_tpu",
+            "sub_path": "filament/fdm_filament_tpu.json"
         },
         {
             "name": "Bambu ABS @base",
             "sub_path": "filament/Bambu ABS @base.json"
-        },
-        {
-            "name": "Generic ABS @base",
-            "sub_path": "filament/Generic ABS @base.json"
-        },
-        {
-            "name": "PolyLite ABS @base",
-            "sub_path": "filament/PolyLite ABS @base.json"
         },
         {
             "name": "Bambu ABS-GF @base",
@@ -914,28 +690,16 @@
             "sub_path": "filament/Bambu Support for ABS @base.json"
         },
         {
-            "name": "Bambu PC @base",
-            "sub_path": "filament/Bambu PC @base.json"
+            "name": "Generic ABS @base",
+            "sub_path": "filament/Generic ABS @base.json"
         },
         {
-            "name": "Generic PC @base",
-            "sub_path": "filament/Generic PC @base.json"
-        },
-        {
-            "name": "Bambu PC FR @base",
-            "sub_path": "filament/Bambu PC FR @base.json"
-        },
-        {
-            "name": "Generic ASA @base",
-            "sub_path": "filament/Generic ASA @base.json"
+            "name": "PolyLite ABS @base",
+            "sub_path": "filament/PolyLite ABS @base.json"
         },
         {
             "name": "Bambu ASA @base",
             "sub_path": "filament/Bambu ASA @base.json"
-        },
-        {
-            "name": "PolyLite ASA @base",
-            "sub_path": "filament/PolyLite ASA @base.json"
         },
         {
             "name": "Bambu ASA-Aero @base",
@@ -946,44 +710,28 @@
             "sub_path": "filament/Bambu ASA-CF @base.json"
         },
         {
-            "name": "Generic PVA @base",
-            "sub_path": "filament/Generic PVA @base.json"
+            "name": "Generic ASA @base",
+            "sub_path": "filament/Generic ASA @base.json"
         },
         {
-            "name": "Bambu PVA @base",
-            "sub_path": "filament/Bambu PVA @base.json"
+            "name": "PolyLite ASA @base",
+            "sub_path": "filament/PolyLite ASA @base.json"
         },
         {
-            "name": "Bambu Support G @base",
-            "sub_path": "filament/Bambu Support G @base.json"
+            "name": "Generic BVOH @base",
+            "sub_path": "filament/Generic BVOH @base.json"
+        },
+        {
+            "name": "Generic EVA @base",
+            "sub_path": "filament/Generic EVA @base.json"
+        },
+        {
+            "name": "Generic HIPS @base",
+            "sub_path": "filament/Generic HIPS @base.json"
         },
         {
             "name": "Bambu PA-CF @base",
             "sub_path": "filament/Bambu PA-CF @base.json"
-        },
-        {
-            "name": "Generic PA",
-            "sub_path": "filament/Generic PA.json"
-        },
-        {
-            "name": "Generic PA-CF",
-            "sub_path": "filament/Generic PA-CF.json"
-        },
-        {
-            "name": "Bambu PAHT-CF @base",
-            "sub_path": "filament/Bambu PAHT-CF @base.json"
-        },
-        {
-            "name": "Generic PA-CF @BBL P1P",
-            "sub_path": "filament/P1P/Generic PA-CF @BBL P1P.json"
-        },
-        {
-            "name": "Generic PA @BBL P1P",
-            "sub_path": "filament/P1P/Generic PA @BBL P1P.json"
-        },
-        {
-            "name": "Bambu Support For PA/PET @base",
-            "sub_path": "filament/Bambu Support For PA PET @base.json"
         },
         {
             "name": "Bambu PA6-CF @base",
@@ -994,6 +742,22 @@
             "sub_path": "filament/Bambu PA6-GF @base.json"
         },
         {
+            "name": "Bambu PAHT-CF @base",
+            "sub_path": "filament/Bambu PAHT-CF @base.json"
+        },
+        {
+            "name": "Bambu Support For PA/PET @base",
+            "sub_path": "filament/Bambu Support For PA PET @base.json"
+        },
+        {
+            "name": "Bambu Support G @base",
+            "sub_path": "filament/Bambu Support G @base.json"
+        },
+        {
+            "name": "Fiberon PA12-CF @base",
+            "sub_path": "filament/Fiberon PA12-CF @base.json"
+        },
+        {
             "name": "Fiberon PA6-CF @base",
             "sub_path": "filament/Fiberon PA6-CF @base.json"
         },
@@ -1002,40 +766,40 @@
             "sub_path": "filament/Fiberon PA6-GF @base.json"
         },
         {
-            "name": "Fiberon PA12-CF @base",
-            "sub_path": "filament/Fiberon PA12-CF @base.json"
-        },
-        {
             "name": "Fiberon PA612-CF @base",
             "sub_path": "filament/Fiberon PA612-CF @base.json"
         },
         {
-            "name": "Generic HIPS @base",
-            "sub_path": "filament/Generic HIPS @base.json"
+            "name": "Generic PA",
+            "sub_path": "filament/Generic PA.json"
         },
         {
-            "name": "Generic PPS-CF @base",
-            "sub_path": "filament/Generic PPS-CF @base.json"
+            "name": "Generic PA @BBL P1P",
+            "sub_path": "filament/P1P/Generic PA @BBL P1P.json"
         },
         {
-            "name": "Generic PPS @base",
-            "sub_path": "filament/Generic PPS @base.json"
+            "name": "Generic PA-CF",
+            "sub_path": "filament/Generic PA-CF.json"
         },
         {
-            "name": "Bambu PPS-CF @base",
-            "sub_path": "filament/Bambu PPS-CF @base.json"
+            "name": "Generic PA-CF @BBL P1P",
+            "sub_path": "filament/P1P/Generic PA-CF @BBL P1P.json"
         },
         {
-            "name": "Bambu PPA-CF @base",
-            "sub_path": "filament/Bambu PPA-CF @base.json"
+            "name": "Bambu PC @base",
+            "sub_path": "filament/Bambu PC @base.json"
         },
         {
-            "name": "Generic PPA-CF @base",
-            "sub_path": "filament/Generic PPA-CF @base.json"
+            "name": "Bambu PC FR @base",
+            "sub_path": "filament/Bambu PC FR @base.json"
         },
         {
-            "name": "Generic PPA-GF @base",
-            "sub_path": "filament/Generic PPA-GF @base.json"
+            "name": "Generic PC @base",
+            "sub_path": "filament/Generic PC @base.json"
+        },
+        {
+            "name": "Generic PCTG @base",
+            "sub_path": "filament/Generic PCTG @base.json"
         },
         {
             "name": "Generic PE @base",
@@ -1044,6 +808,194 @@
         {
             "name": "Generic PE-CF @base",
             "sub_path": "filament/Generic PE-CF @base.json"
+        },
+        {
+            "name": "Bambu PET-CF @base",
+            "sub_path": "filament/Bambu PET-CF @base.json"
+        },
+        {
+            "name": "Bambu PETG Basic @base",
+            "sub_path": "filament/Bambu PETG Basic @base.json"
+        },
+        {
+            "name": "Bambu PETG HF @base",
+            "sub_path": "filament/Bambu PETG HF @base.json"
+        },
+        {
+            "name": "Bambu PETG Translucent @base",
+            "sub_path": "filament/Bambu PETG Translucent @base.json"
+        },
+        {
+            "name": "Bambu PETG-CF @base",
+            "sub_path": "filament/Bambu PETG-CF @base.json"
+        },
+        {
+            "name": "Fiberon PET-CF @base",
+            "sub_path": "filament/Fiberon PET-CF @base.json"
+        },
+        {
+            "name": "Fiberon PETG-ESD @base",
+            "sub_path": "filament/Fiberon PETG-ESD @base.json"
+        },
+        {
+            "name": "Fiberon PETG-rCF @base",
+            "sub_path": "filament/Fiberon PETG-rCF @base.json"
+        },
+        {
+            "name": "Generic PETG @base",
+            "sub_path": "filament/Generic PETG @base.json"
+        },
+        {
+            "name": "Generic PETG HF @base",
+            "sub_path": "filament/Generic PETG HF @base.json"
+        },
+        {
+            "name": "Generic PETG-CF @base",
+            "sub_path": "filament/Generic PETG-CF @base.json"
+        },
+        {
+            "name": "PolyLite PETG @base",
+            "sub_path": "filament/PolyLite PETG @base.json"
+        },
+        {
+            "name": "SUNLU PETG @base",
+            "sub_path": "filament/SUNLU/SUNLU PETG @base.json"
+        },
+        {
+            "name": "Generic PHA @base",
+            "sub_path": "filament/Generic PHA @base.json"
+        },
+        {
+            "name": "Bambu PLA Aero @base",
+            "sub_path": "filament/Bambu PLA Aero @base.json"
+        },
+        {
+            "name": "Bambu PLA Basic @base",
+            "sub_path": "filament/Bambu PLA Basic @base.json"
+        },
+        {
+            "name": "Bambu PLA Dynamic @base",
+            "sub_path": "filament/Bambu PLA Dynamic @base.json"
+        },
+        {
+            "name": "Bambu PLA Galaxy @base",
+            "sub_path": "filament/Bambu PLA Galaxy @base.json"
+        },
+        {
+            "name": "Bambu PLA Glow @base",
+            "sub_path": "filament/Bambu PLA Glow @base.json"
+        },
+        {
+            "name": "Bambu PLA Impact @base",
+            "sub_path": "filament/Bambu PLA Impact @base.json"
+        },
+        {
+            "name": "Bambu PLA Marble @base",
+            "sub_path": "filament/Bambu PLA Marble @base.json"
+        },
+        {
+            "name": "Bambu PLA Matte @base",
+            "sub_path": "filament/Bambu PLA Matte @base.json"
+        },
+        {
+            "name": "Bambu PLA Metal @base",
+            "sub_path": "filament/Bambu PLA Metal @base.json"
+        },
+        {
+            "name": "Bambu PLA Silk @base",
+            "sub_path": "filament/Bambu PLA Silk @base.json"
+        },
+        {
+            "name": "Bambu PLA Silk+ @base",
+            "sub_path": "filament/Bambu PLA Silk+ @base.json"
+        },
+        {
+            "name": "Bambu PLA Sparkle @base",
+            "sub_path": "filament/Bambu PLA Sparkle @base.json"
+        },
+        {
+            "name": "Bambu PLA Tough @base",
+            "sub_path": "filament/Bambu PLA Tough @base.json"
+        },
+        {
+            "name": "Bambu PLA Wood @base",
+            "sub_path": "filament/Bambu PLA Wood @base.json"
+        },
+        {
+            "name": "Bambu PLA-CF @base",
+            "sub_path": "filament/Bambu PLA-CF @base.json"
+        },
+        {
+            "name": "Bambu Support For PLA @base",
+            "sub_path": "filament/Bambu Support For PLA @base.json"
+        },
+        {
+            "name": "Bambu Support For PLA/PETG @base",
+            "sub_path": "filament/Bambu Support For PLA-PETG @base.json"
+        },
+        {
+            "name": "Bambu Support W @base",
+            "sub_path": "filament/Bambu Support W @base.json"
+        },
+        {
+            "name": "Generic PLA @base",
+            "sub_path": "filament/Generic PLA @base.json"
+        },
+        {
+            "name": "Generic PLA High Speed @base",
+            "sub_path": "filament/Generic PLA High Speed @base.json"
+        },
+        {
+            "name": "Generic PLA Silk @base",
+            "sub_path": "filament/Generic PLA Silk @base.json"
+        },
+        {
+            "name": "Generic PLA-CF @base",
+            "sub_path": "filament/Generic PLA-CF @base.json"
+        },
+        {
+            "name": "Overture Matte PLA @base",
+            "sub_path": "filament/Overture Matte PLA @base.json"
+        },
+        {
+            "name": "Overture PLA @base",
+            "sub_path": "filament/Overture PLA @base.json"
+        },
+        {
+            "name": "PolyLite PLA @base",
+            "sub_path": "filament/PolyLite PLA @base.json"
+        },
+        {
+            "name": "PolyTerra PLA @base",
+            "sub_path": "filament/PolyTerra PLA @base.json"
+        },
+        {
+            "name": "SUNLU PLA Marble @base",
+            "sub_path": "filament/SUNLU/SUNLU Marble PLA @base.json"
+        },
+        {
+            "name": "SUNLU PLA Matte @base",
+            "sub_path": "filament/SUNLU/SUNLU PLA Matte @base.json"
+        },
+        {
+            "name": "SUNLU PLA+ 2.0 @base",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @base.json"
+        },
+        {
+            "name": "SUNLU PLA+ @base",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ @base.json"
+        },
+        {
+            "name": "SUNLU Silk PLA+ @base",
+            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @base.json"
+        },
+        {
+            "name": "SUNLU Wood PLA @base",
+            "sub_path": "filament/SUNLU/SUNLU Wood PLA @base.json"
+        },
+        {
+            "name": "eSUN PLA+ @base",
+            "sub_path": "filament/eSUN PLA+ @base.json"
         },
         {
             "name": "Generic PP @base",
@@ -1058,1096 +1010,576 @@
             "sub_path": "filament/Generic PP-GF @base.json"
         },
         {
-            "name": "Generic EVA @base",
-            "sub_path": "filament/Generic EVA @base.json"
+            "name": "Bambu PPA-CF @base",
+            "sub_path": "filament/Bambu PPA-CF @base.json"
         },
         {
-            "name": "Generic PHA @base",
-            "sub_path": "filament/Generic PHA @base.json"
+            "name": "Generic PPA-CF @base",
+            "sub_path": "filament/Generic PPA-CF @base.json"
         },
         {
-            "name": "Generic BVOH @base",
-            "sub_path": "filament/Generic BVOH @base.json"
+            "name": "Generic PPA-GF @base",
+            "sub_path": "filament/Generic PPA-GF @base.json"
         },
         {
-            "name": "Bambu PLA Matte @BBL X1C",
-            "sub_path": "filament/Bambu PLA Matte @BBL X1C.json"
+            "name": "Bambu PPS-CF @base",
+            "sub_path": "filament/Bambu PPS-CF @base.json"
         },
         {
-            "name": "Bambu PLA Matte @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Matte @BBL X1C 0.2 nozzle.json"
+            "name": "Generic PPS @base",
+            "sub_path": "filament/Generic PPS @base.json"
         },
         {
-            "name": "Bambu PLA Matte @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PLA Matte @BBL X1C 0.8 nozzle.json"
+            "name": "Generic PPS-CF @base",
+            "sub_path": "filament/Generic PPS-CF @base.json"
         },
         {
-            "name": "Bambu PLA Matte @BBL X1",
-            "sub_path": "filament/Bambu PLA Matte @BBL X1.json"
+            "name": "Bambu PVA @base",
+            "sub_path": "filament/Bambu PVA @base.json"
         },
         {
-            "name": "Bambu PLA Matte @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Bambu PLA Matte @BBL P1P 0.2 nozzle.json"
+            "name": "Generic PVA @base",
+            "sub_path": "filament/Generic PVA @base.json"
         },
         {
-            "name": "Bambu PLA Matte @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PLA Matte @BBL P1P.json"
+            "name": "Generic SBS @base",
+            "sub_path": "filament/Generic SBS @base.json"
         },
         {
-            "name": "Bambu PLA Matte @BBL A1M",
-            "sub_path": "filament/Bambu PLA Matte @BBL A1M.json"
+            "name": "Bambu TPU 95A @base",
+            "sub_path": "filament/Bambu TPU 95A @base.json"
         },
         {
-            "name": "Bambu PLA Matte @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Matte @BBL A1M 0.2 nozzle.json"
+            "name": "Bambu TPU 95A HF @base",
+            "sub_path": "filament/Bambu TPU 95A HF @base.json"
         },
         {
-            "name": "Bambu PLA Matte @BBL A1",
-            "sub_path": "filament/Bambu PLA Matte @BBL A1.json"
+            "name": "Bambu TPU for AMS @base",
+            "sub_path": "filament/Bambu TPU for AMS @base.json"
         },
         {
-            "name": "Bambu PLA Matte @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Matte @BBL A1 0.2 nozzle.json"
+            "name": "Generic TPU",
+            "sub_path": "filament/Generic TPU.json"
         },
         {
-            "name": "Bambu PLA Basic @BBL X1C",
-            "sub_path": "filament/Bambu PLA Basic @BBL X1C.json"
+            "name": "Generic TPU @BBL P1P",
+            "sub_path": "filament/P1P/Generic TPU @BBL P1P.json"
         },
         {
-            "name": "Bambu PLA Basic @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Basic @BBL X1C 0.2 nozzle.json"
+            "name": "Generic TPU for AMS @base",
+            "sub_path": "filament/Generic TPU for AMS @base.json"
         },
         {
-            "name": "Bambu PLA Basic @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PLA Basic @BBL X1C 0.8 nozzle.json"
+            "name": "Bambu ABS @BBL A1",
+            "sub_path": "filament/Bambu ABS @BBL A1.json"
         },
         {
-            "name": "Bambu PLA Basic @BBL X1",
-            "sub_path": "filament/Bambu PLA Basic @BBL X1.json"
+            "name": "Bambu ABS @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu ABS @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Basic @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Bambu PLA Basic @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu ABS @BBL P1P",
+            "sub_path": "filament/P1P/Bambu ABS @BBL P1P.json"
         },
         {
-            "name": "Bambu PLA Basic @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PLA Basic @BBL P1P.json"
+            "name": "Bambu ABS @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Bambu ABS @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Basic @BBL A1M",
-            "sub_path": "filament/Bambu PLA Basic @BBL A1M.json"
+            "name": "Bambu ABS @BBL X1C",
+            "sub_path": "filament/Bambu ABS @BBL X1C.json"
         },
         {
-            "name": "Bambu PLA Basic @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Basic @BBL A1M 0.2 nozzle.json"
+            "name": "Bambu ABS @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu ABS @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Basic @BBL A1",
-            "sub_path": "filament/Bambu PLA Basic @BBL A1.json"
+            "name": "Bambu ABS @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu ABS @BBL X1C 0.8 nozzle.json"
         },
         {
-            "name": "Bambu PLA Basic @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Basic @BBL A1 0.2 nozzle.json"
+            "name": "Bambu ABS-GF @BBL A1",
+            "sub_path": "filament/Bambu ABS-GF @BBL A1.json"
         },
         {
-            "name": "Bambu PLA Tough @BBL X1C",
-            "sub_path": "filament/Bambu PLA Tough @BBL X1C.json"
+            "name": "Bambu ABS-GF @BBL P1P",
+            "sub_path": "filament/Bambu ABS-GF @BBL P1P.json"
         },
         {
-            "name": "Bambu PLA Tough @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Tough @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu ABS-GF @BBL X1C",
+            "sub_path": "filament/Bambu ABS-GF @BBL X1C.json"
         },
         {
-            "name": "Bambu PLA Tough @BBL X1",
-            "sub_path": "filament/Bambu PLA Tough @BBL X1.json"
+            "name": "Bambu Support for ABS @BBL A1",
+            "sub_path": "filament/Bambu Support for ABS @BBL A1.json"
         },
         {
-            "name": "Bambu PLA Tough @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Bambu PLA Tough @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu Support for ABS @BBL X1C",
+            "sub_path": "filament/Bambu Support for ABS @BBL X1C.json"
         },
         {
-            "name": "Bambu PLA Tough @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PLA Tough @BBL P1P.json"
+            "name": "Generic ABS",
+            "sub_path": "filament/Generic ABS.json"
         },
         {
-            "name": "Bambu PLA Tough @BBL A1M",
-            "sub_path": "filament/Bambu PLA Tough @BBL A1M.json"
+            "name": "Generic ABS @0.2 nozzle",
+            "sub_path": "filament/Generic ABS @0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Tough @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Tough @BBL A1M 0.2 nozzle.json"
+            "name": "Generic ABS @BBL A1",
+            "sub_path": "filament/Generic ABS @BBL A1.json"
         },
         {
-            "name": "Bambu PLA Tough @BBL A1",
-            "sub_path": "filament/Bambu PLA Tough @BBL A1.json"
+            "name": "Generic ABS @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Generic ABS @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Tough @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Tough @BBL A1 0.2 nozzle.json"
+            "name": "Generic ABS @BBL P1P",
+            "sub_path": "filament/P1P/Generic ABS @BBL P1P.json"
         },
         {
-            "name": "Bambu PLA Marble @BBL X1",
-            "sub_path": "filament/Bambu PLA Marble @BBL X1.json"
+            "name": "Generic ABS @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Generic ABS @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Marble @BBL X1C",
-            "sub_path": "filament/Bambu PLA Marble @BBL X1C.json"
+            "name": "PolyLite ABS @BBL A1",
+            "sub_path": "filament/PolyLite ABS @BBL A1.json"
         },
         {
-            "name": "Bambu PLA Marble @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PLA Marble @BBL P1P.json"
+            "name": "PolyLite ABS @BBL A1 0.2 nozzle",
+            "sub_path": "filament/PolyLite ABS @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Marble @BBL A1M",
-            "sub_path": "filament/Bambu PLA Marble @BBL A1M.json"
+            "name": "PolyLite ABS @BBL P1P",
+            "sub_path": "filament/PolyLite ABS @BBL P1P.json"
         },
         {
-            "name": "Bambu PLA Marble @BBL A1",
-            "sub_path": "filament/Bambu PLA Marble @BBL A1.json"
+            "name": "PolyLite ABS @BBL X1C",
+            "sub_path": "filament/PolyLite ABS @BBL X1C.json"
         },
         {
-            "name": "Bambu PLA Sparkle @BBL X1",
-            "sub_path": "filament/Bambu PLA Sparkle @BBL X1.json"
+            "name": "Bambu ASA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu ASA @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Sparkle @BBL X1C",
-            "sub_path": "filament/Bambu PLA Sparkle @BBL X1C.json"
+            "name": "Bambu ASA @BBL A1 0.4 nozzle",
+            "sub_path": "filament/Bambu ASA @BBL A1 0.4 nozzle.json"
         },
         {
-            "name": "Bambu PLA Sparkle @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PLA Sparkle @BBL P1P.json"
+            "name": "Bambu ASA @BBL A1 0.6 nozzle",
+            "sub_path": "filament/Bambu ASA @BBL A1 0.6 nozzle.json"
         },
         {
-            "name": "Bambu PLA Sparkle @BBL A1M",
-            "sub_path": "filament/Bambu PLA Sparkle @BBL A1M.json"
+            "name": "Bambu ASA @BBL X1 0.2 nozzle",
+            "sub_path": "filament/Bambu ASA @BBL X1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Sparkle @BBL A1",
-            "sub_path": "filament/Bambu PLA Sparkle @BBL A1.json"
+            "name": "Bambu ASA @BBL X1 0.6 nozzle",
+            "sub_path": "filament/Bambu ASA @BBL X1 0.6 nozzle.json"
         },
         {
-            "name": "Bambu PLA Metal @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Metal @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu ASA @BBL X1C",
+            "sub_path": "filament/Bambu ASA @BBL X1C.json"
         },
         {
-            "name": "Bambu PLA Metal @BBL X1",
-            "sub_path": "filament/Bambu PLA Metal @BBL X1.json"
+            "name": "Bambu ASA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu ASA @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Metal @BBL X1C",
-            "sub_path": "filament/Bambu PLA Metal @BBL X1C.json"
+            "name": "Bambu ASA @BBL X1C 0.4 nozzle",
+            "sub_path": "filament/Bambu ASA @BBL X1C 0.4 nozzle.json"
         },
         {
-            "name": "Bambu PLA Metal @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Bambu PLA Metal @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu ASA-Aero @BBL A1",
+            "sub_path": "filament/Bambu ASA-Aero @BBL A1.json"
         },
         {
-            "name": "Bambu PLA Metal @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PLA Metal @BBL P1P.json"
+            "name": "Bambu ASA-Aero @BBL P1P",
+            "sub_path": "filament/Bambu ASA-Aero @BBL P1P.json"
         },
         {
-            "name": "Bambu PLA Metal @BBL A1M",
-            "sub_path": "filament/Bambu PLA Metal @BBL A1M.json"
+            "name": "Bambu ASA-Aero @BBL X1C",
+            "sub_path": "filament/Bambu ASA-Aero @BBL X1C.json"
         },
         {
-            "name": "Bambu PLA Metal @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Metal @BBL A1M 0.2 nozzle.json"
+            "name": "Bambu ASA-CF @BBL A1",
+            "sub_path": "filament/Bambu ASA-CF @BBL A1.json"
         },
         {
-            "name": "Bambu PLA Metal @BBL A1",
-            "sub_path": "filament/Bambu PLA Metal @BBL A1.json"
+            "name": "Bambu ASA-CF @BBL A1 0.6 nozzle",
+            "sub_path": "filament/Bambu ASA-CF @BBL A1 0.6 nozzle.json"
         },
         {
-            "name": "Bambu PLA Metal @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Metal @BBL A1 0.2 nozzle.json"
+            "name": "Bambu ASA-CF @BBL P1P",
+            "sub_path": "filament/Bambu ASA-CF @BBL P1P.json"
         },
         {
-            "name": "Bambu PLA Silk @BBL X1",
-            "sub_path": "filament/Bambu PLA Silk @BBL X1.json"
+            "name": "Bambu ASA-CF @BBL P1P 0.6 nozzle",
+            "sub_path": "filament/Bambu ASA-CF @BBL P1P 0.6 nozzle.json"
         },
         {
-            "name": "Bambu PLA Silk @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Silk @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu ASA-CF @BBL X1C",
+            "sub_path": "filament/Bambu ASA-CF @BBL X1C.json"
         },
         {
-            "name": "Bambu PLA Silk @BBL X1C",
-            "sub_path": "filament/Bambu PLA Silk @BBL X1C.json"
+            "name": "Bambu ASA-CF @BBL X1C 0.6 nozzle",
+            "sub_path": "filament/Bambu ASA-CF @BBL X1C 0.6 nozzle.json"
         },
         {
-            "name": "Bambu PLA Silk @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PLA Silk @BBL P1P.json"
+            "name": "Generic ASA",
+            "sub_path": "filament/Generic ASA.json"
         },
         {
-            "name": "Bambu PLA Silk @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Bambu PLA Silk @BBL P1P 0.2 nozzle.json"
+            "name": "Generic ASA @0.2 nozzle",
+            "sub_path": "filament/Generic ASA @0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Silk @BBL A1M",
-            "sub_path": "filament/Bambu PLA Silk @BBL A1M.json"
+            "name": "Generic ASA @BBL A1",
+            "sub_path": "filament/Generic ASA @BBL A1.json"
         },
         {
-            "name": "Bambu PLA Silk @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Silk @BBL A1M 0.2 nozzle.json"
+            "name": "Generic ASA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Generic ASA @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PLA Silk @BBL A1",
-            "sub_path": "filament/Bambu PLA Silk @BBL A1.json"
+            "name": "Generic ASA @BBL P1P",
+            "sub_path": "filament/P1P/Generic ASA @BBL P1P.json"
         },
         {
-            "name": "Bambu PLA Silk @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Silk @BBL A1 0.2 nozzle.json"
+            "name": "Generic ASA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Generic ASA @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Bambu Support W @BBL X1C",
-            "sub_path": "filament/Bambu Support W @BBL X1C.json"
+            "name": "PolyLite ASA @BBL A1",
+            "sub_path": "filament/PolyLite ASA @BBL A1.json"
         },
         {
-            "name": "Bambu Support W @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu Support W @BBL X1C 0.2 nozzle.json"
+            "name": "PolyLite ASA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/PolyLite ASA @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu Support W @BBL X1",
-            "sub_path": "filament/Bambu Support W @BBL X1.json"
+            "name": "PolyLite ASA @BBL P1P",
+            "sub_path": "filament/PolyLite ASA @BBL P1P.json"
         },
         {
-            "name": "Bambu Support W @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Bambu Support W @BBL P1P 0.2 nozzle.json"
+            "name": "PolyLite ASA @BBL X1C",
+            "sub_path": "filament/PolyLite ASA @BBL X1C.json"
         },
         {
-            "name": "Bambu Support W @BBL P1P",
-            "sub_path": "filament/P1P/Bambu Support W @BBL P1P.json"
+            "name": "Generic BVOH @BBL A1",
+            "sub_path": "filament/Generic BVOH @BBL A1.json"
         },
         {
-            "name": "Bambu Support W @BBL A1M",
-            "sub_path": "filament/Bambu Support W @BBL A1M.json"
+            "name": "Generic BVOH @BBL A1M",
+            "sub_path": "filament/Generic BVOH @BBL A1M.json"
         },
         {
-            "name": "Bambu Support W @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu Support W @BBL A1M 0.2 nozzle.json"
+            "name": "Generic BVOH @BBL X1C",
+            "sub_path": "filament/Generic BVOH @BBL X1C.json"
         },
         {
-            "name": "Bambu Support W @BBL A1",
-            "sub_path": "filament/Bambu Support W @BBL A1.json"
+            "name": "Generic EVA @BBL A1",
+            "sub_path": "filament/Generic EVA @BBL A1.json"
         },
         {
-            "name": "Bambu Support W @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu Support W @BBL A1 0.2 nozzle.json"
+            "name": "Generic EVA @BBL A1M",
+            "sub_path": "filament/Generic EVA @BBL A1M.json"
         },
         {
-            "name": "SUNLU PLA Matte @BBL X1C",
-            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL X1C.json"
+            "name": "Generic EVA @BBL X1C",
+            "sub_path": "filament/Generic EVA @BBL X1C.json"
         },
         {
-            "name": "SUNLU PLA Matte @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL X1C 0.2 nozzle.json"
+            "name": "Generic HIPS @BBL A1",
+            "sub_path": "filament/Generic HIPS @BBL A1.json"
         },
         {
-            "name": "SUNLU PLA Matte @BBL X1",
-            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL X1.json"
+            "name": "Generic HIPS @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Generic HIPS @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "SUNLU PLA Matte @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL P1P 0.2 nozzle.json"
+            "name": "Generic HIPS @BBL A1M",
+            "sub_path": "filament/Generic HIPS @BBL A1M.json"
         },
         {
-            "name": "SUNLU PLA Matte @BBL P1P",
-            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL P1P.json"
+            "name": "Generic HIPS @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Generic HIPS @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "SUNLU PLA Matte @BBL A1M",
-            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL A1M.json"
+            "name": "Generic HIPS @BBL X1C",
+            "sub_path": "filament/Generic HIPS @BBL X1C.json"
         },
         {
-            "name": "SUNLU PLA Matte @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL A1M 0.2 nozzle.json"
+            "name": "Generic HIPS @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Generic HIPS @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "SUNLU PLA Matte @BBL A1",
-            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL A1.json"
+            "name": "Bambu PA-CF @BBL A1",
+            "sub_path": "filament/Bambu PA-CF @BBL A1.json"
         },
         {
-            "name": "SUNLU PLA Matte @BBL A1 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PA-CF @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PA-CF @BBL P1P.json"
         },
         {
-            "name": "SUNLU PLA+ @BBL X1C",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL X1C.json"
+            "name": "Bambu PA-CF @BBL X1C",
+            "sub_path": "filament/Bambu PA-CF @BBL X1C.json"
         },
         {
-            "name": "SUNLU PLA+ @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu PA6-CF @BBL A1",
+            "sub_path": "filament/Bambu PA6-CF @BBL A1.json"
         },
         {
-            "name": "SUNLU PLA+ @BBL X1",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL X1.json"
+            "name": "Bambu PA6-CF @BBL X1C",
+            "sub_path": "filament/Bambu PA6-CF @BBL X1C.json"
         },
         {
-            "name": "SUNLU PLA+ @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu PA6-CF @BBL X1E",
+            "sub_path": "filament/Bambu PA6-CF @BBL X1E.json"
         },
         {
-            "name": "SUNLU PLA+ @BBL P1P",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL P1P.json"
+            "name": "Bambu PA6-GF @BBL A1",
+            "sub_path": "filament/Bambu PA6-GF @BBL A1.json"
         },
         {
-            "name": "SUNLU PLA+ @BBL A1M",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL A1M.json"
+            "name": "Bambu PA6-GF @BBL P1P",
+            "sub_path": "filament/Bambu PA6-GF @BBL P1P.json"
         },
         {
-            "name": "SUNLU PLA+ @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL A1M 0.2 nozzle.json"
+            "name": "Bambu PA6-GF @BBL X1C",
+            "sub_path": "filament/Bambu PA6-GF @BBL X1C.json"
         },
         {
-            "name": "SUNLU PLA+ @BBL A1",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL A1.json"
+            "name": "Bambu PAHT-CF @BBL A1",
+            "sub_path": "filament/Bambu PAHT-CF @BBL A1.json"
         },
         {
-            "name": "SUNLU PLA+ @BBL A1 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PAHT-CF @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PAHT-CF @BBL P1P.json"
         },
         {
-            "name": "SUNLU PLA+ 2.0 @BBL X1C",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL X1C.json"
+            "name": "Bambu PAHT-CF @BBL X1C",
+            "sub_path": "filament/Bambu PAHT-CF @BBL X1C.json"
         },
         {
-            "name": "SUNLU PLA+ 2.0 @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu Support For PA/PET @BBL A1",
+            "sub_path": "filament/Bambu Support For PA PET @BBL A1.json"
         },
         {
-            "name": "SUNLU PLA+ 2.0 @BBL X1",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL X1.json"
+            "name": "Bambu Support For PA/PET @BBL P1P",
+            "sub_path": "filament/P1P/Bambu Support For PA PET @BBL P1P.json"
         },
         {
-            "name": "SUNLU PLA+ 2.0 @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu Support For PA/PET @BBL X1C",
+            "sub_path": "filament/Bambu Support For PA PET @BBL X1C.json"
         },
         {
-            "name": "SUNLU PLA+ 2.0 @BBL P1P",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL P1P.json"
+            "name": "Bambu Support G @BBL A1",
+            "sub_path": "filament/Bambu Support G @BBL A1.json"
         },
         {
-            "name": "SUNLU PLA+ 2.0 @BBL A1M",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL A1M.json"
+            "name": "Bambu Support G @BBL P1P",
+            "sub_path": "filament/P1P/Bambu Support G @BBL P1P.json"
         },
         {
-            "name": "SUNLU PLA+ 2.0 @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL A1M 0.2 nozzle.json"
+            "name": "Bambu Support G @BBL X1C",
+            "sub_path": "filament/Bambu Support G @BBL X1C.json"
         },
         {
-            "name": "SUNLU PLA+ 2.0 @BBL A1",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL A1.json"
+            "name": "Fiberon PA12-CF @BBL X1C",
+            "sub_path": "filament/Fiberon PA12-CF @BBL X1C.json"
         },
         {
-            "name": "SUNLU PLA+ 2.0 @BBL A1 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL A1 0.2 nozzle.json"
+            "name": "Fiberon PA6-CF @BBL X1C",
+            "sub_path": "filament/Fiberon PA6-CF @BBL X1C.json"
         },
         {
-            "name": "SUNLU Silk PLA+ @BBL X1C",
-            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL X1C.json"
+            "name": "Fiberon PA6-GF @BBL X1C",
+            "sub_path": "filament/Fiberon PA6-GF @BBL X1C.json"
         },
         {
-            "name": "SUNLU Silk PLA+ @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL X1C 0.2 nozzle.json"
+            "name": "Fiberon PA612-CF @BBL X1C",
+            "sub_path": "filament/Fiberon PA612-CF @BBL X1C.json"
         },
         {
-            "name": "SUNLU Silk PLA+ @BBL X1",
-            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL X1.json"
+            "name": "Generic PA @BBL A1",
+            "sub_path": "filament/Generic PA @BBL A1.json"
         },
         {
-            "name": "SUNLU Silk PLA+ @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL P1P 0.2 nozzle.json"
+            "name": "Generic PA-CF @BBL A1",
+            "sub_path": "filament/Generic PA-CF @BBL A1.json"
         },
         {
-            "name": "SUNLU Silk PLA+ @BBL P1P",
-            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL P1P.json"
+            "name": "Generic PA-CF @BBL X1E",
+            "sub_path": "filament/Generic PA-CF @BBL X1E.json"
         },
         {
-            "name": "SUNLU Silk PLA+ @BBL A1M",
-            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL A1M.json"
+            "name": "Bambu PC @BBL A1",
+            "sub_path": "filament/Bambu PC @BBL A1.json"
         },
         {
-            "name": "SUNLU Silk PLA+ @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL A1M 0.2 nozzle.json"
+            "name": "Bambu PC @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PC @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "SUNLU Silk PLA+ @BBL A1",
-            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL A1.json"
+            "name": "Bambu PC @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PC @BBL P1P.json"
         },
         {
-            "name": "SUNLU Silk PLA+ @BBL A1 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PC @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Bambu PC @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "SUNLU PLA Marble @BBL X1C",
-            "sub_path": "filament/SUNLU/SUNLU Marble PLA @BBL X1C.json"
+            "name": "Bambu PC @BBL X1C",
+            "sub_path": "filament/Bambu PC @BBL X1C.json"
         },
         {
-            "name": "SUNLU PLA Marble @BBL X1",
-            "sub_path": "filament/SUNLU/SUNLU Marble PLA @BBL X1.json"
+            "name": "Bambu PC @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PC @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "SUNLU PLA Marble @BBL P1P",
-            "sub_path": "filament/SUNLU/SUNLU Marble PLA @BBL P1P.json"
+            "name": "Bambu PC @BBL X1C 0.6 nozzle",
+            "sub_path": "filament/Bambu PC @BBL X1C 0.6 nozzle.json"
         },
         {
-            "name": "SUNLU PLA Marble @BBL A1M",
-            "sub_path": "filament/SUNLU/SUNLU Marble PLA @BBL A1M.json"
+            "name": "Bambu PC @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PC @BBL X1C 0.8 nozzle.json"
         },
         {
-            "name": "SUNLU PLA Marble @BBL A1",
-            "sub_path": "filament/SUNLU/SUNLU Marble PLA @BBL A1.json"
+            "name": "Bambu PC FR @BBL A1",
+            "sub_path": "filament/Bambu PC FR @BBL A1.json"
         },
         {
-            "name": "SUNLU Wood PLA @BBL X1C",
-            "sub_path": "filament/SUNLU/SUNLU Wood PLA @BBL X1C.json"
+            "name": "Bambu PC FR @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "SUNLU Wood PLA @BBL X1",
-            "sub_path": "filament/SUNLU/SUNLU Wood PLA @BBL X1.json"
+            "name": "Bambu PC FR @BBL P1P",
+            "sub_path": "filament/Bambu PC FR @BBL P1P.json"
         },
         {
-            "name": "SUNLU Wood PLA @BBL P1P",
-            "sub_path": "filament/SUNLU/SUNLU Wood PLA @BBL P1P.json"
+            "name": "Bambu PC FR @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "SUNLU Wood PLA @BBL A1M",
-            "sub_path": "filament/SUNLU/SUNLU Wood PLA @BBL A1M.json"
+            "name": "Bambu PC FR @BBL P1S",
+            "sub_path": "filament/Bambu PC FR @BBL P1S.json"
         },
         {
-            "name": "SUNLU Wood PLA @BBL A1",
-            "sub_path": "filament/SUNLU/SUNLU Wood PLA @BBL A1.json"
+            "name": "Bambu PC FR @BBL P1S 0.2 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL P1S 0.2 nozzle.json"
         },
         {
-            "name": "SUNLU PETG @BBL X1C",
-            "sub_path": "filament/SUNLU/SUNLU PETG @BBL X1C.json"
+            "name": "Bambu PC FR @BBL P1S 0.6 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL P1S 0.6 nozzle.json"
         },
         {
-            "name": "SUNLU PETG @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PETG @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu PC FR @BBL P1S 0.8 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL P1S 0.8 nozzle.json"
         },
         {
-            "name": "SUNLU PETG @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PETG @BBL X1C 0.8 nozzle.json"
+            "name": "Bambu PC FR @BBL X1C",
+            "sub_path": "filament/Bambu PC FR @BBL X1C.json"
         },
         {
-            "name": "SUNLU PETG @BBL A1M",
-            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1M.json"
+            "name": "Bambu PC FR @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "SUNLU PETG @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1M 0.2 nozzle.json"
+            "name": "Bambu PC FR @BBL X1C 0.6 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL X1C 0.6 nozzle.json"
         },
         {
-            "name": "SUNLU PETG @BBL A1",
-            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1.json"
+            "name": "Bambu PC FR @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL X1C 0.8 nozzle.json"
         },
         {
-            "name": "SUNLU PETG @BBL A1 0.2 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PC FR @BBL X1E",
+            "sub_path": "filament/Bambu PC FR @BBL X1E.json"
         },
         {
-            "name": "SUNLU PETG @BBL A1 0.8 nozzle",
-            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1 0.8 nozzle.json"
+            "name": "Bambu PC FR @BBL X1E 0.2 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL X1E 0.2 nozzle.json"
         },
         {
-            "name": "eSUN PLA+ @BBL X1C",
-            "sub_path": "filament/eSUN PLA+ @BBL X1C.json"
+            "name": "Bambu PC FR @BBL X1E 0.6 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL X1E 0.6 nozzle.json"
         },
         {
-            "name": "eSUN PLA+ @BBL X1",
-            "sub_path": "filament/eSUN PLA+ @BBL X1.json"
+            "name": "Bambu PC FR @BBL X1E 0.8 nozzle",
+            "sub_path": "filament/Bambu PC FR @BBL X1E 0.8 nozzle.json"
         },
         {
-            "name": "eSUN PLA+ @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/eSUN PLA+ @BBL X1C 0.2 nozzle.json"
+            "name": "Generic PC",
+            "sub_path": "filament/Generic PC.json"
         },
         {
-            "name": "eSUN PLA+ @BBL P1P",
-            "sub_path": "filament/P1P/eSUN PLA+ @BBL P1P.json"
+            "name": "Generic PC @0.2 nozzle",
+            "sub_path": "filament/Generic PC @0.2 nozzle.json"
         },
         {
-            "name": "eSUN PLA+ @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/eSUN PLA+ @BBL P1P 0.2 nozzle.json"
+            "name": "Generic PC @BBL A1",
+            "sub_path": "filament/Generic PC @BBL A1.json"
         },
         {
-            "name": "eSUN PLA+ @BBL A1M",
-            "sub_path": "filament/eSUN PLA+ @BBL A1M.json"
+            "name": "Generic PC @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Generic PC @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "eSUN PLA+ @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/eSUN PLA+ @BBL A1M 0.2 nozzle.json"
+            "name": "Generic PC @BBL P1P",
+            "sub_path": "filament/P1P/Generic PC @BBL P1P.json"
         },
         {
-            "name": "eSUN PLA+ @BBL A1",
-            "sub_path": "filament/eSUN PLA+ @BBL A1.json"
+            "name": "Generic PC @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Generic PC @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "eSUN PLA+ @BBL A1 0.2 nozzle",
-            "sub_path": "filament/eSUN PLA+ @BBL A1 0.2 nozzle.json"
+            "name": "Generic PCTG @BBL A1",
+            "sub_path": "filament/Generic PCTG @BBL A1.json"
         },
         {
-            "name": "PolyTerra PLA @BBL X1C",
-            "sub_path": "filament/PolyTerra PLA @BBL X1C.json"
+            "name": "Generic PCTG @BBL A1M",
+            "sub_path": "filament/Generic PCTG @BBL A1M.json"
         },
         {
-            "name": "PolyTerra PLA @BBL X1",
-            "sub_path": "filament/PolyTerra PLA @BBL X1.json"
+            "name": "Generic PCTG @BBL X1C",
+            "sub_path": "filament/Generic PCTG @BBL X1C.json"
         },
         {
-            "name": "PolyTerra PLA @BBL P1P",
-            "sub_path": "filament/P1P/PolyTerra PLA @BBL P1P.json"
+            "name": "Generic PE @BBL A1",
+            "sub_path": "filament/Generic PE @BBL A1.json"
         },
         {
-            "name": "PolyTerra PLA @BBL A1M",
-            "sub_path": "filament/PolyTerra PLA @BBL A1M.json"
+            "name": "Generic PE @BBL A1M",
+            "sub_path": "filament/Generic PE @BBL A1M.json"
         },
         {
-            "name": "PolyTerra PLA @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/PolyTerra PLA @BBL A1M 0.2 nozzle.json"
+            "name": "Generic PE @BBL X1C",
+            "sub_path": "filament/Generic PE @BBL X1C.json"
         },
         {
-            "name": "PolyTerra PLA @BBL A1",
-            "sub_path": "filament/PolyTerra PLA @BBL A1.json"
+            "name": "Generic PE-CF @BBL A1",
+            "sub_path": "filament/Generic PE-CF @BBL A1.json"
         },
         {
-            "name": "PolyTerra PLA @BBL A1 0.2 nozzle",
-            "sub_path": "filament/PolyTerra PLA @BBL A1 0.2 nozzle.json"
+            "name": "Generic PE-CF @BBL A1M",
+            "sub_path": "filament/Generic PE-CF @BBL A1M.json"
         },
         {
-            "name": "PolyLite PLA @BBL X1C",
-            "sub_path": "filament/PolyLite PLA @BBL X1C.json"
+            "name": "Generic PE-CF @BBL X1C",
+            "sub_path": "filament/Generic PE-CF @BBL X1C.json"
         },
         {
-            "name": "PolyLite PLA @BBL X1",
-            "sub_path": "filament/PolyLite PLA @BBL X1.json"
+            "name": "Bambu PET-CF @BBL A1",
+            "sub_path": "filament/Bambu PET-CF @BBL A1.json"
         },
         {
-            "name": "PolyLite PLA @BBL P1P",
-            "sub_path": "filament/P1P/PolyLite PLA @BBL P1P.json"
+            "name": "Bambu PET-CF @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PET-CF @BBL P1P.json"
         },
         {
-            "name": "PolyLite PLA @BBL A1M",
-            "sub_path": "filament/PolyLite PLA @BBL A1M.json"
-        },
-        {
-            "name": "PolyLite PLA @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/PolyLite PLA @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "PolyLite PLA @BBL A1",
-            "sub_path": "filament/PolyLite PLA @BBL A1.json"
-        },
-        {
-            "name": "PolyLite PLA @BBL A1 0.2 nozzle",
-            "sub_path": "filament/PolyLite PLA @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PLA",
-            "sub_path": "filament/Generic PLA.json"
-        },
-        {
-            "name": "Generic PLA @0.2 nozzle",
-            "sub_path": "filament/Generic PLA @0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PLA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Generic PLA @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PLA @BBL P1P",
-            "sub_path": "filament/P1P/Generic PLA @BBL P1P.json"
-        },
-        {
-            "name": "Generic PLA @BBL A1M",
-            "sub_path": "filament/Generic PLA @BBL A1M.json"
-        },
-        {
-            "name": "Generic PLA @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Generic PLA @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PLA @BBL A1",
-            "sub_path": "filament/Generic PLA @BBL A1.json"
-        },
-        {
-            "name": "Generic PLA @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Generic PLA @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PLA Silk",
-            "sub_path": "filament/Generic PLA Silk.json"
-        },
-        {
-            "name": "Generic PLA Silk @BBL P1P",
-            "sub_path": "filament/P1P/Generic PLA Silk @BBL P1P.json"
-        },
-        {
-            "name": "Generic PLA Silk @BBL A1M",
-            "sub_path": "filament/Generic PLA Silk @BBL A1M.json"
-        },
-        {
-            "name": "Generic PLA Silk @BBL A1",
-            "sub_path": "filament/Generic PLA Silk @BBL A1.json"
-        },
-        {
-            "name": "Generic PLA-CF",
-            "sub_path": "filament/Generic PLA-CF.json"
-        },
-        {
-            "name": "Generic PLA-CF @BBL P1P",
-            "sub_path": "filament/P1P/Generic PLA-CF @BBL P1P.json"
-        },
-        {
-            "name": "Generic PLA-CF @BBL A1M",
-            "sub_path": "filament/Generic PLA-CF @BBL A1M.json"
-        },
-        {
-            "name": "Generic PLA-CF @BBL A1",
-            "sub_path": "filament/Generic PLA-CF @BBL A1.json"
-        },
-        {
-            "name": "Generic SBS",
-            "sub_path": "filament/Generic SBS.json"
-        },
-        {
-            "name": "Bambu PLA-CF @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PLA-CF @BBL X1C 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA-CF @BBL X1C",
-            "sub_path": "filament/Bambu PLA-CF @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PLA-CF @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PLA-CF @BBL P1P.json"
-        },
-        {
-            "name": "Bambu PLA-CF @BBL P1P 0.8 nozzle",
-            "sub_path": "filament/P1P/Bambu PLA-CF @BBL P1P 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA-CF @BBL A1M",
-            "sub_path": "filament/Bambu PLA-CF @BBL A1M.json"
-        },
-        {
-            "name": "Bambu PLA-CF @BBL A1M 0.8 nozzle",
-            "sub_path": "filament/Bambu PLA-CF @BBL A1M 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA-CF @BBL A1",
-            "sub_path": "filament/Bambu PLA-CF @BBL A1.json"
-        },
-        {
-            "name": "Bambu PLA-CF @BBL A1 0.8 nozzle",
-            "sub_path": "filament/Bambu PLA-CF @BBL A1 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu Support For PLA @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu Support For PLA @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu Support For PLA @BBL X1C",
-            "sub_path": "filament/Bambu Support For PLA @BBL X1C.json"
-        },
-        {
-            "name": "Bambu Support For PLA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Bambu Support For PLA @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu Support For PLA @BBL P1P",
-            "sub_path": "filament/P1P/Bambu Support For PLA @BBL P1P.json"
-        },
-        {
-            "name": "Bambu Support For PLA @BBL A1M",
-            "sub_path": "filament/Bambu Support For PLA @BBL A1M.json"
-        },
-        {
-            "name": "Bambu Support For PLA @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu Support For PLA @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu Support For PLA @BBL A1",
-            "sub_path": "filament/Bambu Support For PLA @BBL A1.json"
-        },
-        {
-            "name": "Bambu Support For PLA @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu Support For PLA @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Aero @BBL X1",
-            "sub_path": "filament/Bambu PLA Aero @BBL X1.json"
-        },
-        {
-            "name": "Bambu PLA Aero @BBL X1C",
-            "sub_path": "filament/Bambu PLA Aero @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PLA Aero @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PLA Aero @BBL P1P.json"
-        },
-        {
-            "name": "Bambu PLA Aero @BBL A1M",
-            "sub_path": "filament/Bambu PLA Aero @BBL A1M.json"
-        },
-        {
-            "name": "Bambu PLA Aero @BBL A1",
-            "sub_path": "filament/Bambu PLA Aero @BBL A1.json"
-        },
-        {
-            "name": "Overture PLA @BBL X1C",
-            "sub_path": "filament/Overture PLA @BBL X1C.json"
-        },
-        {
-            "name": "Overture PLA @BBL X1",
-            "sub_path": "filament/Overture PLA @BBL X1.json"
-        },
-        {
-            "name": "Overture PLA @BBL P1P",
-            "sub_path": "filament/Overture PLA @BBL P1P.json"
-        },
-        {
-            "name": "Overture PLA @BBL A1M",
-            "sub_path": "filament/Overture PLA @BBL A1M.json"
-        },
-        {
-            "name": "Overture PLA @BBL A1",
-            "sub_path": "filament/Overture PLA @BBL A1.json"
-        },
-        {
-            "name": "Overture PLA @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Overture PLA @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Overture Matte PLA @BBL X1C",
-            "sub_path": "filament/Overture Matte PLA @BBL X1C.json"
-        },
-        {
-            "name": "Overture Matte PLA @BBL X1",
-            "sub_path": "filament/Overture Matte PLA @BBL X1.json"
-        },
-        {
-            "name": "Overture Matte PLA @BBL P1P",
-            "sub_path": "filament/Overture Matte PLA @BBL P1P.json"
-        },
-        {
-            "name": "Overture Matte PLA @BBL A1M",
-            "sub_path": "filament/Overture Matte PLA @BBL A1M.json"
-        },
-        {
-            "name": "Overture Matte PLA @BBL A1",
-            "sub_path": "filament/Overture Matte PLA @BBL A1.json"
-        },
-        {
-            "name": "Overture Matte PLA @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Overture Matte PLA @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PLA High Speed @BBL X1C",
-            "sub_path": "filament/Generic PLA High Speed @BBL X1C.json"
-        },
-        {
-            "name": "Generic PLA High Speed @BBL P1P",
-            "sub_path": "filament/Generic PLA High Speed @BBL P1P.json"
-        },
-        {
-            "name": "Generic PLA High Speed @BBL A1M",
-            "sub_path": "filament/Generic PLA High Speed @BBL A1M.json"
-        },
-        {
-            "name": "Generic PLA High Speed @BBL A1",
-            "sub_path": "filament/Generic PLA High Speed @BBL A1.json"
-        },
-        {
-            "name": "Generic PLA High Speed @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Generic PLA High Speed @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Glow @BBL X1C",
-            "sub_path": "filament/Bambu PLA Glow @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PLA Glow @BBL P1P",
-            "sub_path": "filament/Bambu PLA Glow @BBL P1P.json"
-        },
-        {
-            "name": "Bambu PLA Glow @BBL X1E",
-            "sub_path": "filament/Bambu PLA Glow @BBL X1E.json"
-        },
-        {
-            "name": "Bambu PLA Glow @BBL X1",
-            "sub_path": "filament/Bambu PLA Glow @BBL X1.json"
-        },
-        {
-            "name": "Bambu PLA Glow @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Glow @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Glow @BBL A1",
-            "sub_path": "filament/Bambu PLA Glow @BBL A1.json"
-        },
-        {
-            "name": "Bambu PLA Dynamic @BBL X1C",
-            "sub_path": "filament/Bambu PLA Dynamic @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PLA Dynamic @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Dynamic @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Dynamic @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PLA Dynamic @BBL X1C 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Dynamic @BBL P1P",
-            "sub_path": "filament/Bambu PLA Dynamic @BBL P1P.json"
-        },
-        {
-            "name": "Bambu PLA Dynamic @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Dynamic @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Dynamic @BBL A1",
-            "sub_path": "filament/Bambu PLA Dynamic @BBL A1.json"
-        },
-        {
-            "name": "Bambu PLA Dynamic @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Dynamic @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Dynamic @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Dynamic @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Dynamic @BBL A1M",
-            "sub_path": "filament/Bambu PLA Dynamic @BBL A1M.json"
-        },
-        {
-            "name": "Bambu PLA Galaxy @BBL X1C",
-            "sub_path": "filament/Bambu PLA Galaxy @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PLA Galaxy @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Galaxy @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Galaxy @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PLA Galaxy @BBL X1C 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Galaxy @BBL P1P",
-            "sub_path": "filament/Bambu PLA Galaxy @BBL P1P.json"
-        },
-        {
-            "name": "Bambu PLA Galaxy @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Galaxy @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Galaxy @BBL A1",
-            "sub_path": "filament/Bambu PLA Galaxy @BBL A1.json"
-        },
-        {
-            "name": "Bambu PLA Galaxy @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Galaxy @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Galaxy @BBL A1M",
-            "sub_path": "filament/Bambu PLA Galaxy @BBL A1M.json"
-        },
-        {
-            "name": "Bambu PLA Galaxy @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Galaxy @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu Support For PLA/PETG @BBL X1C",
-            "sub_path": "filament/Bambu Support For PLA-PETG @BBL X1C.json"
-        },
-        {
-            "name": "Bambu Support For PLA/PETG @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu Support For PLA-PETG @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu Support For PLA/PETG @BBL P1P",
-            "sub_path": "filament/Bambu Support For PLA-PETG @BBL P1P.json"
-        },
-        {
-            "name": "Bambu Support For PLA/PETG @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Bambu Support For PLA-PETG @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu Support For PLA/PETG @BBL A1M",
-            "sub_path": "filament/Bambu Support For PLA-PETG @BBL A1M.json"
-        },
-        {
-            "name": "Bambu Support For PLA/PETG @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu Support For PLA-PETG @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu Support For PLA/PETG @BBL A1",
-            "sub_path": "filament/Bambu Support For PLA-PETG @BBL A1.json"
-        },
-        {
-            "name": "Bambu Support For PLA/PETG @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu Support For PLA-PETG @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Wood @BBL X1C",
-            "sub_path": "filament/Bambu PLA Wood @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PLA Wood @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PLA Wood @BBL X1C 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Wood @BBL X1",
-            "sub_path": "filament/Bambu PLA Wood @BBL X1.json"
-        },
-        {
-            "name": "Bambu PLA Wood @BBL P1P",
-            "sub_path": "filament/Bambu PLA Wood @BBL P1P.json"
-        },
-        {
-            "name": "Bambu PLA Wood @BBL A1",
-            "sub_path": "filament/Bambu PLA Wood @BBL A1.json"
-        },
-        {
-            "name": "Bambu PLA Wood @BBL A1M",
-            "sub_path": "filament/Bambu PLA Wood @BBL A1M.json"
-        },
-        {
-            "name": "Bambu PLA Silk+ @BBL X1C",
-            "sub_path": "filament/Bambu PLA Silk+ @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PLA Silk+ @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Silk+ @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Silk+ @BBL X1",
-            "sub_path": "filament/Bambu PLA Silk+ @BBL X1.json"
-        },
-        {
-            "name": "Bambu PLA Silk+ @BBL P1P",
-            "sub_path": "filament/Bambu PLA Silk+ @BBL P1P.json"
-        },
-        {
-            "name": "Bambu PLA Silk+ @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Silk+ @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Silk+ @BBL A1",
-            "sub_path": "filament/Bambu PLA Silk+ @BBL A1.json"
-        },
-        {
-            "name": "Bambu PLA Silk+ @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Silk+ @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Silk+ @BBL A1M",
-            "sub_path": "filament/Bambu PLA Silk+ @BBL A1M.json"
-        },
-        {
-            "name": "Bambu PLA Silk+ @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Silk+ @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu TPU 95A @BBL X1C",
-            "sub_path": "filament/Bambu TPU 95A @BBL X1C.json"
-        },
-        {
-            "name": "Bambu TPU 95A @BBL X1",
-            "sub_path": "filament/Bambu TPU 95A @BBL X1.json"
-        },
-        {
-            "name": "Bambu TPU 95A @BBL P1P",
-            "sub_path": "filament/P1P/Bambu TPU 95A @BBL P1P.json"
-        },
-        {
-            "name": "Bambu TPU 95A @BBL A1M",
-            "sub_path": "filament/Bambu TPU 95A @BBL A1M.json"
-        },
-        {
-            "name": "Bambu TPU 95A @BBL A1",
-            "sub_path": "filament/Bambu TPU 95A @BBL A1.json"
-        },
-        {
-            "name": "Generic TPU @BBL A1M",
-            "sub_path": "filament/Generic TPU @BBL A1M.json"
-        },
-        {
-            "name": "Generic TPU @BBL A1",
-            "sub_path": "filament/Generic TPU @BBL A1.json"
-        },
-        {
-            "name": "Bambu TPU 95A HF @BBL X1C",
-            "sub_path": "filament/Bambu TPU 95A HF @BBL X1C.json"
-        },
-        {
-            "name": "Bambu TPU 95A HF @BBL X1",
-            "sub_path": "filament/Bambu TPU 95A HF @BBL X1.json"
-        },
-        {
-            "name": "Bambu TPU 95A HF @BBL P1P",
-            "sub_path": "filament/Bambu TPU 95A HF @BBL P1P.json"
-        },
-        {
-            "name": "Bambu TPU 95A HF @BBL P1S",
-            "sub_path": "filament/Bambu TPU 95A HF @BBL P1S.json"
-        },
-        {
-            "name": "Bambu TPU 95A HF @BBL X1E",
-            "sub_path": "filament/Bambu TPU 95A HF @BBL X1E.json"
-        },
-        {
-            "name": "Bambu TPU 95A HF @BBL A1M",
-            "sub_path": "filament/Bambu TPU 95A HF @BBL A1M.json"
-        },
-        {
-            "name": "Bambu TPU 95A HF @BBL A1",
-            "sub_path": "filament/Bambu TPU 95A HF @BBL A1.json"
-        },
-        {
-            "name": "Generic TPU for AMS @BBL X1C",
-            "sub_path": "filament/Generic TPU for AMS @BBL X1C.json"
-        },
-        {
-            "name": "Generic TPU for AMS @BBL P1P",
-            "sub_path": "filament/Generic TPU for AMS @BBL P1P.json"
-        },
-        {
-            "name": "Generic TPU for AMS @BBL A1",
-            "sub_path": "filament/Generic TPU for AMS @BBL A1.json"
-        },
-        {
-            "name": "Generic TPU for AMS @BBL A1M",
-            "sub_path": "filament/Generic TPU for AMS @BBL A1M.json"
-        },
-        {
-            "name": "Bambu TPU for AMS @BBL X1C",
-            "sub_path": "filament/Bambu TPU for AMS @BBL X1C.json"
-        },
-        {
-            "name": "Bambu TPU for AMS @BBL P1P",
-            "sub_path": "filament/Bambu TPU for AMS @BBL P1P.json"
-        },
-        {
-            "name": "Bambu TPU for AMS @BBL A1",
-            "sub_path": "filament/Bambu TPU for AMS @BBL A1.json"
-        },
-        {
-            "name": "Bambu TPU for AMS @BBL A1M",
-            "sub_path": "filament/Bambu TPU for AMS @BBL A1M.json"
-        },
-        {
-            "name": "Bambu PETG Basic @BBL X1C",
-            "sub_path": "filament/Bambu PETG Basic @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PETG Basic @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PETG Basic @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG Basic @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PETG Basic @BBL X1C 0.8 nozzle.json"
+            "name": "Bambu PET-CF @BBL X1C",
+            "sub_path": "filament/Bambu PET-CF @BBL X1C.json"
         },
         {
             "name": "Bambu PETG Basic @BBL A1",
@@ -2162,156 +1594,16 @@
             "sub_path": "filament/Bambu PETG Basic @BBL A1 0.8 nozzle.json"
         },
         {
-            "name": "Bambu PET-CF @BBL X1C",
-            "sub_path": "filament/Bambu PET-CF @BBL X1C.json"
+            "name": "Bambu PETG Basic @BBL X1C",
+            "sub_path": "filament/Bambu PETG Basic @BBL X1C.json"
         },
         {
-            "name": "Bambu PET-CF @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PET-CF @BBL P1P.json"
+            "name": "Bambu PETG Basic @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PETG Basic @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PET-CF @BBL A1",
-            "sub_path": "filament/Bambu PET-CF @BBL A1.json"
-        },
-        {
-            "name": "Generic PETG",
-            "sub_path": "filament/Generic PETG.json"
-        },
-        {
-            "name": "Generic PETG @0.2 nozzle",
-            "sub_path": "filament/Generic PETG @0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PETG @BBL P1P",
-            "sub_path": "filament/P1P/Generic PETG @BBL P1P.json"
-        },
-        {
-            "name": "Generic PETG @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Generic PETG @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PETG @BBL A1M",
-            "sub_path": "filament/Generic PETG @BBL A1M.json"
-        },
-        {
-            "name": "Generic PETG @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Generic PETG @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PETG @BBL A1",
-            "sub_path": "filament/Generic PETG @BBL A1.json"
-        },
-        {
-            "name": "Generic PETG @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Generic PETG @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PETG-CF @BBL X1C",
-            "sub_path": "filament/Generic PETG-CF @BBL X1C.json"
-        },
-        {
-            "name": "Generic PETG-CF @BBL P1P",
-            "sub_path": "filament/P1P/Generic PETG-CF @BBL P1P.json"
-        },
-        {
-            "name": "Generic PETG-CF @BBL A1",
-            "sub_path": "filament/Generic PETG-CF @BBL A1.json"
-        },
-        {
-            "name": "Bambu PETG-CF @BBL X1C",
-            "sub_path": "filament/Bambu PETG-CF @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PETG-CF @BBL X1C 0.4 nozzle",
-            "sub_path": "filament/Bambu PETG-CF @BBL X1C 0.4 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG-CF @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PETG-CF @BBL P1P.json"
-        },
-        {
-            "name": "Bambu PETG-CF @BBL P1P 0.4 nozzle",
-            "sub_path": "filament/P1P/Bambu PETG-CF @BBL P1P 0.4 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG-CF @BBL A1M",
-            "sub_path": "filament/Bambu PETG-CF @BBL A1M.json"
-        },
-        {
-            "name": "Bambu PETG-CF @BBL A1 0.4 nozzle",
-            "sub_path": "filament/Bambu PETG-CF @BBL A1 0.4 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG-CF @BBL A1 0.8 nozzle",
-            "sub_path": "filament/Bambu PETG-CF @BBL A1 0.8 nozzle.json"
-        },
-        {
-            "name": "PolyLite PETG @BBL X1C",
-            "sub_path": "filament/PolyLite PETG @BBL X1C.json"
-        },
-        {
-            "name": "PolyLite PETG @BBL P1P",
-            "sub_path": "filament/PolyLite PETG @BBL P1P.json"
-        },
-        {
-            "name": "PolyLite PETG @BBL A1M",
-            "sub_path": "filament/PolyLite PETG @BBL A1M.json"
-        },
-        {
-            "name": "PolyLite PETG @BBL A1",
-            "sub_path": "filament/PolyLite PETG @BBL A1.json"
-        },
-        {
-            "name": "PolyLite PETG @BBL A1 0.2 nozzle",
-            "sub_path": "filament/PolyLite PETG @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG Translucent @BBL X1C",
-            "sub_path": "filament/Bambu PETG Translucent @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PETG Translucent @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PETG Translucent @BBL X1C 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG Translucent @BBL A1M",
-            "sub_path": "filament/Bambu PETG Translucent @BBL A1M.json"
-        },
-        {
-            "name": "Bambu PETG Translucent @BBL A1M 0.8 nozzle",
-            "sub_path": "filament/Bambu PETG Translucent @BBL A1M 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG Translucent @BBL A1 0.8 nozzle",
-            "sub_path": "filament/Bambu PETG Translucent @BBL A1 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG Translucent @BBL A1",
-            "sub_path": "filament/Bambu PETG Translucent @BBL A1.json"
-        },
-        {
-            "name": "Bambu PETG Translucent @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PETG Translucent @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG Translucent @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu PETG Translucent @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG Translucent @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PETG Translucent @BBL A1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG HF @BBL X1C",
-            "sub_path": "filament/Bambu PETG HF @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PETG HF @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PETG HF @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG HF @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PETG HF @BBL X1C 0.8 nozzle.json"
+            "name": "Bambu PETG Basic @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PETG Basic @BBL X1C 0.8 nozzle.json"
         },
         {
             "name": "Bambu PETG HF @BBL A1",
@@ -2338,16 +1630,84 @@
             "sub_path": "filament/Bambu PETG HF @BBL A1M 0.8 nozzle.json"
         },
         {
-            "name": "Generic PCTG @BBL X1C",
-            "sub_path": "filament/Generic PCTG @BBL X1C.json"
+            "name": "Bambu PETG HF @BBL X1C",
+            "sub_path": "filament/Bambu PETG HF @BBL X1C.json"
         },
         {
-            "name": "Generic PCTG @BBL A1",
-            "sub_path": "filament/Generic PCTG @BBL A1.json"
+            "name": "Bambu PETG HF @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PETG HF @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Generic PCTG @BBL A1M",
-            "sub_path": "filament/Generic PCTG @BBL A1M.json"
+            "name": "Bambu PETG HF @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PETG HF @BBL X1C 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu PETG Translucent @BBL A1",
+            "sub_path": "filament/Bambu PETG Translucent @BBL A1.json"
+        },
+        {
+            "name": "Bambu PETG Translucent @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PETG Translucent @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PETG Translucent @BBL A1 0.8 nozzle",
+            "sub_path": "filament/Bambu PETG Translucent @BBL A1 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu PETG Translucent @BBL A1M",
+            "sub_path": "filament/Bambu PETG Translucent @BBL A1M.json"
+        },
+        {
+            "name": "Bambu PETG Translucent @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu PETG Translucent @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PETG Translucent @BBL A1M 0.8 nozzle",
+            "sub_path": "filament/Bambu PETG Translucent @BBL A1M 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu PETG Translucent @BBL X1C",
+            "sub_path": "filament/Bambu PETG Translucent @BBL X1C.json"
+        },
+        {
+            "name": "Bambu PETG Translucent @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PETG Translucent @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PETG Translucent @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PETG Translucent @BBL X1C 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu PETG-CF @BBL A1 0.4 nozzle",
+            "sub_path": "filament/Bambu PETG-CF @BBL A1 0.4 nozzle.json"
+        },
+        {
+            "name": "Bambu PETG-CF @BBL A1 0.8 nozzle",
+            "sub_path": "filament/Bambu PETG-CF @BBL A1 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu PETG-CF @BBL A1M",
+            "sub_path": "filament/Bambu PETG-CF @BBL A1M.json"
+        },
+        {
+            "name": "Bambu PETG-CF @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PETG-CF @BBL P1P.json"
+        },
+        {
+            "name": "Bambu PETG-CF @BBL P1P 0.4 nozzle",
+            "sub_path": "filament/P1P/Bambu PETG-CF @BBL P1P 0.4 nozzle.json"
+        },
+        {
+            "name": "Bambu PETG-CF @BBL X1C",
+            "sub_path": "filament/Bambu PETG-CF @BBL X1C.json"
+        },
+        {
+            "name": "Bambu PETG-CF @BBL X1C 0.4 nozzle",
+            "sub_path": "filament/Bambu PETG-CF @BBL X1C 0.4 nozzle.json"
+        },
+        {
+            "name": "Fiberon PET-CF @BBL X1C",
+            "sub_path": "filament/Fiberon PET-CF @BBL X1C.json"
         },
         {
             "name": "Fiberon PETG-ESD @BBL X1C",
@@ -2358,24 +1718,36 @@
             "sub_path": "filament/Fiberon PETG-rCF @BBL X1C.json"
         },
         {
-            "name": "Fiberon PET-CF @BBL X1C",
-            "sub_path": "filament/Fiberon PET-CF @BBL X1C.json"
+            "name": "Generic PETG",
+            "sub_path": "filament/Generic PETG.json"
         },
         {
-            "name": "Generic PETG HF @BBL X1C",
-            "sub_path": "filament/Generic PETG HF @BBL X1C.json"
+            "name": "Generic PETG @0.2 nozzle",
+            "sub_path": "filament/Generic PETG @0.2 nozzle.json"
         },
         {
-            "name": "Generic PETG HF @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Generic PETG HF @BBL X1C 0.2 nozzle.json"
+            "name": "Generic PETG @BBL A1",
+            "sub_path": "filament/Generic PETG @BBL A1.json"
         },
         {
-            "name": "Generic PETG HF @BBL P1P",
-            "sub_path": "filament/Generic PETG HF @BBL P1P.json"
+            "name": "Generic PETG @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Generic PETG @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Generic PETG HF @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Generic PETG HF @BBL P1P 0.2 nozzle.json"
+            "name": "Generic PETG @BBL A1M",
+            "sub_path": "filament/Generic PETG @BBL A1M.json"
+        },
+        {
+            "name": "Generic PETG @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Generic PETG @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PETG @BBL P1P",
+            "sub_path": "filament/P1P/Generic PETG @BBL P1P.json"
+        },
+        {
+            "name": "Generic PETG @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Generic PETG @BBL P1P 0.2 nozzle.json"
         },
         {
             "name": "Generic PETG HF @BBL A1",
@@ -2394,368 +1766,1100 @@
             "sub_path": "filament/Generic PETG HF @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "Bambu ABS @BBL X1C",
-            "sub_path": "filament/Bambu ABS @BBL X1C.json"
+            "name": "Generic PETG HF @BBL P1P",
+            "sub_path": "filament/Generic PETG HF @BBL P1P.json"
         },
         {
-            "name": "Bambu ABS @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu ABS @BBL X1C 0.2 nozzle.json"
+            "name": "Generic PETG HF @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Generic PETG HF @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Bambu ABS @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu ABS @BBL X1C 0.8 nozzle.json"
+            "name": "Generic PETG HF @BBL X1C",
+            "sub_path": "filament/Generic PETG HF @BBL X1C.json"
         },
         {
-            "name": "Bambu ABS @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Bambu ABS @BBL P1P 0.2 nozzle.json"
+            "name": "Generic PETG HF @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Generic PETG HF @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Bambu ABS @BBL P1P",
-            "sub_path": "filament/P1P/Bambu ABS @BBL P1P.json"
+            "name": "Generic PETG-CF @BBL A1",
+            "sub_path": "filament/Generic PETG-CF @BBL A1.json"
         },
         {
-            "name": "Bambu ABS @BBL A1",
-            "sub_path": "filament/Bambu ABS @BBL A1.json"
+            "name": "Generic PETG-CF @BBL P1P",
+            "sub_path": "filament/P1P/Generic PETG-CF @BBL P1P.json"
         },
         {
-            "name": "Bambu ABS @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu ABS @BBL A1 0.2 nozzle.json"
+            "name": "Generic PETG-CF @BBL X1C",
+            "sub_path": "filament/Generic PETG-CF @BBL X1C.json"
         },
         {
-            "name": "Generic ABS",
-            "sub_path": "filament/Generic ABS.json"
+            "name": "PolyLite PETG @BBL A1",
+            "sub_path": "filament/PolyLite PETG @BBL A1.json"
         },
         {
-            "name": "Generic ABS @0.2 nozzle",
-            "sub_path": "filament/Generic ABS @0.2 nozzle.json"
+            "name": "PolyLite PETG @BBL A1 0.2 nozzle",
+            "sub_path": "filament/PolyLite PETG @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Generic ABS @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Generic ABS @BBL P1P 0.2 nozzle.json"
+            "name": "PolyLite PETG @BBL A1M",
+            "sub_path": "filament/PolyLite PETG @BBL A1M.json"
         },
         {
-            "name": "Generic ABS @BBL P1P",
-            "sub_path": "filament/P1P/Generic ABS @BBL P1P.json"
+            "name": "PolyLite PETG @BBL P1P",
+            "sub_path": "filament/PolyLite PETG @BBL P1P.json"
         },
         {
-            "name": "Generic ABS @BBL A1",
-            "sub_path": "filament/Generic ABS @BBL A1.json"
+            "name": "PolyLite PETG @BBL X1C",
+            "sub_path": "filament/PolyLite PETG @BBL X1C.json"
         },
         {
-            "name": "Generic ABS @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Generic ABS @BBL A1 0.2 nozzle.json"
+            "name": "SUNLU PETG @BBL A1",
+            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1.json"
         },
         {
-            "name": "PolyLite ABS @BBL X1C",
-            "sub_path": "filament/PolyLite ABS @BBL X1C.json"
+            "name": "SUNLU PETG @BBL A1 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "PolyLite ABS @BBL P1P",
-            "sub_path": "filament/PolyLite ABS @BBL P1P.json"
+            "name": "SUNLU PETG @BBL A1 0.8 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1 0.8 nozzle.json"
         },
         {
-            "name": "PolyLite ABS @BBL A1",
-            "sub_path": "filament/PolyLite ABS @BBL A1.json"
+            "name": "SUNLU PETG @BBL X1C",
+            "sub_path": "filament/SUNLU/SUNLU PETG @BBL X1C.json"
         },
         {
-            "name": "PolyLite ABS @BBL A1 0.2 nozzle",
-            "sub_path": "filament/PolyLite ABS @BBL A1 0.2 nozzle.json"
+            "name": "SUNLU PETG @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PETG @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Bambu ABS-GF @BBL X1C",
-            "sub_path": "filament/Bambu ABS-GF @BBL X1C.json"
+            "name": "SUNLU PETG @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PETG @BBL X1C 0.8 nozzle.json"
         },
         {
-            "name": "Bambu ABS-GF @BBL P1P",
-            "sub_path": "filament/Bambu ABS-GF @BBL P1P.json"
+            "name": "Generic PHA @BBL A1",
+            "sub_path": "filament/Generic PHA @BBL A1.json"
         },
         {
-            "name": "Bambu ABS-GF @BBL A1",
-            "sub_path": "filament/Bambu ABS-GF @BBL A1.json"
+            "name": "Generic PHA @BBL A1M",
+            "sub_path": "filament/Generic PHA @BBL A1M.json"
         },
         {
-            "name": "Bambu Support for ABS @BBL X1C",
-            "sub_path": "filament/Bambu Support for ABS @BBL X1C.json"
+            "name": "Generic PHA @BBL X1C",
+            "sub_path": "filament/Generic PHA @BBL X1C.json"
         },
         {
-            "name": "Bambu Support for ABS @BBL A1",
-            "sub_path": "filament/Bambu Support for ABS @BBL A1.json"
+            "name": "Bambu PLA Aero @BBL A1",
+            "sub_path": "filament/Bambu PLA Aero @BBL A1.json"
         },
         {
-            "name": "Bambu PC @BBL X1C",
-            "sub_path": "filament/Bambu PC @BBL X1C.json"
+            "name": "Bambu PLA Aero @BBL A1M",
+            "sub_path": "filament/Bambu PLA Aero @BBL A1M.json"
         },
         {
-            "name": "Bambu PC @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PC @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu PLA Aero @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PLA Aero @BBL P1P.json"
         },
         {
-            "name": "Bambu PC @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PC @BBL X1C 0.8 nozzle.json"
+            "name": "Bambu PLA Aero @BBL X1",
+            "sub_path": "filament/Bambu PLA Aero @BBL X1.json"
         },
         {
-            "name": "Bambu PC @BBL X1C 0.6 nozzle",
-            "sub_path": "filament/Bambu PC @BBL X1C 0.6 nozzle.json"
+            "name": "Bambu PLA Aero @BBL X1C",
+            "sub_path": "filament/Bambu PLA Aero @BBL X1C.json"
         },
         {
-            "name": "Bambu PC @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PC @BBL P1P.json"
+            "name": "Bambu PLA Basic @BBL A1",
+            "sub_path": "filament/Bambu PLA Basic @BBL A1.json"
         },
         {
-            "name": "Bambu PC @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Bambu PC @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu PLA Basic @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Basic @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PC @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PC @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PLA Basic @BBL A1M",
+            "sub_path": "filament/Bambu PLA Basic @BBL A1M.json"
         },
         {
-            "name": "Bambu PC @BBL A1",
-            "sub_path": "filament/Bambu PC @BBL A1.json"
+            "name": "Bambu PLA Basic @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Basic @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "Generic PC @0.2 nozzle",
-            "sub_path": "filament/Generic PC @0.2 nozzle.json"
+            "name": "Bambu PLA Basic @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PLA Basic @BBL P1P.json"
         },
         {
-            "name": "Generic PC",
-            "sub_path": "filament/Generic PC.json"
+            "name": "Bambu PLA Basic @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Bambu PLA Basic @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Generic PC @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Generic PC @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu PLA Basic @BBL X1",
+            "sub_path": "filament/Bambu PLA Basic @BBL X1.json"
         },
         {
-            "name": "Generic PC @BBL P1P",
-            "sub_path": "filament/P1P/Generic PC @BBL P1P.json"
+            "name": "Bambu PLA Basic @BBL X1C",
+            "sub_path": "filament/Bambu PLA Basic @BBL X1C.json"
         },
         {
-            "name": "Generic PC @BBL A1",
-            "sub_path": "filament/Generic PC @BBL A1.json"
+            "name": "Bambu PLA Basic @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Basic @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Generic PC @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Generic PC @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PLA Basic @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PLA Basic @BBL X1C 0.8 nozzle.json"
         },
         {
-            "name": "Bambu PC FR @BBL X1C",
-            "sub_path": "filament/Bambu PC FR @BBL X1C.json"
+            "name": "Bambu PLA Dynamic @BBL A1",
+            "sub_path": "filament/Bambu PLA Dynamic @BBL A1.json"
         },
         {
-            "name": "Bambu PC FR @BBL X1C 0.6 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL X1C 0.6 nozzle.json"
+            "name": "Bambu PLA Dynamic @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Dynamic @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PC FR @BBL X1C 0.8 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL X1C 0.8 nozzle.json"
+            "name": "Bambu PLA Dynamic @BBL A1M",
+            "sub_path": "filament/Bambu PLA Dynamic @BBL A1M.json"
         },
         {
-            "name": "Bambu PC FR @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu PLA Dynamic @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Dynamic @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PC FR @BBL P1S",
-            "sub_path": "filament/Bambu PC FR @BBL P1S.json"
+            "name": "Bambu PLA Dynamic @BBL P1P",
+            "sub_path": "filament/Bambu PLA Dynamic @BBL P1P.json"
         },
         {
-            "name": "Bambu PC FR @BBL P1S 0.2 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL P1S 0.2 nozzle.json"
+            "name": "Bambu PLA Dynamic @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Dynamic @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PC FR @BBL P1S 0.6 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL P1S 0.6 nozzle.json"
+            "name": "Bambu PLA Dynamic @BBL X1C",
+            "sub_path": "filament/Bambu PLA Dynamic @BBL X1C.json"
         },
         {
-            "name": "Bambu PC FR @BBL P1S 0.8 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL P1S 0.8 nozzle.json"
+            "name": "Bambu PLA Dynamic @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Dynamic @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PC FR @BBL P1P",
-            "sub_path": "filament/Bambu PC FR @BBL P1P.json"
+            "name": "Bambu PLA Dynamic @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PLA Dynamic @BBL X1C 0.8 nozzle.json"
         },
         {
-            "name": "Bambu PC FR @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu PLA Galaxy @BBL A1",
+            "sub_path": "filament/Bambu PLA Galaxy @BBL A1.json"
         },
         {
-            "name": "Bambu PC FR @BBL X1E",
-            "sub_path": "filament/Bambu PC FR @BBL X1E.json"
+            "name": "Bambu PLA Galaxy @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Galaxy @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PC FR @BBL X1E 0.2 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL X1E 0.2 nozzle.json"
+            "name": "Bambu PLA Galaxy @BBL A1M",
+            "sub_path": "filament/Bambu PLA Galaxy @BBL A1M.json"
         },
         {
-            "name": "Bambu PC FR @BBL X1E 0.6 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL X1E 0.6 nozzle.json"
+            "name": "Bambu PLA Galaxy @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Galaxy @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PC FR @BBL X1E 0.8 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL X1E 0.8 nozzle.json"
+            "name": "Bambu PLA Galaxy @BBL P1P",
+            "sub_path": "filament/Bambu PLA Galaxy @BBL P1P.json"
         },
         {
-            "name": "Bambu PC FR @BBL A1",
-            "sub_path": "filament/Bambu PC FR @BBL A1.json"
+            "name": "Bambu PLA Galaxy @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Galaxy @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PC FR @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu PC FR @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PLA Galaxy @BBL X1C",
+            "sub_path": "filament/Bambu PLA Galaxy @BBL X1C.json"
         },
         {
-            "name": "Generic ASA @0.2 nozzle",
-            "sub_path": "filament/Generic ASA @0.2 nozzle.json"
+            "name": "Bambu PLA Galaxy @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Galaxy @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Generic ASA",
-            "sub_path": "filament/Generic ASA.json"
+            "name": "Bambu PLA Galaxy @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PLA Galaxy @BBL X1C 0.8 nozzle.json"
         },
         {
-            "name": "Generic ASA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Generic ASA @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu PLA Glow @BBL A1",
+            "sub_path": "filament/Bambu PLA Glow @BBL A1.json"
         },
         {
-            "name": "Generic ASA @BBL P1P",
-            "sub_path": "filament/P1P/Generic ASA @BBL P1P.json"
+            "name": "Bambu PLA Glow @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Glow @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Generic ASA @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Generic ASA @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PLA Glow @BBL P1P",
+            "sub_path": "filament/Bambu PLA Glow @BBL P1P.json"
         },
         {
-            "name": "Generic ASA @BBL A1",
-            "sub_path": "filament/Generic ASA @BBL A1.json"
+            "name": "Bambu PLA Glow @BBL X1",
+            "sub_path": "filament/Bambu PLA Glow @BBL X1.json"
         },
         {
-            "name": "Bambu ASA @BBL X1 0.2 nozzle",
-            "sub_path": "filament/Bambu ASA @BBL X1 0.2 nozzle.json"
+            "name": "Bambu PLA Glow @BBL X1C",
+            "sub_path": "filament/Bambu PLA Glow @BBL X1C.json"
         },
         {
-            "name": "Bambu ASA @BBL X1 0.6 nozzle",
-            "sub_path": "filament/Bambu ASA @BBL X1 0.6 nozzle.json"
+            "name": "Bambu PLA Glow @BBL X1E",
+            "sub_path": "filament/Bambu PLA Glow @BBL X1E.json"
         },
         {
-            "name": "Bambu ASA @BBL X1C",
-            "sub_path": "filament/Bambu ASA @BBL X1C.json"
+            "name": "Bambu PLA Impact @BBL X1C",
+            "sub_path": "filament/Bambu PLA Impact @BBL X1C.json"
         },
         {
-            "name": "Bambu ASA @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu ASA @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu PLA Marble @BBL A1",
+            "sub_path": "filament/Bambu PLA Marble @BBL A1.json"
         },
         {
-            "name": "Bambu ASA @BBL X1C 0.4 nozzle",
-            "sub_path": "filament/Bambu ASA @BBL X1C 0.4 nozzle.json"
+            "name": "Bambu PLA Marble @BBL A1M",
+            "sub_path": "filament/Bambu PLA Marble @BBL A1M.json"
         },
         {
-            "name": "Bambu ASA @BBL A1 0.6 nozzle",
-            "sub_path": "filament/Bambu ASA @BBL A1 0.6 nozzle.json"
+            "name": "Bambu PLA Marble @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PLA Marble @BBL P1P.json"
         },
         {
-            "name": "Bambu ASA @BBL A1 0.4 nozzle",
-            "sub_path": "filament/Bambu ASA @BBL A1 0.4 nozzle.json"
+            "name": "Bambu PLA Marble @BBL X1",
+            "sub_path": "filament/Bambu PLA Marble @BBL X1.json"
         },
         {
-            "name": "Bambu ASA @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Bambu ASA @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PLA Marble @BBL X1C",
+            "sub_path": "filament/Bambu PLA Marble @BBL X1C.json"
         },
         {
-            "name": "PolyLite ASA @BBL X1C",
-            "sub_path": "filament/PolyLite ASA @BBL X1C.json"
+            "name": "Bambu PLA Matte @BBL A1",
+            "sub_path": "filament/Bambu PLA Matte @BBL A1.json"
         },
         {
-            "name": "PolyLite ASA @BBL P1P",
-            "sub_path": "filament/PolyLite ASA @BBL P1P.json"
+            "name": "Bambu PLA Matte @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Matte @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "PolyLite ASA @BBL A1 0.2 nozzle",
-            "sub_path": "filament/PolyLite ASA @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PLA Matte @BBL A1M",
+            "sub_path": "filament/Bambu PLA Matte @BBL A1M.json"
         },
         {
-            "name": "PolyLite ASA @BBL A1",
-            "sub_path": "filament/PolyLite ASA @BBL A1.json"
+            "name": "Bambu PLA Matte @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Matte @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "Bambu ASA-Aero @BBL X1C",
-            "sub_path": "filament/Bambu ASA-Aero @BBL X1C.json"
+            "name": "Bambu PLA Matte @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PLA Matte @BBL P1P.json"
         },
         {
-            "name": "Bambu ASA-Aero @BBL P1P",
-            "sub_path": "filament/Bambu ASA-Aero @BBL P1P.json"
+            "name": "Bambu PLA Matte @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Bambu PLA Matte @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Bambu ASA-Aero @BBL A1",
-            "sub_path": "filament/Bambu ASA-Aero @BBL A1.json"
+            "name": "Bambu PLA Matte @BBL X1",
+            "sub_path": "filament/Bambu PLA Matte @BBL X1.json"
         },
         {
-            "name": "Bambu ASA-CF @BBL X1C",
-            "sub_path": "filament/Bambu ASA-CF @BBL X1C.json"
+            "name": "Bambu PLA Matte @BBL X1C",
+            "sub_path": "filament/Bambu PLA Matte @BBL X1C.json"
         },
         {
-            "name": "Bambu ASA-CF @BBL X1C 0.6 nozzle",
-            "sub_path": "filament/Bambu ASA-CF @BBL X1C 0.6 nozzle.json"
+            "name": "Bambu PLA Matte @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Matte @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Bambu ASA-CF @BBL P1P",
-            "sub_path": "filament/Bambu ASA-CF @BBL P1P.json"
+            "name": "Bambu PLA Matte @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PLA Matte @BBL X1C 0.8 nozzle.json"
         },
         {
-            "name": "Bambu ASA-CF @BBL P1P 0.6 nozzle",
-            "sub_path": "filament/Bambu ASA-CF @BBL P1P 0.6 nozzle.json"
+            "name": "Bambu PLA Metal @BBL A1",
+            "sub_path": "filament/Bambu PLA Metal @BBL A1.json"
         },
         {
-            "name": "Bambu ASA-CF @BBL A1",
-            "sub_path": "filament/Bambu ASA-CF @BBL A1.json"
+            "name": "Bambu PLA Metal @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Metal @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu ASA-CF @BBL A1 0.6 nozzle",
-            "sub_path": "filament/Bambu ASA-CF @BBL A1 0.6 nozzle.json"
+            "name": "Bambu PLA Metal @BBL A1M",
+            "sub_path": "filament/Bambu PLA Metal @BBL A1M.json"
         },
         {
-            "name": "Generic PVA @0.2 nozzle",
-            "sub_path": "filament/Generic PVA @0.2 nozzle.json"
+            "name": "Bambu PLA Metal @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Metal @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "Generic PVA",
-            "sub_path": "filament/Generic PVA.json"
+            "name": "Bambu PLA Metal @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PLA Metal @BBL P1P.json"
         },
         {
-            "name": "Generic PVA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/Generic PVA @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu PLA Metal @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Bambu PLA Metal @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Generic PVA @BBL P1P",
-            "sub_path": "filament/P1P/Generic PVA @BBL P1P.json"
+            "name": "Bambu PLA Metal @BBL X1",
+            "sub_path": "filament/Bambu PLA Metal @BBL X1.json"
         },
         {
-            "name": "Generic PVA @BBL A1M",
-            "sub_path": "filament/Generic PVA @BBL A1M.json"
+            "name": "Bambu PLA Metal @BBL X1C",
+            "sub_path": "filament/Bambu PLA Metal @BBL X1C.json"
         },
         {
-            "name": "Generic PVA @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Generic PVA @BBL A1M 0.2 nozzle.json"
+            "name": "Bambu PLA Metal @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Metal @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Generic PVA @BBL A1",
-            "sub_path": "filament/Generic PVA @BBL A1.json"
+            "name": "Bambu PLA Silk @BBL A1",
+            "sub_path": "filament/Bambu PLA Silk @BBL A1.json"
         },
         {
-            "name": "Generic PVA @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Generic PVA @BBL A1 0.2 nozzle.json"
+            "name": "Bambu PLA Silk @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Silk @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PVA @BBL X1C",
-            "sub_path": "filament/Bambu PVA @BBL X1C.json"
+            "name": "Bambu PLA Silk @BBL A1M",
+            "sub_path": "filament/Bambu PLA Silk @BBL A1M.json"
         },
         {
-            "name": "Bambu PVA @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PVA @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu PLA Silk @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Silk @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PVA @BBL P1P",
-            "sub_path": "filament/Bambu PVA @BBL P1P.json"
+            "name": "Bambu PLA Silk @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PLA Silk @BBL P1P.json"
         },
         {
-            "name": "Bambu PVA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Bambu PVA @BBL P1P 0.2 nozzle.json"
+            "name": "Bambu PLA Silk @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Bambu PLA Silk @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Silk @BBL X1",
+            "sub_path": "filament/Bambu PLA Silk @BBL X1.json"
+        },
+        {
+            "name": "Bambu PLA Silk @BBL X1C",
+            "sub_path": "filament/Bambu PLA Silk @BBL X1C.json"
+        },
+        {
+            "name": "Bambu PLA Silk @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Silk @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Silk+ @BBL A1",
+            "sub_path": "filament/Bambu PLA Silk+ @BBL A1.json"
+        },
+        {
+            "name": "Bambu PLA Silk+ @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Silk+ @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Silk+ @BBL A1M",
+            "sub_path": "filament/Bambu PLA Silk+ @BBL A1M.json"
+        },
+        {
+            "name": "Bambu PLA Silk+ @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Silk+ @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Silk+ @BBL P1P",
+            "sub_path": "filament/Bambu PLA Silk+ @BBL P1P.json"
+        },
+        {
+            "name": "Bambu PLA Silk+ @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Silk+ @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Silk+ @BBL X1",
+            "sub_path": "filament/Bambu PLA Silk+ @BBL X1.json"
+        },
+        {
+            "name": "Bambu PLA Silk+ @BBL X1C",
+            "sub_path": "filament/Bambu PLA Silk+ @BBL X1C.json"
+        },
+        {
+            "name": "Bambu PLA Silk+ @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Silk+ @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Sparkle @BBL A1",
+            "sub_path": "filament/Bambu PLA Sparkle @BBL A1.json"
+        },
+        {
+            "name": "Bambu PLA Sparkle @BBL A1M",
+            "sub_path": "filament/Bambu PLA Sparkle @BBL A1M.json"
+        },
+        {
+            "name": "Bambu PLA Sparkle @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PLA Sparkle @BBL P1P.json"
+        },
+        {
+            "name": "Bambu PLA Sparkle @BBL X1",
+            "sub_path": "filament/Bambu PLA Sparkle @BBL X1.json"
+        },
+        {
+            "name": "Bambu PLA Sparkle @BBL X1C",
+            "sub_path": "filament/Bambu PLA Sparkle @BBL X1C.json"
+        },
+        {
+            "name": "Bambu PLA Tough @BBL A1",
+            "sub_path": "filament/Bambu PLA Tough @BBL A1.json"
+        },
+        {
+            "name": "Bambu PLA Tough @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Tough @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Tough @BBL A1M",
+            "sub_path": "filament/Bambu PLA Tough @BBL A1M.json"
+        },
+        {
+            "name": "Bambu PLA Tough @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Tough @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Tough @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PLA Tough @BBL P1P.json"
+        },
+        {
+            "name": "Bambu PLA Tough @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Bambu PLA Tough @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Tough @BBL X1",
+            "sub_path": "filament/Bambu PLA Tough @BBL X1.json"
+        },
+        {
+            "name": "Bambu PLA Tough @BBL X1C",
+            "sub_path": "filament/Bambu PLA Tough @BBL X1C.json"
+        },
+        {
+            "name": "Bambu PLA Tough @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Tough @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Wood @BBL A1",
+            "sub_path": "filament/Bambu PLA Wood @BBL A1.json"
+        },
+        {
+            "name": "Bambu PLA Wood @BBL A1M",
+            "sub_path": "filament/Bambu PLA Wood @BBL A1M.json"
+        },
+        {
+            "name": "Bambu PLA Wood @BBL P1P",
+            "sub_path": "filament/Bambu PLA Wood @BBL P1P.json"
+        },
+        {
+            "name": "Bambu PLA Wood @BBL X1",
+            "sub_path": "filament/Bambu PLA Wood @BBL X1.json"
+        },
+        {
+            "name": "Bambu PLA Wood @BBL X1C",
+            "sub_path": "filament/Bambu PLA Wood @BBL X1C.json"
+        },
+        {
+            "name": "Bambu PLA Wood @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PLA Wood @BBL X1C 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA-CF @BBL A1",
+            "sub_path": "filament/Bambu PLA-CF @BBL A1.json"
+        },
+        {
+            "name": "Bambu PLA-CF @BBL A1 0.8 nozzle",
+            "sub_path": "filament/Bambu PLA-CF @BBL A1 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA-CF @BBL A1M",
+            "sub_path": "filament/Bambu PLA-CF @BBL A1M.json"
+        },
+        {
+            "name": "Bambu PLA-CF @BBL A1M 0.8 nozzle",
+            "sub_path": "filament/Bambu PLA-CF @BBL A1M 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA-CF @BBL P1P",
+            "sub_path": "filament/P1P/Bambu PLA-CF @BBL P1P.json"
+        },
+        {
+            "name": "Bambu PLA-CF @BBL P1P 0.8 nozzle",
+            "sub_path": "filament/P1P/Bambu PLA-CF @BBL P1P 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA-CF @BBL X1C",
+            "sub_path": "filament/Bambu PLA-CF @BBL X1C.json"
+        },
+        {
+            "name": "Bambu PLA-CF @BBL X1C 0.8 nozzle",
+            "sub_path": "filament/Bambu PLA-CF @BBL X1C 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu Support For PLA @BBL A1",
+            "sub_path": "filament/Bambu Support For PLA @BBL A1.json"
+        },
+        {
+            "name": "Bambu Support For PLA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu Support For PLA @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support For PLA @BBL A1M",
+            "sub_path": "filament/Bambu Support For PLA @BBL A1M.json"
+        },
+        {
+            "name": "Bambu Support For PLA @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu Support For PLA @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support For PLA @BBL P1P",
+            "sub_path": "filament/P1P/Bambu Support For PLA @BBL P1P.json"
+        },
+        {
+            "name": "Bambu Support For PLA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Bambu Support For PLA @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support For PLA @BBL X1C",
+            "sub_path": "filament/Bambu Support For PLA @BBL X1C.json"
+        },
+        {
+            "name": "Bambu Support For PLA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu Support For PLA @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support For PLA/PETG @BBL A1",
+            "sub_path": "filament/Bambu Support For PLA-PETG @BBL A1.json"
+        },
+        {
+            "name": "Bambu Support For PLA/PETG @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu Support For PLA-PETG @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support For PLA/PETG @BBL A1M",
+            "sub_path": "filament/Bambu Support For PLA-PETG @BBL A1M.json"
+        },
+        {
+            "name": "Bambu Support For PLA/PETG @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu Support For PLA-PETG @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support For PLA/PETG @BBL P1P",
+            "sub_path": "filament/Bambu Support For PLA-PETG @BBL P1P.json"
+        },
+        {
+            "name": "Bambu Support For PLA/PETG @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Bambu Support For PLA-PETG @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support For PLA/PETG @BBL X1C",
+            "sub_path": "filament/Bambu Support For PLA-PETG @BBL X1C.json"
+        },
+        {
+            "name": "Bambu Support For PLA/PETG @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu Support For PLA-PETG @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support W @BBL A1",
+            "sub_path": "filament/Bambu Support W @BBL A1.json"
+        },
+        {
+            "name": "Bambu Support W @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Bambu Support W @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support W @BBL A1M",
+            "sub_path": "filament/Bambu Support W @BBL A1M.json"
+        },
+        {
+            "name": "Bambu Support W @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu Support W @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support W @BBL P1P",
+            "sub_path": "filament/P1P/Bambu Support W @BBL P1P.json"
+        },
+        {
+            "name": "Bambu Support W @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Bambu Support W @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu Support W @BBL X1",
+            "sub_path": "filament/Bambu Support W @BBL X1.json"
+        },
+        {
+            "name": "Bambu Support W @BBL X1C",
+            "sub_path": "filament/Bambu Support W @BBL X1C.json"
+        },
+        {
+            "name": "Bambu Support W @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu Support W @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PLA",
+            "sub_path": "filament/Generic PLA.json"
+        },
+        {
+            "name": "Generic PLA @0.2 nozzle",
+            "sub_path": "filament/Generic PLA @0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PLA @BBL A1",
+            "sub_path": "filament/Generic PLA @BBL A1.json"
+        },
+        {
+            "name": "Generic PLA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Generic PLA @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PLA @BBL A1M",
+            "sub_path": "filament/Generic PLA @BBL A1M.json"
+        },
+        {
+            "name": "Generic PLA @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Generic PLA @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PLA @BBL P1P",
+            "sub_path": "filament/P1P/Generic PLA @BBL P1P.json"
+        },
+        {
+            "name": "Generic PLA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Generic PLA @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PLA High Speed @BBL A1",
+            "sub_path": "filament/Generic PLA High Speed @BBL A1.json"
+        },
+        {
+            "name": "Generic PLA High Speed @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Generic PLA High Speed @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PLA High Speed @BBL A1M",
+            "sub_path": "filament/Generic PLA High Speed @BBL A1M.json"
+        },
+        {
+            "name": "Generic PLA High Speed @BBL P1P",
+            "sub_path": "filament/Generic PLA High Speed @BBL P1P.json"
+        },
+        {
+            "name": "Generic PLA High Speed @BBL X1C",
+            "sub_path": "filament/Generic PLA High Speed @BBL X1C.json"
+        },
+        {
+            "name": "Generic PLA Silk",
+            "sub_path": "filament/Generic PLA Silk.json"
+        },
+        {
+            "name": "Generic PLA Silk @BBL A1",
+            "sub_path": "filament/Generic PLA Silk @BBL A1.json"
+        },
+        {
+            "name": "Generic PLA Silk @BBL A1M",
+            "sub_path": "filament/Generic PLA Silk @BBL A1M.json"
+        },
+        {
+            "name": "Generic PLA Silk @BBL P1P",
+            "sub_path": "filament/P1P/Generic PLA Silk @BBL P1P.json"
+        },
+        {
+            "name": "Generic PLA-CF",
+            "sub_path": "filament/Generic PLA-CF.json"
+        },
+        {
+            "name": "Generic PLA-CF @BBL A1",
+            "sub_path": "filament/Generic PLA-CF @BBL A1.json"
+        },
+        {
+            "name": "Generic PLA-CF @BBL A1M",
+            "sub_path": "filament/Generic PLA-CF @BBL A1M.json"
+        },
+        {
+            "name": "Generic PLA-CF @BBL P1P",
+            "sub_path": "filament/P1P/Generic PLA-CF @BBL P1P.json"
+        },
+        {
+            "name": "Overture Matte PLA @BBL A1",
+            "sub_path": "filament/Overture Matte PLA @BBL A1.json"
+        },
+        {
+            "name": "Overture Matte PLA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Overture Matte PLA @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "Overture Matte PLA @BBL A1M",
+            "sub_path": "filament/Overture Matte PLA @BBL A1M.json"
+        },
+        {
+            "name": "Overture Matte PLA @BBL P1P",
+            "sub_path": "filament/Overture Matte PLA @BBL P1P.json"
+        },
+        {
+            "name": "Overture Matte PLA @BBL X1",
+            "sub_path": "filament/Overture Matte PLA @BBL X1.json"
+        },
+        {
+            "name": "Overture Matte PLA @BBL X1C",
+            "sub_path": "filament/Overture Matte PLA @BBL X1C.json"
+        },
+        {
+            "name": "Overture PLA @BBL A1",
+            "sub_path": "filament/Overture PLA @BBL A1.json"
+        },
+        {
+            "name": "Overture PLA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Overture PLA @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "Overture PLA @BBL A1M",
+            "sub_path": "filament/Overture PLA @BBL A1M.json"
+        },
+        {
+            "name": "Overture PLA @BBL P1P",
+            "sub_path": "filament/Overture PLA @BBL P1P.json"
+        },
+        {
+            "name": "Overture PLA @BBL X1",
+            "sub_path": "filament/Overture PLA @BBL X1.json"
+        },
+        {
+            "name": "Overture PLA @BBL X1C",
+            "sub_path": "filament/Overture PLA @BBL X1C.json"
+        },
+        {
+            "name": "PolyLite PLA @BBL A1",
+            "sub_path": "filament/PolyLite PLA @BBL A1.json"
+        },
+        {
+            "name": "PolyLite PLA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/PolyLite PLA @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyLite PLA @BBL A1M",
+            "sub_path": "filament/PolyLite PLA @BBL A1M.json"
+        },
+        {
+            "name": "PolyLite PLA @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/PolyLite PLA @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyLite PLA @BBL P1P",
+            "sub_path": "filament/P1P/PolyLite PLA @BBL P1P.json"
+        },
+        {
+            "name": "PolyLite PLA @BBL X1",
+            "sub_path": "filament/PolyLite PLA @BBL X1.json"
+        },
+        {
+            "name": "PolyLite PLA @BBL X1C",
+            "sub_path": "filament/PolyLite PLA @BBL X1C.json"
+        },
+        {
+            "name": "PolyTerra PLA @BBL A1",
+            "sub_path": "filament/PolyTerra PLA @BBL A1.json"
+        },
+        {
+            "name": "PolyTerra PLA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/PolyTerra PLA @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyTerra PLA @BBL A1M",
+            "sub_path": "filament/PolyTerra PLA @BBL A1M.json"
+        },
+        {
+            "name": "PolyTerra PLA @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/PolyTerra PLA @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyTerra PLA @BBL P1P",
+            "sub_path": "filament/P1P/PolyTerra PLA @BBL P1P.json"
+        },
+        {
+            "name": "PolyTerra PLA @BBL X1",
+            "sub_path": "filament/PolyTerra PLA @BBL X1.json"
+        },
+        {
+            "name": "PolyTerra PLA @BBL X1C",
+            "sub_path": "filament/PolyTerra PLA @BBL X1C.json"
+        },
+        {
+            "name": "SUNLU PLA Marble @BBL A1",
+            "sub_path": "filament/SUNLU/SUNLU Marble PLA @BBL A1.json"
+        },
+        {
+            "name": "SUNLU PLA Marble @BBL A1M",
+            "sub_path": "filament/SUNLU/SUNLU Marble PLA @BBL A1M.json"
+        },
+        {
+            "name": "SUNLU PLA Marble @BBL P1P",
+            "sub_path": "filament/SUNLU/SUNLU Marble PLA @BBL P1P.json"
+        },
+        {
+            "name": "SUNLU PLA Marble @BBL X1",
+            "sub_path": "filament/SUNLU/SUNLU Marble PLA @BBL X1.json"
+        },
+        {
+            "name": "SUNLU PLA Marble @BBL X1C",
+            "sub_path": "filament/SUNLU/SUNLU Marble PLA @BBL X1C.json"
+        },
+        {
+            "name": "SUNLU PLA Matte @BBL A1",
+            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL A1.json"
+        },
+        {
+            "name": "SUNLU PLA Matte @BBL A1 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA Matte @BBL A1M",
+            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL A1M.json"
+        },
+        {
+            "name": "SUNLU PLA Matte @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA Matte @BBL P1P",
+            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL P1P.json"
+        },
+        {
+            "name": "SUNLU PLA Matte @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA Matte @BBL X1",
+            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL X1.json"
+        },
+        {
+            "name": "SUNLU PLA Matte @BBL X1C",
+            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL X1C.json"
+        },
+        {
+            "name": "SUNLU PLA Matte @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA Matte @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA+ 2.0 @BBL A1",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL A1.json"
+        },
+        {
+            "name": "SUNLU PLA+ 2.0 @BBL A1 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA+ 2.0 @BBL A1M",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL A1M.json"
+        },
+        {
+            "name": "SUNLU PLA+ 2.0 @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA+ 2.0 @BBL P1P",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL P1P.json"
+        },
+        {
+            "name": "SUNLU PLA+ 2.0 @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA+ 2.0 @BBL X1",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL X1.json"
+        },
+        {
+            "name": "SUNLU PLA+ 2.0 @BBL X1C",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL X1C.json"
+        },
+        {
+            "name": "SUNLU PLA+ 2.0 @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ 2.0 @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA+ @BBL A1",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL A1.json"
+        },
+        {
+            "name": "SUNLU PLA+ @BBL A1 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA+ @BBL A1M",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL A1M.json"
+        },
+        {
+            "name": "SUNLU PLA+ @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA+ @BBL P1P",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL P1P.json"
+        },
+        {
+            "name": "SUNLU PLA+ @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PLA+ @BBL X1",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL X1.json"
+        },
+        {
+            "name": "SUNLU PLA+ @BBL X1C",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL X1C.json"
+        },
+        {
+            "name": "SUNLU PLA+ @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PLA+ @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU Silk PLA+ @BBL A1",
+            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL A1.json"
+        },
+        {
+            "name": "SUNLU Silk PLA+ @BBL A1 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU Silk PLA+ @BBL A1M",
+            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL A1M.json"
+        },
+        {
+            "name": "SUNLU Silk PLA+ @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU Silk PLA+ @BBL P1P",
+            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL P1P.json"
+        },
+        {
+            "name": "SUNLU Silk PLA+ @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU Silk PLA+ @BBL X1",
+            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL X1.json"
+        },
+        {
+            "name": "SUNLU Silk PLA+ @BBL X1C",
+            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL X1C.json"
+        },
+        {
+            "name": "SUNLU Silk PLA+ @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU Silk PLA+ @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU Wood PLA @BBL A1",
+            "sub_path": "filament/SUNLU/SUNLU Wood PLA @BBL A1.json"
+        },
+        {
+            "name": "SUNLU Wood PLA @BBL A1M",
+            "sub_path": "filament/SUNLU/SUNLU Wood PLA @BBL A1M.json"
+        },
+        {
+            "name": "SUNLU Wood PLA @BBL P1P",
+            "sub_path": "filament/SUNLU/SUNLU Wood PLA @BBL P1P.json"
+        },
+        {
+            "name": "SUNLU Wood PLA @BBL X1",
+            "sub_path": "filament/SUNLU/SUNLU Wood PLA @BBL X1.json"
+        },
+        {
+            "name": "SUNLU Wood PLA @BBL X1C",
+            "sub_path": "filament/SUNLU/SUNLU Wood PLA @BBL X1C.json"
+        },
+        {
+            "name": "eSUN PLA+ @BBL A1",
+            "sub_path": "filament/eSUN PLA+ @BBL A1.json"
+        },
+        {
+            "name": "eSUN PLA+ @BBL A1 0.2 nozzle",
+            "sub_path": "filament/eSUN PLA+ @BBL A1 0.2 nozzle.json"
+        },
+        {
+            "name": "eSUN PLA+ @BBL A1M",
+            "sub_path": "filament/eSUN PLA+ @BBL A1M.json"
+        },
+        {
+            "name": "eSUN PLA+ @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/eSUN PLA+ @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "eSUN PLA+ @BBL P1P",
+            "sub_path": "filament/P1P/eSUN PLA+ @BBL P1P.json"
+        },
+        {
+            "name": "eSUN PLA+ @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/eSUN PLA+ @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "eSUN PLA+ @BBL X1",
+            "sub_path": "filament/eSUN PLA+ @BBL X1.json"
+        },
+        {
+            "name": "eSUN PLA+ @BBL X1C",
+            "sub_path": "filament/eSUN PLA+ @BBL X1C.json"
+        },
+        {
+            "name": "eSUN PLA+ @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/eSUN PLA+ @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PP @BBL A1",
+            "sub_path": "filament/Generic PP @BBL A1.json"
+        },
+        {
+            "name": "Generic PP @BBL A1M",
+            "sub_path": "filament/Generic PP @BBL A1M.json"
+        },
+        {
+            "name": "Generic PP @BBL X1C",
+            "sub_path": "filament/Generic PP @BBL X1C.json"
+        },
+        {
+            "name": "Generic PP-CF @BBL A1",
+            "sub_path": "filament/Generic PP-CF @BBL A1.json"
+        },
+        {
+            "name": "Generic PP-CF @BBL X1C",
+            "sub_path": "filament/Generic PP-CF @BBL X1C.json"
+        },
+        {
+            "name": "Generic PP-GF @BBL A1",
+            "sub_path": "filament/Generic PP-GF @BBL A1.json"
+        },
+        {
+            "name": "Generic PP-GF @BBL X1C",
+            "sub_path": "filament/Generic PP-GF @BBL X1C.json"
+        },
+        {
+            "name": "Bambu PPA-CF @BBL X1C",
+            "sub_path": "filament/Bambu PPA-CF @BBL X1C.json"
+        },
+        {
+            "name": "Bambu PPA-CF @BBL X1E",
+            "sub_path": "filament/Bambu PPA-CF @BBL X1E.json"
+        },
+        {
+            "name": "Generic PPA-CF @BBL X1C",
+            "sub_path": "filament/Generic PPA-CF @BBL X1C.json"
+        },
+        {
+            "name": "Generic PPA-CF @BBL X1E",
+            "sub_path": "filament/Generic PPA-CF @BBL X1E.json"
+        },
+        {
+            "name": "Generic PPA-GF @BBL X1C",
+            "sub_path": "filament/Generic PPA-GF @BBL X1C.json"
+        },
+        {
+            "name": "Generic PPA-GF @BBL X1E",
+            "sub_path": "filament/Generic PPA-GF @BBL X1E.json"
+        },
+        {
+            "name": "Bambu PPS-CF @BBL X1E",
+            "sub_path": "filament/Bambu PPS-CF @BBL X1E.json"
+        },
+        {
+            "name": "Generic PPS @BBL X1E",
+            "sub_path": "filament/Generic PPS @BBL X1E.json"
+        },
+        {
+            "name": "Generic PPS-CF @BBL X1E",
+            "sub_path": "filament/Generic PPS-CF @BBL X1E.json"
         },
         {
             "name": "Bambu PVA @BBL A1",
@@ -2774,356 +2878,144 @@
             "sub_path": "filament/Bambu PVA @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "Bambu Support G @BBL X1C",
-            "sub_path": "filament/Bambu Support G @BBL X1C.json"
+            "name": "Bambu PVA @BBL P1P",
+            "sub_path": "filament/Bambu PVA @BBL P1P.json"
         },
         {
-            "name": "Bambu Support G @BBL P1P",
-            "sub_path": "filament/P1P/Bambu Support G @BBL P1P.json"
+            "name": "Bambu PVA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Bambu PVA @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Bambu Support G @BBL A1",
-            "sub_path": "filament/Bambu Support G @BBL A1.json"
+            "name": "Bambu PVA @BBL X1C",
+            "sub_path": "filament/Bambu PVA @BBL X1C.json"
         },
         {
-            "name": "Bambu PA-CF @BBL X1C",
-            "sub_path": "filament/Bambu PA-CF @BBL X1C.json"
+            "name": "Bambu PVA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PVA @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PA-CF @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PA-CF @BBL P1P.json"
+            "name": "Generic PVA",
+            "sub_path": "filament/Generic PVA.json"
         },
         {
-            "name": "Bambu PA-CF @BBL A1",
-            "sub_path": "filament/Bambu PA-CF @BBL A1.json"
+            "name": "Generic PVA @0.2 nozzle",
+            "sub_path": "filament/Generic PVA @0.2 nozzle.json"
         },
         {
-            "name": "Generic PA @BBL A1",
-            "sub_path": "filament/Generic PA @BBL A1.json"
+            "name": "Generic PVA @BBL A1",
+            "sub_path": "filament/Generic PVA @BBL A1.json"
         },
         {
-            "name": "Generic PA-CF @BBL X1E",
-            "sub_path": "filament/Generic PA-CF @BBL X1E.json"
+            "name": "Generic PVA @BBL A1 0.2 nozzle",
+            "sub_path": "filament/Generic PVA @BBL A1 0.2 nozzle.json"
         },
         {
-            "name": "Generic PA-CF @BBL A1",
-            "sub_path": "filament/Generic PA-CF @BBL A1.json"
+            "name": "Generic PVA @BBL A1M",
+            "sub_path": "filament/Generic PVA @BBL A1M.json"
         },
         {
-            "name": "Bambu PAHT-CF @BBL X1C",
-            "sub_path": "filament/Bambu PAHT-CF @BBL X1C.json"
+            "name": "Generic PVA @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Generic PVA @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PAHT-CF @BBL P1P",
-            "sub_path": "filament/P1P/Bambu PAHT-CF @BBL P1P.json"
+            "name": "Generic PVA @BBL P1P",
+            "sub_path": "filament/P1P/Generic PVA @BBL P1P.json"
         },
         {
-            "name": "Bambu PAHT-CF @BBL A1",
-            "sub_path": "filament/Bambu PAHT-CF @BBL A1.json"
+            "name": "Generic PVA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/Generic PVA @BBL P1P 0.2 nozzle.json"
         },
         {
-            "name": "Bambu Support For PA/PET @BBL P1P",
-            "sub_path": "filament/P1P/Bambu Support For PA PET @BBL P1P.json"
+            "name": "Generic SBS",
+            "sub_path": "filament/Generic SBS.json"
         },
         {
-            "name": "Bambu Support For PA/PET @BBL X1C",
-            "sub_path": "filament/Bambu Support For PA PET @BBL X1C.json"
+            "name": "Bambu TPU 95A @BBL A1",
+            "sub_path": "filament/Bambu TPU 95A @BBL A1.json"
         },
         {
-            "name": "Bambu Support For PA/PET @BBL A1",
-            "sub_path": "filament/Bambu Support For PA PET @BBL A1.json"
+            "name": "Bambu TPU 95A @BBL A1M",
+            "sub_path": "filament/Bambu TPU 95A @BBL A1M.json"
         },
         {
-            "name": "Bambu PA6-CF @BBL X1C",
-            "sub_path": "filament/Bambu PA6-CF @BBL X1C.json"
+            "name": "Bambu TPU 95A @BBL P1P",
+            "sub_path": "filament/P1P/Bambu TPU 95A @BBL P1P.json"
         },
         {
-            "name": "Bambu PA6-CF @BBL X1E",
-            "sub_path": "filament/Bambu PA6-CF @BBL X1E.json"
+            "name": "Bambu TPU 95A @BBL X1",
+            "sub_path": "filament/Bambu TPU 95A @BBL X1.json"
         },
         {
-            "name": "Bambu PA6-CF @BBL A1",
-            "sub_path": "filament/Bambu PA6-CF @BBL A1.json"
+            "name": "Bambu TPU 95A @BBL X1C",
+            "sub_path": "filament/Bambu TPU 95A @BBL X1C.json"
         },
         {
-            "name": "Bambu PA6-GF @BBL X1C",
-            "sub_path": "filament/Bambu PA6-GF @BBL X1C.json"
+            "name": "Bambu TPU 95A HF @BBL A1",
+            "sub_path": "filament/Bambu TPU 95A HF @BBL A1.json"
         },
         {
-            "name": "Bambu PA6-GF @BBL P1P",
-            "sub_path": "filament/Bambu PA6-GF @BBL P1P.json"
+            "name": "Bambu TPU 95A HF @BBL A1M",
+            "sub_path": "filament/Bambu TPU 95A HF @BBL A1M.json"
         },
         {
-            "name": "Bambu PA6-GF @BBL A1",
-            "sub_path": "filament/Bambu PA6-GF @BBL A1.json"
+            "name": "Bambu TPU 95A HF @BBL P1P",
+            "sub_path": "filament/Bambu TPU 95A HF @BBL P1P.json"
         },
         {
-            "name": "Fiberon PA6-CF @BBL X1C",
-            "sub_path": "filament/Fiberon PA6-CF @BBL X1C.json"
+            "name": "Bambu TPU 95A HF @BBL P1S",
+            "sub_path": "filament/Bambu TPU 95A HF @BBL P1S.json"
         },
         {
-            "name": "Fiberon PA6-GF @BBL X1C",
-            "sub_path": "filament/Fiberon PA6-GF @BBL X1C.json"
+            "name": "Bambu TPU 95A HF @BBL X1",
+            "sub_path": "filament/Bambu TPU 95A HF @BBL X1.json"
         },
         {
-            "name": "Fiberon PA12-CF @BBL X1C",
-            "sub_path": "filament/Fiberon PA12-CF @BBL X1C.json"
+            "name": "Bambu TPU 95A HF @BBL X1C",
+            "sub_path": "filament/Bambu TPU 95A HF @BBL X1C.json"
         },
         {
-            "name": "Fiberon PA612-CF @BBL X1C",
-            "sub_path": "filament/Fiberon PA612-CF @BBL X1C.json"
+            "name": "Bambu TPU 95A HF @BBL X1E",
+            "sub_path": "filament/Bambu TPU 95A HF @BBL X1E.json"
         },
         {
-            "name": "Generic HIPS @BBL X1C",
-            "sub_path": "filament/Generic HIPS @BBL X1C.json"
+            "name": "Bambu TPU for AMS @BBL A1",
+            "sub_path": "filament/Bambu TPU for AMS @BBL A1.json"
         },
         {
-            "name": "Generic HIPS @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Generic HIPS @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu TPU for AMS @BBL A1M",
+            "sub_path": "filament/Bambu TPU for AMS @BBL A1M.json"
         },
         {
-            "name": "Generic HIPS @BBL A1M",
-            "sub_path": "filament/Generic HIPS @BBL A1M.json"
+            "name": "Bambu TPU for AMS @BBL P1P",
+            "sub_path": "filament/Bambu TPU for AMS @BBL P1P.json"
         },
         {
-            "name": "Generic HIPS @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Generic HIPS @BBL A1M 0.2 nozzle.json"
+            "name": "Bambu TPU for AMS @BBL X1C",
+            "sub_path": "filament/Bambu TPU for AMS @BBL X1C.json"
         },
         {
-            "name": "Generic HIPS @BBL A1",
-            "sub_path": "filament/Generic HIPS @BBL A1.json"
+            "name": "Generic TPU @BBL A1",
+            "sub_path": "filament/Generic TPU @BBL A1.json"
         },
         {
-            "name": "Generic HIPS @BBL A1 0.2 nozzle",
-            "sub_path": "filament/Generic HIPS @BBL A1 0.2 nozzle.json"
+            "name": "Generic TPU @BBL A1M",
+            "sub_path": "filament/Generic TPU @BBL A1M.json"
         },
         {
-            "name": "Generic PPS-CF @BBL X1E",
-            "sub_path": "filament/Generic PPS-CF @BBL X1E.json"
+            "name": "Generic TPU for AMS @BBL A1",
+            "sub_path": "filament/Generic TPU for AMS @BBL A1.json"
         },
         {
-            "name": "Generic PPS @BBL X1E",
-            "sub_path": "filament/Generic PPS @BBL X1E.json"
+            "name": "Generic TPU for AMS @BBL A1M",
+            "sub_path": "filament/Generic TPU for AMS @BBL A1M.json"
         },
         {
-            "name": "Bambu PPS-CF @BBL X1E",
-            "sub_path": "filament/Bambu PPS-CF @BBL X1E.json"
+            "name": "Generic TPU for AMS @BBL P1P",
+            "sub_path": "filament/Generic TPU for AMS @BBL P1P.json"
         },
         {
-            "name": "Bambu PPA-CF @BBL X1C",
-            "sub_path": "filament/Bambu PPA-CF @BBL X1C.json"
-        },
-        {
-            "name": "Bambu PPA-CF @BBL X1E",
-            "sub_path": "filament/Bambu PPA-CF @BBL X1E.json"
-        },
-        {
-            "name": "Generic PPA-CF @BBL X1E",
-            "sub_path": "filament/Generic PPA-CF @BBL X1E.json"
-        },
-        {
-            "name": "Generic PPA-CF @BBL X1C",
-            "sub_path": "filament/Generic PPA-CF @BBL X1C.json"
-        },
-        {
-            "name": "Generic PPA-GF @BBL X1C",
-            "sub_path": "filament/Generic PPA-GF @BBL X1C.json"
-        },
-        {
-            "name": "Generic PPA-GF @BBL X1E",
-            "sub_path": "filament/Generic PPA-GF @BBL X1E.json"
-        },
-        {
-            "name": "Generic PE @BBL X1C",
-            "sub_path": "filament/Generic PE @BBL X1C.json"
-        },
-        {
-            "name": "Generic PE @BBL A1",
-            "sub_path": "filament/Generic PE @BBL A1.json"
-        },
-        {
-            "name": "Generic PE @BBL A1M",
-            "sub_path": "filament/Generic PE @BBL A1M.json"
-        },
-        {
-            "name": "Generic PE-CF @BBL X1C",
-            "sub_path": "filament/Generic PE-CF @BBL X1C.json"
-        },
-        {
-            "name": "Generic PE-CF @BBL A1",
-            "sub_path": "filament/Generic PE-CF @BBL A1.json"
-        },
-        {
-            "name": "Generic PE-CF @BBL A1M",
-            "sub_path": "filament/Generic PE-CF @BBL A1M.json"
-        },
-        {
-            "name": "Generic PP @BBL X1C",
-            "sub_path": "filament/Generic PP @BBL X1C.json"
-        },
-        {
-            "name": "Generic PP @BBL A1",
-            "sub_path": "filament/Generic PP @BBL A1.json"
-        },
-        {
-            "name": "Generic PP @BBL A1M",
-            "sub_path": "filament/Generic PP @BBL A1M.json"
-        },
-        {
-            "name": "Generic PP-CF @BBL X1C",
-            "sub_path": "filament/Generic PP-CF @BBL X1C.json"
-        },
-        {
-            "name": "Generic PP-CF @BBL A1",
-            "sub_path": "filament/Generic PP-CF @BBL A1.json"
-        },
-        {
-            "name": "Generic PP-GF @BBL X1C",
-            "sub_path": "filament/Generic PP-GF @BBL X1C.json"
-        },
-        {
-            "name": "Generic PP-GF @BBL A1",
-            "sub_path": "filament/Generic PP-GF @BBL A1.json"
-        },
-        {
-            "name": "Generic EVA @BBL X1C",
-            "sub_path": "filament/Generic EVA @BBL X1C.json"
-        },
-        {
-            "name": "Generic EVA @BBL A1",
-            "sub_path": "filament/Generic EVA @BBL A1.json"
-        },
-        {
-            "name": "Generic EVA @BBL A1M",
-            "sub_path": "filament/Generic EVA @BBL A1M.json"
-        },
-        {
-            "name": "Generic PHA @BBL X1C",
-            "sub_path": "filament/Generic PHA @BBL X1C.json"
-        },
-        {
-            "name": "Generic PHA @BBL A1M",
-            "sub_path": "filament/Generic PHA @BBL A1M.json"
-        },
-        {
-            "name": "Generic PHA @BBL A1",
-            "sub_path": "filament/Generic PHA @BBL A1.json"
-        },
-        {
-            "name": "Generic BVOH @BBL X1C",
-            "sub_path": "filament/Generic BVOH @BBL X1C.json"
-        },
-        {
-            "name": "Generic BVOH @BBL A1M",
-            "sub_path": "filament/Generic BVOH @BBL A1M.json"
-        },
-        {
-            "name": "Generic BVOH @BBL A1",
-            "sub_path": "filament/Generic BVOH @BBL A1.json"
-        },
-        {
-            "name": "PolyTerra PLA @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/PolyTerra PLA @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "PolyTerra PLA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/PolyTerra PLA @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "PolyLite PLA @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/PolyLite PLA @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "PolyLite PLA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/P1P/PolyLite PLA @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Overture PLA @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Overture PLA @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Overture PLA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Overture PLA @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Overture PLA @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Overture PLA @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Overture Matte PLA @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Overture Matte PLA @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Overture Matte PLA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Overture Matte PLA @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Overture Matte PLA @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Overture Matte PLA @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PLA High Speed @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Generic PLA High Speed @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PLA High Speed @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Generic PLA High Speed @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Generic PLA High Speed @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Generic PLA High Speed @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Glow @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Glow @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Glow @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Glow @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Glow @BBL X1E 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Glow @BBL X1E 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PLA Glow @BBL X1 0.2 nozzle",
-            "sub_path": "filament/Bambu PLA Glow @BBL X1 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG Basic @BBL A1M 0.4 nozzle",
-            "sub_path": "filament/Bambu PETG Basic @BBL A1M 0.4 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG Basic @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/Bambu PETG Basic @BBL A1M 0.2 nozzle.json"
-        },
-        {
-            "name": "Bambu PETG Basic @BBL A1M 0.8 nozzle",
-            "sub_path": "filament/Bambu PETG Basic @BBL A1M 0.8 nozzle.json"
-        },
-        {
-            "name": "Generic PETG-CF @BBL A1M",
-            "sub_path": "filament/P1P/Generic PETG-CF @BBL A1M.json"
-        },
-        {
-            "name": "Bambu PETG-CF @BBL A1M 0.4 nozzle",
-            "sub_path": "filament/Bambu PETG-CF @BBL A1M 0.4 nozzle.json"
-        },
-        {
-            "name": "Bambu PET-CF @BBL X1E",
-            "sub_path": "filament/Bambu PET-CF @BBL X1E.json"
-        },
-        {
-            "name": "PolyLite PETG @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/PolyLite PETG @BBL X1C 0.2 nozzle.json"
-        },
-        {
-            "name": "PolyLite PETG @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/PolyLite PETG @BBL P1P 0.2 nozzle.json"
-        },
-        {
-            "name": "PolyLite PETG @BBL A1M 0.2 nozzle",
-            "sub_path": "filament/PolyLite PETG @BBL A1M 0.2 nozzle.json"
+            "name": "Generic TPU for AMS @BBL X1C",
+            "sub_path": "filament/Generic TPU for AMS @BBL X1C.json"
         },
         {
             "name": "Bambu ABS @BBL X1E",
@@ -3146,16 +3038,56 @@
             "sub_path": "filament/Generic ABS @BBL X1E 0.2 nozzle.json"
         },
         {
-            "name": "PolyLite ABS @BBL X1E",
-            "sub_path": "filament/PolyLite ABS @BBL X1E.json"
+            "name": "PolyLite ABS @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/PolyLite ABS @BBL P1P 0.2 nozzle.json"
         },
         {
             "name": "PolyLite ABS @BBL X1C 0.2 nozzle",
             "sub_path": "filament/PolyLite ABS @BBL X1C 0.2 nozzle.json"
         },
         {
-            "name": "PolyLite ABS @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/PolyLite ABS @BBL P1P 0.2 nozzle.json"
+            "name": "PolyLite ABS @BBL X1E",
+            "sub_path": "filament/PolyLite ABS @BBL X1E.json"
+        },
+        {
+            "name": "Bambu ASA @BBL X1E",
+            "sub_path": "filament/Bambu ASA @BBL X1E.json"
+        },
+        {
+            "name": "Bambu ASA @BBL X1E 0.2 nozzle",
+            "sub_path": "filament/Bambu ASA @BBL X1E 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu ASA @BBL X1E 0.4 nozzle",
+            "sub_path": "filament/Bambu ASA @BBL X1E 0.4 nozzle.json"
+        },
+        {
+            "name": "Generic ASA @BBL X1E",
+            "sub_path": "filament/Generic ASA @BBL X1E.json"
+        },
+        {
+            "name": "Generic ASA @BBL X1E 0.2 nozzle",
+            "sub_path": "filament/Generic ASA @BBL X1E 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyLite ASA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/PolyLite ASA @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyLite ASA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/PolyLite ASA @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyLite ASA @BBL X1E",
+            "sub_path": "filament/PolyLite ASA @BBL X1E.json"
+        },
+        {
+            "name": "Bambu PA-CF @BBL X1E",
+            "sub_path": "filament/Bambu PA-CF @BBL X1E.json"
+        },
+        {
+            "name": "Bambu Support G @BBL X1E",
+            "sub_path": "filament/Bambu Support G @BBL X1E.json"
         },
         {
             "name": "Bambu PC @BBL P1S",
@@ -3174,14 +3106,6 @@
             "sub_path": "filament/Bambu PC @BBL X1E 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PC @BBL P1S 0.8 nozzle",
-            "sub_path": "filament/Bambu PC @BBL P1S 0.8 nozzle.json"
-        },
-        {
-            "name": "Bambu PC @BBL X1E 0.8 nozzle",
-            "sub_path": "filament/Bambu PC @BBL X1E 0.8 nozzle.json"
-        },
-        {
             "name": "Bambu PC @BBL P1S 0.6 nozzle",
             "sub_path": "filament/Bambu PC @BBL P1S 0.6 nozzle.json"
         },
@@ -3190,12 +3114,12 @@
             "sub_path": "filament/Bambu PC @BBL X1E 0.6 nozzle.json"
         },
         {
-            "name": "Generic PC @BBL P1S 0.2 nozzle",
-            "sub_path": "filament/Generic PC @BBL P1S 0.2 nozzle.json"
+            "name": "Bambu PC @BBL P1S 0.8 nozzle",
+            "sub_path": "filament/Bambu PC @BBL P1S 0.8 nozzle.json"
         },
         {
-            "name": "Generic PC @BBL X1E 0.2 nozzle",
-            "sub_path": "filament/Generic PC @BBL X1E 0.2 nozzle.json"
+            "name": "Bambu PC @BBL X1E 0.8 nozzle",
+            "sub_path": "filament/Bambu PC @BBL X1E 0.8 nozzle.json"
         },
         {
             "name": "Generic PC @BBL P1S",
@@ -3206,44 +3130,128 @@
             "sub_path": "filament/Generic PC @BBL X1E.json"
         },
         {
-            "name": "Generic ASA @BBL X1E 0.2 nozzle",
-            "sub_path": "filament/Generic ASA @BBL X1E 0.2 nozzle.json"
+            "name": "Generic PC @BBL P1S 0.2 nozzle",
+            "sub_path": "filament/Generic PC @BBL P1S 0.2 nozzle.json"
         },
         {
-            "name": "Generic ASA @BBL X1E",
-            "sub_path": "filament/Generic ASA @BBL X1E.json"
+            "name": "Generic PC @BBL X1E 0.2 nozzle",
+            "sub_path": "filament/Generic PC @BBL X1E 0.2 nozzle.json"
         },
         {
-            "name": "Bambu ASA @BBL X1E",
-            "sub_path": "filament/Bambu ASA @BBL X1E.json"
+            "name": "Bambu PET-CF @BBL X1E",
+            "sub_path": "filament/Bambu PET-CF @BBL X1E.json"
         },
         {
-            "name": "Bambu ASA @BBL X1E 0.2 nozzle",
-            "sub_path": "filament/Bambu ASA @BBL X1E 0.2 nozzle.json"
+            "name": "Bambu PETG Basic @BBL A1M 0.4 nozzle",
+            "sub_path": "filament/Bambu PETG Basic @BBL A1M 0.4 nozzle.json"
         },
         {
-            "name": "Bambu ASA @BBL X1E 0.4 nozzle",
-            "sub_path": "filament/Bambu ASA @BBL X1E 0.4 nozzle.json"
+            "name": "Bambu PETG Basic @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Bambu PETG Basic @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "PolyLite ASA @BBL X1C 0.2 nozzle",
-            "sub_path": "filament/PolyLite ASA @BBL X1C 0.2 nozzle.json"
+            "name": "Bambu PETG Basic @BBL A1M 0.8 nozzle",
+            "sub_path": "filament/Bambu PETG Basic @BBL A1M 0.8 nozzle.json"
         },
         {
-            "name": "PolyLite ASA @BBL X1E",
-            "sub_path": "filament/PolyLite ASA @BBL X1E.json"
+            "name": "Bambu PETG-CF @BBL A1M 0.4 nozzle",
+            "sub_path": "filament/Bambu PETG-CF @BBL A1M 0.4 nozzle.json"
         },
         {
-            "name": "PolyLite ASA @BBL P1P 0.2 nozzle",
-            "sub_path": "filament/PolyLite ASA @BBL P1P 0.2 nozzle.json"
+            "name": "Generic PETG-CF @BBL A1M",
+            "sub_path": "filament/P1P/Generic PETG-CF @BBL A1M.json"
         },
         {
-            "name": "Bambu Support G @BBL X1E",
-            "sub_path": "filament/Bambu Support G @BBL X1E.json"
+            "name": "PolyLite PETG @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/PolyLite PETG @BBL A1M 0.2 nozzle.json"
         },
         {
-            "name": "Bambu PA-CF @BBL X1E",
-            "sub_path": "filament/Bambu PA-CF @BBL X1E.json"
+            "name": "PolyLite PETG @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/PolyLite PETG @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyLite PETG @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/PolyLite PETG @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PETG @BBL A1M 0.4 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1M.json"
+        },
+        {
+            "name": "SUNLU PETG @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "SUNLU PETG @BBL A1M 0.8 nozzle",
+            "sub_path": "filament/SUNLU/SUNLU PETG @BBL A1M 0.8 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Glow @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Glow @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Glow @BBL X1 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Glow @BBL X1 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Glow @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Glow @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Bambu PLA Glow @BBL X1E 0.2 nozzle",
+            "sub_path": "filament/Bambu PLA Glow @BBL X1E 0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PLA High Speed @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Generic PLA High Speed @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PLA High Speed @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Generic PLA High Speed @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Generic PLA High Speed @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Generic PLA High Speed @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Overture Matte PLA @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Overture Matte PLA @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Overture Matte PLA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Overture Matte PLA @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Overture Matte PLA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Overture Matte PLA @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "Overture PLA @BBL A1M 0.2 nozzle",
+            "sub_path": "filament/Overture PLA @BBL A1M 0.2 nozzle.json"
+        },
+        {
+            "name": "Overture PLA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/Overture PLA @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "Overture PLA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/Overture PLA @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyLite PLA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/PolyLite PLA @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyLite PLA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/PolyLite PLA @BBL X1C 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyTerra PLA @BBL P1P 0.2 nozzle",
+            "sub_path": "filament/P1P/PolyTerra PLA @BBL P1P 0.2 nozzle.json"
+        },
+        {
+            "name": "PolyTerra PLA @BBL X1C 0.2 nozzle",
+            "sub_path": "filament/PolyTerra PLA @BBL X1C 0.2 nozzle.json"
         },
         {
             "name": "PolyLite ABS @BBL X1E 0.2 nozzle",
@@ -3252,6 +3260,26 @@
         {
             "name": "PolyLite ASA @BBL X1E 0.2 nozzle",
             "sub_path": "filament/PolyLite ASA @BBL X1E 0.2 nozzle.json"
+        },
+        {
+            "name": "AliZ PA-CF @P1-X1",
+            "sub_path": "filament/AliZ/AliZ PA-CF @P1-X1.json"
+        },
+        {
+            "name": "AliZ PETG @P1-X1",
+            "sub_path": "filament/AliZ/AliZ PETG @P1-X1.json"
+        },
+        {
+            "name": "AliZ PETG-CF @P1-X1",
+            "sub_path": "filament/AliZ/AliZ PETG-CF @P1-X1.json"
+        },
+        {
+            "name": "AliZ PETG-Metal @P1-X1",
+            "sub_path": "filament/AliZ/AliZ PETG-Metal @P1-X1.json"
+        },
+        {
+            "name": "AliZ PLA @P1-X1",
+            "sub_path": "filament/AliZ/AliZ PLA @P1-X1.json"
         }
     ],
     "machine_list": [

--- a/resources/profiles/BBL/filament/AliZ/AliZ PA-CF @P1-X1.json
+++ b/resources/profiles/BBL/filament/AliZ/AliZ PA-CF @P1-X1.json
@@ -1,0 +1,21 @@
+{
+    "type": "filament",
+    "setting_id": "AliZPX1FSA04",
+    "name": "AliZ PA-CF @P1-X1",
+    "from": "system",
+    "instantiation": "true",
+    "inherits": "AliZ PA-CF @base",
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.026"
+    ],
+    "compatible_printers": [
+            "Bambu Lab X1 Carbon 0.4 nozzle",
+            "Bambu Lab X1 0.4 nozzle",
+            "Bambu Lab P1P 0.4 nozzle",
+            "Bambu Lab P1S 0.4 nozzle",
+            "Bambu Lab X1E 0.4 nozzle"
+        ]
+}

--- a/resources/profiles/BBL/filament/AliZ/AliZ PETG @P1-X1.json
+++ b/resources/profiles/BBL/filament/AliZ/AliZ PETG @P1-X1.json
@@ -1,0 +1,22 @@
+{
+    "type": "filament",
+    "filament_id": "GFG99",
+    "setting_id": "AliZPX1FSA04",
+    "name": "AliZ PETG @P1-X1",
+    "from": "system",
+    "instantiation": "true",
+    "inherits": "AliZ PETG @base",
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.026"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab X1E 0.4 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/AliZ/AliZ PETG-CF @P1-X1.json
+++ b/resources/profiles/BBL/filament/AliZ/AliZ PETG-CF @P1-X1.json
@@ -1,0 +1,21 @@
+{
+    "type": "filament",
+    "name": "AliZ PETG-CF @P1-X1",
+    "inherits": "AliZ PETG-CF @base",
+    "from": "system",
+    "setting_id": "AliZPX1FSG50",
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.026"
+    ],
+    "instantiation": "true",
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab X1E 0.4 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/AliZ/AliZ PETG-Metal @P1-X1.json
+++ b/resources/profiles/BBL/filament/AliZ/AliZ PETG-Metal @P1-X1.json
@@ -1,0 +1,21 @@
+{
+    "type": "filament",
+    "name": "AliZ PETG-Metal @P1-X1",
+    "inherits": "AliZ PETG-Metal @base",
+    "from": "system",
+    "setting_id": "AliZPX1FSG50",
+    "instantiation": "true",    
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.026"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab X1E 0.4 nozzle"
+    ]
+}

--- a/resources/profiles/BBL/filament/AliZ/AliZ PLA @P1-X1.json
+++ b/resources/profiles/BBL/filament/AliZ/AliZ PLA @P1-X1.json
@@ -1,0 +1,21 @@
+{
+    "type": "filament",
+    "setting_id": "AliZPX1FSA04",
+    "name": "AliZ PLA @P1-X1",
+    "from": "system",
+    "instantiation": "true",
+    "inherits": "AliZ PLA @base",
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "pressure_advance": [
+        "0.015"
+    ],
+    "compatible_printers": [
+        "Bambu Lab X1 Carbon 0.4 nozzle",
+        "Bambu Lab X1 0.4 nozzle",
+        "Bambu Lab P1P 0.4 nozzle",
+        "Bambu Lab P1S 0.4 nozzle",
+        "Bambu Lab X1E 0.4 nozzle"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -133,6 +133,10 @@
             "sub_path": "filament/Generic HIPS @System.json"
         },
         {
+            "name": "AliZ PA-CF @base",
+            "sub_path": "filament/AliZ/AliZ PA-CF @base.json"
+        },
+        {
             "name": "Bambu PA-CF @base",
             "sub_path": "filament/Bambu/Bambu PA-CF @base.json"
         },
@@ -205,6 +209,10 @@
             "sub_path": "filament/Generic PE-CF @System.json"
         },
         {
+            "name": "AliZ PETG @base",
+            "sub_path": "filament/AliZ/AliZ PETG @base.json"
+        },
+        {
             "name": "Bambu PET-CF @base",
             "sub_path": "filament/Bambu/Bambu PET-CF @base.json"
         },
@@ -259,6 +267,10 @@
         {
             "name": "Generic PHA @System",
             "sub_path": "filament/Generic PHA @System.json"
+        },
+        {
+            "name": "AliZ PLA @base",
+            "sub_path": "filament/AliZ/AliZ PLA @base.json"
         },
         {
             "name": "Bambu PLA Aero @base",
@@ -481,6 +493,10 @@
             "sub_path": "filament/Polymaker/PolyLite ASA @System.json"
         },
         {
+            "name": "AliZ PA-CF @System",
+            "sub_path": "filament/AliZ/AliZ PA-CF @System.json"
+        },
+        {
             "name": "Bambu PA-CF @System",
             "sub_path": "filament/Bambu/Bambu PA-CF @System.json"
         },
@@ -529,6 +545,18 @@
             "sub_path": "filament/Bambu/Bambu PC FR @System.json"
         },
         {
+            "name": "AliZ PETG @System",
+            "sub_path": "filament/AliZ/AliZ PETG @System.json"
+        },
+        {
+            "name": "AliZ PETG-CF @base",
+            "sub_path": "filament/AliZ/AliZ PETG-CF @base.json"
+        },
+        {
+            "name": "AliZ PETG-Metal @base",
+            "sub_path": "filament/AliZ/AliZ PETG-Metal @base.json"
+        },
+        {
             "name": "Bambu PET-CF @System",
             "sub_path": "filament/Bambu/Bambu PET-CF @System.json"
         },
@@ -567,6 +595,10 @@
         {
             "name": "SUNLU PETG @System",
             "sub_path": "filament/SUNLU/SUNLU PETG @System.json"
+        },
+        {
+            "name": "AliZ PLA @System",
+            "sub_path": "filament/AliZ/AliZ PLA @System.json"
         },
         {
             "name": "Bambu PLA Aero @System",
@@ -711,6 +743,14 @@
         {
             "name": "Bambu TPU 95A HF @System",
             "sub_path": "filament/Bambu/Bambu TPU 95A HF @System.json"
+        },
+        {
+            "name": "AliZ PETG-CF @System",
+            "sub_path": "filament/AliZ/AliZ PETG-CF @System.json"
+        },
+        {
+            "name": "AliZ PETG-Metal @System",
+            "sub_path": "filament/AliZ/AliZ PETG-Metal @System.json"
         }
     ]
 }

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PA-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PA-CF @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "setting_id": "AliZGFSA04",
+    "name": "AliZ PA-CF @System",
+    "from": "system",
+    "instantiation": "true",
+    "inherits": "AliZ PA-CF @base",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PA-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PA-CF @base.json
@@ -1,0 +1,77 @@
+{
+    "type": "filament",
+    "filament_id": "GFN98",
+    "name": "AliZ PA-CF @base",
+    "from": "system",
+    "instantiation": "false",
+    "inherits": "fdm_filament_pa",
+    "filament_type": [
+        "PA-CF"
+    ],
+    "complete_print_exhaust_fan_speed": [
+        "80"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "60"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "80"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "80"
+    ],
+    "fan_cooling_layer_time": [
+        "5"
+    ],
+    "fan_max_speed": [
+        "30"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "49.9"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "8"
+    ],
+    "filament_vendor": [
+        "Aliz"
+    ],
+    "full_fan_speed_layer": [
+        "2"
+    ],
+    "nozzle_temperature": [
+        "290"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "290"
+    ],
+    "nozzle_temperature_range_high": [
+        "300"
+    ],
+    "nozzle_temperature_range_low": [
+        "260"
+    ],
+    "overhang_fan_speed": [
+        "40"
+    ],
+    "overhang_fan_threshold": [
+        "0%"
+    ],
+    "pressure_advance": [
+        "0.026"
+    ],
+    "slow_down_layer_time": [
+        "2"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG @System.json
@@ -1,0 +1,10 @@
+{
+    "type": "filament",
+    "filament_id": "GFG99",
+    "setting_id": "AliZGFSA04",
+    "name": "AliZ PETG @System",
+    "from": "system",
+    "instantiation": "true",
+    "inherits": "AliZ PETG @base",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG @base.json
@@ -1,0 +1,56 @@
+{
+    "type": "filament",
+    "filament_id": "GFG99",
+    "name": "AliZ PETG @base",
+    "from": "system",
+    "instantiation": "false",
+    "inherits": "fdm_filament_pet",
+    "close_fan_the_first_x_layers": [
+        "2"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_cost": [
+        "49.9"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "15"
+    ],
+    "filament_vendor": [
+        "Aliz"
+    ],
+    "hot_plate_temp": [
+        "79"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "79"
+    ],
+    "nozzle_temperature": [
+        "250"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "250"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "pressure_advance": [
+        "0.036"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-CF @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-CF @System.json
@@ -1,0 +1,8 @@
+{
+    "type": "filament",
+    "name": "AliZ PETG-CF @System",
+    "inherits": "AliZ PETG-CF @base",
+    "from": "system",
+    "setting_id": "AliZGFSG50",
+    "instantiation": "true"
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-CF @base.json
@@ -1,0 +1,74 @@
+{
+    "type": "filament",
+    "name": "AliZ PETG-CF @base",
+    "inherits": "AliZ PETG @base",
+    "filament_id": "GFG50",
+    "from": "system",
+    "instantiation": "false",
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "close_fan_the_first_x_layers": [
+        "2"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "pressure_advance": [
+        "0.033"
+    ],
+    "fan_max_speed": [
+        "35"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_cost": [
+        "49.9"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "10"
+    ],
+    "filament_type": [
+        "PETG-CF"
+    ],
+    "filament_vendor": [
+        "Aliz"
+    ],
+    "hot_plate_temp": [
+        "79"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "79"
+    ],
+    "nozzle_temperature": [
+        "275"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "275"
+    ],
+    "nozzle_temperature_range_high": [
+        "290"
+    ],
+    "nozzle_temperature_range_low": [
+        "260"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-Metal @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-Metal @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "name": "AliZ PETG-Metal @System",
+    "inherits": "AliZ PETG-Metal @base",
+    "from": "system",
+    "setting_id": "AliZGFSG50",
+    "instantiation": "true",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-Metal @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-Metal @base.json
@@ -1,0 +1,64 @@
+{
+    "type": "filament",
+    "name": "AliZ PETG-Metal @base",
+    "inherits": "AliZ PETG @base",
+    "from": "system",
+    "instantiation": "false",
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "overhang_fan_speed": [
+        "100"
+    ],
+    "close_fan_the_first_x_layers": [
+        "2"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "30"
+    ],
+    "filament_cost": [
+        "49.9"
+    ],
+    "filament_flow_ratio": [
+        "1"
+    ],
+    "filament_max_volumetric_speed": [
+        "13"
+    ],
+    "filament_vendor": [
+        "Aliz"
+    ],
+    "hot_plate_temp": [
+        "79"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "79"
+    ],
+    "nozzle_temperature": [
+        "260"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "pressure_advance": [
+        "0.036"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "textured_plate_temp": [
+        "70"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "70"
+    ]
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PLA @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "setting_id": "AliZGFSA04",
+    "name": "AliZ PLA @System",
+    "from": "system",
+    "instantiation": "true",
+    "inherits": "AliZ PLA @base",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PLA @base.json
@@ -1,0 +1,43 @@
+{
+    "type": "filament",
+    "name": "AliZ PLA @base",
+    "from": "system",
+    "instantiation": "false",
+    "inherits": "fdm_filament_pla",
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "filament_cost": [
+        "69"
+    ],
+    "filament_density": [
+        "1.27"
+    ],
+    "filament_vendor": [
+        "Aliz"
+    ],
+    "filament_wipe_distance": [
+        "0"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "pressure_advance": [
+        "0.025"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ]
+}


### PR DESCRIPTION
# Description

This PR demonstrates how to add filament profiles to Orca.
There are two parts:
1. Add filaments into the global Orca Filament Library, we shall define all the major parameters in `AliZ PLA @base.json` file
```
resources\profiles\OrcaFilamentLibrary\filament\AliZ\AliZ PLA @base.json
resources\profiles\OrcaFilamentLibrary\filament\AliZ\AliZ PLA @System.json
```

2. (Optional) Add machine specialized version of filament into vendor's profiles
```
resources\profiles\BBL\filament\AliZ\AliZ PLA @P1-X1.json
```
`AliZ PLA @P1-X1` is derived from `AliZ PLA @base` and includes only the modified parameters. Additionally, we must define `compatible_printers` for these profiles to inform OrcaSlicer which printer models they are optimized for
```json
{
    "type": "filament",
    "setting_id": "AliZPX1FSA04",
    "name": "AliZ PLA @P1-X1",
    "from": "system",
    "instantiation": "true",
    "inherits": "AliZ PLA @base",
    "enable_pressure_advance": [
        "1"
    ],
    "pressure_advance": [
        "0.015"
    ],
    "compatible_printers": [
        "Bambu Lab X1 Carbon 0.4 nozzle",
        "Bambu Lab X1 0.4 nozzle",
        "Bambu Lab P1P 0.4 nozzle",
        "Bambu Lab P1S 0.4 nozzle",
        "Bambu Lab X1E 0.4 nozzle"
    ]
}
```
# Screenshots/Recordings/Graphs

![image](https://github.com/user-attachments/assets/df413079-f556-4a77-acec-2faf487a483d)
![image](https://github.com/user-attachments/assets/99d914cc-7667-4b96-a026-a03742b87ba4)

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
