### PR TITLE
Correct Flying Bear S1 / Ghost 6 extruder clearance radius

### DIFF
--- a/resources/profiles/FlyingBear/machine/FlyingBear Ghost 6 0.4 nozzle.json
+++ b/resources/profiles/FlyingBear/machine/FlyingBear Ghost 6 0.4 nozzle.json
@@ -110,7 +110,7 @@
     ],
     "extruder_clearance_height_to_lid": "80",
     "extruder_clearance_height_to_rod": "64",
-    "extruder_clearance_radius": "40",
+    "extruder_clearance_radius": "55",
     "z_hop": [
         "0.2"
     ],

--- a/resources/profiles/FlyingBear/machine/S1/FlyingBear S1 0.4 nozzle.json
+++ b/resources/profiles/FlyingBear/machine/S1/FlyingBear S1 0.4 nozzle.json
@@ -29,7 +29,7 @@
   "extra_loading_move": "-2",
   "extruder_clearance_height_to_lid": "69",
   "extruder_clearance_height_to_rod": "69",
-  "extruder_clearance_radius": "49",
+  "extruder_clearance_radius": "55",
   "extruder_colour": [
       "#FCE94F"
   ],


### PR DESCRIPTION
Current values are wrong as previously was pointed out here https://github.com/SoftFever/OrcaSlicer/pull/7822

The head size of these two 3D printers is the same.
