### PR TITLE
Restore translations for string with removed space at the end

### DIFF
--- a/localization/i18n/ca/OrcaSlicer_ca.po
+++ b/localization/i18n/ca/OrcaSlicer_ca.po
@@ -3259,7 +3259,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Deseu el projecte i reinicieu el programa."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Processant el Codi-G del fitxer anterior..."
@@ -18641,9 +18641,6 @@ msgstr ""
 "Sabíeu que quan imprimiu materials propensos a deformar-se, com ara l'ABS, "
 "augmentar adequadament la temperatura del llit pot reduir la probabilitat de "
 "deformació."
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Deseu el projecte i reinicieu el programa. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -3199,7 +3199,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Uložte projekt a restartujte program."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Zpracovává se G-kód z předchozího souboru..."
@@ -17143,9 +17143,6 @@ msgid ""
 "ABS, appropriately increasing the heatbed temperature can reduce the "
 "probability of warping."
 msgstr ""
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Uložte projekt a restartujte program. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -3289,7 +3289,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Bitte speichern Sie das Projekt und starten Sie das Programm neu."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Verarbeite G-Code der vorherigen Datei..."
@@ -18754,9 +18754,6 @@ msgstr ""
 "Wussten Sie, dass beim Drucken von Materialien, die zu Verwerfungen neigen, "
 "wie z.B. ABS, durch eine entsprechende Erhöhung der Heizbetttemperatur die "
 "Wahrscheinlichkeit von Verwerfungen verringert werden kann."
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Bitte speichern Sie das Projekt und starten Sie das Programm neu. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -3171,7 +3171,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Please save your project and restart the application."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Processing G-Code from previous file…"
@@ -16963,9 +16963,6 @@ msgstr ""
 "Did you know that when printing materials that are prone to warping such as "
 "ABS, appropriately increasing the heatbed temperature can reduce the "
 "probability of warping?"
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Please save your project and restart the application."
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -3289,7 +3289,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Guarde el proyecto y reinicie el programa."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Procesando el G-Code del archivo anterior..."
@@ -18524,9 +18524,6 @@ msgstr ""
 "Sabías que al imprimir materiales propensos a la deformación como el ABS, "
 "aumentar adecuadamente la temperatura de la cama térmica puede reducir la "
 "probabilidad de deformaciones."
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Guarde el proyecto y reinicie el programa. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -3293,7 +3293,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Veuillez enregistrer le projet et redémarrer le programme."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Traitement du G-Code du fichier précédent…"
@@ -15977,7 +15977,7 @@ msgstr ""
 "2 :avertissement, 3 :info, 4 :débogage, 5 :trace\n"
 
 msgid "Enable timelapse for print"
-msgstr ""
+msgstr "Activer le timelapse pour l’impression"
 
 msgid "If enabled, this slicing will be considered using timelapse"
 msgstr ""
@@ -18910,12 +18910,6 @@ msgstr ""
 "Saviez-vous que lors de l’impression de matériaux susceptibles de se "
 "déformer, tels que l’ABS, une augmentation appropriée de la température du "
 "plateau chauffant peut réduire la probabilité de déformation."
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Veuillez enregistrer le projet et redémarrer le programme. "
-
-#~ msgid "Enable timeplapse for print"
-#~ msgstr "Activer le timelapse pour l’impression"
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -3197,7 +3197,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Kérjük, mentsd el a projektet és indítsd újra a programot."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "G-kód feldolgozása egy előző fájlból..."
@@ -17150,9 +17150,6 @@ msgstr ""
 "Vetemedés elkerülése\n"
 "Tudtad, hogy a vetemedésre hajlamos anyagok (például ABS) nyomtatásakor a "
 "tárgyasztal hőmérsékletének növelése csökkentheti a vetemedés valószínűségét?"
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Kérjük, mentsd el a projektet és indítsd újra a programot. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -3287,7 +3287,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Salva il progetto e riavvia l'applicazione."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Elaborazione G-Code dal file precedente..."
@@ -18797,9 +18797,6 @@ msgstr ""
 #~ "OrcaSlicer ha esaurito la memoria e verrà chiuso. Questo potrebbe "
 #~ "essere \n"
 #~ "un bug. Si prega di segnalare questo errore al supporto tecnico."
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Salva il progetto e riavvia l'applicazione. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -3160,7 +3160,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "プロジェクトを保存して、アプリケーションを再起動してください。"
 
 msgid "Processing G-Code from Previous file..."
 msgstr "G-codeを処理中"
@@ -16916,9 +16916,6 @@ msgstr ""
 "反りを避ける\n"
 "ABSのような反りやすい素材を印刷する場合、ヒートベッドの温度を適切に上げること"
 "で、反りが発生する確率を下げることができることをご存知ですか？"
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "プロジェクトを保存して、アプリケーションを再起動してください。"
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -3181,7 +3181,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "프로젝트를 저장하고 프로그램을 다시 시작하세요."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "이전 파일의 G코드를 처리하는 중..."
@@ -17763,9 +17763,6 @@ msgstr ""
 "뒤틀림 방지\n"
 "ABS와 같이 뒤틀림이 발생하기 쉬운 소재를 출력할 때, 히트베드 온도를 적절하게 "
 "높이면 뒤틀림 가능성을 줄일 수 있다는 사실을 알고 계셨나요?"
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "프로젝트를 저장하고 프로그램을 다시 시작하세요. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -3229,7 +3229,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Sla uw project alstublieft op en herstart het programma."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "De G-code van het vorige bestand wordt verwerkt..."
@@ -17419,9 +17419,6 @@ msgstr ""
 "Wist je dat bij het printen van materialen die gevoelig zijn voor "
 "kromtrekken, zoals ABS, een juiste verhoging van de temperatuur van het "
 "warmtebed de kans op kromtrekken kan verkleinen?"
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Sla uw project alstublieft op en herstart het programma. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/pl/OrcaSlicer_pl.po
+++ b/localization/i18n/pl/OrcaSlicer_pl.po
@@ -3259,7 +3259,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Proszę zapisać projekt i ponownie uruchomić program."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Przetwarzanie G-code z poprzedniego pliku..."
@@ -18347,9 +18347,6 @@ msgstr ""
 "Czy wiesz, że podczas drukowania filamentami podatnymi na odkształcenia, "
 "takimi jak ABS, odpowiednie zwiększenie temperatury podgrzewanej płyty może "
 "zmniejszyć prawdopodobieństwo odkształceń."
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Proszę zapisać projekt i ponownie uruchomić program. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
+++ b/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
@@ -3247,10 +3247,10 @@ msgstr ""
 
 #, boost-format
 msgid "A fatal error occurred: \"%1%\""
-msgstr ""
+msgstr "Ocorreu um erro fatal: \"%1%\""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Por favor, salve o projeto e reinicie o programa."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Processando G-Code do arquivo anterior..."
@@ -18405,9 +18405,6 @@ msgstr ""
 "Você sabia que ao imprimir materiais propensos ao empenamento, como ABS, "
 "aumentar adequadamente a temperatura da mesa aquecida pode reduzir a "
 "probabilidade de empenamento?"
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Por favor, salve o projeto e reinicie o programa. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -3284,7 +3284,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Пожалуйста, сохраните проект и перезапустите программу."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Обработка G-кода из предыдущего файла..."
@@ -18821,9 +18821,6 @@ msgstr ""
 "Знаете ли вы, что при печати материалами, склонными к короблению, таких как "
 "ABS, повышение температуры подогреваемого стола может снизить эту "
 "вероятность?"
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Пожалуйста, сохраните проект и перезапустите программу. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -3181,7 +3181,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Spara projekt och starta om programmet."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Processera G-Code från Föregående fil…"
@@ -16984,9 +16984,6 @@ msgstr ""
 "Visste du att när du skriver ut material som är benägna att vrida, såsom "
 "ABS, kan en lämplig ökning av värmebäddens temperatur minska sannolikheten "
 "för vridning."
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Spara projekt och starta om programmet. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -3229,7 +3229,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Lütfen projeyi kaydedin ve programı yeniden başlatın."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Önceki dosyadan G Kodu işleniyor..."
@@ -18341,9 +18341,6 @@ msgstr ""
 "ABS gibi bükülmeye yatkın malzemelere baskı yaparken, ısıtma yatağı "
 "sıcaklığının uygun şekilde arttırılmasının bükülme olasılığını "
 "azaltabileceğini biliyor muydunuz?"
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Lütfen projeyi kaydedin ve programı yeniden başlatın. "
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -3259,7 +3259,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "Збережіть проект і перезапустіть програму."
 
 msgid "Processing G-Code from Previous file..."
 msgstr "Обробка G-коду з попереднього файлу..."
@@ -18474,6 +18474,3 @@ msgstr ""
 "Чи знаєте ви, що при друку матеріалами, схильними до деформації, такими як "
 "ABS, відповідне підвищення температури гарячого ліжка може зменшити "
 "ймовірність деформації."
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "Збережіть проект і перезапустіть програму. "

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -3114,7 +3114,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "请保存项目并重启程序。"
 
 msgid "Processing G-Code from Previous file..."
 msgstr "从之前的文件加载G代码..."
@@ -16757,9 +16757,6 @@ msgid ""
 msgstr ""
 "避免翘曲\n"
 "您知道吗？打印ABS这类易翘曲材料时，适当提高热床温度可以降低翘曲的概率。"
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "请保存项目并重启程序。"
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -3117,7 +3117,7 @@ msgid "A fatal error occurred: \"%1%\""
 msgstr ""
 
 msgid "Please save project and restart the program."
-msgstr ""
+msgstr "請儲存專案項目並重啟程式。"
 
 msgid "Processing G-Code from Previous file..."
 msgstr "從之前的檔案載入 G-Code..."
@@ -17066,9 +17066,6 @@ msgstr ""
 "避免翹曲\n"
 "你知道嗎？當列印容易翹曲的材料（如 ABS）時，適當提高熱床溫度\n"
 "可以降低翹曲的機率。"
-
-#~ msgid "Please save project and restart the program. "
-#~ msgstr "請儲存專案項目並重啟程式。"
 
 #~ msgid ""
 #~ "We have added an experimental style \"Tree Slim\" that features smaller "


### PR DESCRIPTION
# Description
I believe one of my patches removed a trailing space, but I forgot to update the .po files.  Restoring the translations.