### PR TITLE
Add: additional constant wipe tower volume

### DIFF
--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -557,7 +557,8 @@ WipeTower2::WipeTower2(const PrintConfig& config, const PrintRegionConfig& defau
     m_perimeter_speed(default_region_config.inner_wall_speed),
     m_current_tool(initial_tool),
     wipe_volumes(wiping_matrix),
-    m_wipe_tower_max_purge_speed(float(config.wipe_tower_max_purge_speed))
+    m_wipe_tower_max_purge_speed(float(config.wipe_tower_max_purge_speed)),
+    m_wipe_tower_additional_volume(float(config.wipe_tower_additional_volume))
 {
     // Read absolute value of first layer speed, if given as percentage,
     // it is taken over following default. Speeds from config are not

--- a/src/libslic3r/GCode/WipeTower2.hpp
+++ b/src/libslic3r/GCode/WipeTower2.hpp
@@ -192,6 +192,7 @@ private:
     float  m_travel_speed       = 0.f;
 	float  m_infill_speed       = 0.f;
     float  m_wipe_tower_max_purge_speed   = 90.f;
+    float  m_wipe_tower_additional_volume   = 0.f;
 	float  m_perimeter_speed    = 0.f;
     float  m_first_layer_speed  = 0.f;
     size_t m_first_layer_idx    = size_t(-1);

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -831,7 +831,7 @@ static std::vector<std::string> s_Preset_print_options {
      "tree_support_brim_width", "gcode_comments", "gcode_label_objects",
      "initial_layer_travel_speed", "exclude_object", "slow_down_layers", "infill_anchor", "infill_anchor_max","initial_layer_min_bead_width",
      "make_overhang_printable", "make_overhang_printable_angle", "make_overhang_printable_hole_size" ,"notes",
-     "wipe_tower_cone_angle", "wipe_tower_extra_spacing","wipe_tower_max_purge_speed", "wipe_tower_filament", "wiping_volumes_extruders","wipe_tower_bridging", "wipe_tower_extra_flow","single_extruder_multi_material_priming",
+     "wipe_tower_cone_angle", "wipe_tower_extra_spacing","wipe_tower_max_purge_speed", "wipe_tower_additional_volume", "wipe_tower_filament", "wiping_volumes_extruders","wipe_tower_bridging", "wipe_tower_extra_flow","single_extruder_multi_material_priming",
      "wipe_tower_rotation_angle", "tree_support_branch_distance_organic", "tree_support_branch_diameter_organic", "tree_support_branch_angle_organic",
      "hole_to_polyhole", "hole_to_polyhole_threshold", "hole_to_polyhole_twisted", "mmu_segmented_region_max_width", "mmu_segmented_region_interlocking_depth",
      "small_area_infill_flow_compensation", "small_area_infill_flow_compensation_model",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -303,6 +303,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
             || opt_key == "wipe_tower_cone_angle"
             || opt_key == "wipe_tower_extra_spacing"
             || opt_key == "wipe_tower_max_purge_speed"
+            || opt_key == "wipe_tower_additional_volume"
             || opt_key == "wipe_tower_filament"
             || opt_key == "wiping_volumes_extruders"
             || opt_key == "enable_filament_ramming"
@@ -2661,6 +2662,15 @@ void Print::_make_wipe_tower()
     if (!m_wipe_tower_data.tool_ordering.has_wipe_tower())
         // Don't generate any wipe tower.
         return;
+
+    // add additional constant purge volume if needed
+    if (m_config.wipe_tower_additional_volume > 0) {
+    	for (unsigned int i = 0; i < number_of_extruders; ++i) {
+            for (unsigned int j = 0; j < number_of_extruders; ++j) {
+                 wipe_volumes[i][j] += m_config.wipe_tower_additional_volume;
+            }
+        }
+    }
 
     // Check whether there are any layers in m_tool_ordering, which are marked with has_wipe_tower,
     // they print neither object, nor support. These layers are above the raft and below the object, and they

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5341,6 +5341,15 @@ void PrintConfigDef::init_fff_params()
     def->min = 10;
     def->set_default_value(new ConfigOptionFloat(90.));
 
+    def = this->add("wipe_tower_additional_volume", coFloat);
+    def->label = L("Additional wipe tower purged volume");
+    def->tooltip = L("A constant volume added to wipe tower to offset additional material left in melt zone."
+                     "When changing material, in certain cases, such as hotends with long melt zones, a significant amount of filament may need to be purged in addition to the volume calculated between colors.");
+    def->sidetext = L("mm³");
+    def->mode = comAdvanced;
+    def->min = 0;
+    def->set_default_value(new ConfigOptionFloat(0.));
+
     def = this->add("wipe_tower_filament", coInt);
     def->gui_type = ConfigOptionDef::GUIType::i_enum_open;
     def->label = L("Wipe tower");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1317,6 +1317,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
 
     // Orca: mmu support
     ((ConfigOptionFloat,              wipe_tower_cone_angle))
+    ((ConfigOptionFloat,              wipe_tower_additional_volume))
     ((ConfigOptionPercent,            wipe_tower_extra_spacing))
     ((ConfigOptionFloat,              wipe_tower_max_purge_speed))
     ((ConfigOptionInt,                wipe_tower_filament))

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -682,7 +682,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     for (auto el : {"wipe_tower_rotation_angle", "wipe_tower_cone_angle",
                     "wipe_tower_extra_spacing", "wipe_tower_max_purge_speed",
                     "wipe_tower_bridging", "wipe_tower_extra_flow",
-                    "wipe_tower_no_sparse_layers"})
+                    "wipe_tower_no_sparse_layers", "wipe_tower_additional_volume"})
       toggle_line(el, have_prime_tower && !is_BBL_Printer);
 
     toggle_line("single_extruder_multi_material_priming", !bSEMM && have_prime_tower && !is_BBL_Printer);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2799,8 +2799,8 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
         "brim_width", "wall_loops", "wall_filament", "sparse_infill_density", "sparse_infill_filament", "top_shell_layers",
         "enable_support", "support_filament", "support_interface_filament",
         "support_top_z_distance", "support_bottom_z_distance", "raft_layers",
-        "wipe_tower_rotation_angle", "wipe_tower_cone_angle", "wipe_tower_extra_spacing", "wipe_tower_extra_flow", "wipe_tower_max_purge_speed", "wipe_tower_filament",
-        "best_object_pos"
+        "wipe_tower_rotation_angle", "wipe_tower_cone_angle", "wipe_tower_extra_spacing", "wipe_tower_extra_flow",
+          "wipe_tower_max_purge_speed", "wipe_tower_filament", "wipe_tower_additional_volume", "best_object_pos"
         }))
     , sidebar(new Sidebar(q))
     , notification_manager(std::make_unique<NotificationManager>(q))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2307,6 +2307,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("wipe_tower_extra_spacing");
         optgroup->append_single_option_line("wipe_tower_extra_flow");
         optgroup->append_single_option_line("wipe_tower_max_purge_speed");
+        optgroup->append_single_option_line("wipe_tower_additional_volume");
         optgroup->append_single_option_line("wipe_tower_no_sparse_layers");
         optgroup->append_single_option_line("single_extruder_multi_material_priming");
 


### PR DESCRIPTION
# Description

I use a filament cutter on my printer with ERCF. It leads to a small fragment of filament always being left in the hotend. I not find any way to simply add the volume to purge tower to purge the fragment first, minimum purge volume per filament is not an optimal option here.
Without such an added volume when doing changes with low purge volume the calculated volume (for example white to black) needs to be multiplied by a lot, which leads to large waste of filament with purges with large volumes (such as black to white). 
Adding a volume allows for the calculated volume purge to start at a point where at the end of melt zone there is new filament instead of the tip.

This change adds an option to simply add a constant volume to purge tower purge volume.
Little of the source code was changed: I added option to the interface and a loop that adds the volume to matrix elements if it's not 0. 

# Screenshots/Recordings/Graphs
With value of 0
![image](https://github.com/user-attachments/assets/c534c460-0490-427e-91fb-56ba943c1974)

With some value (no other options changed)
![image](https://github.com/user-attachments/assets/e431f980-dc04-43d9-878c-b2421d9544b5)

## Tests
I have ensured the values are saved, the default value is 0 and no preset profiles were modified. The project compiles on Fedora 41 after the changes.


Thank you for your time!
