### PR TITLE
Mention orcaslicer.com as an official platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Join our Discord community here:<br>
  
  <h3>🚨🚨🚨Important Security Alert🚨🚨🚨</h3> 
 
+The only official platforms for OrcaSlicer are **our GitHub project page**, <a href="https://www.orcaslicer.com/">**orcaslicer.com**</a>, and the <a href="https://discord.gg/P4VE9UY9gJ">**official Discord channel**</a>.
+
 Please be aware that "**orcaslicer.net**", "**orcaslicer.co**" or "**orca-slicer.com**" are NOT an official website for OrcaSlicer and may be potentially malicious. These sites appear to use AI-generated content, lacking genuine context and seems to exist solely to profit from advertisements. Worse, it may redirect download links to harmful sources. For your safety, avoid downloading OrcaSlicer from this site as the links may be compromised. 
 
 If you see the above sites in your searches, report them as spam or unsafe to the search engine. This small action will assist everyone.
-
-The only official platforms for OrcaSlicer are our GitHub project page and the  <a href="https://discord.gg/P4VE9UY9gJ">official Discord channel</a> .
 
 We deeply value our OrcaSlicer community and appreciate all the social groups that support us. However, it is crucial to address the risk posed by any group that falsely claims to be official or misleads its members. If you encounter such a group or are part of one, please assist by encouraging the group owner to add a clear disclaimer or by alerting its members.
 


### PR DESCRIPTION
# Description

The readme didn't mention the new website as added in the 2.3.0-beta release:

> Orca Slicer has it's own official website now! https://www.OrcaSlicer.com

https://github.com/SoftFever/OrcaSlicer/releases/tag/v2.3.0-beta