### PR TITLE
Increase upload timeout for Flashforge printers to 10 minutes

### DIFF
--- a/src/slic3r/Utils/Flashforge.cpp
+++ b/src/slic3r/Utils/Flashforge.cpp
@@ -67,6 +67,9 @@ bool Flashforge::upload(PrintHostUpload upload_data, ProgressFn progress_fn, Err
     bool res = true;
 
     Utils::TCPConsole client(m_host, m_console_port);
+    //sometimes FF AD5M is very slow in data upload, so timeout is increased to 10 minutes
+    client.set_write_timeout(std::chrono::minutes(10));
+    client.set_read_timeout(std::chrono::minutes(10));
     client.enqueue_cmd(controlCommand);
    
     client.enqueue_cmd(connect5MCommand);

--- a/src/slic3r/Utils/TCPConsole.hpp
+++ b/src/slic3r/Utils/TCPConsole.hpp
@@ -33,6 +33,14 @@ public:
         m_read_timeout = std::chrono::milliseconds(10000);
     }
 
+    void set_write_timeout(std::chrono::steady_clock::duration timeout) {
+        m_write_timeout = timeout;
+    }
+
+    void set_read_timeout(std::chrono::steady_clock::duration timeout) {
+        m_read_timeout = timeout;
+    }
+
     void set_line_delimiter(const std::string& newline) {
         m_newline = newline;
     }


### PR DESCRIPTION
# Description

When Flashforge AD5m is connected via Wi-fi, I have got frequent timeout errors on big models upload. 
So I increased timeouts for this operation from 10 seconds to 10 minutes, which definely helped. 
Fixes issue #4834 


## Tests

Tested by large Ad5m community - it works.