### PR TITLE
Fix preset transfer crash

### DIFF
--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -2383,13 +2383,17 @@ void DiffPresetDialog::button_event(Action act)
 
 std::string DiffPresetDialog::get_left_preset_name(Preset::Type type)
 {
-    PresetComboBox* cb = m_preset_combos[int(type - Preset::TYPE_PRINT)].presets_left;
+    PresetComboBox* cb = std::find_if(m_preset_combos.begin(), m_preset_combos.end(), [type](const DiffPresets& p) {
+                             return p.presets_left->get_type() == type;
+                         })->presets_left;
     return Preset::remove_suffix_modified(get_selection(cb));
 }
 
 std::string DiffPresetDialog::get_right_preset_name(Preset::Type type)
 {
-    PresetComboBox* cb = m_preset_combos[int(type - Preset::TYPE_PRINT)].presets_right;
+    PresetComboBox* cb = std::find_if(m_preset_combos.begin(), m_preset_combos.end(), [type](const DiffPresets& p) {
+                             return p.presets_right->get_type() == type;
+                         })->presets_right;
     return Preset::remove_suffix_modified(get_selection(cb));
 }
 


### PR DESCRIPTION
The issue is caused by #7573, the order of the combox no longer matches the order of enum `Preset::Type`, which breaks `DiffPresetDialog::get_left_preset_name` and `DiffPresetDialog::get_right_preset_name`, which rely on the combox order:
https://github.com/SoftFever/OrcaSlicer/blob/36a5a14507db6cdecbfc9b0d2768f06b18123f30/src/slic3r/GUI/UnsavedChangesDialog.cpp#L2384-L2394

This PR fixes this by using `std::find_if` instead so it no longer relies on the enum order.

Fix #7991
Fix #8632
Fix #8674
Fix #8678
Fix #8715
Fix #8732

