### PR TITLE
Fix bedplate texture appears black until viewport refresh

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -737,6 +737,9 @@ void PartPlate::render_logo_texture(GLTexture &logo_texture, GLModel& logo_buffe
 			shader->stop_using();
 		}
 	}
+    // ORCA Refresh viewport after loading texture
+    m_plater->get_current_canvas3D()->set_as_dirty();
+    m_plater->get_current_canvas3D()->request_extra_frame();
 }
 
 void PartPlate::render_logo(bool bottom, bool render_cali)


### PR DESCRIPTION
![Screenshot-20250302001727](https://github.com/user-attachments/assets/91a57d2a-0c40-42eb-8c2c-13cb45d4f6f4)

Refreshes viewport after soon as texture load ended

Normally texture appears black until user moves mouse cursor to viewport

more information on https://github.com/SoftFever/OrcaSlicer/issues/4566