### PR TITLE
Fix Creality Hi extruder_clearance_height_to_lid

### DIFF
--- a/resources/profiles/Creality/machine/Creality Hi 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Hi 0.4 nozzle.json
@@ -118,7 +118,7 @@
         "1"
     ],
     "enable_filament_ramming": "0",
-    "extruder_clearance_height_to_lid": "27",
+    "extruder_clearance_height_to_lid": "301",
     "extruder_clearance_height_to_rod": "27",
     "extruder_clearance_radius": "55",
     "z_hop": [

--- a/resources/profiles/Creality/machine/Creality Hi 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Hi 0.6 nozzle.json
@@ -118,7 +118,7 @@
         "1"
     ],
     "enable_filament_ramming": "0",
-    "extruder_clearance_height_to_lid": "27",
+    "extruder_clearance_height_to_lid": "301",
     "extruder_clearance_height_to_rod": "27",
     "extruder_clearance_radius": "55",
     "z_hop": [


### PR DESCRIPTION
# Description

Fix extruder_clearance_height_to_lid parameter for Creality Hi.
Profile parameter comes from Creality Print but it is not correct.
This change will allow printing by object in different colors.

# Screenshots/Recordings/Graphs

Before
<img width="957" alt="Capture d’écran 2025-03-11 à 09 21 37" src="https://github.com/user-attachments/assets/f04f2b5e-ccdf-4042-9ad2-a34240a92e52" />

After
<img width="911" alt="Capture d’écran 2025-03-11 à 09 21 51" src="https://github.com/user-attachments/assets/64303cad-fe2d-4090-bf01-ffb006a03a05" />

