### PR TITLE
Allow compilation on distributions based on Ubuntu/Debian

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -78,10 +78,13 @@ then
     exit 0
 fi
 
-DISTRIBUTION=$(awk -F= '/^ID=/ {print $2}' /etc/os-release)
-# treat any ubuntu based os as debian
-if [ "${DISTRIBUTION_LIKE}" == "\"ubuntu debian"\" ]
-then
+DISTRIBUTION=$(awk -F= '/^ID=/ {print $2}' /etc/os-release | tr -d '"')
+DISTRIBUTION_LIKE=$(awk -F= '/^ID_LIKE=/ {print $2}' /etc/os-release | tr -d '"')
+# Check for direct distribution match to Ubuntu/Debian
+if [ "${DISTRIBUTION}" == "ubuntu" ] || [ "${DISTRIBUTION}" == "linuxmint" ]; then
+    DISTRIBUTION="debian"
+# Check if distribution is Debian/Ubuntu-like based on ID_LIKE
+elif [[ "${DISTRIBUTION_LIKE}" == *"debian"* ]] || [[ "${DISTRIBUTION_LIKE}" == *"ubuntu"* ]]; then
     DISTRIBUTION="debian"
 fi
 if [ ! -f ./linux.d/${DISTRIBUTION} ]

--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -80,7 +80,7 @@ fi
 
 DISTRIBUTION=$(awk -F= '/^ID=/ {print $2}' /etc/os-release)
 # treat any ubuntu based os as debian
-if [ "${DISTRIBUTION_LIKE}" == "\"ubuntu debian\"" ]
+if [ "${DISTRIBUTION_LIKE}" == "\"ubuntu debian"\" ]
 then
     DISTRIBUTION="debian"
 fi

--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -79,8 +79,8 @@ then
 fi
 
 DISTRIBUTION=$(awk -F= '/^ID=/ {print $2}' /etc/os-release)
-# treat ubuntu as debian
-if [ "${DISTRIBUTION}" == "ubuntu" ] || [ "${DISTRIBUTION}" == "linuxmint" ]
+# treat any ubuntu based os as debian
+if [ "${DISTRIBUTION_LIKE}" == "\"ubuntu debian\"" ]
 then
     DISTRIBUTION="debian"
 fi


### PR DESCRIPTION
Fixes #7803

If a Linux distribution is based on Ubuntu/Debian, it will compile Orca Slicer rather than giving a unsupported distro error.