### PR TITLE
Enable checkbox in printer profiles to permit first layer scanning to be enabled/disabled via the slicer

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3776,6 +3776,7 @@ void TabPrinter::build_fff()
         optgroup->append_single_option_line("gcode_flavor");
         optgroup->append_single_option_line("pellet_modded_printer", "pellet-flow-coefficient");
         optgroup->append_single_option_line("bbl_use_printhost");
+        optgroup->append_single_option_line("scan_first_layer");
         optgroup->append_single_option_line("disable_m73");
         option = optgroup->get_option("thumbnails");
         option.opt.full_width = true;


### PR DESCRIPTION
# Description

Bambu Studio has an boolean option scan_first_layer and this is used in the G-Code to allow the slicer to enable or disable the first layer scan. 

![image](https://github.com/user-attachments/assets/33d0c353-5b02-4dbc-be3b-7bd469c85c3c)

Orca Slicer has all the logic for this in place but does not allow the user to edit this setting. 

This pull request simply enables a checkbox to control this in the printer profile on the basic tab under advanced. This option will be hidden by default unless the user selects to enable advanced settings or developer mode

# Screenshots/Recordings/Graphs

<img width="750" alt="image" src="https://github.com/user-attachments/assets/60af05fa-0938-4bd2-9587-ee50f03a836e" />

## Tests

This has compiled successfully, and I have confirmed that when the printer profile is saved the setting is restored on reloading.
