### PR TITLE
Enhancement "Only one wall on top surfaces": better support for interface_shells

### DIFF
--- a/src/libslic3r/LayerRegion.cpp
+++ b/src/libslic3r/LayerRegion.cpp
@@ -107,7 +107,11 @@ void LayerRegion::make_perimeters(const SurfaceCollection &slices, const LayerRe
         g.lower_slices = &this->layer()->lower_layer->lslices;
     if (this->layer()->upper_layer != NULL)
         g.upper_slices = &this->layer()->upper_layer->lslices;
-    
+
+    int region_id = this->region().print_object_region_id();
+    if (this->layer()->upper_layer != NULL)
+        g.upper_slices_same_region = &this->layer()->upper_layer->get_region(region_id)->slices;
+
     g.layer_id              = (int)this->layer()->id();
     g.ext_perimeter_flow    = this->flow(frExternalPerimeter);
     g.overhang_flow         = this->bridging_flow(frPerimeter, object_config.thick_bridges);

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1368,7 +1368,13 @@ void PerimeterGenerator::split_top_surfaces(const ExPolygons &orig_polygons, ExP
     double min_width_top_surface = std::max(double(ext_perimeter_spacing / 2. + 10), scale_(config->min_width_top_surface.get_abs_value(unscale_(perimeter_width))));
 
     // get the Polygons upper the polygon this layer
-    Polygons upper_polygons_series_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, last_box);
+    Polygons upper_polygons_series_clipped;
+    if (object_config->interface_shells) {
+        auto upper_slicer_same_region = to_expolygons(this->upper_slices_same_region->surfaces);
+        upper_polygons_series_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(upper_slicer_same_region, last_box);
+    } else
+        upper_polygons_series_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*this->upper_slices, last_box);
+
     upper_polygons_series_clipped          = offset(upper_polygons_series_clipped, min_width_top_surface);
 
     // set the clip to a virtual "second perimeter"
@@ -2991,7 +2997,13 @@ void PerimeterGenerator::process_arachne()
             coord_t perimeter_width = this->perimeter_flow.scaled_width();
 
             // Get top ExPolygons from current infill contour.
-            Polygons upper_slices_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*upper_slices, infill_contour_bbox);
+            Polygons upper_slices_clipped;
+            if (object_config->interface_shells) {
+                auto upper_slicer_same_region = to_expolygons(this->upper_slices_same_region->surfaces);
+                upper_slices_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(upper_slicer_same_region, infill_contour_bbox);
+            } else
+                upper_slices_clipped = ClipperUtils::clip_clipper_polygons_with_subject_bbox(*upper_slices, infill_contour_bbox);
+
             top_expolygons = diff_ex(infill_contour, upper_slices_clipped);
 
             if (!top_expolygons.empty()) {

--- a/src/libslic3r/PerimeterGenerator.hpp
+++ b/src/libslic3r/PerimeterGenerator.hpp
@@ -63,6 +63,7 @@ public:
     const SurfaceCollection     *slices;
     const LayerRegionPtrs       *compatible_regions;
     const ExPolygons            *upper_slices;
+    const SurfaceCollection     *upper_slices_same_region;
     const ExPolygons            *lower_slices;
     double                       layer_height;
     int                          layer_id;


### PR DESCRIPTION
# Description

This PR aims to enhance OrcaSlicer's `Only one wall on top surfaces` feature.
Previously, walls were incorrectly generated if both `interface_shells` and `only_one_wall_top` are enabled where there should be a wall because(Ref to the screenshot)

# Screenshots/Recordings/Graphs
![onewall](https://github.com/user-attachments/assets/3f5c2d7c-f4f9-453f-a9e5-148642ec8297)



## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
[KayTag_Test.zip](https://github.com/user-attachments/files/19039228/KayTag_Test.zip)
