### PR TITLE
Launching and directly loading GCode will result in missing information.

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -2942,6 +2942,7 @@ void Print::export_gcode_from_previous_file(const std::string& file, GCodeProces
 {
     try {
         GCodeProcessor processor;
+        GCodeProcessor::s_IsBBLPrinter = is_BBL_printer();
         const Vec3d origin = this->get_plate_origin();
         processor.set_xy_offset(origin(0), origin(1));
         //processor.enable_producers(true);

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10135,6 +10135,7 @@ void Plater::load_gcode(const wxString& filename)
     GCodeProcessor processor;
     try
     {
+        GCodeProcessor::s_IsBBLPrinter = wxGetApp().preset_bundle->is_bbl_vendor();
         processor.process_file(filename.ToUTF8().data());
     }
     catch (const std::exception& ex)


### PR DESCRIPTION
When launching the software and directly loading a GCode file, the GCode preview may lose a lot of information. This happens because `GCodeProcessor::s_IsBBLPrinter` is set to true by default, causing the GCode to be loaded following Bambu's rules.


Before
![image](https://github.com/user-attachments/assets/e1cc6e13-ddc8-414e-ac7b-770d296ff02a)


After
![image](https://github.com/user-attachments/assets/593a517b-c876-4427-93ba-197481431bcc)

