### PR TITLE
Remove non-translated translations

### DIFF
--- a/localization/i18n/ca/OrcaSlicer_ca.po
+++ b/localization/i18n/ca/OrcaSlicer_ca.po
@@ -18975,15 +18975,6 @@ msgstr ""
 #~ "La mida del fitxer supera el límit de pujada de 100 MB. Si us plau, "
 #~ "carregueu el vostre fitxer a través del panell."
 
-#~ msgid "X"
-#~ msgstr "X"
-
-#~ msgid "Y"
-#~ msgstr "Y"
-
-#~ msgid "V"
-#~ msgstr "V"
-
 #, fuzzy
 #~ msgid "Maximum print speed when purging"
 #~ msgstr "Màxima velocitat d'impressió en purgar"
@@ -19027,20 +19018,8 @@ msgstr ""
 #~ msgid "Unload Filament"
 #~ msgstr "Descarregar Filament"
 
-#~ msgid "MC"
-#~ msgstr "MC"
-
 #~ msgid "MainBoard"
 #~ msgstr "Placa Base"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
 
 #, fuzzy
 #~| msgid "Unsaved Changes"
@@ -19247,9 +19226,6 @@ msgstr ""
 
 #~ msgid "Resize"
 #~ msgstr "Redimensionar"
-
-#~ msgid " "
-#~ msgstr " "
 
 #~ msgid "The Config cannot be loaded."
 #~ msgstr "La Configuració no es pot carregar."

--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -3768,7 +3768,7 @@ msgid "Heatbed preheating"
 msgstr "Předehřev vyhřívané podložky"
 
 msgid "Sweeping XY mech mode"
-msgstr "Sweeping XY mech mode"
+msgstr ""
 
 msgid "Changing filament"
 msgstr "Výměna filamentu"
@@ -4211,7 +4211,7 @@ msgid "travel"
 msgstr "Cestování"
 
 msgid "Extruder"
-msgstr "Extruder"
+msgstr ""
 
 msgid "Filament change times"
 msgstr "Doby výměny Filamentu"
@@ -7804,7 +7804,7 @@ msgid "G-code output"
 msgstr "Výstup G-kódu"
 
 msgid "Post-processing Scripts"
-msgstr "Post-processing Scripts"
+msgstr ""
 
 msgid "Notes"
 msgstr "Poznámky"
@@ -17322,12 +17322,6 @@ msgstr ""
 #~ msgid "Scale"
 #~ msgstr "Měřítko"
 
-#~ msgid "Orca Slicer "
-#~ msgstr "Orca Slicer "
-
-#~ msgid "Cool plate"
-#~ msgstr "Cool podložka"
-
 #~ msgid "Lift Z Enforcement"
 #~ msgstr "Vynutit Zvednout Z"
 
@@ -17528,9 +17522,6 @@ msgstr ""
 #~ msgid "Please find the cornor with perfect degree of extrusion"
 #~ msgstr "Prosím, najděte roh s dokonalým stupněm extruze"
 
-#~ msgid "V"
-#~ msgstr "V"
-
 #~ msgid ""
 #~ "Orca Slicer is based on BambuStudio by Bambulab, which is from "
 #~ "PrusaSlicer by Prusa Research.  PrusaSlicer is from Slic3r by Alessandro "
@@ -17563,36 +17554,8 @@ msgstr ""
 #~ msgid "Unload Filament"
 #~ msgstr "Vysunout Filament"
 
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "Vyberte slot AMS a poté stiskněte \" Načíst \" nebo \" Uvolnit \" pro "
-#~ "automatické načtení nebo vyjměte vlákno."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
 #~ msgid "MainBoard"
 #~ msgstr "Základní deska"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
-
-#~ msgid "- ℃"
-#~ msgstr "- ℃"
-
-#~ msgid "0.5"
-#~ msgstr "0.5"
-
-#~ msgid "0.005"
-#~ msgstr "0.005"
 
 #~ msgid "active"
 #~ msgstr "aktivní"
@@ -17715,9 +17678,6 @@ msgstr ""
 #~ "Přidá plnou výplň u šikmých ploch pro garanci tloušťky svislých stěn "
 #~ "(vrchních a spodních plných vrstev)"
 
-#~ msgid " "
-#~ msgstr " "
-
 #~ msgid "Configuration package updated to "
 #~ msgstr "Konfigurační balíček aktualizován na "
 
@@ -17793,9 +17753,6 @@ msgstr ""
 
 #~ msgid "Choose SLA archive:"
 #~ msgstr "Vyberte SLA archiv:"
-
-#~ msgid "Import file"
-#~ msgstr "Importovat soubor"
 
 #~ msgid "Import model and profile"
 #~ msgstr "Importovat model a profil"
@@ -17882,9 +17839,6 @@ msgstr ""
 #, c-format, boost-format
 #~ msgid " doesn't work at 100%% density "
 #~ msgstr " nefunguje při 100%% hustotě "
-
-#~ msgid "Ctrl + Shift + Enter"
-#~ msgstr "Ctrl + Shift + Enter"
 
 #~ msgid "Tool-Lay on Face"
 #~ msgstr "Nástroj-Plochou na podložku"
@@ -18094,9 +18048,6 @@ msgstr ""
 #~ msgid "Calibration of extrusion"
 #~ msgstr "Kalibrace extruze"
 
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "Zasuňte nový filament do extruderu"
-
 #, c-format, boost-format
 #~ msgid ""
 #~ "Bed temperature of other layer is lower than bed temperature of initial "
@@ -18168,11 +18119,6 @@ msgstr ""
 #~ "zlepšit kvalitu horního povrchu, zejména když je nízká hustota výplně. "
 #~ "Tato hodnota určuje tloušťku podpůrných smyček. Hodnota 0 znamená, že "
 #~ "tato funkce je zakázána."
-
-#, fuzzy, c-format, boost-format
-#~ msgid ""
-#~ "Klipper's max_accel_to_decel will be adjusted to this % of acceleration"
-#~ msgstr "Klipper max_accel_to_decel bude upraven na toto % zrychlení"
 
 #~ msgid ""
 #~ "Style and shape of the support. For normal support, projecting the "

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -976,7 +976,7 @@ msgid "Undo boldness"
 msgstr "Dicke rückgängig machen"
 
 msgid "Tiny / Wide glyphs"
-msgstr "Tiny / Wide glyphs"
+msgstr ""
 
 msgid "Undo letter's skew"
 msgstr "Rückgängig machen der Schriftneigung"
@@ -1415,7 +1415,7 @@ msgid "Distance XYZ"
 msgstr "Entfernung XYZ"
 
 msgid "Parallel"
-msgstr "Parallel"
+msgstr "Parallele"
 
 msgid "Center coincidence"
 msgstr "Zentrumsgleichheit"
@@ -5027,7 +5027,7 @@ msgid "Flow rate"
 msgstr "Durchflussrate"
 
 msgid "Pressure advance"
-msgstr "Pressure advance"
+msgstr ""
 
 msgid "Retraction test"
 msgstr "Rückzugslängen Test"
@@ -7093,7 +7093,7 @@ msgid "The period of backup in seconds."
 msgstr "Die Zeitdauer für die Sicherung in Sekunden."
 
 msgid "Downloads"
-msgstr "Downloads"
+msgstr ""
 
 msgid "Dark Mode"
 msgstr "Dunkler Modus"
@@ -7674,7 +7674,7 @@ msgstr ""
 "Der Drucker unterstützt nicht das Senden an die MicroSD-Karte des Druckers."
 
 msgid "Slice ok."
-msgstr "Slice ok."
+msgstr ""
 
 msgid "View all Daily tips"
 msgstr "Zeige alle täglichen Tipps"
@@ -7863,10 +7863,6 @@ msgid ""
 "0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
 "disable independent support layer height"
 msgstr ""
-"When using support material for the support interface, We recommend the "
-"following settings:\n"
-"0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
-"disable independent support layer height"
 
 msgid ""
 "Change these settings automatically? \n"
@@ -8116,7 +8112,7 @@ msgid "G-code output"
 msgstr "G-Code-Ausgabe"
 
 msgid "Post-processing Scripts"
-msgstr "Post-Processing Scripts"
+msgstr ""
 
 msgid "Notes"
 msgstr "Notizen"
@@ -8740,58 +8736,54 @@ msgid "The configuration is up to date."
 msgstr "Die Konfiguration ist auf dem neuesten Stand."
 
 msgid "Obj file Import color"
-msgstr "Obj file Import color"
+msgstr ""
 
 msgid "Specify number of colors:"
-msgstr "Specify number of colors:"
+msgstr ""
 
 #, c-format, boost-format
 msgid "The color count should be in range [%d, %d]."
-msgstr "The color count should be in range [%d, %d]."
+msgstr ""
 
 msgid "Recommended "
-msgstr "Recommended "
+msgstr ""
 
 msgid "Current filament colors:"
-msgstr "Current filament colors:"
+msgstr ""
 
 msgid "Quick set:"
-msgstr "Quick set:"
+msgstr ""
 
 msgid "Color match"
-msgstr "Color match"
+msgstr ""
 
 msgid "Approximate color matching."
-msgstr "Approximate color matching."
+msgstr ""
 
 msgid "Append"
-msgstr "Append"
+msgstr ""
 
 msgid "Add consumable extruder after existing extruders."
-msgstr "Add consumable extruder after existing extruders."
+msgstr ""
 
 msgid "Reset mapped extruders."
-msgstr "Reset mapped extruders."
+msgstr ""
 
 msgid "Cluster colors"
-msgstr "Cluster colors"
+msgstr ""
 
 msgid "Map Filament"
-msgstr "Map Filament"
+msgstr ""
 
 msgid ""
 "Note:The color has been selected, you can choose OK \n"
 " to continue or manually adjust it."
 msgstr ""
-"Note:The color has been selected, you can choose OK \n"
-" to continue or manually adjust it."
 
 msgid ""
 "Waring:The count of newly added and \n"
 " current extruders exceeds 16."
 msgstr ""
-"Warning: The count of newly added and \n"
-" current extruders exceeds 16."
 
 msgid "Ramming customization"
 msgstr "Ramming-Anpassung"
@@ -10177,7 +10169,7 @@ msgstr ""
 "diese Funktion."
 
 msgid "mm or %"
-msgstr "mm or %"
+msgstr "mm o. %"
 
 msgid "Other layers"
 msgstr "Andere Schichten"
@@ -12365,7 +12357,7 @@ msgstr ""
 "berechnet."
 
 msgid "mm/s² or %"
-msgstr "mm/s² or %"
+msgstr "mm/s² o. %"
 
 msgid ""
 "Acceleration of sparse infill. If the value is expressed as a percentage "
@@ -13360,6 +13352,7 @@ msgstr ""
 msgid "Extrusion rate smoothing"
 msgstr "Glättung der Extrusionsrate"
 
+#, fuzzy
 msgid ""
 "This parameter smooths out sudden extrusion rate changes that happen when "
 "the printer transitions from printing a high flow (high speed/larger width) "
@@ -13408,7 +13401,7 @@ msgstr ""
 "In diesen Fällen wird ein hoher Wert von ca. 300-350mm3/s2 empfohlen, da "
 
 msgid "mm³/s²"
-msgstr "m"
+msgstr ""
 
 msgid "Smoothing segment length"
 msgstr "Segmentlänge für die Glättung"
@@ -14630,10 +14623,10 @@ msgid "XY separation between an object and its support"
 msgstr "XY-Abstand zwischen einem Objekt und seinen Stützstrukturen."
 
 msgid "Support/object first layer gap"
-msgstr "Support/object first layer gap"
+msgstr ""
 
 msgid "XY separation between an object and its support at the first layer."
-msgstr "XY separation between an object and its support at the first layer."
+msgstr ""
 
 msgid "Pattern angle"
 msgstr "Winkel des Musters"
@@ -15640,7 +15633,7 @@ msgid "Load cached slicing data from directory"
 msgstr "Zwischengespeicherte Slicing-Daten aus dem Verzeichnis laden"
 
 msgid "Export STL"
-msgstr "Export STL"
+msgstr ""
 
 msgid "Export the objects as single STL."
 msgstr "Exportieren Sie die Objekte als einzelne STL."
@@ -16238,7 +16231,7 @@ msgstr ""
 "1)."
 
 msgid "Layer z"
-msgstr "Layer z"
+msgstr ""
 
 msgid ""
 "Height of the current layer above the print bed, measured to the top of the "
@@ -16837,7 +16830,7 @@ msgstr ""
 "Matte)"
 
 msgid "Pattern"
-msgstr "Pattern"
+msgstr ""
 
 msgid "Method"
 msgstr "Methode"
@@ -17418,13 +17411,13 @@ msgid "Printable Space"
 msgstr "Druckbarer Raum"
 
 msgid "Hot Bed STL"
-msgstr "Hot Bed STL"
+msgstr ""
 
 msgid "Load stl"
 msgstr "STL laden"
 
 msgid "Hot Bed SVG"
-msgstr "Hot Bed SVG"
+msgstr ""
 
 msgid "Load svg"
 msgstr "SVG laden"
@@ -18362,7 +18355,7 @@ msgid "Brim Ears"
 msgstr "Mausohren"
 
 msgid "Please select single object."
-msgstr "Please select single object."
+msgstr ""
 
 #: resources/data/hints.ini: [hint:Precise wall]
 msgid ""
@@ -19058,12 +19051,6 @@ msgstr ""
 #~ msgid "Scale"
 #~ msgstr "Skalieren"
 
-#~ msgid "Orca Slicer "
-#~ msgstr "Orca Slicer "
-
-#~ msgid "Cool plate"
-#~ msgstr "Kalte Druckplatte"
-
 #~ msgid "Lift Z Enforcement"
 #~ msgstr "Z-Höhe einhalten"
 
@@ -19584,12 +19571,6 @@ msgstr ""
 #~ msgid "Please find the cornor with perfect degree of extrusion"
 #~ msgstr "Bitte finden Sie die Ecke mit perfektem Extrusionsgrad"
 
-#~ msgid "X"
-#~ msgstr "X"
-
-#~ msgid "Y"
-#~ msgstr "Y"
-
 #~ msgid ""
 #~ "Associate OrcaSlicer with prusaslicer:// links so that Orca can open "
 #~ "PrusaSlicer links from Printable.com"
@@ -19617,9 +19598,6 @@ msgstr ""
 #~ "befestigt ist, was zu einer schlechteren Oberflächenqualität führt. Es "
 #~ "kann auch dazu führen, dass die Füllung durch die äußeren Oberflächen des "
 #~ "Teils schimmert."
-
-#~ msgid "V"
-#~ msgstr "V"
 
 #~ msgid "Maximum print speed when purging"
 #~ msgstr "Maximale Druckgeschwindigkeit beim Reinigen"
@@ -19743,37 +19721,6 @@ msgstr ""
 #~ msgid "Unload Filament"
 #~ msgstr "Entladen"
 
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "Wählen Sie einen AMS-Slot und drücken Sie dann \"Laden\" oder "
-#~ "\"Entladen\", um automatisch Filament zu laden oder zu entladen."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
-#~ msgid "MainBoard"
-#~ msgstr "Mainboard"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
-
-#~ msgid "- ℃"
-#~ msgstr "- ℃"
-
-#~ msgid "0.5"
-#~ msgstr "0,5"
-
-#~ msgid "0.005"
-#~ msgstr "0,005"
-
 #~ msgid "New Flow Dynamics Calibration"
 #~ msgstr "Neue Flussdynamik-Kalibrierung"
 
@@ -19877,9 +19824,6 @@ msgstr ""
 
 #~ msgid "Failed to fetching model information from printer."
 #~ msgstr "Die Modellinformationen konnten nicht vom Drucker abgerufen werden."
-
-#~ msgid "Failed to parse model informations."
-#~ msgstr "Modellinformationen konnten nicht analysiert werden"
 
 #~ msgid "Connection lost. Please retry."
 #~ msgstr "Verbindung verloren. Bitte versuchen Sie es erneut."
@@ -20029,9 +19973,6 @@ msgstr ""
 #~ msgid "Scale per instance"
 #~ msgstr "Skalierung pro Instanz"
 
-#~ msgid " "
-#~ msgstr " "
-
 #~ msgid "Text-Rotate"
 #~ msgstr "Text-Drehen"
 
@@ -20073,17 +20014,6 @@ msgstr ""
 
 #~ msgid "wiki"
 #~ msgstr "wiki"
-
-#~ msgid ""
-#~ "Relative extrusion is recommended when using \"label_objects\" "
-#~ "option.Some extruders work better with this option unchecked (absolute "
-#~ "extrusion mode). Wipe tower is only compatible with relative mode. It is "
-#~ "always enabled on BambuLab printers. Default is checked"
-#~ msgstr ""
-#~ "Die relative Extrusion wird empfohlen, wenn die Option „label_objects“ "
-#~ "verwendet wird. Einige Extruder funktionieren besser, wenn diese Option "
-#~ "deaktiviert ist (Absolute Extrusion). Der Wipe-Turm ist nur im relativen "
-#~ "Modus kompatibel. Er ist immer auf BambuLab-Druckern aktiviert"
 
 #~ msgid "Movement:"
 #~ msgstr "Bewegung:"
@@ -20153,9 +20083,6 @@ msgstr ""
 
 #~ msgid "Choose SLA archive:"
 #~ msgstr "SLA-Archiv auswählen:"
-
-#~ msgid "Import file"
-#~ msgstr "Datei importieren"
 
 #~ msgid "Import model and profile"
 #~ msgstr "Modell und Profil importieren"
@@ -20231,10 +20158,6 @@ msgstr ""
 #~ "Zu geradlinigen Mustern wechseln?\n"
 #~ "Ja - Automatisches auf das geradlinige Muster wechseln\n"
 #~ "Nein - Dichte automatisch auf den Standardwert unter 100% zurücksetzen"
-
-#~ msgid "Please heat the nozzle to above 170 degree before loading filament."
-#~ msgstr ""
-#~ "Bitte heizen Sie die Düse auf über 170 Grad auf, bevor Sie Filament laden."
 
 #, c-format, boost-format
 #~ msgid "This slicer file version %s is newer than %s's version:"
@@ -20398,15 +20321,6 @@ msgstr ""
 #~ "der 3D-Szene mit der Maus und dem Touchpad steuern können?"
 
 #~ msgid ""
-#~ "Fix Model\n"
-#~ "Did you know that you can fix a corrupted 3D model to avoid a lot of "
-#~ "slicing problems?"
-#~ msgstr ""
-#~ "Modell reparieren\n"
-#~ "Wussten Sie, dass Sie ein beschädigtes 3D-Modell reparieren können, um "
-#~ "viele Probleme beim Slicen zu vermeiden?"
-
-#~ msgid ""
 #~ "When need to print with the printer door opened\n"
 #~ "Opening the printer door can reduce the probability of extruder/hotend "
 #~ "clogging when printing lower temperature filament with a higher enclosure "
@@ -20522,9 +20436,6 @@ msgstr ""
 #~ msgid "Calibration of extrusion"
 #~ msgstr "Kalibrierung der Extrusion"
 
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "Neues Filament in den Extruder schieben"
-
 #, c-format, boost-format
 #~ msgid ""
 #~ "Bed temperature of other layer is lower than bed temperature of initial "
@@ -20603,13 +20514,6 @@ msgstr ""
 #~ "insbesondere wenn die Fülldichte des Sparmodus niedrig ist. Dieser Wert "
 #~ "bestimmt die Dicke der Stützschleifen. 0 bedeutet, diese Funktion zu "
 #~ "deaktivieren."
-
-#, fuzzy, c-format, boost-format
-#~ msgid ""
-#~ "Klipper's max_accel_to_decel will be adjusted to this % of acceleration"
-#~ msgstr ""
-#~ "Klipper’s max_accel_to_decel wird auf % of  Prozentsatz der "
-#~ "Beschleunigung eingestellt"
 
 #~ msgid "Target chamber temperature"
 #~ msgstr "Druckraum Temperatur"

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -18,86 +18,86 @@ msgid "Supports Painting"
 msgstr "Support Painting"
 
 msgid "Alt + Mouse wheel"
-msgstr "Alt + Mouse wheel"
+msgstr ""
 
 msgid "Section view"
-msgstr "Section view"
+msgstr ""
 
 msgid "Reset direction"
-msgstr "Reset direction"
+msgstr ""
 
 msgid "Ctrl + Mouse wheel"
-msgstr "Ctrl + Mouse wheel"
+msgstr ""
 
 msgid "Pen size"
-msgstr "Pen size"
+msgstr ""
 
 msgid "Left mouse button"
-msgstr "Left mouse button"
+msgstr ""
 
 msgid "Enforce supports"
-msgstr "Enforce supports"
+msgstr ""
 
 msgid "Right mouse button"
-msgstr "Right mouse button"
+msgstr ""
 
 msgid "Block supports"
-msgstr "Block supports"
+msgstr ""
 
 msgid "Shift + Left mouse button"
-msgstr "Shift + Left mouse button"
+msgstr ""
 
 msgid "Erase"
-msgstr "Erase"
+msgstr ""
 
 msgid "Erase all painting"
-msgstr "Erase all painting"
+msgstr ""
 
 msgid "Highlight overhang areas"
 msgstr "Highlight overhangs"
 
 msgid "Gap fill"
-msgstr "Gap fill"
+msgstr ""
 
 msgid "Perform"
 msgstr "Apply"
 
 msgid "Gap area"
-msgstr "Gap area"
+msgstr ""
 
 msgid "Tool type"
-msgstr "Tool type"
+msgstr ""
 
 msgid "Smart fill angle"
-msgstr "Smart fill angle"
+msgstr ""
 
 msgid "On overhangs only"
-msgstr "On overhangs only"
+msgstr ""
 
 msgid "Auto support threshold angle: "
-msgstr "Auto support threshold angle: "
+msgstr ""
 
 msgid "Circle"
-msgstr "Circle"
+msgstr ""
 
 msgid "Sphere"
-msgstr "Sphere"
+msgstr ""
 
 msgid "Fill"
-msgstr "Fill"
+msgstr ""
 
 msgid "Gap Fill"
-msgstr "Gap Fill"
+msgstr ""
 
 #, boost-format
 msgid "Allows painting only on facets selected by: \"%1%\""
-msgstr "Allows painting only on facets selected by: \"%1%\""
+msgstr ""
 
 msgid "Highlight faces according to overhang angle."
-msgstr "Highlight faces according to overhang angle."
+msgstr ""
 
 msgid "No auto support"
-msgstr "No auto support"
+msgstr ""
 
 msgid "Support Generated"
 msgstr "Support generated"
@@ -120,110 +120,110 @@ msgid "Color Painting"
 msgstr "Color painting"
 
 msgid "Pen shape"
-msgstr "Pen shape"
+msgstr ""
 
 msgid "Paint"
-msgstr "Paint"
+msgstr ""
 
 msgid "Key 1~9"
-msgstr "Key 1~9"
+msgstr ""
 
 msgid "Choose filament"
-msgstr "Choose filament"
+msgstr ""
 
 msgid "Edge detection"
-msgstr "Edge detection"
+msgstr ""
 
 msgid "Triangles"
-msgstr "Triangles"
+msgstr ""
 
 msgid "Filaments"
-msgstr "Filaments"
+msgstr ""
 
 msgid "Brush"
-msgstr "Brush"
+msgstr ""
 
 msgid "Smart fill"
-msgstr "Smart fill"
+msgstr ""
 
 msgid "Bucket fill"
-msgstr "Bucket fill"
+msgstr ""
 
 msgid "Height range"
-msgstr "Height range"
+msgstr ""
 
 msgid "Alt + Shift + Enter"
-msgstr "Alt + Shift + Enter"
+msgstr ""
 
 msgid "Toggle Wireframe"
-msgstr "Toggle Wireframe"
+msgstr ""
 
 msgid "Shortcut Key "
-msgstr "Shortcut Key "
+msgstr ""
 
 msgid "Triangle"
-msgstr "Triangle"
+msgstr ""
 
 msgid "Height Range"
-msgstr "Height Range"
+msgstr ""
 
 msgid "Vertical"
-msgstr "Vertical"
+msgstr ""
 
 msgid "Horizontal"
-msgstr "Horizontal"
+msgstr ""
 
 msgid "Remove painted color"
-msgstr "Remove painted color"
+msgstr ""
 
 #, boost-format
 msgid "Painted using: Filament %1%"
-msgstr "Painted using: Filament %1%"
+msgstr ""
 
 msgid "Move"
-msgstr "Move"
+msgstr ""
 
 msgid "Gizmo-Move"
 msgstr ""
 
 msgid "Rotate"
-msgstr "Rotate"
+msgstr ""
 
 msgid "Gizmo-Rotate"
 msgstr ""
 
 msgid "Optimize orientation"
-msgstr "Optimize orientation"
+msgstr ""
 
 msgid "Apply"
-msgstr "Apply"
+msgstr ""
 
 msgid "Scale"
-msgstr "Scale"
+msgstr ""
 
 msgid "Gizmo-Scale"
 msgstr ""
 
 msgid "Error: Please close all toolbar menus first"
-msgstr "Error: Please close all toolbar menus first"
+msgstr ""
 
 msgid "in"
-msgstr "in"
+msgstr ""
 
 msgid "mm"
-msgstr "mm"
+msgstr ""
 
 msgid "Position"
-msgstr "Position"
+msgstr ""
 
 #. TRN - Input label. Be short as possible
 #. Angle between Y axis and text line direction.
 #. TRN - Input label. Be short as possible
 msgid "Rotation"
-msgstr "Rotation"
+msgstr ""
 
 msgid "Scale ratios"
-msgstr "Scale ratios"
+msgstr ""
 
 msgid "Object Operations"
 msgstr "Object operations"
@@ -232,7 +232,7 @@ msgid "Volume Operations"
 msgstr "Volume operations"
 
 msgid "Translate"
-msgstr "Translate"
+msgstr ""
 
 msgid "Group Operations"
 msgstr "Group operations"
@@ -253,101 +253,101 @@ msgid "Reset Rotation"
 msgstr "Reset rotation"
 
 msgid "World coordinates"
-msgstr "World coordinates"
+msgstr ""
 
 msgid "Object coordinates"
 msgstr ""
 
 msgid "°"
-msgstr "°"
+msgstr ""
 
 #. TRN - Input label. Be short as possible
 msgid "Size"
-msgstr "Size"
+msgstr ""
 
 msgid "%"
-msgstr "%"
+msgstr ""
 
 msgid "uniform scale"
 msgstr "Uniform scale"
 
 msgid "Planar"
-msgstr "Planar"
+msgstr ""
 
 msgid "Dovetail"
-msgstr "Dovetail"
+msgstr ""
 
 msgid "Auto"
-msgstr "Auto"
+msgstr ""
 
 msgid "Manual"
-msgstr "Manual"
+msgstr ""
 
 msgid "Plug"
-msgstr "Plug"
+msgstr ""
 
 msgid "Dowel"
-msgstr "Dowel"
+msgstr ""
 
 msgid "Snap"
-msgstr "Snap"
+msgstr ""
 
 msgid "Prism"
 msgstr ""
 
 msgid "Frustum"
-msgstr "Frustum"
+msgstr ""
 
 msgid "Square"
-msgstr "Square"
+msgstr ""
 
 msgid "Hexagon"
-msgstr "Hexagon"
+msgstr ""
 
 msgid "Keep orientation"
-msgstr "Keep orientation"
+msgstr ""
 
 msgid "Place on cut"
-msgstr "Place on cut"
+msgstr ""
 
 msgid "Flip upside down"
 msgstr ""
 
 msgid "Connectors"
-msgstr "Connectors"
+msgstr ""
 
 msgid "Type"
-msgstr "Type"
+msgstr ""
 
 msgid "Style"
-msgstr "Style"
+msgstr ""
 
 msgid "Shape"
-msgstr "Shape"
+msgstr ""
 
 #. TRN - Input label. Be short as possible
 #. Size in emboss direction
 #. TRN - Input label. Be short as possible
 msgid "Depth"
-msgstr "Depth"
+msgstr ""
 
 msgid "Groove"
-msgstr "Groove"
+msgstr ""
 
 msgid "Width"
-msgstr "Width"
+msgstr ""
 
 msgid "Flap Angle"
-msgstr "Flap Angle"
+msgstr ""
 
 msgid "Groove Angle"
-msgstr "Groove Angle"
+msgstr ""
 
 msgid "Part"
-msgstr "Part"
+msgstr ""
 
 msgid "Object"
-msgstr "Object"
+msgstr ""
 
 msgid ""
 "Click to flip the cut plane\n"
@@ -364,70 +364,70 @@ msgid "Move cut plane"
 msgstr ""
 
 msgid "Mode"
-msgstr "Mode"
+msgstr ""
 
 msgid "Change cut mode"
 msgstr ""
 
 msgid "Tolerance"
-msgstr "Tolerance"
+msgstr ""
 
 msgid "Drag"
-msgstr "Drag"
+msgstr ""
 
 msgid "Draw cut line"
 msgstr ""
 
 msgid "Left click"
-msgstr "Left click"
+msgstr ""
 
 msgid "Add connector"
-msgstr "Add connector"
+msgstr ""
 
 msgid "Right click"
-msgstr "Right click"
+msgstr ""
 
 msgid "Remove connector"
-msgstr "Remove connector"
+msgstr ""
 
 msgid "Move connector"
-msgstr "Move connector"
+msgstr ""
 
 msgid "Add connector to selection"
-msgstr "Add connector to selection"
+msgstr ""
 
 msgid "Remove connector from selection"
-msgstr "Remove connector from selection"
+msgstr ""
 
 msgid "Select all connectors"
-msgstr "Select all connectors"
+msgstr ""
 
 msgid "Cut"
-msgstr "Cut"
+msgstr ""
 
 msgid "Rotate cut plane"
 msgstr ""
 
 msgid "Remove connectors"
-msgstr "Remove connectors"
+msgstr ""
 
 msgid "Bulge"
-msgstr "Bulge"
+msgstr ""
 
 msgid "Bulge proportion related to radius"
 msgstr ""
 
 msgid "Space"
-msgstr "Space"
+msgstr ""
 
 msgid "Space proportion related to radius"
 msgstr ""
 
 msgid "Confirm connectors"
-msgstr "Confirm connectors"
+msgstr ""
 
 msgid "Cancel"
-msgstr "Cancel"
+msgstr ""
 
 msgid "Build Volume"
 msgstr ""
@@ -439,7 +439,7 @@ msgid "Groove change"
 msgstr ""
 
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. TRN: This is an entry in the Undo/Redo stack. The whole line will be 'Edited: (name of whatever was edited)'.
 msgid "Edited"
@@ -452,10 +452,10 @@ msgid "Reset cutting plane"
 msgstr ""
 
 msgid "Edit connectors"
-msgstr "Edit connectors"
+msgstr ""
 
 msgid "Add connectors"
-msgstr "Add connectors"
+msgstr ""
 
 msgid "Reset cut"
 msgstr ""
@@ -464,31 +464,31 @@ msgid "Reset cutting plane and remove connectors"
 msgstr ""
 
 msgid "Upper part"
-msgstr "Upper part"
+msgstr ""
 
 msgid "Lower part"
-msgstr "Lower part"
+msgstr ""
 
 msgid "Keep"
-msgstr "Keep"
+msgstr ""
 
 msgid "Flip"
-msgstr "Flip"
+msgstr ""
 
 msgid "After cut"
-msgstr "After cut"
+msgstr ""
 
 msgid "Cut to parts"
-msgstr "Cut to parts"
+msgstr ""
 
 msgid "Perform cut"
-msgstr "Perform cut"
+msgstr ""
 
 msgid "Warning"
-msgstr "Warning"
+msgstr ""
 
 msgid "Invalid connectors detected"
-msgstr "Invalid connectors detected"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%1$d connector is out of cut contour"
@@ -503,7 +503,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Some connectors are overlapped"
-msgstr "Some connectors are overlapped"
+msgstr ""
 
 msgid "Select at least one object to keep after cutting."
 msgstr ""
@@ -515,7 +515,7 @@ msgid "Cut plane with groove is invalid"
 msgstr ""
 
 msgid "Connector"
-msgstr "Connector"
+msgstr ""
 
 msgid "Cut by Plane"
 msgstr ""
@@ -524,7 +524,7 @@ msgid "non-manifold edges be caused by cut tool, do you want to fix it now?"
 msgstr "Non-manifold edges be caused by cut tool: do you want to fix now?"
 
 msgid "Repairing model object"
-msgstr "Repairing model object"
+msgstr ""
 
 msgid "Cut by line"
 msgstr ""
@@ -533,90 +533,87 @@ msgid "Delete connector"
 msgstr ""
 
 msgid "Mesh name"
-msgstr "Mesh name"
+msgstr ""
 
 msgid "Detail level"
-msgstr "Detail level"
+msgstr ""
 
 msgid "Decimate ratio"
-msgstr "Decimate ratio"
+msgstr ""
 
 #, boost-format
 msgid ""
 "Processing model '%1%' with more than 1M triangles could be slow. It is "
 "highly recommended to simplify the model."
 msgstr ""
-"Processing model '%1%' with more than 1M triangles could be slow. It is "
-"highly recommended to simplify the model."
 
 msgid "Simplify model"
-msgstr "Simplify model"
+msgstr ""
 
 msgid "Simplify"
-msgstr "Simplify"
+msgstr ""
 
 msgid "Simplification is currently only allowed when a single part is selected"
 msgstr ""
-"Simplification is currently only allowed when a single part is selected"
 
 msgid "Error"
-msgstr "Error"
+msgstr ""
 
 msgid "Extra high"
-msgstr "Extra high"
+msgstr ""
 
 msgid "High"
-msgstr "High"
+msgstr ""
 
 msgid "Medium"
-msgstr "Medium"
+msgstr ""
 
 msgid "Low"
-msgstr "Low"
+msgstr ""
 
 msgid "Extra low"
-msgstr "Extra low"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%d triangles"
-msgstr "%d triangles"
+msgstr ""
 
 msgid "Show wireframe"
-msgstr "Show wireframe"
+msgstr ""
 
 #, boost-format
 msgid "%1%"
-msgstr "%1%"
+msgstr ""
 
 msgid "Can't apply when process preview."
 msgstr "Unable to apply when processing preview"
 
 msgid "Operation already cancelling. Please wait few seconds."
-msgstr "Operation already cancelling. Please wait few seconds."
+msgstr ""
 
 msgid "Face recognition"
-msgstr "Face recognition"
+msgstr ""
 
 msgid "Perform Recognition"
-msgstr "Perform Recognition"
+msgstr ""
 
 msgid "Brush size"
-msgstr "Brush size"
+msgstr ""
 
 msgid "Brush shape"
-msgstr "Brush shape"
+msgstr ""
 
 msgid "Enforce seam"
-msgstr "Enforce seam"
+msgstr ""
 
 msgid "Block seam"
-msgstr "Block seam"
+msgstr ""
 
 msgid "Seam painting"
-msgstr "Seam painting"
+msgstr ""
 
 msgid "Remove selection"
-msgstr "Remove selection"
+msgstr ""
 
 msgid "Entering Seam painting"
 msgstr "Entering seam painting"
@@ -625,21 +622,21 @@ msgid "Leaving Seam painting"
 msgstr "Leaving Seam Painting"
 
 msgid "Paint-on seam editing"
-msgstr "Paint-on seam editing"
+msgstr ""
 
 #. TRN - Input label. Be short as possible
 #. Select look of letter shape
 msgid "Font"
-msgstr "Font"
+msgstr ""
 
 msgid "Thickness"
-msgstr "Thickness"
+msgstr ""
 
 msgid "Text Gap"
-msgstr "Text Gap"
+msgstr ""
 
 msgid "Angle"
-msgstr "Angle"
+msgstr ""
 
 msgid ""
 "Embedded\n"
@@ -647,22 +644,22 @@ msgid ""
 msgstr "Embedded depth"
 
 msgid "Input text"
-msgstr "Input text"
+msgstr ""
 
 msgid "Surface"
-msgstr "Surface"
+msgstr ""
 
 msgid "Horizontal text"
-msgstr "Horizontal text"
+msgstr ""
 
 msgid "Shift + Mouse move up or down"
-msgstr "Shift + Mouse move up or down"
+msgstr ""
 
 msgid "Rotate text"
-msgstr "Rotate text"
+msgstr ""
 
 msgid "Text shape"
-msgstr "Text shape"
+msgstr ""
 
 #. TRN - Title in Undo/Redo stack after rotate with text around emboss axe
 msgid "Text rotate"
@@ -712,7 +709,7 @@ msgid "Default font"
 msgstr ""
 
 msgid "Advanced"
-msgstr "Advanced"
+msgstr ""
 
 msgid ""
 "The text cannot be written using the selected font. Please try choosing a "
@@ -764,13 +761,13 @@ msgstr ""
 
 msgctxt "EmbossOperation"
 msgid "Cut"
-msgstr "Cut"
+msgstr ""
 
 msgid "Click to change part type into negative volume."
 msgstr ""
 
 msgid "Modifier"
-msgstr "Modifier"
+msgstr ""
 
 msgid "Click to change part type into modifier."
 msgstr ""
@@ -789,7 +786,7 @@ msgid "Name has to be unique."
 msgstr ""
 
 msgid "OK"
-msgstr "OK"
+msgstr ""
 
 msgid "Rename style"
 msgstr ""
@@ -906,19 +903,19 @@ msgstr ""
 
 msgctxt "Alignment"
 msgid "Left"
-msgstr "Left"
+msgstr ""
 
 msgctxt "Alignment"
 msgid "Center"
-msgstr "Center"
+msgstr ""
 
 msgctxt "Alignment"
 msgid "Right"
-msgstr "Right"
+msgstr ""
 
 msgctxt "Alignment"
 msgid "Top"
-msgstr "Top"
+msgstr ""
 
 msgctxt "Alignment"
 msgid "Middle"
@@ -926,7 +923,7 @@ msgstr ""
 
 msgctxt "Alignment"
 msgid "Bottom"
-msgstr "Bottom"
+msgstr ""
 
 msgid "Revert alignment."
 msgstr ""
@@ -1000,7 +997,7 @@ msgid "No symbol"
 msgstr ""
 
 msgid "Loading"
-msgstr "Loading"
+msgstr ""
 
 msgid "In queue"
 msgstr ""
@@ -1008,7 +1005,7 @@ msgstr ""
 #. TRN - Input label. Be short as possible
 #. Height of one text line - Font Ascent
 msgid "Height"
-msgstr "Height"
+msgstr ""
 
 #. TRN - Input label. Be short as possible
 #. Copy surface of model on surface of the embossed text
@@ -1220,7 +1217,7 @@ msgstr ""
 
 #. TRN - Input label. Be short as possible
 msgid "Mirror"
-msgstr "Mirror"
+msgstr ""
 
 msgid "Choose SVG file for emboss:"
 msgstr ""
@@ -1245,49 +1242,49 @@ msgid "No feature"
 msgstr ""
 
 msgid "Vertex"
-msgstr "Vertex"
+msgstr ""
 
 msgid "Edge"
-msgstr "Edge"
+msgstr ""
 
 msgid "Plane"
-msgstr "Plane"
+msgstr ""
 
 msgid "Point on edge"
-msgstr "Point on edge"
+msgstr ""
 
 msgid "Point on circle"
-msgstr "Point on circle"
+msgstr ""
 
 msgid "Point on plane"
-msgstr "Point on plane"
+msgstr ""
 
 msgid "Center of edge"
-msgstr "Center of edge"
+msgstr ""
 
 msgid "Center of circle"
-msgstr "Center of circle"
+msgstr ""
 
 msgid "Select feature"
-msgstr "Select feature"
+msgstr ""
 
 msgid "Select point"
-msgstr "Select point"
+msgstr ""
 
 msgid "Delete"
-msgstr "Delete"
+msgstr ""
 
 msgid "Restart selection"
-msgstr "Restart selection"
+msgstr ""
 
 msgid "Esc"
-msgstr "Esc"
+msgstr ""
 
 msgid "Cancel a feature until exit"
-msgstr "Cancel a feature until exit"
+msgstr ""
 
 msgid "Measure"
-msgstr "Measure"
+msgstr ""
 
 msgid ""
 "Please confirm explosion ratio = 1,and please select at least one object"
@@ -1295,59 +1292,53 @@ msgstr ""
 "Please confirm explosion ratio = 1, and please select at least one object"
 
 msgid "Please select at least one object."
-msgstr "Please select at least one object."
+msgstr ""
 
 msgid "Edit to scale"
-msgstr "Edit to scale"
+msgstr ""
 
 msgctxt "Verb"
 msgid "Scale all"
-msgstr "Scale all"
+msgstr ""
 
 msgid "None"
-msgstr "None"
+msgstr ""
 
 msgid "Diameter"
-msgstr "Diameter"
+msgstr ""
 
 msgid "Length"
-msgstr "Length"
+msgstr ""
 
 msgid "Selection"
-msgstr "Selection"
+msgstr ""
 
 msgid " (Moving)"
-msgstr " (Moving)"
+msgstr ""
 
 msgid ""
 "Select 2 faces on objects and \n"
 " make objects assemble together."
 msgstr ""
-"Select 2 faces on objects and \n"
-" make objects assemble together."
 
 msgid ""
 "Select 2 points or circles on objects and \n"
 " specify distance between them."
 msgstr ""
-"Select 2 points or circles on objects and \n"
-" specify distance between them."
 
 msgid "Face"
-msgstr "Face"
+msgstr ""
 
 msgid " (Fixed)"
-msgstr " (Fixed)"
+msgstr ""
 
 msgid "Point"
-msgstr "Point"
+msgstr ""
 
 msgid ""
 "Feature 1 has been reset, \n"
 "feature 2 has been feature 1"
 msgstr ""
-"Feature 1 has been reset, \n"
-"feature 2 has been feature 1"
 
 msgid "Warning:please select Plane's feature."
 msgstr "Warning: please select Plane's feature."
@@ -1359,68 +1350,68 @@ msgid "Warning:please select two different mesh."
 msgstr "Warning: please select two different meshes."
 
 msgid "Copy to clipboard"
-msgstr "Copy to clipboard"
+msgstr ""
 
 msgid "Perpendicular distance"
-msgstr "Perpendicular distance"
+msgstr ""
 
 msgid "Distance"
-msgstr "Distance"
+msgstr ""
 
 msgid "Direct distance"
-msgstr "Direct distance"
+msgstr ""
 
 msgid "Distance XYZ"
-msgstr "Distance XYZ"
+msgstr ""
 
 msgid "Parallel"
-msgstr "Parallel"
+msgstr ""
 
 msgid "Center coincidence"
-msgstr "Center coincidence"
+msgstr ""
 
 msgid "Featue 1"
 msgstr "Feature 1"
 
 msgid "Reverse rotation"
-msgstr "Reverse rotation"
+msgstr ""
 
 msgid "Rotate around center:"
-msgstr "Rotate around center:"
+msgstr ""
 
 msgid "Parallel distance:"
 msgstr ""
 
 msgid "Flip by Face 2"
-msgstr "Flip by Face 2"
+msgstr ""
 
 msgid "Ctrl+"
-msgstr "Ctrl+"
+msgstr ""
 
 msgid "Notice"
-msgstr "Notice"
+msgstr ""
 
 msgid "Undefined"
-msgstr "Undefined"
+msgstr ""
 
 #, boost-format
 msgid "%1% was replaced with %2%"
-msgstr "%1% was replaced with %2%"
+msgstr ""
 
 msgid "The configuration may be generated by a newer version of OrcaSlicer."
 msgstr ""
 
 msgid "Some values have been replaced. Please check them:"
-msgstr "Some values have been replaced. Please check them:"
+msgstr ""
 
 msgid "Process"
-msgstr "Process"
+msgstr ""
 
 msgid "Filament"
-msgstr "Filament"
+msgstr ""
 
 msgid "Machine"
-msgstr "Machine"
+msgstr ""
 
 msgid "Configuration package was loaded, but some values were not recognized."
 msgstr ""
@@ -1440,7 +1431,7 @@ msgstr ""
 "It will be appreciated if you report the issue to our team."
 
 msgid "Fatal error"
-msgstr "Fatal error"
+msgstr ""
 
 msgid ""
 "OrcaSlicer will terminate because of a localization error. It will be "
@@ -1448,27 +1439,27 @@ msgid ""
 msgstr ""
 
 msgid "Critical error"
-msgstr "Critical error"
+msgstr ""
 
 #, boost-format
 msgid "OrcaSlicer got an unhandled exception: %1%"
 msgstr ""
 
 msgid "Untitled"
-msgstr "Untitled"
+msgstr ""
 
 msgid "Downloading Bambu Network Plug-in"
-msgstr "Downloading Bambu Network Plug-in"
+msgstr ""
 
 msgid "Login information expired. Please login again."
-msgstr "Login information expired. Please login again."
+msgstr ""
 
 msgid "Incorrect password"
-msgstr "Incorrect password"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Connect %s failed! [SN:%s, code=%s]"
-msgstr "Connect %s failed! [SN:%s, code=%s]"
+msgstr ""
 
 msgid ""
 "Orca Slicer requires the Microsoft WebView2 Runtime to operate certain "
@@ -1484,27 +1475,25 @@ msgid ""
 "%s\n"
 "Do you want to continue?"
 msgstr ""
-"%s\n"
-"Do you want to continue?"
 
 msgid "Remember my choice"
-msgstr "Remember my choice"
+msgstr ""
 
 msgid "Loading configuration"
-msgstr "Loading configuration"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Click to download new version in default browser: %s"
-msgstr "Click to download new version in default browser: %s"
+msgstr ""
 
 msgid "The Orca Slicer needs an upgrade"
 msgstr "Orca Slicer needs an update"
 
 msgid "This is the newest version."
-msgstr "This is the newest version."
+msgstr ""
 
 msgid "Info"
-msgstr "Info"
+msgstr ""
 
 msgid ""
 "The OrcaSlicer configuration file may be corrupted and cannot be parsed.\n"
@@ -1514,22 +1503,22 @@ msgid ""
 msgstr ""
 
 msgid "Rebuild"
-msgstr "Rebuild"
+msgstr ""
 
 msgid "Loading current presets"
-msgstr "Loading current presets"
+msgstr ""
 
 msgid "Loading a mode view"
-msgstr "Loading a mode view"
+msgstr ""
 
 msgid "Choose one file (3mf):"
 msgstr ""
 
 msgid "Choose one or more files (3mf/step/stl/svg/obj/amf/usd*/abc/ply):"
-msgstr "Choose one or more files (3mf/step/stl/svg/obj/amf/usd*/abc/ply):"
+msgstr ""
 
 msgid "Choose one or more files (3mf/step/stl/svg/obj/amf):"
-msgstr "Choose one or more files (3mf/step/stl/svg/obj/amf):"
+msgstr ""
 
 msgid "Choose ZIP file"
 msgstr ""
@@ -1538,7 +1527,7 @@ msgid "Choose one file (gcode/3mf):"
 msgstr ""
 
 msgid "Some presets are modified."
-msgstr "Some presets are modified."
+msgstr ""
 
 msgid ""
 "You can keep the modified presets to the new project, discard or save "
@@ -1548,57 +1537,53 @@ msgstr ""
 "changes as new presets."
 
 msgid "User logged out"
-msgstr "User logged out"
+msgstr ""
 
 msgid "new or open project file is not allowed during the slicing process!"
-msgstr "new or open project file is not allowed during the slicing process!"
+msgstr ""
 
 msgid "Open Project"
-msgstr "Open Project"
+msgstr ""
 
 msgid ""
 "The version of Orca Slicer is too low and needs to be updated to the latest "
 "version before it can be used normally"
 msgstr ""
-"The version of Orca Slicer is too low and needs to be updated to the latest "
-"version before it can be used normally"
 
 msgid "Privacy Policy Update"
-msgstr "Privacy Policy Update"
+msgstr ""
 
 msgid ""
 "The number of user presets cached in the cloud has exceeded the upper limit, "
 "newly created user presets can only be used locally."
 msgstr ""
-"The number of user presets cached in the cloud has exceeded the upper limit, "
-"newly created user presets can only be used locally."
 
 msgid "Sync user presets"
-msgstr "Sync user presets"
+msgstr ""
 
 msgid "Loading user preset"
-msgstr "Loading user preset"
+msgstr ""
 
 msgid "Switching application language"
-msgstr "Switching application language"
+msgstr ""
 
 msgid "Select the language"
-msgstr "Select the language"
+msgstr ""
 
 msgid "Language"
-msgstr "Language"
+msgstr ""
 
 msgid "*"
-msgstr "*"
+msgstr ""
 
 msgid "The uploads are still ongoing"
-msgstr "The uploads are still ongoing"
+msgstr ""
 
 msgid "Stop them and continue anyway?"
-msgstr "Stop them and continue anyway?"
+msgstr ""
 
 msgid "Ongoing uploads"
-msgstr "Ongoing uploads"
+msgstr ""
 
 msgid "Select a G-code file:"
 msgstr ""
@@ -1609,47 +1594,47 @@ msgid ""
 msgstr ""
 
 msgid "Import File"
-msgstr "Import File"
+msgstr ""
 
 msgid "Choose files"
-msgstr "Choose files"
+msgstr ""
 
 msgid "New Folder"
-msgstr "New Folder"
+msgstr ""
 
 msgid "Open"
-msgstr "Open"
+msgstr ""
 
 msgid "Rename"
-msgstr "Rename"
+msgstr ""
 
 msgid "Orca Slicer GUI initialization failed"
-msgstr "Orca Slicer GUI initialization failed"
+msgstr ""
 
 #, boost-format
 msgid "Fatal error, exception caught: %1%"
 msgstr "Fatal error, exception: %1%"
 
 msgid "Quality"
-msgstr "Quality"
+msgstr ""
 
 msgid "Shell"
-msgstr "Shell"
+msgstr ""
 
 msgid "Infill"
-msgstr "Infill"
+msgstr ""
 
 msgid "Support"
-msgstr "Support"
+msgstr ""
 
 msgid "Flush options"
-msgstr "Flush options"
+msgstr ""
 
 msgid "Speed"
-msgstr "Speed"
+msgstr ""
 
 msgid "Strength"
-msgstr "Strength"
+msgstr ""
 
 msgid "Top Solid Layers"
 msgstr "Top solid layers"
@@ -1664,22 +1649,22 @@ msgid "Bottom Minimum Shell Thickness"
 msgstr "Bottom minimum shell thickness"
 
 msgid "Ironing"
-msgstr "Ironing"
+msgstr ""
 
 msgid "Fuzzy Skin"
 msgstr "Fuzzy skin"
 
 msgid "Extruders"
-msgstr "Extruders"
+msgstr ""
 
 msgid "Extrusion Width"
 msgstr "Extrusion width"
 
 msgid "Wipe options"
-msgstr "Wipe options"
+msgstr ""
 
 msgid "Bed adhesion"
-msgstr "Bed adhesion"
+msgstr ""
 
 msgid "Add part"
 msgstr "Add Part"
@@ -1715,43 +1700,43 @@ msgid "Add SVG modifier"
 msgstr ""
 
 msgid "Select settings"
-msgstr "Select settings"
+msgstr ""
 
 msgid "Hide"
-msgstr "Hide"
+msgstr ""
 
 msgid "Show"
-msgstr "Show"
+msgstr ""
 
 msgid "Del"
-msgstr "Del"
+msgstr ""
 
 msgid "Delete the selected object"
-msgstr "Delete the selected object"
+msgstr ""
 
 msgid "Load..."
-msgstr "Load..."
+msgstr ""
 
 msgid "Cube"
-msgstr "Cube"
+msgstr ""
 
 msgid "Cylinder"
-msgstr "Cylinder"
+msgstr ""
 
 msgid "Cone"
-msgstr "Cone"
+msgstr ""
 
 msgid "Disc"
-msgstr "Disc"
+msgstr ""
 
 msgid "Torus"
-msgstr "Torus"
+msgstr ""
 
 msgid "Orca Cube"
 msgstr ""
 
 msgid "3DBenchy"
-msgstr "3DBenchy"
+msgstr ""
 
 msgid "Autodesk FDM Test"
 msgstr ""
@@ -1792,71 +1777,71 @@ msgid "Set as individual objects"
 msgstr "Set as Individual Objects"
 
 msgid "Fill bed with copies"
-msgstr "Fill bed with copies"
+msgstr ""
 
 msgid "Fill the remaining area of bed with copies of the selected object"
-msgstr "Fill the remaining area of bed with copies of the selected object"
+msgstr ""
 
 msgid "Printable"
-msgstr "Printable"
+msgstr ""
 
 msgid "Fix model"
 msgstr "Fix Model"
 
 msgid "Export as one STL"
-msgstr "Export as one STL"
+msgstr ""
 
 msgid "Export as STLs"
-msgstr "Export as STLs"
+msgstr ""
 
 msgid "Reload from disk"
-msgstr "Reload from disk"
+msgstr ""
 
 msgid "Reload the selected parts from disk"
-msgstr "Reload the selected parts from disk"
+msgstr ""
 
 msgid "Replace with STL"
-msgstr "Replace with STL"
+msgstr ""
 
 msgid "Replace the selected part with new STL"
-msgstr "Replace the selected part with new STL"
+msgstr ""
 
 msgid "Change filament"
-msgstr "Change filament"
+msgstr ""
 
 msgid "Set filament for selected items"
-msgstr "Set filament for selected items"
+msgstr ""
 
 msgid "Default"
-msgstr "Default"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Filament %d"
-msgstr "Filament %d"
+msgstr ""
 
 msgid "current"
-msgstr "current"
+msgstr ""
 
 msgid "Scale to build volume"
-msgstr "Scale to build volume"
+msgstr ""
 
 msgid "Scale an object to fit the build volume"
-msgstr "Scale an object to fit the build volume"
+msgstr ""
 
 msgid "Flush Options"
-msgstr "Flush Options"
+msgstr ""
 
 msgid "Flush into objects' infill"
-msgstr "Flush into objects' infill"
+msgstr ""
 
 msgid "Flush into this object"
-msgstr "Flush into this object"
+msgstr ""
 
 msgid "Flush into objects' support"
-msgstr "Flush into objects' support"
+msgstr ""
 
 msgid "Edit in Parameter Table"
-msgstr "Edit in Parameter Table"
+msgstr ""
 
 msgid "Convert from inch"
 msgstr "Convert from Inches"
@@ -1871,7 +1856,7 @@ msgid "Restore to meter"
 msgstr "Restore to Meter"
 
 msgid "Assemble"
-msgstr "Assemble"
+msgstr ""
 
 msgid "Assemble the selected objects to an object with multiple parts"
 msgstr "Assemble the selected objects into an object with multiple parts"
@@ -1880,10 +1865,10 @@ msgid "Assemble the selected objects to an object with single part"
 msgstr "Assemble the selected objects into an object with single part"
 
 msgid "Mesh boolean"
-msgstr "Mesh boolean"
+msgstr ""
 
 msgid "Mesh boolean operations including union and subtraction"
-msgstr "Mesh boolean operations including union and subtraction"
+msgstr ""
 
 msgid "Along X axis"
 msgstr "Along X Axis"
@@ -1904,7 +1889,7 @@ msgid "Mirror along the Z axis"
 msgstr "Mirror along the Z Axis"
 
 msgid "Mirror object"
-msgstr "Mirror object"
+msgstr ""
 
 msgid "Edit text"
 msgstr ""
@@ -1919,58 +1904,58 @@ msgid "Change SVG source file, projection, size, ..."
 msgstr ""
 
 msgid "Invalidate cut info"
-msgstr "Invalidate cut info"
+msgstr ""
 
 msgid "Add Primitive"
-msgstr "Add Primitive"
+msgstr ""
 
 msgid "Add Handy models"
 msgstr ""
 
 msgid "Add Models"
-msgstr "Add Models"
+msgstr ""
 
 msgid "Show Labels"
-msgstr "Show Labels"
+msgstr ""
 
 msgid "To objects"
 msgstr "To Objects"
 
 msgid "Split the selected object into multiple objects"
-msgstr "Split the selected object into multiple objects"
+msgstr ""
 
 msgid "To parts"
 msgstr "To Parts"
 
 msgid "Split the selected object into multiple parts"
-msgstr "Split the selected object into multiple parts"
+msgstr ""
 
 msgid "Split"
-msgstr "Split"
+msgstr ""
 
 msgid "Split the selected object"
-msgstr "Split the selected object"
+msgstr ""
 
 msgid "Auto orientation"
-msgstr "Auto orientation"
+msgstr ""
 
 msgid "Auto orient the object to improve print quality."
-msgstr "Auto orient the object to improve print quality."
+msgstr ""
 
 msgid "Select All"
-msgstr "Select All"
+msgstr ""
 
 msgid "select all objects on current plate"
 msgstr "Select all objects on the current plate"
 
 msgid "Delete All"
-msgstr "Delete All"
+msgstr ""
 
 msgid "delete all objects on current plate"
 msgstr "Delete all objects on the current plate"
 
 msgid "Arrange"
-msgstr "Arrange"
+msgstr ""
 
 msgid "arrange current plate"
 msgstr "Arrange current plate"
@@ -1982,85 +1967,85 @@ msgid "reload all from disk"
 msgstr ""
 
 msgid "Auto Rotate"
-msgstr "Auto Rotate"
+msgstr ""
 
 msgid "auto rotate current plate"
 msgstr "Auto rotate current plate"
 
 msgid "Delete Plate"
-msgstr "Delete Plate"
+msgstr ""
 
 msgid "Remove the selected plate"
-msgstr "Remove the selected plate"
+msgstr ""
 
 msgid "Clone"
-msgstr "Clone"
+msgstr ""
 
 msgid "Simplify Model"
-msgstr "Simplify Model"
+msgstr ""
 
 msgid "Center"
-msgstr "Center"
+msgstr ""
 
 msgid "Drop"
 msgstr ""
 
 msgid "Edit Process Settings"
-msgstr "Edit Process Settings"
+msgstr ""
 
 msgid "Edit print parameters for a single object"
-msgstr "Edit print parameters for a single object"
+msgstr ""
 
 msgid "Change Filament"
-msgstr "Change Filament"
+msgstr ""
 
 msgid "Set Filament for selected items"
-msgstr "Set Filament for selected items"
+msgstr ""
 
 msgid "Unlock"
-msgstr "Unlock"
+msgstr ""
 
 msgid "Lock"
-msgstr "Lock"
+msgstr ""
 
 msgid "Edit Plate Name"
-msgstr "Edit Plate Name"
+msgstr ""
 
 msgid "Name"
-msgstr "Name"
+msgstr ""
 
 msgid "Fila."
-msgstr "Fila."
+msgstr ""
 
 #, c-format, boost-format
 msgid "%1$d error repaired"
 msgid_plural "%1$d errors repaired"
-msgstr[0] "%1$d error repaired"
-msgstr[1] "%1$d errors repaired"
+msgstr[0] ""
+msgstr[1] ""
 
 #, c-format, boost-format
 msgid "Error: %1$d non-manifold edge."
 msgid_plural "Error: %1$d non-manifold edges."
-msgstr[0] "Error: %1$d non-manifold edge."
-msgstr[1] "Error: %1$d non-manifold edges."
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Remaining errors"
-msgstr "Remaining errors"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%1$d non-manifold edge"
 msgid_plural "%1$d non-manifold edges"
-msgstr[0] "%1$d non-manifold edge"
-msgstr[1] "%1$d non-manifold edges"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Right click the icon to fix model object"
-msgstr "Right click the icon to fix model object"
+msgstr ""
 
 msgid "Right button click the icon to drop the object settings"
 msgstr "Right click the icon to drop the object settings"
 
 msgid "Click the icon to reset all settings of the object"
-msgstr "Click the icon to reset all settings of the object"
+msgstr ""
 
 msgid "Right button click the icon to drop the object printable property"
 msgstr "Right click the icon to drop the object printable property"
@@ -2069,54 +2054,50 @@ msgid "Click the icon to toggle printable property of the object"
 msgstr "Click the icon to toggle printable properties of the object"
 
 msgid "Click the icon to edit support painting of the object"
-msgstr "Click the icon to edit support painting of the object"
+msgstr ""
 
 msgid "Click the icon to edit color painting of the object"
 msgstr "Click the icon to edit color painting for the object"
 
 msgid "Click the icon to shift this object to the bed"
-msgstr "Click the icon to shift this object to the bed"
+msgstr ""
 
 msgid "Loading file"
-msgstr "Loading file"
+msgstr ""
 
 msgid "Error!"
-msgstr "Error!"
+msgstr ""
 
 msgid "Failed to get the model data in the current file."
-msgstr "Failed to get the model data in the current file."
+msgstr ""
 
 msgid "Generic"
-msgstr "Generic"
+msgstr ""
 
 msgid "Add Modifier"
-msgstr "Add Modifier"
+msgstr ""
 
 msgid "Switch to per-object setting mode to edit modifier settings."
-msgstr "Switch to per-object setting mode to edit modifier settings."
+msgstr ""
 
 msgid ""
 "Switch to per-object setting mode to edit process settings of selected "
 "objects."
 msgstr ""
-"Switch to per-object setting mode to edit process settings of selected "
-"objects."
 
 msgid "Delete connector from object which is a part of cut"
-msgstr "Delete connector from object which is a part of cut"
+msgstr ""
 
 msgid "Delete solid part from object which is a part of cut"
-msgstr "Delete solid part from object which is a part of cut"
+msgstr ""
 
 msgid "Delete negative volume from object which is a part of cut"
-msgstr "Delete negative volume from object which is a part of cut"
+msgstr ""
 
 msgid ""
 "To save cut correspondence you can delete all connectors from all related "
 "objects."
 msgstr ""
-"To save cut correspondence you can delete all connectors from all related "
-"objects."
 
 msgid ""
 "This action will break a cut correspondence.\n"
@@ -2132,25 +2113,25 @@ msgstr ""
 "cut information first."
 
 msgid "Delete all connectors"
-msgstr "Delete all connectors"
+msgstr ""
 
 msgid "Deleting the last solid part is not allowed."
-msgstr "Deleting the last solid part is not allowed."
+msgstr ""
 
 msgid "The target object contains only one part and cannot be split."
 msgstr ""
 
 msgid "Assembly"
-msgstr "Assembly"
+msgstr ""
 
 msgid "Cut Connectors information"
-msgstr "Cut Connectors information"
+msgstr ""
 
 msgid "Object manipulation"
-msgstr "Object manipulation"
+msgstr ""
 
 msgid "Group manipulation"
-msgstr "Group manipulation"
+msgstr ""
 
 msgid "Object Settings to modify"
 msgstr "Object Settings to Modify"
@@ -2162,22 +2143,22 @@ msgid "Layer range Settings to modify"
 msgstr "Layer Range Settings to Modify"
 
 msgid "Part manipulation"
-msgstr "Part manipulation"
+msgstr ""
 
 msgid "Instance manipulation"
-msgstr "Instance manipulation"
+msgstr ""
 
 msgid "Height ranges"
-msgstr "Height ranges"
+msgstr ""
 
 msgid "Settings for height range"
-msgstr "Settings for height range"
+msgstr ""
 
 msgid "Layer"
-msgstr "Layer"
+msgstr ""
 
 msgid "Selection conflicts"
-msgstr "Selection conflicts"
+msgstr ""
 
 msgid ""
 "If first selected item is an object, the second one should also be object."
@@ -2196,25 +2177,25 @@ msgid "The type of the last solid object part is not to be changed."
 msgstr "The type of the last solid object part cannot be changed."
 
 msgid "Negative Part"
-msgstr "Negative Part"
+msgstr ""
 
 msgid "Support Blocker"
-msgstr "Support Blocker"
+msgstr ""
 
 msgid "Support Enforcer"
-msgstr "Support Enforcer"
+msgstr ""
 
 msgid "Type:"
-msgstr "Type:"
+msgstr ""
 
 msgid "Choose part type"
-msgstr "Choose part type"
+msgstr ""
 
 msgid "Enter new name"
-msgstr "Enter new name"
+msgstr ""
 
 msgid "Renaming"
-msgstr "Renaming"
+msgstr ""
 
 msgid "Following model object has been repaired"
 msgid_plural "Following model objects have been repaired"
@@ -2227,25 +2208,25 @@ msgstr[0] "Failed to repair the following model object"
 msgstr[1] "Failed to repair the following model objects"
 
 msgid "Repairing was canceled"
-msgstr "Repairing was canceled"
+msgstr ""
 
 msgid "Additional process preset"
-msgstr "Additional process preset"
+msgstr ""
 
 msgid "Remove parameter"
-msgstr "Remove parameter"
+msgstr ""
 
 msgid "to"
-msgstr "to"
+msgstr ""
 
 msgid "Remove height range"
-msgstr "Remove height range"
+msgstr ""
 
 msgid "Add height range"
-msgstr "Add height range"
+msgstr ""
 
 msgid "Invalid numeric."
-msgstr "Invalid numeric."
+msgstr ""
 
 msgid "one cell can only be copied to one or multiple cells in the same column"
 msgstr "One cell can only be copied to one or more cells in the same column."
@@ -2254,58 +2235,58 @@ msgid "multiple cells copy is not supported"
 msgstr "Copying multiple cells is not supported."
 
 msgid "Outside"
-msgstr "Outside"
+msgstr ""
 
 msgid "Layer height"
-msgstr "Layer height"
+msgstr ""
 
 msgid "Wall loops"
-msgstr "Wall loops"
+msgstr ""
 
 msgid "Infill density(%)"
-msgstr "Infill density(%)"
+msgstr ""
 
 msgid "Auto Brim"
-msgstr "Auto Brim"
+msgstr ""
 
 msgid "Mouse ear"
 msgstr ""
 
 msgid "Outer brim only"
-msgstr "Outer brim only"
+msgstr ""
 
 msgid "Inner brim only"
-msgstr "Inner brim only"
+msgstr ""
 
 msgid "Outer and inner brim"
-msgstr "Outer and inner brim"
+msgstr ""
 
 msgid "No-brim"
-msgstr "No-brim"
+msgstr ""
 
 msgid "Outer wall speed"
-msgstr "Outer wall speed"
+msgstr ""
 
 msgid "Plate"
-msgstr "Plate"
+msgstr ""
 
 msgid "Brim"
-msgstr "Brim"
+msgstr ""
 
 msgid "Object/Part Setting"
 msgstr "Object/part setting"
 
 msgid "Reset parameter"
-msgstr "Reset parameter"
+msgstr ""
 
 msgid "Multicolor Print"
-msgstr "Multicolor Print"
+msgstr ""
 
 msgid "Line Type"
-msgstr "Line Type"
+msgstr ""
 
 msgid "More"
-msgstr "More"
+msgstr ""
 
 msgid "Open Preferences."
 msgstr "Open Preferences"
@@ -2320,19 +2301,19 @@ msgid "Color"
 msgstr ""
 
 msgid "Pause"
-msgstr "Pause"
+msgstr ""
 
 msgid "Template"
-msgstr "Template"
+msgstr ""
 
 msgid "Custom"
-msgstr "Custom"
+msgstr ""
 
 msgid "Pause:"
-msgstr "Pause:"
+msgstr ""
 
 msgid "Custom Template:"
-msgstr "Custom Template:"
+msgstr ""
 
 msgid "Custom G-code:"
 msgstr ""
@@ -2350,10 +2331,10 @@ msgid "Please enter the layer number"
 msgstr "Please enter the layer number."
 
 msgid "Add Pause"
-msgstr "Add Pause"
+msgstr ""
 
 msgid "Insert a pause command at the beginning of this layer."
-msgstr "Insert a pause command at the beginning of this layer."
+msgstr ""
 
 msgid "Add Custom G-code"
 msgstr ""
@@ -2362,22 +2343,22 @@ msgid "Insert custom G-code at the beginning of this layer."
 msgstr ""
 
 msgid "Add Custom Template"
-msgstr "Add Custom Template"
+msgstr ""
 
 msgid "Insert template custom G-code at the beginning of this layer."
 msgstr ""
 
 msgid "Filament "
-msgstr "Filament "
+msgstr ""
 
 msgid "Change filament at the beginning of this layer."
-msgstr "Change filament at the beginning of this layer."
+msgstr ""
 
 msgid "Delete Pause"
-msgstr "Delete Pause"
+msgstr ""
 
 msgid "Delete Custom Template"
-msgstr "Delete Custom Template"
+msgstr ""
 
 msgid "Edit Custom G-code"
 msgstr ""
@@ -2386,118 +2367,118 @@ msgid "Delete Custom G-code"
 msgstr ""
 
 msgid "Delete Filament Change"
-msgstr "Delete Filament Change"
+msgstr ""
 
 msgid "No printer"
-msgstr "No printer"
+msgstr ""
 
 msgid "..."
-msgstr "..."
+msgstr ""
 
 msgid "Failed to connect to the server"
-msgstr "Failed to connect to the server"
+msgstr ""
 
 msgid "Check the status of current system services"
-msgstr "Check the status of current system services"
+msgstr ""
 
 msgid "code"
-msgstr "code"
+msgstr ""
 
 msgid "Failed to connect to cloud service"
-msgstr "Failed to connect to cloud service"
+msgstr ""
 
 msgid "Please click on the hyperlink above to view the cloud service status"
-msgstr "Please click on the hyperlink above to view the cloud service status"
+msgstr ""
 
 msgid "Failed to connect to the printer"
-msgstr "Failed to connect to the printer"
+msgstr ""
 
 msgid "Connection to printer failed"
-msgstr "Connection to printer failed"
+msgstr ""
 
 msgid "Please check the network connection of the printer and Orca."
-msgstr "Please check the network connection of the printer and Orca."
+msgstr ""
 
 msgid "Connecting..."
-msgstr "Connecting..."
+msgstr ""
 
 msgid "?"
-msgstr "?"
+msgstr ""
 
 msgid "/"
-msgstr "/"
+msgstr ""
 
 msgid "Empty"
-msgstr "Empty"
+msgstr ""
 
 msgid "AMS"
-msgstr "AMS"
+msgstr ""
 
 msgid "Auto Refill"
-msgstr "Auto Refill"
+msgstr ""
 
 msgid "AMS not connected"
-msgstr "AMS not connected"
+msgstr ""
 
 msgid "Load"
-msgstr "Load"
+msgstr ""
 
 msgid "Unload"
-msgstr "Unload"
+msgstr ""
 
 msgid "Ext Spool"
-msgstr "Ext Spool"
+msgstr ""
 
 msgid "Tips"
-msgstr "Tips"
+msgstr ""
 
 msgid "Guide"
-msgstr "Guide"
+msgstr ""
 
 msgid "Retry"
-msgstr "Retry"
+msgstr ""
 
 msgid "Calibrating AMS..."
-msgstr "Calibrating AMS..."
+msgstr ""
 
 msgid "A problem occurred during calibration. Click to view the solution."
-msgstr "A problem occurred during calibration. Click to view the solution."
+msgstr ""
 
 msgid "Calibrate again"
-msgstr "Calibrate again"
+msgstr ""
 
 msgid "Cancel calibration"
-msgstr "Cancel calibration"
+msgstr ""
 
 msgid "Idling..."
-msgstr "Idling..."
+msgstr ""
 
 msgid "Heat the nozzle"
-msgstr "Heat the nozzle"
+msgstr ""
 
 msgid "Cut filament"
-msgstr "Cut filament"
+msgstr ""
 
 msgid "Pull back current filament"
 msgstr "Pull back the current filament"
 
 msgid "Push new filament into extruder"
-msgstr "Push new filament into extruder"
+msgstr ""
 
 msgid "Purge old filament"
-msgstr "Purge old filament"
+msgstr ""
 
 msgid "Feed Filament"
-msgstr "Feed Filament"
+msgstr ""
 
 msgid "Confirm extruded"
-msgstr "Confirm extruded"
+msgstr ""
 
 msgid "Check filament location"
-msgstr "Check filament location"
+msgstr ""
 
 msgid "Grab new filament"
-msgstr "Grab new filament"
+msgstr ""
 
 msgid ""
 "Choose an AMS slot then press \"Load\" or \"Unload\" button to automatically "
@@ -2507,7 +2488,7 @@ msgstr ""
 "load or unload filament."
 
 msgid "Edit"
-msgstr "Edit"
+msgstr ""
 
 msgid ""
 "All the selected objects are on a locked plate.\n"
@@ -2515,7 +2496,7 @@ msgid ""
 msgstr ""
 
 msgid "No arrangeable objects are selected."
-msgstr "No arrangeable objects are selected."
+msgstr ""
 
 msgid ""
 "This plate is locked.\n"
@@ -2523,13 +2504,13 @@ msgid ""
 msgstr ""
 
 msgid "Arranging..."
-msgstr "Arranging..."
+msgstr ""
 
 msgid "Arranging"
-msgstr "Arranging"
+msgstr ""
 
 msgid "Arranging canceled."
-msgstr "Arranging canceled."
+msgstr ""
 
 msgid ""
 "Arranging is done but there are unpacked items. Reduce spacing and try again."
@@ -2538,12 +2519,11 @@ msgstr ""
 "spacing and try again."
 
 msgid "Arranging done."
-msgstr "Arranging done."
+msgstr ""
 
 msgid ""
 "Arrange failed. Found some exceptions when processing object geometries."
 msgstr ""
-"Arrange failed. Found some exceptions when processing object geometries."
 
 #, c-format, boost-format
 msgid ""
@@ -2551,9 +2531,6 @@ msgid ""
 "bed:\n"
 "%s"
 msgstr ""
-"Arrangement ignored the following objects which can't fit into a single "
-"bed:\n"
-"%s"
 
 msgid ""
 "All the selected objects are on a locked plate.\n"
@@ -2566,22 +2543,22 @@ msgid ""
 msgstr ""
 
 msgid "Orienting..."
-msgstr "Orienting..."
+msgstr ""
 
 msgid "Orienting"
-msgstr "Orienting"
+msgstr ""
 
 msgid "Orienting canceled."
 msgstr ""
 
 msgid "Filling"
-msgstr "Filling"
+msgstr ""
 
 msgid "Bed filling canceled."
-msgstr "Bed filling canceled."
+msgstr ""
 
 msgid "Bed filling done."
-msgstr "Bed filling done."
+msgstr ""
 
 msgid "Searching for optimal orientation"
 msgstr ""
@@ -2593,25 +2570,25 @@ msgid "Orientation found."
 msgstr ""
 
 msgid "Logging in"
-msgstr "Logging in"
+msgstr ""
 
 msgid "Login failed"
-msgstr "Login failed"
+msgstr ""
 
 msgid "Please check the printer network connection."
-msgstr "Please check the printer network connection."
+msgstr ""
 
 msgid "Abnormal print file data. Please slice again."
 msgstr "Abnormal print file data: please slice again."
 
 msgid "Task canceled."
-msgstr "Task canceled."
+msgstr ""
 
 msgid "Upload task timed out. Please check the network status and try again."
-msgstr "Upload task timed out. Please check the network status and try again."
+msgstr ""
 
 msgid "Cloud service connection failed. Please try again."
-msgstr "Cloud service connection failed. Please try again."
+msgstr ""
 
 msgid "Print file not found. please slice again."
 msgstr "Print file not found; please slice again."
@@ -2620,14 +2597,12 @@ msgid ""
 "The print file exceeds the maximum allowable size (1GB). Please simplify the "
 "model and slice again."
 msgstr ""
-"The print file exceeds the maximum allowable size (1GB). Please simplify the "
-"model and slice again."
 
 msgid "Failed to send the print job. Please try again."
-msgstr "Failed to send the print job. Please try again."
+msgstr ""
 
 msgid "Failed to upload file to ftp. Please try again."
-msgstr "Failed to upload file to ftp. Please try again."
+msgstr ""
 
 msgid ""
 "Check the current status of the bambu server by clicking on the link above."
@@ -2639,8 +2614,6 @@ msgid ""
 "The size of the print file is too large. Please adjust the file size and try "
 "again."
 msgstr ""
-"The size of the print file is too large. Please adjust the file size and try "
-"again."
 
 msgid "Print file not found, Please slice it again and send it for printing."
 msgstr "Print file not found; please slice it again and send it for printing."
@@ -2653,30 +2626,30 @@ msgstr ""
 "again."
 
 msgid "Sending print job over LAN"
-msgstr "Sending print job over LAN"
+msgstr ""
 
 msgid "Sending print job through cloud service"
-msgstr "Sending print job through cloud service"
+msgstr ""
 
 msgid "Print task sending times out."
-msgstr "Print task sending times out."
+msgstr ""
 
 msgid "Service Unavailable"
-msgstr "Service Unavailable"
+msgstr ""
 
 msgid "Unknown Error."
-msgstr "Unknown Error."
+msgstr ""
 
 msgid "Sending print configuration"
-msgstr "Sending print configuration"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Successfully sent. Will automatically jump to the device page in %ss"
-msgstr "Successfully sent. Will automatically jump to the device page in %ss"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Successfully sent. Will automatically jump to the next page in %ss"
-msgstr "Successfully sent. Will automatically jump to the next page in %ss"
+msgstr ""
 
 msgid "An SD card needs to be inserted before printing via LAN."
 msgstr "A MicroSD card needs to be inserted before printing via LAN."
@@ -2689,13 +2662,13 @@ msgstr "Sending G-code file to MicroSD card"
 
 #, c-format, boost-format
 msgid "Successfully sent. Close current page in %s s"
-msgstr "Successfully sent. Close current page in %s s"
+msgstr ""
 
 msgid "An SD card needs to be inserted before sending to printer."
 msgstr "A MicroSD card needs to be inserted before sending to printer."
 
 msgid "Importing SLA archive"
-msgstr "Importing SLA archive"
+msgstr ""
 
 msgid ""
 "The SLA archive doesn't contain any presets. Please activate some SLA "
@@ -2705,32 +2678,30 @@ msgstr ""
 "printer presets first before importing that SLA archive."
 
 msgid "Importing canceled."
-msgstr "Importing canceled."
+msgstr ""
 
 msgid "Importing done."
-msgstr "Importing done."
+msgstr ""
 
 msgid ""
 "The imported SLA archive did not contain any presets. The current SLA "
 "presets were used as fallback."
 msgstr ""
-"The imported SLA archive did not contain any presets. The current SLA "
-"presets were used as fallback."
 
 msgid "You cannot load SLA project with a multi-part object on the bed"
 msgstr "You cannot load an SLA project with a multi-part object on the bed"
 
 msgid "Please check your object list before preset changing."
-msgstr "Please check your object list before preset changing."
+msgstr ""
 
 msgid "Attention!"
-msgstr "Attention!"
+msgstr ""
 
 msgid "Downloading"
-msgstr "Downloading"
+msgstr ""
 
 msgid "Download failed"
-msgstr "Download failed"
+msgstr ""
 
 msgid "Canceled"
 msgstr ""
@@ -2739,42 +2710,40 @@ msgid "Install successfully."
 msgstr "Installed successfully"
 
 msgid "Installing"
-msgstr "Installing"
+msgstr ""
 
 msgid "Install failed"
-msgstr "Install failed"
+msgstr ""
 
 msgid "Portions copyright"
 msgstr "License Info"
 
 msgid "Copyright"
-msgstr "Copyright"
+msgstr ""
 
 msgid "License"
-msgstr "License"
+msgstr ""
 
 msgid "Orca Slicer is licensed under "
-msgstr "Orca Slicer is licensed under "
+msgstr ""
 
 msgid "GNU Affero General Public License, version 3"
-msgstr "GNU Affero General Public License, version 3"
+msgstr ""
 
 msgid "Orca Slicer is based on PrusaSlicer and BambuStudio"
 msgstr ""
 
 msgid "Libraries"
-msgstr "Libraries"
+msgstr ""
 
 msgid ""
 "This software uses open source components whose copyright and other "
 "proprietary rights belong to their respective owners"
 msgstr ""
-"This software uses open source components whose copyright and other "
-"proprietary rights belong to their respective owners"
 
 #, c-format, boost-format
 msgid "About %s"
-msgstr "About %s"
+msgstr ""
 
 msgid "OrcaSlicer is based on BambuStudio, PrusaSlicer, and SuperSlicer."
 msgstr ""
@@ -2783,70 +2752,66 @@ msgid "BambuStudio is originally based on PrusaSlicer by PrusaResearch."
 msgstr ""
 
 msgid "PrusaSlicer is originally based on Slic3r by Alessandro Ranellucci."
-msgstr "PrusaSlicer is originally based on Slic3r by Alessandro Ranellucci."
+msgstr ""
 
 msgid ""
 "Slic3r was created by Alessandro Ranellucci with the help of many other "
 "contributors."
 msgstr ""
-"Slic3r was created by Alessandro Ranellucci with the help of many other "
-"contributors."
 
 msgid "Version"
-msgstr "Version"
+msgstr ""
 
 msgid "AMS Materials Setting"
-msgstr "AMS Materials Setting"
+msgstr ""
 
 msgid "Confirm"
-msgstr "Confirm"
+msgstr ""
 
 msgid "Close"
-msgstr "Close"
+msgstr ""
 
 msgid ""
 "Nozzle\n"
 "Temperature"
 msgstr ""
-"Nozzle\n"
-"Temperature"
 
 msgid "max"
-msgstr "max"
+msgstr ""
 
 msgid "min"
-msgstr "min"
+msgstr ""
 
 #, boost-format
 msgid "The input value should be greater than %1% and less than %2%"
-msgstr "The input value should be greater than %1% and less than %2%"
+msgstr ""
 
 msgid "SN"
-msgstr "SN"
+msgstr ""
 
 msgid "Factors of Flow Dynamics Calibration"
-msgstr "Factors of Flow Dynamics Calibration"
+msgstr ""
 
 msgid "PA Profile"
-msgstr "PA Profile"
+msgstr ""
 
 msgid "Factor K"
-msgstr "Factor K"
+msgstr ""
 
 msgid "Factor N"
-msgstr "Factor N"
+msgstr ""
 
 msgid "Setting AMS slot information while printing is not supported"
-msgstr "Setting AMS slot information while printing is not supported"
+msgstr ""
 
 msgid "Setting Virtual slot information while printing is not supported"
-msgstr "Setting Virtual slot information while printing is not supported"
+msgstr ""
 
 msgid "Are you sure you want to clear the filament information?"
-msgstr "Are you sure you want to clear the filament information?"
+msgstr ""
 
 msgid "You need to select the material type and color first."
-msgstr "You need to select the material type and color first."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Please input a valid value (K in %.1f~%.1f)"
@@ -2857,104 +2822,97 @@ msgid "Please input a valid value (K in %.1f~%.1f, N in %.1f~%.1f)"
 msgstr ""
 
 msgid "Other Color"
-msgstr "Other Color"
+msgstr ""
 
 msgid "Custom Color"
-msgstr "Custom Color"
+msgstr ""
 
 msgid "Dynamic flow calibration"
-msgstr "Dynamic flow calibration"
+msgstr ""
 
 msgid ""
 "The nozzle temp and max volumetric speed will affect the calibration "
 "results. Please fill in the same values as the actual printing. They can be "
 "auto-filled by selecting a filament preset."
 msgstr ""
-"The nozzle temp and max volumetric speed will affect the calibration "
-"results. Please fill in the same values as the actual printing. They can be "
-"auto-filled by selecting a filament preset."
 
 msgid "Nozzle Diameter"
-msgstr "Nozzle Diameter"
+msgstr ""
 
 msgid "Bed Type"
 msgstr "Plate Type"
 
 msgid "Nozzle temperature"
-msgstr "Nozzle temperature"
+msgstr ""
 
 msgid "Bed Temperature"
-msgstr "Bed Temperature"
+msgstr ""
 
 msgid "Max volumetric speed"
-msgstr "Max volumetric speed"
+msgstr ""
 
 msgid "℃"
 msgstr ""
 
 msgid "Bed temperature"
-msgstr "Bed temperature"
+msgstr ""
 
 msgid "mm³"
-msgstr "mm³"
+msgstr ""
 
 msgid "Start calibration"
 msgstr "Start"
 
 msgid "Next"
-msgstr "Next"
+msgstr ""
 
 msgid ""
 "Calibration completed. Please find the most uniform extrusion line on your "
 "hot bed like the picture below, and fill the value on its left side into the "
 "factor K input box."
 msgstr ""
-"Calibration completed. Please find the most uniform extrusion line on your "
-"hot bed like the picture below, and fill the value on its left side into the "
-"factor K input box."
 
 msgid "Save"
-msgstr "Save"
+msgstr ""
 
 msgid "Last Step"
 msgstr "Back"
 
 msgid "Example"
-msgstr "Example"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Calibrating... %d%%"
-msgstr "Calibrating... %d%%"
+msgstr ""
 
 msgid "Calibration completed"
-msgstr "Calibration completed"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s does not support %s"
-msgstr "%s does not support %s"
+msgstr ""
 
 msgid "Dynamic flow Calibration"
 msgstr "Dynamic flow calibration"
 
 msgid "Step"
-msgstr "Step"
+msgstr ""
 
 msgid "AMS Slots"
-msgstr "AMS Slots"
+msgstr ""
 
 msgid ""
 "Note: Only the AMS slots loaded with the same material type can be selected."
 msgstr ""
-"Note: Only the AMS slots loaded with the same material type can be selected."
 
 msgid "Enable AMS"
-msgstr "Enable AMS"
+msgstr ""
 
 msgid "Print with filaments in the AMS"
 msgstr "Print with filament in the AMS"
 
 msgid "Disable AMS"
-msgstr "Disable AMS"
+msgstr ""
 
 msgid "Print with the filament mounted on the back of chassis"
 msgstr "Print with filament on external spool"
@@ -2979,16 +2937,16 @@ msgstr ""
 "Configure which AMS slot should be used for a filament used in the print job."
 
 msgid "Filament used in this print job"
-msgstr "Filament used in this print job"
+msgstr ""
 
 msgid "AMS slot used for this filament"
-msgstr "AMS slot used for this filament"
+msgstr ""
 
 msgid "Click to select AMS slot manually"
-msgstr "Click to select AMS slot manually"
+msgstr ""
 
 msgid "Do not Enable AMS"
-msgstr "Do not Enable AMS"
+msgstr ""
 
 msgid "Print using materials mounted on the back of the case"
 msgstr "Print using filament on external spool."
@@ -3003,14 +2961,12 @@ msgid ""
 "When the current material run out, the printer will continue to print in the "
 "following order."
 msgstr ""
-"When the current material run out, the printer will continue to print in the "
-"following order."
 
 msgid "Group"
-msgstr "Group"
+msgstr ""
 
 msgid "The printer does not currently support auto refill."
-msgstr "The printer does not currently support auto refill."
+msgstr ""
 
 msgid ""
 "AMS filament backup is not enabled, please enable it in the AMS settings."
@@ -3029,16 +2985,16 @@ msgstr ""
 "brand, material type, and color)"
 
 msgid "DRY"
-msgstr "DRY"
+msgstr ""
 
 msgid "WET"
-msgstr "WET"
+msgstr ""
 
 msgid "AMS Settings"
-msgstr "AMS Settings"
+msgstr ""
 
 msgid "Insertion update"
-msgstr "Insertion update"
+msgstr ""
 
 msgid ""
 "The AMS will automatically read the filament information when inserting a "
@@ -3051,15 +3007,11 @@ msgid ""
 "Note: if a new filament is inserted during  printing, the AMS will not "
 "automatically read any information until printing is completed."
 msgstr ""
-"Note: if a new filament is inserted during  printing, the AMS will not "
-"automatically read any information until printing is completed."
 
 msgid ""
 "When inserting a new filament, the AMS will not automatically read its "
 "information, leaving it blank for you to enter manually."
 msgstr ""
-"When inserting a new filament, the AMS will not automatically read its "
-"information, leaving it blank for you to enter manually."
 
 msgid "Power on update"
 msgstr "Update on startup"
@@ -3078,24 +3030,18 @@ msgid ""
 "during startup and will continue to use the information recorded before the "
 "last shutdown."
 msgstr ""
-"The AMS will not automatically read information from inserted filament "
-"during startup and will continue to use the information recorded before the "
-"last shutdown."
 
 msgid "Update remaining capacity"
-msgstr "Update remaining capacity"
+msgstr ""
 
 msgid ""
 "The AMS will estimate Bambu filament's remaining capacity after the filament "
 "info is updated. During printing, remaining capacity will be updated "
 "automatically."
 msgstr ""
-"The AMS will estimate Bambu filament's remaining capacity after the filament "
-"info is updated. During printing, remaining capacity will be updated "
-"automatically."
 
 msgid "AMS filament backup"
-msgstr "AMS filament backup"
+msgstr ""
 
 msgid ""
 "AMS will continue to another spool with the same properties of filament "
@@ -3105,20 +3051,18 @@ msgstr ""
 "automatically when current filament runs out."
 
 msgid "Air Printing Detection"
-msgstr "Air Printing Detection"
+msgstr ""
 
 msgid ""
 "Detects clogging and filament grinding, halting printing immediately to "
 "conserve time and filament."
 msgstr ""
-"Detects clogging and filament grinding, halting printing immediately to "
-"conserve time and filament."
 
 msgid "File"
-msgstr "File"
+msgstr ""
 
 msgid "Calibration"
-msgstr "Calibration"
+msgstr ""
 
 msgid ""
 "Failed to download the plug-in. Please check your firewall settings and vpn "
@@ -3135,20 +3079,18 @@ msgstr ""
 "been deleted by anti-virus software."
 
 msgid "click here to see more info"
-msgstr "click here to see more info"
+msgstr ""
 
 msgid "Please home all axes (click "
-msgstr "Please home all axes (click "
+msgstr ""
 
 msgid ""
 ") to locate the toolhead's position. This prevents device moving beyond the "
 "printable boundary and causing equipment wear."
 msgstr ""
-") to locate the toolhead's position. This prevents device moving beyond the "
-"printable boundary and causing equipment wear."
 
 msgid "Go Home"
-msgstr "Go Home"
+msgstr ""
 
 msgid ""
 "A error occurred. Maybe memory of system is not enough or it's a bug of the "
@@ -3168,34 +3110,34 @@ msgid "Processing G-code from Previous file..."
 msgstr "Processing G-Code from previous file…"
 
 msgid "Slicing complete"
-msgstr "Slicing complete"
+msgstr ""
 
 msgid "Access violation"
-msgstr "Access violation"
+msgstr ""
 
 msgid "Illegal instruction"
-msgstr "Illegal instruction"
+msgstr ""
 
 msgid "Divide by zero"
-msgstr "Divide by zero"
+msgstr ""
 
 msgid "Overflow"
-msgstr "Overflow"
+msgstr ""
 
 msgid "Underflow"
-msgstr "Underflow"
+msgstr ""
 
 msgid "Floating reserved operand"
-msgstr "Floating reserved operand"
+msgstr ""
 
 msgid "Stack overflow"
-msgstr "Stack overflow"
+msgstr ""
 
 msgid "Running post-processing scripts"
-msgstr "Running post-processing scripts"
+msgstr ""
 
 msgid "Successfully executed post-processing script"
-msgstr "Successfully executed post-processing script"
+msgstr ""
 
 msgid "Unknown error occurred during exporting G-code."
 msgstr ""
@@ -3251,16 +3193,16 @@ msgstr "Copying of the temporary G-code to the output G-code failed."
 
 #, boost-format
 msgid "Scheduling upload to `%1%`. See Window -> Print Host Upload Queue"
-msgstr "Scheduling upload to `%1%`. See Window -> Print Host Upload Queue"
+msgstr ""
 
 msgid "Device"
-msgstr "Device"
+msgstr ""
 
 msgid "Task Sending"
-msgstr "Task Sending"
+msgstr ""
 
 msgid "Task Sent"
-msgstr "Task Sent"
+msgstr ""
 
 msgid "Edit multiple printers"
 msgstr ""
@@ -3277,50 +3219,50 @@ msgid "The maximum number of printers that can be selected is %d"
 msgstr ""
 
 msgid "Offline"
-msgstr "Offline"
+msgstr ""
 
 msgid "No task"
-msgstr "No task"
+msgstr ""
 
 msgid "View"
-msgstr "View"
+msgstr ""
 
 msgid "N/A"
-msgstr "N/A"
+msgstr ""
 
 msgid "Edit Printers"
 msgstr ""
 
 msgid "Device Name"
-msgstr "Device Name"
+msgstr ""
 
 msgid "Task Name"
-msgstr "Task Name"
+msgstr ""
 
 msgid "Device Status"
-msgstr "Device Status"
+msgstr ""
 
 msgid "Actions"
-msgstr "Actions"
+msgstr ""
 
 msgid ""
 "Please select the devices you would like to manage here (up to 6 devices)"
 msgstr ""
 
 msgid "Add"
-msgstr "Add"
+msgstr ""
 
 msgid "Idle"
-msgstr "Idle"
+msgstr ""
 
 msgid "Printing"
-msgstr "Printing"
+msgstr ""
 
 msgid "Upgrading"
 msgstr ""
 
 msgid "Incompatible"
-msgstr "Incompatible"
+msgstr ""
 
 msgid "syncing"
 msgstr ""
@@ -3335,16 +3277,16 @@ msgid "Printing Pause"
 msgstr ""
 
 msgid "Prepare"
-msgstr "Prepare"
+msgstr ""
 
 msgid "Slicing"
-msgstr "Slicing"
+msgstr ""
 
 msgid "Pending"
 msgstr ""
 
 msgid "Sending"
-msgstr "Sending"
+msgstr ""
 
 msgid "Sending Finish"
 msgstr ""
@@ -3365,37 +3307,37 @@ msgid "Removed"
 msgstr ""
 
 msgid "Resume"
-msgstr "Resume"
+msgstr ""
 
 msgid "Stop"
-msgstr "Stop"
+msgstr ""
 
 msgid "Task Status"
-msgstr "Task Status"
+msgstr ""
 
 msgid "Sent Time"
-msgstr "Sent Time"
+msgstr ""
 
 msgid "There are no tasks to be sent!"
-msgstr "There are no tasks to be sent!"
+msgstr ""
 
 msgid "No historical tasks!"
-msgstr "No historical tasks!"
+msgstr ""
 
 msgid "Loading..."
-msgstr "Loading..."
+msgstr ""
 
 msgid "No AMS"
-msgstr "No AMS"
+msgstr ""
 
 msgid "Send to Multi-device"
-msgstr "Send to Multi-device"
+msgstr ""
 
 msgid "Preparing print job"
-msgstr "Preparing print job"
+msgstr ""
 
 msgid "Abnormal print file data. Please slice again"
-msgstr "Abnormal print file data. Please slice again"
+msgstr ""
 
 msgid "There is no device available to send printing."
 msgstr ""
@@ -3404,31 +3346,31 @@ msgid "The number of printers in use simultaneously cannot be equal to 0."
 msgstr ""
 
 msgid "Use External Spool"
-msgstr "Use External Spool"
+msgstr ""
 
 msgid "Use AMS"
-msgstr "Use AMS"
+msgstr ""
 
 msgid "Select Printers"
-msgstr "Select Printers"
+msgstr ""
 
 msgid "Ams Status"
 msgstr "AMS Status"
 
 msgid "Printing Options"
-msgstr "Printing Options"
+msgstr ""
 
 msgid "Bed Leveling"
 msgstr "Bed leveling"
 
 msgid "Timelapse"
-msgstr "Timelapse"
+msgstr ""
 
 msgid "Flow Dynamic Calibration"
 msgstr ""
 
 msgid "Send Options"
-msgstr "Send Options"
+msgstr ""
 
 msgid "Send to"
 msgstr ""
@@ -3441,7 +3383,7 @@ msgstr ""
 "heating at the same time.)"
 
 msgid "Wait"
-msgstr "Wait"
+msgstr ""
 
 msgid ""
 "minute each batch.(It depends on how long it takes to complete the heating.)"
@@ -3449,10 +3391,10 @@ msgstr ""
 "minute each batch. (It depends on how long it takes to complete heating.)"
 
 msgid "Send"
-msgstr "Send"
+msgstr ""
 
 msgid "Name is invalid;"
-msgstr "Name is invalid;"
+msgstr ""
 
 msgid "illegal characters:"
 msgstr "Illegal characters:"
@@ -3470,13 +3412,13 @@ msgid "The name is not allowed to end with space character."
 msgstr "The name is not allowed to end with a space."
 
 msgid "The name length exceeds the limit."
-msgstr "The name length exceeds the limit."
+msgstr ""
 
 msgid "Origin"
-msgstr "Origin"
+msgstr ""
 
 msgid "Size in X and Y of the rectangular plate."
-msgstr "Size in X and Y of the rectangular plate."
+msgstr ""
 
 msgid ""
 "Distance of the 0,0 G-code coordinate from the front left corner of the "
@@ -3487,44 +3429,42 @@ msgid ""
 "Diameter of the print bed. It is assumed that origin (0,0) is located in the "
 "center."
 msgstr ""
-"Diameter of the print bed. It is assumed that origin (0,0) is located in the "
-"center."
 
 msgid "Rectangular"
-msgstr "Rectangular"
+msgstr ""
 
 msgid "Circular"
-msgstr "Circular"
+msgstr ""
 
 msgid "Load shape from STL..."
-msgstr "Load shape from STL..."
+msgstr ""
 
 msgid "Settings"
-msgstr "Settings"
+msgstr ""
 
 msgid "Texture"
-msgstr "Texture"
+msgstr ""
 
 msgid "Remove"
-msgstr "Remove"
+msgstr ""
 
 msgid "Not found:"
-msgstr "Not found:"
+msgstr ""
 
 msgid "Model"
-msgstr "Model"
+msgstr ""
 
 msgid "Choose an STL file to import bed shape from:"
-msgstr "Choose an STL file to import bed shape from:"
+msgstr ""
 
 msgid "Invalid file format."
-msgstr "Invalid file format."
+msgstr ""
 
 msgid "Error! Invalid model"
 msgstr "Error: invalid model"
 
 msgid "The selected file contains no geometry."
-msgstr "The selected file contains no geometry."
+msgstr ""
 
 msgid ""
 "The selected file contains several disjoint areas. This is not supported."
@@ -3532,30 +3472,26 @@ msgstr ""
 "The selected file contains several disjointed areas. This is not supported."
 
 msgid "Choose a file to import bed texture from (PNG/SVG):"
-msgstr "Choose a file to import bed texture from (PNG/SVG):"
+msgstr ""
 
 msgid "Choose an STL file to import bed model from:"
-msgstr "Choose an STL file to import bed model from:"
+msgstr ""
 
 msgid "Bed Shape"
-msgstr "Bed Shape"
+msgstr ""
 
 msgid ""
 "The recommended minimum temperature is less than 190 degree or the "
 "recommended maximum temperature is greater than 300 degree.\n"
 msgstr ""
-"The recommended minimum temperature is less than 190 degree or the "
-"recommended maximum temperature is greater than 300 degree.\n"
 
 msgid ""
 "The recommended minimum temperature cannot be higher than the recommended "
 "maximum temperature.\n"
 msgstr ""
-"The recommended minimum temperature cannot be higher than the recommended "
-"maximum temperature.\n"
 
 msgid "Please check.\n"
-msgstr "Please check.\n"
+msgstr ""
 
 msgid ""
 "Nozzle may be blocked when the temperature is out of recommended range.\n"
@@ -3659,11 +3595,6 @@ msgid ""
 "YES - Keep Prime Tower\n"
 "NO  - Keep Adaptive Layer Height and Independent Support Layer Height"
 msgstr ""
-"Prime tower does not work when Adaptive Layer Height or Independent Support "
-"Layer Height is on.\n"
-"Which do you want to keep?\n"
-"YES - Keep Prime Tower\n"
-"NO  - Keep Adaptive Layer Height and Independent Support Layer Height"
 
 msgid ""
 "Prime tower does not work when Adaptive Layer Height is on.\n"
@@ -3671,10 +3602,6 @@ msgid ""
 "YES - Keep Prime Tower\n"
 "NO  - Keep Adaptive Layer Height"
 msgstr ""
-"Prime tower does not work when Adaptive Layer Height is on.\n"
-"Which do you want to keep?\n"
-"YES - Keep Prime Tower\n"
-"NO  - Keep Adaptive Layer Height"
 
 msgid ""
 "Prime tower does not work when Independent Support Layer Height is on.\n"
@@ -3682,10 +3609,6 @@ msgid ""
 "YES - Keep Prime Tower\n"
 "NO  - Keep Independent Support Layer Height"
 msgstr ""
-"Prime tower does not work when Independent Support Layer Height is on.\n"
-"Which do you want to keep?\n"
-"YES - Keep Prime Tower\n"
-"NO  - Keep Independent Support Layer Height"
 
 msgid ""
 "seam_slope_start_height need to be smaller than layer_height.\n"
@@ -3696,11 +3619,9 @@ msgid ""
 "Spiral mode only works when wall loops is 1, support is disabled, top shell "
 "layers is 0, sparse infill density is 0 and timelapse type is traditional."
 msgstr ""
-"Spiral mode only works when wall loops is 1, support is disabled, top shell "
-"layers is 0, sparse infill density is 0 and timelapse type is traditional."
 
 msgid " But machines with I3 structure will not generate timelapse videos."
-msgstr " But machines with I3 structure will not generate timelapse videos."
+msgstr ""
 
 msgid ""
 "Change these settings automatically? \n"
@@ -3712,133 +3633,133 @@ msgstr ""
 "No  - Cancel enabling spiral mode"
 
 msgid "Auto bed leveling"
-msgstr "Auto bed leveling"
+msgstr ""
 
 msgid "Heatbed preheating"
-msgstr "Heatbed preheating"
+msgstr ""
 
 msgid "Sweeping XY mech mode"
-msgstr "Sweeping XY mech mode"
+msgstr ""
 
 msgid "Changing filament"
-msgstr "Changing filament"
+msgstr ""
 
 msgid "M400 pause"
-msgstr "M400 pause"
+msgstr ""
 
 msgid "Paused due to filament runout"
-msgstr "Paused due to filament runout"
+msgstr ""
 
 msgid "Heating hotend"
-msgstr "Heating hotend"
+msgstr ""
 
 msgid "Calibrating extrusion"
-msgstr "Calibrating extrusion"
+msgstr ""
 
 msgid "Scanning bed surface"
-msgstr "Scanning bed surface"
+msgstr ""
 
 msgid "Inspecting first layer"
-msgstr "Inspecting first layer"
+msgstr ""
 
 msgid "Identifying build plate type"
-msgstr "Identifying build plate type"
+msgstr ""
 
 msgid "Calibrating Micro Lidar"
-msgstr "Calibrating Micro Lidar"
+msgstr ""
 
 msgid "Homing toolhead"
-msgstr "Homing toolhead"
+msgstr ""
 
 msgid "Cleaning nozzle tip"
-msgstr "Cleaning nozzle tip"
+msgstr ""
 
 msgid "Checking extruder temperature"
-msgstr "Checking extruder temperature"
+msgstr ""
 
 msgid "Printing was paused by the user"
-msgstr "Printing was paused by the user"
+msgstr ""
 
 msgid "Pause of front cover falling"
-msgstr "Pause of front cover falling"
+msgstr ""
 
 msgid "Calibrating the micro lida"
 msgstr "Calibrating the micro lidar"
 
 msgid "Calibrating extrusion flow"
-msgstr "Calibrating extrusion flow"
+msgstr ""
 
 msgid "Paused due to nozzle temperature malfunction"
-msgstr "Paused due to nozzle temperature malfunction"
+msgstr ""
 
 msgid "Paused due to heat bed temperature malfunction"
-msgstr "Paused due to heat bed temperature malfunction"
+msgstr ""
 
 msgid "Filament unloading"
-msgstr "Filament unloading"
+msgstr ""
 
 msgid "Skip step pause"
-msgstr "Skip step pause"
+msgstr ""
 
 msgid "Filament loading"
-msgstr "Filament loading"
+msgstr ""
 
 msgid "Motor noise calibration"
-msgstr "Motor noise calibration"
+msgstr ""
 
 msgid "Paused due to AMS lost"
-msgstr "Paused due to AMS lost"
+msgstr ""
 
 msgid "Paused due to low speed of the heat break fan"
-msgstr "Paused due to low speed of the heat break fan"
+msgstr ""
 
 msgid "Paused due to chamber temperature control error"
-msgstr "Paused due to chamber temperature control error"
+msgstr ""
 
 msgid "Cooling chamber"
-msgstr "Cooling chamber"
+msgstr ""
 
 msgid "Paused by the G-code inserted by user"
 msgstr ""
 
 msgid "Motor noise showoff"
-msgstr "Motor noise showoff"
+msgstr ""
 
 msgid "Nozzle filament covered detected pause"
-msgstr "Nozzle filament covered detected pause"
+msgstr ""
 
 msgid "Cutter error pause"
-msgstr "Cutter error pause"
+msgstr ""
 
 msgid "First layer error pause"
-msgstr "First layer error pause"
+msgstr ""
 
 msgid "Nozzle clog pause"
-msgstr "Nozzle clog pause"
+msgstr ""
 
 msgid "Unknown"
-msgstr "Unknown"
+msgstr ""
 
 msgid "Fatal"
-msgstr "Fatal"
+msgstr ""
 
 msgid "Serious"
-msgstr "Serious"
+msgstr ""
 
 msgid "Common"
-msgstr "Common"
+msgstr ""
 
 msgid "Update successful."
-msgstr "Update successful."
+msgstr ""
 
 msgid "Downloading failed."
-msgstr "Downloading failed."
+msgstr ""
 
 msgid "Verification failed."
-msgstr "Verification failed."
+msgstr ""
 
 msgid "Update failed."
-msgstr "Update failed."
+msgstr ""
 
 msgid ""
 "The current chamber temperature or the target chamber temperature exceeds "
@@ -3873,25 +3794,24 @@ msgstr ""
 msgid ""
 "This calibration does not support the currently selected nozzle diameter"
 msgstr ""
-"This calibration does not support the currently selected nozzle diameter"
 
 msgid "Current flowrate cali param is invalid"
-msgstr "Current flowrate cali param is invalid"
+msgstr ""
 
 msgid "Selected diameter and machine diameter do not match"
-msgstr "Selected diameter and machine diameter do not match"
+msgstr ""
 
 msgid "Failed to generate cali G-code"
 msgstr ""
 
 msgid "Calibration error"
-msgstr "Calibration error"
+msgstr ""
 
 msgid "TPU is not supported by AMS."
-msgstr "TPU is not supported by AMS."
+msgstr ""
 
 msgid "Bambu PET-CF/PA6-CF is not supported by AMS."
-msgstr "Bambu PET-CF/PA6-CF is not supported by AMS."
+msgstr ""
 
 msgid ""
 "Damp PVA will become flexible and get stuck inside AMS,please take care to "
@@ -3904,11 +3824,9 @@ msgid ""
 "CF/GF filaments are hard and brittle, It's easy to break or get stuck in "
 "AMS, please use with caution."
 msgstr ""
-"CF/GF filaments are hard and brittle, It's easy to break or get stuck in "
-"AMS, please use with caution."
 
 msgid "default"
-msgstr "default"
+msgstr ""
 
 #, boost-format
 msgid "Edit Custom G-code (%1%)"
@@ -3958,22 +3876,22 @@ msgid "Specific for %1%"
 msgstr ""
 
 msgid "Presets"
-msgstr "Presets"
+msgstr ""
 
 msgid "Print settings"
-msgstr "Print settings"
+msgstr ""
 
 msgid "Filament settings"
-msgstr "Filament settings"
+msgstr ""
 
 msgid "SLA Materials settings"
 msgstr ""
 
 msgid "Printer settings"
-msgstr "Printer settings"
+msgstr ""
 
 msgid "parameter name"
-msgstr "parameter name"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s can't be percentage"
@@ -3981,17 +3899,17 @@ msgstr "%s can’t be a percentage"
 
 #, c-format, boost-format
 msgid "Value %s is out of range, continue?"
-msgstr "Value %s is out of range, continue?"
+msgstr ""
 
 msgid "Parameter validation"
-msgstr "Parameter validation"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Value %s is out of range. The valid range is from %d to %d."
-msgstr "Value %s is out of range. The valid range is from %d to %d."
+msgstr ""
 
 msgid "Value is out of range."
-msgstr "Value is out of range."
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -3999,9 +3917,6 @@ msgid ""
 "YES for %s%%, \n"
 "NO for %s %s."
 msgstr ""
-"Is it %s%% or %s %s?\n"
-"YES for %s%%, \n"
-"NO for %s %s."
 
 #, boost-format
 msgid ""
@@ -4017,106 +3932,106 @@ msgstr ""
 
 #, boost-format
 msgid "Invalid format. Expected vector format: \"%1%\""
-msgstr "Invalid format. Expected vector format: \"%1%\""
+msgstr ""
 
 msgid "Layer Height"
-msgstr "Layer Height"
+msgstr ""
 
 msgid "Line Width"
-msgstr "Line Width"
+msgstr ""
 
 msgid "Fan Speed"
-msgstr "Fan Speed"
+msgstr ""
 
 msgid "Temperature"
-msgstr "Temperature"
+msgstr ""
 
 msgid "Flow"
-msgstr "Flow"
+msgstr ""
 
 msgid "Tool"
-msgstr "Tool"
+msgstr ""
 
 msgid "Layer Time"
-msgstr "Layer Time"
+msgstr ""
 
 msgid "Layer Time (log)"
-msgstr "Layer Time (log)"
+msgstr ""
 
 msgid "Height: "
-msgstr "Height: "
+msgstr ""
 
 msgid "Width: "
-msgstr "Width: "
+msgstr ""
 
 msgid "Speed: "
-msgstr "Speed: "
+msgstr ""
 
 msgid "Flow: "
-msgstr "Flow: "
+msgstr ""
 
 msgid "Layer Time: "
-msgstr "Layer Time: "
+msgstr ""
 
 msgid "Fan: "
-msgstr "Fan: "
+msgstr ""
 
 msgid "Temperature: "
-msgstr "Temperature: "
+msgstr ""
 
 msgid "Loading G-code"
 msgstr ""
 
 msgid "Generating geometry vertex data"
-msgstr "Generating geometry vertex data"
+msgstr ""
 
 msgid "Generating geometry index data"
-msgstr "Generating geometry index data"
+msgstr ""
 
 msgid "Statistics of All Plates"
-msgstr "Statistics of All Plates"
+msgstr ""
 
 msgid "Display"
-msgstr "Display"
+msgstr ""
 
 msgid "Flushed"
-msgstr "Flushed"
+msgstr ""
 
 msgid "Tower"
-msgstr "Tower"
+msgstr ""
 
 msgid "Total"
-msgstr "Total"
+msgstr ""
 
 msgid "Total Estimation"
 msgstr "Total estimation"
 
 msgid "Total time"
-msgstr "Total time"
+msgstr ""
 
 msgid "Total cost"
-msgstr "Total cost"
+msgstr ""
 
 msgid "up to"
-msgstr "up to"
+msgstr ""
 
 msgid "above"
-msgstr "above"
+msgstr ""
 
 msgid "from"
-msgstr "from"
+msgstr ""
 
 msgid "Color Scheme"
 msgstr "Color scheme"
 
 msgid "Time"
-msgstr "Time"
+msgstr ""
 
 msgid "Percent"
-msgstr "Percent"
+msgstr ""
 
 msgid "Used filament"
-msgstr "Used filament"
+msgstr ""
 
 msgid "Layer Height (mm)"
 msgstr "Layer height (mm)"
@@ -4125,136 +4040,136 @@ msgid "Line Width (mm)"
 msgstr "Line width (mm)"
 
 msgid "Speed (mm/s)"
-msgstr "Speed (mm/s)"
+msgstr ""
 
 msgid "Fan Speed (%)"
 msgstr "Fan speed (%)"
 
 msgid "Temperature (°C)"
-msgstr "Temperature (°C)"
+msgstr ""
 
 msgid "Volumetric flow rate (mm³/s)"
-msgstr "Volumetric flow rate (mm³/s)"
+msgstr ""
 
 msgid "Travel"
-msgstr "Travel"
+msgstr ""
 
 msgid "Seams"
-msgstr "Seams"
+msgstr ""
 
 msgid "Retract"
-msgstr "Retract"
+msgstr ""
 
 msgid "Unretract"
-msgstr "Unretract"
+msgstr ""
 
 msgid "Filament Changes"
 msgstr "Filament changes"
 
 msgid "Wipe"
-msgstr "Wipe"
+msgstr ""
 
 msgid "Options"
-msgstr "Options"
+msgstr ""
 
 msgid "travel"
 msgstr "Travel"
 
 msgid "Extruder"
-msgstr "Extruder"
+msgstr ""
 
 msgid "Filament change times"
-msgstr "Filament change times"
+msgstr ""
 
 msgid "Cost"
-msgstr "Cost"
+msgstr ""
 
 msgid "Color change"
-msgstr "Color change"
+msgstr ""
 
 msgid "Print"
-msgstr "Print"
+msgstr ""
 
 msgid "Printer"
-msgstr "Printer"
+msgstr ""
 
 msgid "Tool Change"
 msgstr ""
 
 msgid "Time Estimation"
-msgstr "Time Estimation"
+msgstr ""
 
 msgid "Normal mode"
-msgstr "Normal mode"
+msgstr ""
 
 msgid "Total Filament"
-msgstr "Total Filament"
+msgstr ""
 
 msgid "Model Filament"
-msgstr "Model Filament"
+msgstr ""
 
 msgid "Prepare time"
-msgstr "Prepare time"
+msgstr ""
 
 msgid "Model printing time"
-msgstr "Model printing time"
+msgstr ""
 
 msgid "Switch to silent mode"
-msgstr "Switch to silent mode"
+msgstr ""
 
 msgid "Switch to normal mode"
-msgstr "Switch to normal mode"
+msgstr ""
 
 msgid "Variable layer height"
-msgstr "Variable layer height"
+msgstr ""
 
 msgid "Adaptive"
-msgstr "Adaptive"
+msgstr ""
 
 msgid "Quality / Speed"
-msgstr "Quality / Speed"
+msgstr ""
 
 msgid "Smooth"
-msgstr "Smooth"
+msgstr ""
 
 msgid "Radius"
-msgstr "Radius"
+msgstr ""
 
 msgid "Keep min"
-msgstr "Keep min"
+msgstr ""
 
 msgid "Left mouse button:"
-msgstr "Left mouse button:"
+msgstr ""
 
 msgid "Add detail"
 msgstr "Add Detail"
 
 msgid "Right mouse button:"
-msgstr "Right mouse button:"
+msgstr ""
 
 msgid "Remove detail"
-msgstr "Remove detail"
+msgstr ""
 
 msgid "Shift + Left mouse button:"
-msgstr "Shift + Left mouse button:"
+msgstr ""
 
 msgid "Reset to base"
-msgstr "Reset to base"
+msgstr ""
 
 msgid "Shift + Right mouse button:"
-msgstr "Shift + Right mouse button:"
+msgstr ""
 
 msgid "Smoothing"
-msgstr "Smoothing"
+msgstr ""
 
 msgid "Mouse wheel:"
-msgstr "Mouse wheel:"
+msgstr ""
 
 msgid "Increase/decrease edit area"
-msgstr "Increase/decrease edit area"
+msgstr ""
 
 msgid "Sequence"
-msgstr "Sequence"
+msgstr ""
 
 msgid "Mirror Object"
 msgstr "Mirror object"
@@ -4263,7 +4178,7 @@ msgid "Tool Move"
 msgstr "Tool move"
 
 msgid "Tool Rotate"
-msgstr "Tool Rotate"
+msgstr ""
 
 msgid "Move Object"
 msgstr "Move object"
@@ -4272,34 +4187,34 @@ msgid "Auto Orientation options"
 msgstr "Auto orientation options"
 
 msgid "Enable rotation"
-msgstr "Enable rotation"
+msgstr ""
 
 msgid "Optimize support interface area"
-msgstr "Optimize support interface area"
+msgstr ""
 
 msgid "Orient"
-msgstr "Orient"
+msgstr ""
 
 msgid "Arrange options"
-msgstr "Arrange options"
+msgstr ""
 
 msgid "Spacing"
-msgstr "Spacing"
+msgstr ""
 
 msgid "0 means auto spacing."
-msgstr "0 means auto spacing."
+msgstr ""
 
 msgid "Auto rotate for arrangement"
-msgstr "Auto rotate for arrangement"
+msgstr ""
 
 msgid "Allow multiple materials on same plate"
-msgstr "Allow multiple materials on same plate"
+msgstr ""
 
 msgid "Avoid extrusion calibration region"
-msgstr "Avoid extrusion calibration region"
+msgstr ""
 
 msgid "Align to Y axis"
-msgstr "Align to Y axis"
+msgstr ""
 
 msgid "Add plate"
 msgstr "Add Plate"
@@ -4308,10 +4223,10 @@ msgid "Auto orient"
 msgstr "Auto Orient"
 
 msgid "Arrange all objects"
-msgstr "Arrange all objects"
+msgstr ""
 
 msgid "Arrange objects on selected plates"
-msgstr "Arrange objects on selected plates"
+msgstr ""
 
 msgid "Split to objects"
 msgstr "Split to Objects"
@@ -4320,40 +4235,40 @@ msgid "Split to parts"
 msgstr "Split to Parts"
 
 msgid "Assembly View"
-msgstr "Assembly View"
+msgstr ""
 
 msgid "Select Plate"
-msgstr "Select Plate"
+msgstr ""
 
 msgid "Assembly Return"
-msgstr "Assembly Return"
+msgstr ""
 
 msgid "return"
-msgstr "return"
+msgstr ""
 
 msgid "Paint Toolbar"
-msgstr "Paint Toolbar"
+msgstr ""
 
 msgid "Explosion Ratio"
-msgstr "Explosion Ratio"
+msgstr ""
 
 msgid "Section View"
-msgstr "Section View"
+msgstr ""
 
 msgid "Assemble Control"
 msgstr "Assembly Control"
 
 msgid "Total Volume:"
-msgstr "Total Volume:"
+msgstr ""
 
 msgid "Assembly Info"
-msgstr "Assembly Info"
+msgstr ""
 
 msgid "Volume:"
-msgstr "Volume:"
+msgstr ""
 
 msgid "Size:"
-msgstr "Size:"
+msgstr ""
 
 #, boost-format
 msgid ""
@@ -4380,61 +4295,58 @@ msgid ""
 msgstr ""
 
 msgid "Calibration step selection"
-msgstr "Calibration step selection"
+msgstr ""
 
 msgid "Micro lidar calibration"
-msgstr "Micro lidar calibration"
+msgstr ""
 
 msgid "Bed leveling"
-msgstr "Bed leveling"
+msgstr ""
 
 msgid "Vibration compensation"
-msgstr "Vibration compensation"
+msgstr ""
 
 msgid "Motor noise cancellation"
-msgstr "Motor noise cancellation"
+msgstr ""
 
 msgid "Calibration program"
-msgstr "Calibration program"
+msgstr ""
 
 msgid ""
 "The calibration program detects the status of your device automatically to "
 "minimize deviation.\n"
 "It keeps the device performing optimally."
 msgstr ""
-"The calibration program detects the status of your device automatically to "
-"minimize deviation.\n"
-"It keeps the device performing optimally."
 
 msgid "Calibration Flow"
-msgstr "Calibration Flow"
+msgstr ""
 
 msgid "Start Calibration"
-msgstr "Start Calibration"
+msgstr ""
 
 msgid "Completed"
-msgstr "Completed"
+msgstr ""
 
 msgid "Calibrating"
-msgstr "Calibrating"
+msgstr ""
 
 msgid "No step selected"
-msgstr "No step selected"
+msgstr ""
 
 msgid "Auto-record Monitoring"
-msgstr "Auto-record Monitoring"
+msgstr ""
 
 msgid "Go Live"
-msgstr "Go Live"
+msgstr ""
 
 msgid "Liveview Retry"
-msgstr "Liveview Retry"
+msgstr ""
 
 msgid "Resolution"
-msgstr "Resolution"
+msgstr ""
 
 msgid "Enable"
-msgstr "Enable"
+msgstr ""
 
 msgid "Hostname or IP"
 msgstr ""
@@ -4443,19 +4355,19 @@ msgid "Custom camera source"
 msgstr ""
 
 msgid "Show \"Live Video\" guide page."
-msgstr "Show \"Live Video\" guide page."
+msgstr ""
 
 msgid "720p"
-msgstr "720p"
+msgstr ""
 
 msgid "1080p"
-msgstr "1080p"
+msgstr ""
 
 msgid "ConnectPrinter(LAN)"
 msgstr "Connect Printer (LAN)"
 
 msgid "Please input the printer access code:"
-msgstr "Please input the printer access code:"
+msgstr ""
 
 msgid ""
 "You can find it in \"Settings > Network > Connection code\"\n"
@@ -4468,169 +4380,169 @@ msgid "Invalid input."
 msgstr "Invalid input"
 
 msgid "New Window"
-msgstr "New Window"
+msgstr ""
 
 msgid "Open a new window"
-msgstr "Open a new window"
+msgstr ""
 
 msgid "Application is closing"
 msgstr "Closing application"
 
 msgid "Closing Application while some presets are modified."
-msgstr "Closing Application while some presets are modified."
+msgstr ""
 
 msgid "Logging"
-msgstr "Logging"
+msgstr ""
 
 msgid "Preview"
-msgstr "Preview"
+msgstr ""
 
 msgid "Multi-device"
-msgstr "Multi-device"
+msgstr ""
 
 msgid "Project"
-msgstr "Project"
+msgstr ""
 
 msgid "Yes"
-msgstr "Yes"
+msgstr ""
 
 msgid "No"
-msgstr "No"
+msgstr ""
 
 msgid "will be closed before creating a new model. Do you want to continue?"
-msgstr "will be closed before creating a new model. Do you want to continue?"
+msgstr ""
 
 msgid "Slice plate"
-msgstr "Slice plate"
+msgstr ""
 
 msgid "Print plate"
-msgstr "Print plate"
+msgstr ""
 
 msgid "Slice all"
-msgstr "Slice all"
+msgstr ""
 
 msgid "Export G-code file"
 msgstr ""
 
 msgid "Export plate sliced file"
-msgstr "Export plate sliced file"
+msgstr ""
 
 msgid "Export all sliced file"
-msgstr "Export all sliced file"
+msgstr ""
 
 msgid "Print all"
-msgstr "Print all"
+msgstr ""
 
 msgid "Send all"
-msgstr "Send all"
+msgstr ""
 
 msgid "Keyboard Shortcuts"
-msgstr "Keyboard Shortcuts"
+msgstr ""
 
 msgid "Show the list of the keyboard shortcuts"
 msgstr "Show the list of keyboard shortcuts"
 
 msgid "Setup Wizard"
-msgstr "Setup Wizard"
+msgstr ""
 
 msgid "Show Configuration Folder"
-msgstr "Show Configuration Folder"
+msgstr ""
 
 msgid "Show Tip of the Day"
-msgstr "Show Tip of the Day"
+msgstr ""
 
 msgid "Check for Update"
 msgstr "Check for Updates"
 
 msgid "Open Network Test"
-msgstr "Open Network Test"
+msgstr ""
 
 #, c-format, boost-format
 msgid "&About %s"
-msgstr "&About %s"
+msgstr ""
 
 msgid "Upload Models"
-msgstr "Upload Models"
+msgstr ""
 
 msgid "Download Models"
-msgstr "Download Models"
+msgstr ""
 
 msgid "Default View"
-msgstr "Default View"
+msgstr ""
 
 #. TRN To be shown in the main menu View->Top
 msgid "Top"
-msgstr "Top"
+msgstr ""
 
 msgid "Top View"
-msgstr "Top View"
+msgstr ""
 
 #. TRN To be shown in the main menu View->Bottom
 msgid "Bottom"
-msgstr "Bottom"
+msgstr ""
 
 msgid "Bottom View"
-msgstr "Bottom View"
+msgstr ""
 
 msgid "Front"
-msgstr "Front"
+msgstr ""
 
 msgid "Front View"
-msgstr "Front View"
+msgstr ""
 
 msgid "Rear"
-msgstr "Rear"
+msgstr ""
 
 msgid "Rear View"
-msgstr "Rear View"
+msgstr ""
 
 msgid "Left"
-msgstr "Left"
+msgstr ""
 
 msgid "Left View"
-msgstr "Left View"
+msgstr ""
 
 msgid "Right"
-msgstr "Right"
+msgstr ""
 
 msgid "Right View"
-msgstr "Right View"
+msgstr ""
 
 msgid "Start a new window"
-msgstr "Start a new window"
+msgstr ""
 
 msgid "New Project"
-msgstr "New Project"
+msgstr ""
 
 msgid "Start a new project"
-msgstr "Start a new project"
+msgstr ""
 
 msgid "Open a project file"
-msgstr "Open a project file"
+msgstr ""
 
 msgid "Recent projects"
 msgstr "Recent Projects"
 
 msgid "Save Project"
-msgstr "Save Project"
+msgstr ""
 
 msgid "Save current project to file"
-msgstr "Save current project to file"
+msgstr ""
 
 msgid "Save Project as"
-msgstr "Save Project as"
+msgstr ""
 
 msgid "Shift+"
-msgstr "Shift+"
+msgstr ""
 
 msgid "Save current project as"
-msgstr "Save current project as"
+msgstr ""
 
 msgid "Import 3MF/STL/STEP/SVG/OBJ/AMF"
-msgstr "Import 3MF/STL/STEP/SVG/OBJ/AMF"
+msgstr ""
 
 msgid "Load a model"
-msgstr "Load a model"
+msgstr ""
 
 msgid "Import Zip Archive"
 msgstr ""
@@ -4639,31 +4551,31 @@ msgid "Load models contained within a zip archive"
 msgstr ""
 
 msgid "Import Configs"
-msgstr "Import Configs"
+msgstr ""
 
 msgid "Load configs"
-msgstr "Load configs"
+msgstr ""
 
 msgid "Import"
-msgstr "Import"
+msgstr ""
 
 msgid "Export all objects as one STL"
-msgstr "Export all objects as one STL"
+msgstr ""
 
 msgid "Export all objects as STLs"
-msgstr "Export all objects as STLs"
+msgstr ""
 
 msgid "Export Generic 3MF"
-msgstr "Export Generic 3MF"
+msgstr ""
 
 msgid "Export 3mf file without using some 3mf-extensions"
-msgstr "Export 3mf file without using some 3mf-extensions"
+msgstr ""
 
 msgid "Export current sliced file"
-msgstr "Export current sliced file"
+msgstr ""
 
 msgid "Export all plate sliced file"
-msgstr "Export all plate sliced file"
+msgstr ""
 
 msgid "Export G-code"
 msgstr ""
@@ -4675,52 +4587,52 @@ msgid "Export Preset Bundle"
 msgstr ""
 
 msgid "Export current configuration to files"
-msgstr "Export current configuration to files"
+msgstr ""
 
 msgid "Export"
-msgstr "Export"
+msgstr ""
 
 msgid "Quit"
-msgstr "Quit"
+msgstr ""
 
 msgid "Undo"
-msgstr "Undo"
+msgstr ""
 
 msgid "Redo"
-msgstr "Redo"
+msgstr ""
 
 msgid "Cut selection to clipboard"
-msgstr "Cut selection to clipboard"
+msgstr ""
 
 msgid "Copy"
-msgstr "Copy"
+msgstr ""
 
 msgid "Copy selection to clipboard"
-msgstr "Copy selection to clipboard"
+msgstr ""
 
 msgid "Paste"
-msgstr "Paste"
+msgstr ""
 
 msgid "Paste clipboard"
-msgstr "Paste clipboard"
+msgstr ""
 
 msgid "Delete selected"
 msgstr "Delete Selected"
 
 msgid "Deletes the current selection"
-msgstr "Deletes the current selection"
+msgstr ""
 
 msgid "Delete all"
 msgstr "Delete All"
 
 msgid "Deletes all objects"
-msgstr "Deletes all objects"
+msgstr ""
 
 msgid "Clone selected"
 msgstr "Clone Selected"
 
 msgid "Clone copies of selections"
-msgstr "Clone copies of selections"
+msgstr ""
 
 msgid "Duplicate Current Plate"
 msgstr ""
@@ -4732,19 +4644,19 @@ msgid "Select all"
 msgstr "Select All"
 
 msgid "Selects all objects"
-msgstr "Selects all objects"
+msgstr ""
 
 msgid "Deselect all"
 msgstr "Deselect All"
 
 msgid "Deselects all objects"
-msgstr "Deselects all objects"
+msgstr ""
 
 msgid "Use Perspective View"
-msgstr "Use Perspective View"
+msgstr ""
 
 msgid "Use Orthogonal View"
-msgstr "Use Orthogonal View"
+msgstr ""
 
 msgid "Auto Perspective"
 msgstr ""
@@ -4773,16 +4685,16 @@ msgid "Reset to default window layout"
 msgstr ""
 
 msgid "Show &Labels"
-msgstr "Show &Labels"
+msgstr ""
 
 msgid "Show object labels in 3D scene"
-msgstr "Show object labels in 3D scene"
+msgstr ""
 
 msgid "Show &Overhang"
-msgstr "Show &Overhang"
+msgstr ""
 
 msgid "Show object overhang highlight in 3D scene"
-msgstr "Show object overhang highlight in 3D scene"
+msgstr ""
 
 msgid "Show Selected Outline (beta)"
 msgstr ""
@@ -4791,25 +4703,25 @@ msgid "Show outline around selected object in 3D scene"
 msgstr ""
 
 msgid "Preferences"
-msgstr "Preferences"
+msgstr ""
 
 msgid "Help"
-msgstr "Help"
+msgstr ""
 
 msgid "Temperature Calibration"
-msgstr "Temperature Calibration"
+msgstr ""
 
 msgid "Pass 1"
-msgstr "Pass 1"
+msgstr ""
 
 msgid "Flow rate test - Pass 1"
-msgstr "Flow rate test - Pass 1"
+msgstr ""
 
 msgid "Pass 2"
-msgstr "Pass 2"
+msgstr ""
 
 msgid "Flow rate test - Pass 2"
-msgstr "Flow rate test - Pass 2"
+msgstr ""
 
 msgid "YOLO (Recommended)"
 msgstr ""
@@ -4824,34 +4736,34 @@ msgid "Orca YOLO flowrate calibration, 0.005 step"
 msgstr ""
 
 msgid "Flow rate"
-msgstr "Flow rate"
+msgstr ""
 
 msgid "Pressure advance"
-msgstr "Pressure advance"
+msgstr ""
 
 msgid "Retraction test"
-msgstr "Retraction test"
+msgstr ""
 
 msgid "Orca Tolerance Test"
-msgstr "Orca Tolerance Test"
+msgstr ""
 
 msgid "Max flowrate"
-msgstr "Max flowrate"
+msgstr ""
 
 msgid "VFA"
-msgstr "VFA"
+msgstr ""
 
 msgid "More..."
-msgstr "More..."
+msgstr ""
 
 msgid "Tutorial"
-msgstr "Tutorial"
+msgstr ""
 
 msgid "Calibration help"
-msgstr "Calibration help"
+msgstr ""
 
 msgid "More calibrations"
-msgstr "More calibrations"
+msgstr ""
 
 msgid "&Open G-code"
 msgstr ""
@@ -4860,38 +4772,38 @@ msgid "Open a G-code file"
 msgstr ""
 
 msgid "Re&load from Disk"
-msgstr "Re&load from Disk"
+msgstr ""
 
 msgid "Reload the plater from disk"
-msgstr "Reload the plater from disk"
+msgstr ""
 
 msgid "Export &Toolpaths as OBJ"
-msgstr "Export &Toolpaths as OBJ"
+msgstr ""
 
 msgid "Export toolpaths as OBJ"
-msgstr "Export toolpaths as OBJ"
+msgstr ""
 
 msgid "Open &Slicer"
-msgstr "Open &Slicer"
+msgstr ""
 
 msgid "Open Slicer"
-msgstr "Open Slicer"
+msgstr ""
 
 msgid "&Quit"
-msgstr "&Quit"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Quit %s"
-msgstr "Quit %s"
+msgstr ""
 
 msgid "&File"
-msgstr "&File"
+msgstr ""
 
 msgid "&View"
-msgstr "&View"
+msgstr ""
 
 msgid "&Help"
-msgstr "&Help"
+msgstr ""
 
 #, c-format, boost-format
 msgid "A file exists with the same name: %s, do you want to overwrite it?"
@@ -4902,19 +4814,19 @@ msgid "A config exists with the same name: %s, do you want to overwrite it?"
 msgstr "A config exists with the same name: %s. Do you want to overwrite it?"
 
 msgid "Overwrite file"
-msgstr "Overwrite file"
+msgstr ""
 
 msgid "Overwrite config"
-msgstr "Overwrite config"
+msgstr ""
 
 msgid "Yes to All"
-msgstr "Yes to All"
+msgstr ""
 
 msgid "No to All"
-msgstr "No to All"
+msgstr ""
 
 msgid "Choose a directory"
-msgstr "Choose a directory"
+msgstr ""
 
 #, c-format, boost-format
 msgid "There is %d config exported. (Only non-system configs)"
@@ -4926,7 +4838,7 @@ msgid "Export result"
 msgstr "Export Result"
 
 msgid "Select profile to load:"
-msgstr "Select profile to load:"
+msgstr ""
 
 #, c-format, boost-format
 msgid "There is %d config imported. (Only non-system and compatible configs)"
@@ -4942,13 +4854,13 @@ msgid ""
 msgstr ""
 
 msgid "Import result"
-msgstr "Import result"
+msgstr ""
 
 msgid "File is missing"
-msgstr "File is missing"
+msgstr ""
 
 msgid "The project is no longer available."
-msgstr "The project is no longer available."
+msgstr ""
 
 msgid "Filament Settings"
 msgstr "Filament settings"
@@ -4967,29 +4879,27 @@ msgstr ""
 "3. Printer presets"
 
 msgid "Synchronization"
-msgstr "Synchronization"
+msgstr ""
 
 msgid "The device cannot handle more conversations. Please retry later."
-msgstr "The device cannot handle more conversations. Please retry later."
+msgstr ""
 
 msgid "Player is malfunctioning. Please reinstall the system player."
-msgstr "Player is malfunctioning. Please reinstall the system player."
+msgstr ""
 
 msgid "The player is not loaded, please click \"play\" button to retry."
 msgstr "The player is not loaded; please click the \"play\" button to retry."
 
 msgid "Please confirm if the printer is connected."
-msgstr "Please confirm if the printer is connected."
+msgstr ""
 
 msgid ""
 "The printer is currently busy downloading. Please try again after it "
 "finishes."
 msgstr ""
-"The printer is currently busy downloading. Please try again after it "
-"finishes."
 
 msgid "Printer camera is malfunctioning."
-msgstr "Printer camera is malfunctioning."
+msgstr ""
 
 msgid "Problem occurred. Please update the printer firmware and try again."
 msgstr "A problem occurred. Please update the printer firmware and try again."
@@ -4997,16 +4907,15 @@ msgstr "A problem occurred. Please update the printer firmware and try again."
 msgid ""
 "LAN Only Liveview is off. Please turn on the liveview on printer screen."
 msgstr ""
-"LAN Only Liveview is off. Please turn on the liveview on printer screen."
 
 msgid "Please enter the IP of printer to connect."
 msgstr "Please enter the IP of the printer to connect."
 
 msgid "Initializing..."
-msgstr "Initializing..."
+msgstr ""
 
 msgid "Connection Failed. Please check the network and try again"
-msgstr "Connection Failed. Please check the network and try again"
+msgstr ""
 
 msgid ""
 "Please check the network and try again, You can restart or update the "
@@ -5016,115 +4925,108 @@ msgstr ""
 "printer if the issue persists."
 
 msgid "The printer has been logged out and cannot connect."
-msgstr "The printer has been logged out and cannot connect."
+msgstr ""
 
 msgid "Video Stopped."
 msgstr ""
 
 msgid "LAN Connection Failed (Failed to start liveview)"
-msgstr "LAN Connection Failed (Failed to start liveview)"
+msgstr ""
 
 msgid ""
 "Virtual Camera Tools is required for this task!\n"
 "Do you want to install them?"
 msgstr ""
-"Virtual Camera Tools is required for this task!\n"
-"Do you want to install them?"
 
 msgid "Downloading Virtual Camera Tools"
-msgstr "Downloading Virtual Camera Tools"
+msgstr ""
 
 msgid ""
 "Another virtual camera is running.\n"
 "Orca Slicer supports only a single virtual camera.\n"
 "Do you want to stop this virtual camera?"
 msgstr ""
-"Another virtual camera is running.\n"
-"Orca Slicer supports only a single virtual camera.\n"
-"Do you want to stop this virtual camera?"
 
 #, c-format, boost-format
 msgid "Virtual camera initialize failed (%s)!"
-msgstr "Virtual camera initialize failed (%s)!"
+msgstr ""
 
 msgid "Network unreachable"
-msgstr "Network unreachable"
+msgstr ""
 
 msgid "Information"
-msgstr "Information"
+msgstr ""
 
 msgid "Playing..."
-msgstr "Playing..."
+msgstr ""
 
 msgid "Year"
-msgstr "Year"
+msgstr ""
 
 msgid "Month"
-msgstr "Month"
+msgstr ""
 
 msgid "All Files"
-msgstr "All Files"
+msgstr ""
 
 msgid "Group files by year, recent first."
-msgstr "Group files by year, recent first."
+msgstr ""
 
 msgid "Group files by month, recent first."
-msgstr "Group files by month, recent first."
+msgstr ""
 
 msgid "Show all files, recent first."
-msgstr "Show all files, recent first."
+msgstr ""
 
 msgid "Switch to timelapse files."
-msgstr "Switch to timelapse files."
+msgstr ""
 
 msgid "Video"
-msgstr "Video"
+msgstr ""
 
 msgid "Switch to video files."
-msgstr "Switch to video files."
+msgstr ""
 
 msgid "Switch to 3mf model files."
-msgstr "Switch to 3mf model files."
+msgstr ""
 
 msgid "Delete selected files from printer."
-msgstr "Delete selected files from printer."
+msgstr ""
 
 msgid "Download"
-msgstr "Download"
+msgstr ""
 
 msgid "Download selected files from printer."
-msgstr "Download selected files from printer."
+msgstr ""
 
 msgid "Select"
-msgstr "Select"
+msgstr ""
 
 msgid "Batch manage files."
-msgstr "Batch manage files."
+msgstr ""
 
 msgid "Refresh"
-msgstr "Refresh"
+msgstr ""
 
 msgid "Reload file list from printer."
-msgstr "Reload file list from printer."
+msgstr ""
 
 msgid "No printers."
-msgstr "No printers."
+msgstr ""
 
 msgid "Loading file list..."
-msgstr "Loading file list..."
+msgstr ""
 
 msgid "No files"
-msgstr "No files"
+msgstr ""
 
 msgid "Load failed"
-msgstr "Load failed"
+msgstr ""
 
 msgid ""
 "Browsing file in SD card is not supported in current firmware. Please update "
 "the printer firmware."
 msgstr ""
-"Browsing file in SD card is not supported in current firmware. Please update "
-"the printer firmware."
 
 msgid ""
 "Please check if the SD card is inserted into the printer.\n"
@@ -5134,10 +5036,10 @@ msgstr ""
 "If it still cannot be read, you can try formatting the card."
 
 msgid "LAN Connection Failed (Failed to view sdcard)"
-msgstr "LAN Connection Failed (Failed to view sdcard)"
+msgstr ""
 
 msgid "Browsing file in SD card is not supported in LAN Only Mode."
-msgstr "Browsing file in SD card is not supported in LAN Only Mode."
+msgstr ""
 
 #, c-format, boost-format
 msgid "You are going to delete %u file from printer. Are you sure to continue?"
@@ -5147,23 +5049,23 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Delete files"
-msgstr "Delete files"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Do you want to delete the file '%s' from printer?"
-msgstr "Do you want to delete the file '%s' from printer?"
+msgstr ""
 
 msgid "Delete file"
-msgstr "Delete file"
+msgstr ""
 
 msgid "Fetching model information..."
-msgstr "Fetching model information..."
+msgstr ""
 
 msgid "Failed to fetch model information from printer."
-msgstr "Failed to fetch model information from printer."
+msgstr ""
 
 msgid "Failed to parse model information."
-msgstr "Failed to parse model information."
+msgstr ""
 
 msgid ""
 "The .gcode.3mf file contains no G-code data.Please slice it with Orca Slicer "
@@ -5174,75 +5076,71 @@ msgstr ""
 
 #, c-format, boost-format
 msgid "File '%s' was lost! Please download it again."
-msgstr "File '%s' was lost! Please download it again."
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "File: %s\n"
 "Title: %s\n"
 msgstr ""
-"File: %s\n"
-"Title: %s\n"
 
 msgid "Download waiting..."
-msgstr "Download waiting..."
+msgstr ""
 
 msgid "Play"
-msgstr "Play"
+msgstr ""
 
 msgid "Open Folder"
-msgstr "Open Folder"
+msgstr ""
 
 msgid "Download finished"
-msgstr "Download finished"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Downloading %d%%..."
-msgstr "Downloading %d%%..."
+msgstr ""
 
 msgid ""
 "Reconnecting the printer, the operation cannot be completed immediately, "
 "please try again later."
 msgstr ""
-"Reconnecting the printer, the operation cannot be completed immediately, "
-"please try again later."
 
 msgid "File does not exist."
-msgstr "File does not exist."
+msgstr ""
 
 msgid "File checksum error. Please retry."
-msgstr "File checksum error. Please retry."
+msgstr ""
 
 msgid "Not supported on the current printer version."
-msgstr "Not supported on the current printer version."
+msgstr ""
 
 msgid "Storage unavailable, insert SD card."
 msgstr "Storage unavailable, insert Micro SD card."
 
 #, c-format, boost-format
 msgid "Error code: %d"
-msgstr "Error code: %d"
+msgstr ""
 
 msgid "Speed:"
-msgstr "Speed:"
+msgstr ""
 
 msgid "Deadzone:"
-msgstr "Deadzone:"
+msgstr ""
 
 msgid "Options:"
-msgstr "Options:"
+msgstr ""
 
 msgid "Zoom"
-msgstr "Zoom"
+msgstr ""
 
 msgid "Translation/Zoom"
-msgstr "Translation/Zoom"
+msgstr ""
 
 msgid "3Dconnexion settings"
-msgstr "3Dconnexion settings"
+msgstr ""
 
 msgid "Swap Y/Z axes"
-msgstr "Swap Y/Z axes"
+msgstr ""
 
 msgid "Invert X axis"
 msgstr ""
@@ -5266,13 +5164,13 @@ msgid "Printing Progress"
 msgstr "Printing progress"
 
 msgid "0"
-msgstr "0"
+msgstr ""
 
 msgid "Layer: N/A"
-msgstr "Layer: N/A"
+msgstr ""
 
 msgid "Clear"
-msgstr "Clear"
+msgstr ""
 
 msgid ""
 "You have completed printing the mall model, \n"
@@ -5282,56 +5180,54 @@ msgstr ""
 "but synchronizing rating information has failed."
 
 msgid "How do you like this printing file?"
-msgstr "How do you like this printing file?"
+msgstr ""
 
 msgid ""
 "(The model has already been rated. Your rating will overwrite the previous "
 "rating.)"
 msgstr ""
-"(The model has already been rated. Your rating will overwrite the previous "
-"rating.)"
 
 msgid "Rate"
-msgstr "Rate"
+msgstr ""
 
 msgid "Camera"
-msgstr "Camera"
+msgstr ""
 
 msgid "SD Card"
 msgstr "MicroSD Card"
 
 msgid "Camera Setting"
-msgstr "Camera Setting"
+msgstr ""
 
 msgid "Switch Camera View"
 msgstr ""
 
 msgid "Control"
-msgstr "Control"
+msgstr ""
 
 msgid "Printer Parts"
-msgstr "Printer Parts"
+msgstr ""
 
 msgid "Print Options"
-msgstr "Print Options"
+msgstr ""
 
 msgid "100%"
-msgstr "100%"
+msgstr ""
 
 msgid "Lamp"
-msgstr "Lamp"
+msgstr ""
 
 msgid "Aux"
-msgstr "Aux"
+msgstr ""
 
 msgid "Cham"
-msgstr "Cham"
+msgstr ""
 
 msgid "Bed"
-msgstr "Bed"
+msgstr ""
 
 msgid "Debug Info"
-msgstr "Debug Info"
+msgstr ""
 
 msgid "No SD Card"
 msgstr "No MicroSD Card"
@@ -5340,16 +5236,16 @@ msgid "SD Card Abnormal"
 msgstr "MicroSD Card Abnormal"
 
 msgid "Cancel print"
-msgstr "Cancel print"
+msgstr ""
 
 msgid "Are you sure you want to cancel this print?"
-msgstr "Are you sure you want to cancel this print?"
+msgstr ""
 
 msgid "Downloading..."
-msgstr "Downloading..."
+msgstr ""
 
 msgid "Cloud Slicing..."
-msgstr "Cloud Slicing..."
+msgstr ""
 
 #, c-format, boost-format
 msgid "In Cloud Slicing Queue, there are %s tasks ahead."
@@ -5357,24 +5253,24 @@ msgstr "In Cloud Slicing Queue, there are %s tasks ahead of you."
 
 #, c-format, boost-format
 msgid "Layer: %s"
-msgstr "Layer: %s"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Layer: %d/%d"
-msgstr "Layer: %d/%d"
+msgstr ""
 
 msgid ""
 "Please heat the nozzle to above 170 degree before loading or unloading "
 "filament."
 msgstr ""
-"Please heat the nozzle to above 170 degree before loading or unloading "
+"Please heat the nozzle to above 170 degrees before loading or unloading "
 "filament."
 
 msgid "Still unload"
-msgstr "Still unload"
+msgstr ""
 
 msgid "Still load"
-msgstr "Still load"
+msgstr ""
 
 msgid "Please select an AMS slot before calibration"
 msgstr "Please select an AMS slot before calibration."
@@ -5387,64 +5283,64 @@ msgstr ""
 "unload the filament and try again."
 
 msgid "This only takes effect during printing"
-msgstr "This only takes effect during printing"
+msgstr ""
 
 msgid "Silent"
-msgstr "Silent"
+msgstr ""
 
 msgid "Standard"
-msgstr "Standard"
+msgstr ""
 
 msgid "Sport"
-msgstr "Sport"
+msgstr ""
 
 msgid "Ludicrous"
-msgstr "Ludicrous"
+msgstr ""
 
 msgid "Can't start this without SD card."
 msgstr "Can't start without MicroSD card."
 
 msgid "Rate the Print Profile"
-msgstr "Rate the Print Profile"
+msgstr ""
 
 msgid "Comment"
-msgstr "Comment"
+msgstr ""
 
 msgid "Rate this print"
-msgstr "Rate this print"
+msgstr ""
 
 msgid "Add Photo"
-msgstr "Add Photo"
+msgstr ""
 
 msgid "Delete Photo"
-msgstr "Delete Photo"
+msgstr ""
 
 msgid "Submit"
-msgstr "Submit"
+msgstr ""
 
 msgid "Please click on the star first."
-msgstr "Please click on the star first."
+msgstr ""
 
 msgid "InFo"
 msgstr "Info"
 
 msgid "Get oss config failed."
-msgstr "Get oss config failed."
+msgstr ""
 
 msgid "Upload Pictures"
-msgstr "Upload Pictures"
+msgstr ""
 
 msgid "Number of images successfully uploaded"
-msgstr "Number of images successfully uploaded"
+msgstr ""
 
 msgid " upload failed"
-msgstr " upload failed"
+msgstr ""
 
 msgid " upload config prase failed\n"
-msgstr " upload config prase failed\n"
+msgstr ""
 
 msgid " No corresponding storage bucket\n"
-msgstr " No corresponding storage bucket\n"
+msgstr ""
 
 msgid " cannot be opened\n"
 msgstr ""
@@ -5454,18 +5350,15 @@ msgid ""
 "want to ignore them?\n"
 "\n"
 msgstr ""
-"The following issues occurred during the process of uploading images. Do you "
-"want to ignore them?\n"
-"\n"
 
 msgid "info"
-msgstr "info"
+msgstr ""
 
 msgid "Synchronizing the printing results. Please retry a few seconds later."
-msgstr "Synchronizing the printing results. Please retry a few seconds later."
+msgstr ""
 
 msgid "Upload failed\n"
-msgstr "Upload failed\n"
+msgstr ""
 
 msgid "obtaining instance_id failed\n"
 msgstr "Obtaining instance_id failed\n"
@@ -5480,7 +5373,7 @@ msgstr ""
 "  error code: "
 
 msgid "error message: "
-msgstr "error message: "
+msgstr ""
 
 msgid ""
 "\n"
@@ -5495,11 +5388,9 @@ msgid ""
 "Some of your images failed to upload. Would you like to redirect to the "
 "webpage for rating?"
 msgstr ""
-"Some of your images failed to upload. Would you like to redirect to the "
-"webpage for rating?"
 
 msgid "You can select up to 16 images."
-msgstr "You can select up to 16 images."
+msgstr ""
 
 msgid ""
 "At least one successful print record of this print profile is required \n"
@@ -5509,43 +5400,43 @@ msgstr ""
 "to give a positive rating (4 or 5 stars)."
 
 msgid "Status"
-msgstr "Status"
+msgstr ""
 
 msgid "Update"
-msgstr "Update"
+msgstr ""
 
 msgid "Don't show again"
-msgstr "Don't show again"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s error"
-msgstr "%s error"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s has encountered an error"
-msgstr "%s has encountered an error"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s warning"
-msgstr "%s warning"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s has a warning"
-msgstr "%s has a warning"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s info"
-msgstr "%s info"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s information"
-msgstr "%s information"
+msgstr ""
 
 msgid "Skip"
-msgstr "Skip"
+msgstr ""
 
 msgid "Newer 3mf version"
-msgstr "Newer 3mf version"
+msgstr ""
 
 msgid ""
 "The 3mf file version is in Beta and it is newer than the current OrcaSlicer  "
@@ -5556,7 +5447,7 @@ msgid "If you would like to try Orca Slicer Beta, you may click to"
 msgstr ""
 
 msgid "Download Beta Version"
-msgstr "Download Beta Version"
+msgstr ""
 
 msgid "The 3mf file version is newer than the current Orca Slicer version."
 msgstr ""
@@ -5565,13 +5456,13 @@ msgid "Update your Orca Slicer could enable all functionality in the 3mf file."
 msgstr ""
 
 msgid "Current Version: "
-msgstr "Current Version: "
+msgstr ""
 
 msgid "Latest Version: "
-msgstr "Latest Version: "
+msgstr ""
 
 msgid "Not for now"
-msgstr "Not for now"
+msgstr ""
 
 msgid "Server Exception"
 msgstr ""
@@ -5593,7 +5484,7 @@ msgid "Don't show this dialog again"
 msgstr ""
 
 msgid "3D Mouse disconnected."
-msgstr "3D Mouse disconnected."
+msgstr ""
 
 msgid "Configuration can update now."
 msgstr "A new configuration is available. Update now?"
@@ -5602,28 +5493,28 @@ msgid "Detail."
 msgstr "More"
 
 msgid "Integration was successful."
-msgstr "Integration was successful."
+msgstr ""
 
 msgid "Integration failed."
-msgstr "Integration failed."
+msgstr ""
 
 msgid "Undo integration was successful."
-msgstr "Undo integration was successful."
+msgstr ""
 
 msgid "New network plug-in available."
 msgstr "New network plug-in available"
 
 msgid "Details"
-msgstr "Details"
+msgstr ""
 
 msgid "New printer config available."
-msgstr "New printer config available."
+msgstr ""
 
 msgid "Wiki"
-msgstr "Wiki"
+msgstr ""
 
 msgid "Undo integration failed."
-msgstr "Undo integration failed."
+msgstr ""
 
 msgid "Exporting."
 msgstr "Exporting"
@@ -5635,22 +5526,22 @@ msgid "Goto download page."
 msgstr "Go to download page"
 
 msgid "Open Folder."
-msgstr "Open Folder."
+msgstr ""
 
 msgid "Safely remove hardware."
-msgstr "Safely remove hardware."
+msgstr ""
 
 #, c-format, boost-format
 msgid "%1$d Object has custom supports."
 msgid_plural "%1$d Objects have custom supports."
-msgstr[0] "%1$d Object has custom supports."
-msgstr[1] "%1$d Objects have custom supports."
+msgstr[0] ""
+msgstr[1] ""
 
 #, c-format, boost-format
 msgid "%1$d Object has color painting."
 msgid_plural "%1$d Objects have color painting."
-msgstr[0] "%1$d Object has color painting."
-msgstr[1] "%1$d Objects have color painting."
+msgstr[0] ""
+msgstr[1] ""
 
 #, c-format, boost-format
 msgid "%1$d object was loaded as a part of cut object."
@@ -5668,34 +5559,34 @@ msgid "CANCELED"
 msgstr ""
 
 msgid "Cancel upload"
-msgstr "Cancel upload"
+msgstr ""
 
 msgid "Jump to"
-msgstr "Jump to"
+msgstr ""
 
 msgid "Error:"
-msgstr "Error:"
+msgstr ""
 
 msgid "Warning:"
-msgstr "Warning:"
+msgstr ""
 
 msgid "Export successfully."
 msgstr "Exported successfully"
 
 msgid "Model file downloaded."
-msgstr "Model file downloaded."
+msgstr ""
 
 msgid "Serious warning:"
-msgstr "Serious warning:"
+msgstr ""
 
 msgid " (Repair)"
-msgstr " (Repair)"
+msgstr ""
 
 msgid " Click here to install it."
-msgstr " Click here to install it."
+msgstr ""
 
 msgid "WARNING:"
-msgstr "WARNING:"
+msgstr ""
 
 msgid "Your model needs support ! Please make support material enable."
 msgstr "Your model needs support! Please enable support material."
@@ -5710,13 +5601,13 @@ msgid "Color painting"
 msgstr "Color Painting"
 
 msgid "Cut connectors"
-msgstr "Cut connectors"
+msgstr ""
 
 msgid "Layers"
-msgstr "Layers"
+msgstr ""
 
 msgid "Range"
-msgstr "Range"
+msgstr ""
 
 msgid ""
 "The application cannot run normally because OpenGL version is lower than "
@@ -5726,38 +5617,36 @@ msgstr ""
 "than 2.0.\n"
 
 msgid "Please upgrade your graphics card driver."
-msgstr "Please upgrade your graphics card driver."
+msgstr ""
 
 msgid "Unsupported OpenGL version"
-msgstr "Unsupported OpenGL version"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "Unable to load shaders:\n"
 "%s"
 msgstr ""
-"Unable to load shaders:\n"
-"%s"
 
 msgid "Error loading shaders"
-msgstr "Error loading shaders"
+msgstr ""
 
 msgctxt "Layers"
 msgid "Top"
-msgstr "Top"
+msgstr ""
 
 msgctxt "Layers"
 msgid "Bottom"
-msgstr "Bottom"
+msgstr ""
 
 msgid "Enable AI monitoring of printing"
-msgstr "Enable AI monitoring of printing"
+msgstr ""
 
 msgid "Sensitivity of pausing is"
-msgstr "Sensitivity of pausing is"
+msgstr ""
 
 msgid "Enable detection of build plate position"
-msgstr "Enable detection of build plate position"
+msgstr ""
 
 msgid ""
 "The localization tag of build plate is detected, and printing is paused if "
@@ -5767,50 +5656,50 @@ msgstr ""
 "be paused if the tag is not in predefined range."
 
 msgid "First Layer Inspection"
-msgstr "First Layer Inspection"
+msgstr ""
 
 msgid "Auto-recovery from step loss"
 msgstr "Auto-recover from step loss"
 
 msgid "Allow Prompt Sound"
-msgstr "Allow Prompt Sound"
+msgstr ""
 
 msgid "Filament Tangle Detect"
 msgstr "Filament Tangle Detection"
 
 msgid "Nozzle Clumping Detection"
-msgstr "Nozzle Clumping Detection"
+msgstr ""
 
 msgid "Check if the nozzle is clumping by filament or other foreign objects."
-msgstr "Check if the nozzle is clumping by filament or other foreign objects."
+msgstr ""
 
 msgid "Nozzle Type"
-msgstr "Nozzle Type"
+msgstr ""
 
 msgid "Stainless Steel"
-msgstr "Stainless Steel"
+msgstr ""
 
 msgid "Hardened Steel"
-msgstr "Hardened Steel"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%.1f"
-msgstr "%.1f"
+msgstr ""
 
 msgid "Global"
-msgstr "Global"
+msgstr ""
 
 msgid "Objects"
-msgstr "Objects"
+msgstr ""
 
 msgid "Advance"
 msgstr "Advanced"
 
 msgid "Compare presets"
-msgstr "Compare presets"
+msgstr ""
 
 msgid "View all object's settings"
-msgstr "View all object's settings"
+msgstr ""
 
 msgid "Material settings"
 msgstr ""
@@ -5841,58 +5730,58 @@ msgstr ""
 
 #, boost-format
 msgid " plate %1%:"
-msgstr " plate %1%:"
+msgstr ""
 
 msgid "Invalid name, the following characters are not allowed:"
-msgstr "Invalid name, the following characters are not allowed:"
+msgstr ""
 
 msgid "Sliced Info"
-msgstr "Sliced Info"
+msgstr ""
 
 msgid "Used Filament (m)"
-msgstr "Used Filament (m)"
+msgstr ""
 
 msgid "Used Filament (mm³)"
-msgstr "Used Filament (mm³)"
+msgstr ""
 
 msgid "Used Filament (g)"
-msgstr "Used Filament (g)"
+msgstr ""
 
 msgid "Used Materials"
-msgstr "Used Materials"
+msgstr ""
 
 msgid "Estimated time"
-msgstr "Estimated time"
+msgstr ""
 
 msgid "Filament changes"
-msgstr "Filament changes"
+msgstr ""
 
 msgid "Click to edit preset"
-msgstr "Click to edit preset"
+msgstr ""
 
 msgid "Connection"
-msgstr "Connection"
+msgstr ""
 
 msgid "Bed type"
-msgstr "Bed type"
+msgstr ""
 
 msgid "Flushing volumes"
-msgstr "Flushing volumes"
+msgstr ""
 
 msgid "Add one filament"
-msgstr "Add one filament"
+msgstr ""
 
 msgid "Remove last filament"
-msgstr "Remove last filament"
+msgstr ""
 
 msgid "Synchronize filament list from AMS"
-msgstr "Synchronize filament list from AMS"
+msgstr ""
 
 msgid "Set filaments to use"
-msgstr "Set filaments to use"
+msgstr ""
 
 msgid "Search plate, object and part."
-msgstr "Search plate, object and part."
+msgstr ""
 
 msgid "Pellets"
 msgstr ""
@@ -5900,17 +5789,14 @@ msgstr ""
 msgid ""
 "No AMS filaments. Please select a printer in 'Device' page to load AMS info."
 msgstr ""
-"No AMS filaments. Please select a printer in 'Device' page to load AMS info."
 
 msgid "Sync filaments with AMS"
-msgstr "Sync filaments with AMS"
+msgstr ""
 
 msgid ""
 "Sync filaments with AMS will drop all current selected filament presets and "
 "colors. Do you want to continue?"
 msgstr ""
-"Sync filaments with AMS will drop all current selected filament presets and "
-"colors. Do you want to continue?"
 
 msgid ""
 "Already did a synchronization, do you want to sync only changes or resync "
@@ -5920,13 +5806,13 @@ msgstr ""
 "all?"
 
 msgid "Sync"
-msgstr "Sync"
+msgstr ""
 
 msgid "Resync"
-msgstr "Resync"
+msgstr ""
 
 msgid "There are no compatible filaments, and sync is not performed."
-msgstr "There are no compatible filaments, and sync is not performed."
+msgstr ""
 
 msgid ""
 "There are some unknown filaments mapped to generic preset. Please update "
@@ -5936,26 +5822,24 @@ msgstr ""
 
 #, boost-format
 msgid "Do you want to save changes to \"%1%\"?"
-msgstr "Do you want to save changes to \"%1%\"?"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "Successfully unmounted. The device %s(%s) can now be safely removed from the "
 "computer."
 msgstr ""
-"Successfully unmounted. The device %s(%s) can now be safely removed from the "
-"computer."
 
 #, c-format, boost-format
 msgid "Ejecting of device %s(%s) has failed."
-msgstr "Ejecting of device %s(%s) has failed."
+msgstr ""
 
 msgid "Previous unsaved project detected, do you want to restore it?"
 msgstr ""
 "Previously unsaved items have been detected. Do you want to restore them?"
 
 msgid "Restore"
-msgstr "Restore"
+msgstr ""
 
 msgid ""
 "The current hot bed temperature is relatively high. The nozzle may be "
@@ -5979,8 +5863,6 @@ msgid ""
 "Enabling traditional timelapse photography may cause surface imperfections. "
 "It is recommended to change to smooth mode."
 msgstr ""
-"Enabling traditional timelapse photography may cause surface imperfections. "
-"It is recommended to change to smooth mode."
 
 msgid "Expand sidebar"
 msgstr ""
@@ -5990,21 +5872,19 @@ msgstr ""
 
 #, c-format, boost-format
 msgid "Loading file: %s"
-msgstr "Loading file: %s"
+msgstr ""
 
 msgid "The 3mf is not supported by OrcaSlicer, load geometry data only."
 msgstr "The 3mf is not supported by OrcaSlicer, loading geometry data only."
 
 msgid "Load 3mf"
-msgstr "Load 3mf"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "The 3mf's version %s is newer than %s's version %s, Found following keys "
 "unrecognized:"
 msgstr ""
-"The 3mf's version %s is newer than %s's version %s, Found following keys "
-"unrecognized:"
 
 msgid "You'd better upgrade your software.\n"
 msgstr "You should update your software.\n"
@@ -6014,11 +5894,9 @@ msgid ""
 "The 3mf's version %s is newer than %s's version %s, Suggest to upgrade your "
 "software."
 msgstr ""
-"The 3mf's version %s is newer than %s's version %s, Suggest to upgrade your "
-"software."
 
 msgid "Invalid values found in the 3mf:"
-msgstr "Invalid values found in the 3mf:"
+msgstr ""
 
 msgid "Please correct them in the param tabs"
 msgstr "Please correct them in the Param tabs"
@@ -6035,7 +5913,7 @@ msgid "Modified G-code"
 msgstr ""
 
 msgid "The 3mf has following customized filament or printer presets:"
-msgstr "The 3mf has following customized filament or printer presets:"
+msgstr ""
 
 msgid ""
 "Please confirm that the G-codes within these presets are safe to prevent any "
@@ -6043,7 +5921,7 @@ msgid ""
 msgstr ""
 
 msgid "Customized Preset"
-msgstr "Customized Preset"
+msgstr ""
 
 msgid "Name of components inside step file is not UTF8 format!"
 msgstr "Component name(s) inside step file not in UTF8 format!"
@@ -6052,17 +5930,17 @@ msgid "The name may show garbage characters!"
 msgstr "Because of unsupported text encoding, garbage characters may appear!"
 
 msgid "Remember my choice."
-msgstr "Remember my choice."
+msgstr ""
 
 #, boost-format
 msgid "Failed loading file \"%1%\". An invalid configuration was found."
-msgstr "Failed loading file \"%1%\". An invalid configuration was found."
+msgstr ""
 
 msgid "Objects with zero volume removed"
-msgstr "Objects with zero volume removed"
+msgstr ""
 
 msgid "The volume of the object is zero"
-msgstr "The volume of the object is zero"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -6073,7 +5951,7 @@ msgstr ""
 " Do you want to scale to millimeters?"
 
 msgid "Object too small"
-msgstr "Object too small"
+msgstr ""
 
 msgid ""
 "This file contains several objects positioned at multiple heights.\n"
@@ -6085,16 +5963,16 @@ msgstr ""
 "the file be loaded as a single object with multiple parts?"
 
 msgid "Multi-part object detected"
-msgstr "Multi-part object detected"
+msgstr ""
 
 msgid "Load these files as a single object with multiple parts?\n"
-msgstr "Load these files as a single object with multiple parts?\n"
+msgstr ""
 
 msgid "Object with multiple parts was detected"
 msgstr "An object with multiple parts was detected"
 
 msgid "The file does not contain any geometry data."
-msgstr "The file does not contain any geometry data."
+msgstr ""
 
 msgid ""
 "Your object appears to be too large, Do you want to scale it down to fit the "
@@ -6104,19 +5982,19 @@ msgstr ""
 "print bed automatically?"
 
 msgid "Object too large"
-msgstr "Object too large"
+msgstr ""
 
 msgid "Export STL file:"
-msgstr "Export STL file:"
+msgstr ""
 
 msgid "Export AMF file:"
-msgstr "Export AMF file:"
+msgstr ""
 
 msgid "Save file as:"
 msgstr "Save file as"
 
 msgid "Export OBJ file:"
-msgstr "Export OBJ file:"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -6127,10 +6005,10 @@ msgstr ""
 "Do you want to replace it?"
 
 msgid "Confirm Save As"
-msgstr "Confirm Save As"
+msgstr ""
 
 msgid "Delete object which is a part of cut object"
-msgstr "Delete object which is a part of cut object"
+msgstr ""
 
 msgid ""
 "You try to delete an object which is a part of a cut object.\n"
@@ -6142,67 +6020,66 @@ msgstr ""
 "After that, model consistency can't be guaranteed."
 
 msgid "The selected object couldn't be split."
-msgstr "The selected object couldn't be split."
+msgstr ""
 
 msgid "Another export job is running."
-msgstr "Another export job is running."
+msgstr ""
 
 msgid "Unable to replace with more than one volume"
-msgstr "Unable to replace with more than one volume"
+msgstr ""
 
 msgid "Error during replace"
 msgstr "Error during replacement"
 
 msgid "Replace from:"
-msgstr "Replace from:"
+msgstr ""
 
 msgid "Select a new file"
-msgstr "Select a new file"
+msgstr ""
 
 msgid "File for the replace wasn't selected"
 msgstr "File for the replacement wasn't selected"
 
 msgid "Please select a file"
-msgstr "Please select a file"
+msgstr ""
 
 msgid "Do you want to replace it"
 msgstr "Do you want to replace it?"
 
 msgid "Message"
-msgstr "Message"
+msgstr ""
 
 msgid "Reload from:"
-msgstr "Reload from:"
+msgstr ""
 
 msgid "Unable to reload:"
-msgstr "Unable to reload:"
+msgstr ""
 
 msgid "Error during reload"
-msgstr "Error during reload"
+msgstr ""
 
 msgid "There are warnings after slicing models:"
-msgstr "There are warnings after slicing models:"
+msgstr ""
 
 msgid "warnings"
-msgstr "warnings"
+msgstr ""
 
 msgid "Invalid data"
-msgstr "Invalid data"
+msgstr ""
 
 msgid "Slicing Canceled"
-msgstr "Slicing Canceled"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Slicing Plate %d"
-msgstr "Slicing Plate %d"
+msgstr ""
 
 msgid "Please resolve the slicing errors and publish again."
-msgstr "Please resolve the slicing errors and publish again."
+msgstr ""
 
 msgid ""
 "Network Plug-in is not detected. Network related features are unavailable."
 msgstr ""
-"Network Plug-in is not detected. Network related features are unavailable."
 
 msgid ""
 "Preview only mode:\n"
@@ -6213,10 +6090,10 @@ msgid "You can keep the modified presets to the new project or discard them"
 msgstr "You can keep the modified presets for the new project or discard them"
 
 msgid "Creating a new project"
-msgstr "Creating a new project"
+msgstr ""
 
 msgid "Load project"
-msgstr "Load project"
+msgstr ""
 
 msgid ""
 "Failed to save the project.\n"
@@ -6228,10 +6105,10 @@ msgstr ""
 "project file open."
 
 msgid "Save project"
-msgstr "Save project"
+msgstr ""
 
 msgid "Importing Model"
-msgstr "Importing Model"
+msgstr ""
 
 msgid "prepare 3mf file..."
 msgstr "preparing 3mf file..."
@@ -6240,14 +6117,14 @@ msgid "Download failed, unknown file format."
 msgstr "Download failed; unknown file format."
 
 msgid "downloading project ..."
-msgstr "downloading project ..."
+msgstr ""
 
 msgid "Download failed, File size exception."
 msgstr "Download failed; File size exception."
 
 #, c-format, boost-format
 msgid "Project downloaded %d%%"
-msgstr "Project downloaded %d%%"
+msgstr ""
 
 msgid ""
 "Importing to Orca Slicer failed. Please download the file and manually "
@@ -6262,19 +6139,19 @@ msgid ""
 msgstr ""
 
 msgid "mm/s²"
-msgstr "mm/s²"
+msgstr ""
 
 msgid "No speeds provided for calibration. Use default optimal speed "
 msgstr ""
 
 msgid "mm/s"
-msgstr "mm/s"
+msgstr ""
 
 msgid "Import SLA archive"
 msgstr ""
 
 msgid "The selected file"
-msgstr "The selected file"
+msgstr ""
 
 msgid "does not contain valid G-code."
 msgstr "Does not contain valid G-code."
@@ -6297,16 +6174,16 @@ msgid "Failed to find unzipped file at %1%. Unzipping of file has failed."
 msgstr ""
 
 msgid "Drop project file"
-msgstr "Drop project file"
+msgstr ""
 
 msgid "Please select an action"
-msgstr "Please select an action"
+msgstr ""
 
 msgid "Open as project"
-msgstr "Open as project"
+msgstr ""
 
 msgid "Import geometry only"
-msgstr "Import geometry only"
+msgstr ""
 
 msgid ""
 "This option can be changed later in preferences, under 'Load Behaviour'."
@@ -6325,7 +6202,7 @@ msgid "Cannot add models when in preview mode!"
 msgstr "Unable to add models in preview mode"
 
 msgid "All objects will be removed, continue?"
-msgstr "All objects will be removed, continue?"
+msgstr ""
 
 msgid "The current project has unsaved changes, save it before continue?"
 msgstr ""
@@ -6333,63 +6210,57 @@ msgstr ""
 "continuing?"
 
 msgid "Number of copies:"
-msgstr "Number of copies:"
+msgstr ""
 
 msgid "Copies of the selected object"
-msgstr "Copies of the selected object"
+msgstr ""
 
 msgid "Save G-code file as:"
 msgstr ""
 
 msgid "Save SLA file as:"
-msgstr "Save SLA file as:"
+msgstr ""
 
 msgid "The provided file name is not valid."
-msgstr "The provided file name is not valid."
+msgstr ""
 
 msgid "The following characters are not allowed by a FAT file system:"
-msgstr "The following characters are not allowed by a FAT file system:"
+msgstr ""
 
 msgid "Save Sliced file as:"
-msgstr "Save Sliced file as:"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "The file %s has been sent to the printer's storage space and can be viewed "
 "on the printer."
 msgstr ""
-"The file %s has been sent to the printer's storage space and can be viewed "
-"on the printer."
 
 msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
 "will be kept. You may fix the meshes and try again."
 msgstr ""
-"Unable to perform boolean operation on model meshes. Only positive parts "
-"will be kept. You may fix the meshes and try again."
 
 #, boost-format
 msgid "Reason: part \"%1%\" is empty."
-msgstr "Reason: part \"%1%\" is empty."
+msgstr ""
 
 #, boost-format
 msgid "Reason: part \"%1%\" does not bound a volume."
-msgstr "Reason: part \"%1%\" does not bound a volume."
+msgstr ""
 
 #, boost-format
 msgid "Reason: part \"%1%\" has self intersection."
-msgstr "Reason: part \"%1%\" has self intersection."
+msgstr ""
 
 #, boost-format
 msgid "Reason: \"%1%\" and another part have no intersection."
-msgstr "Reason: \"%1%\" and another part have no intersection."
+msgstr ""
 
 msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
 "will be exported."
 msgstr ""
-"Unable to perform boolean operation on model meshes. Only positive parts "
-"will be exported."
 
 msgid ""
 "Are you sure you want to store original SVGs with their local paths into the "
@@ -6417,58 +6288,58 @@ msgid "Send G-code"
 msgstr ""
 
 msgid "Send to printer"
-msgstr "Send to printer"
+msgstr ""
 
 msgid "Custom supports and color painting were removed before repairing."
-msgstr "Custom supports and color painting were removed before repairing."
+msgstr ""
 
 msgid "Optimize Rotation"
 msgstr ""
 
 msgid "Invalid number"
-msgstr "Invalid number"
+msgstr ""
 
 msgid "Plate Settings"
-msgstr "Plate Settings"
+msgstr ""
 
 #, boost-format
 msgid "Number of currently selected parts: %1%\n"
-msgstr "Number of currently selected parts: %1%\n"
+msgstr ""
 
 #, boost-format
 msgid "Number of currently selected objects: %1%\n"
-msgstr "Number of currently selected objects: %1%\n"
+msgstr ""
 
 #, boost-format
 msgid "Part name: %1%\n"
-msgstr "Part name: %1%\n"
+msgstr ""
 
 #, boost-format
 msgid "Object name: %1%\n"
-msgstr "Object name: %1%\n"
+msgstr ""
 
 #, boost-format
 msgid "Size: %1% x %2% x %3% in\n"
-msgstr "Size: %1% x %2% x %3% in\n"
+msgstr ""
 
 #, boost-format
 msgid "Size: %1% x %2% x %3% mm\n"
-msgstr "Size: %1% x %2% x %3% mm\n"
+msgstr ""
 
 #, boost-format
 msgid "Volume: %1% in³\n"
-msgstr "Volume: %1% in³\n"
+msgstr ""
 
 #, boost-format
 msgid "Volume: %1% mm³\n"
-msgstr "Volume: %1% mm³\n"
+msgstr ""
 
 #, boost-format
 msgid "Triangles: %1%\n"
-msgstr "Triangles: %1%\n"
+msgstr ""
 
 msgid "Tips:"
-msgstr "Tips:"
+msgstr ""
 
 msgid ""
 "\"Fix Model\" feature is currently only on Windows. Please repair the model "
@@ -6489,31 +6360,31 @@ msgid "Switching the language requires application restart.\n"
 msgstr "Switching languages requires the application to restart.\n"
 
 msgid "Do you want to continue?"
-msgstr "Do you want to continue?"
+msgstr ""
 
 msgid "Language selection"
-msgstr "Language selection"
+msgstr ""
 
 msgid "Switching application language while some presets are modified."
-msgstr "Switching application language while some presets are modified."
+msgstr ""
 
 msgid "Changing application language"
-msgstr "Changing application language"
+msgstr ""
 
 msgid "Changing the region will log out your account.\n"
 msgstr "Changing the region will log you out of your account.\n"
 
 msgid "Region selection"
-msgstr "Region selection"
+msgstr ""
 
 msgid "Second"
-msgstr "Second"
+msgstr ""
 
 msgid "Browse"
-msgstr "Browse"
+msgstr ""
 
 msgid "Choose Download Directory"
-msgstr "Choose Download Directory"
+msgstr ""
 
 msgid "Associate"
 msgstr ""
@@ -6531,25 +6402,25 @@ msgid "Current Instance Path: "
 msgstr ""
 
 msgid "General Settings"
-msgstr "General Settings"
+msgstr ""
 
 msgid "Asia-Pacific"
-msgstr "Asia-Pacific"
+msgstr ""
 
 msgid "China"
-msgstr "China"
+msgstr ""
 
 msgid "Europe"
-msgstr "Europe"
+msgstr ""
 
 msgid "North America"
-msgstr "North America"
+msgstr ""
 
 msgid "Others"
-msgstr "Others"
+msgstr ""
 
 msgid "Login Region"
-msgstr "Login Region"
+msgstr ""
 
 msgid "Stealth Mode"
 msgstr ""
@@ -6566,13 +6437,13 @@ msgid "Check for stable updates only"
 msgstr ""
 
 msgid "Metric"
-msgstr "Metric"
+msgstr ""
 
 msgid "Imperial"
-msgstr "Imperial"
+msgstr ""
 
 msgid "Units"
-msgstr "Units"
+msgstr ""
 
 msgid "Allow only one OrcaSlicer instance"
 msgstr ""
@@ -6582,9 +6453,6 @@ msgid ""
 "it is allowed to run multiple instances of same app from the command line. "
 "In such case this settings will allow only one instance."
 msgstr ""
-"On OSX there is always only one instance of app running by default. However "
-"it is allowed to run multiple instances of same app from the command line. "
-"In such case this setting will allow only one instance."
 
 msgid ""
 "If this is enabled, when starting OrcaSlicer and another instance of the "
@@ -6614,14 +6482,12 @@ msgid ""
 msgstr ""
 
 msgid "Zoom to mouse position"
-msgstr "Zoom to mouse position"
+msgstr ""
 
 msgid ""
 "Zoom in towards the mouse pointer's position in the 3D view, rather than the "
 "2D window center."
 msgstr ""
-"Zoom in towards the mouse pointer's position in the 3D view, rather than the "
-"2D window center."
 
 msgid "Use free camera"
 msgstr ""
@@ -6642,13 +6508,13 @@ msgid "Show the splash screen during startup."
 msgstr ""
 
 msgid "Show \"Tip of the day\" notification after start"
-msgstr "Show \"Tip of the day\" notification after start"
+msgstr ""
 
 msgid "If enabled, useful hints are displayed at startup."
-msgstr "If enabled, useful hints are displayed at startup."
+msgstr ""
 
 msgid "Flushing volumes: Auto-calculate every time the color changed."
-msgstr "Flushing volumes: Auto-calculate every time the color changed."
+msgstr ""
 
 msgid "If enabled, auto-calculate every time the color changed."
 msgstr "If enabled, auto-calculate every time the color changes."
@@ -6675,8 +6541,6 @@ msgid ""
 "With this option enabled, you can send a task to multiple devices at the "
 "same time and manage multiple devices."
 msgstr ""
-"With this option enabled, you can send a task to multiple devices at the "
-"same time and manage multiple devices."
 
 msgid "Auto arrange plate after cloning"
 msgstr ""
@@ -6691,16 +6555,16 @@ msgid "Auto sync user presets(Printer/Filament/Process)"
 msgstr "Auto sync user presets (Printer/Filament/Process)"
 
 msgid "User Sync"
-msgstr "User Sync"
+msgstr ""
 
 msgid "Update built-in Presets automatically."
 msgstr "Update built-in presets automatically."
 
 msgid "System Sync"
-msgstr "System Sync"
+msgstr ""
 
 msgid "Clear my choice on the unsaved presets."
-msgstr "Clear my choice on the unsaved presets."
+msgstr ""
 
 msgid "Associate files to OrcaSlicer"
 msgstr "Associate files to Orca Slicer"
@@ -6754,19 +6618,19 @@ msgid "Should printer/filament/process settings be loaded when opening a .3mf?"
 msgstr ""
 
 msgid "Maximum recent projects"
-msgstr "Maximum recent projects"
+msgstr ""
 
 msgid "Maximum count of recent projects"
-msgstr "Maximum count of recent projects"
+msgstr ""
 
 msgid "Clear my choice on the unsaved projects."
-msgstr "Clear my choice on the unsaved projects."
+msgstr ""
 
 msgid "No warnings when loading 3MF with modified G-code"
 msgstr ""
 
 msgid "Auto-Backup"
-msgstr "Auto-Backup"
+msgstr ""
 
 msgid ""
 "Backup your project periodically for restoring from the occasional crash."
@@ -6775,16 +6639,16 @@ msgstr ""
 "crash."
 
 msgid "every"
-msgstr "every"
+msgstr ""
 
 msgid "The period of backup in seconds."
-msgstr "The period of backup in seconds."
+msgstr ""
 
 msgid "Downloads"
-msgstr "Downloads"
+msgstr ""
 
 msgid "Dark Mode"
-msgstr "Dark Mode"
+msgstr ""
 
 msgid "Enable Dark mode"
 msgstr "Enable Dark Mode"
@@ -6793,28 +6657,28 @@ msgid "Develop mode"
 msgstr "Developer mode"
 
 msgid "Skip AMS blacklist check"
-msgstr "Skip AMS blacklist check"
+msgstr ""
 
 msgid "Home page and daily tips"
-msgstr "Home page and daily tips"
+msgstr ""
 
 msgid "Show home page on startup"
-msgstr "Show home page on startup"
+msgstr ""
 
 msgid "Sync settings"
-msgstr "Sync settings"
+msgstr ""
 
 msgid "User sync"
-msgstr "User sync"
+msgstr ""
 
 msgid "Preset sync"
-msgstr "Preset sync"
+msgstr ""
 
 msgid "Preferences sync"
-msgstr "Preferences sync"
+msgstr ""
 
 msgid "View control settings"
-msgstr "View control settings"
+msgstr ""
 
 msgid "Rotate of view"
 msgstr "Rotate View"
@@ -6826,58 +6690,58 @@ msgid "Zoom of view"
 msgstr "Zoom View"
 
 msgid "Other"
-msgstr "Other"
+msgstr ""
 
 msgid "Mouse wheel reverses when zooming"
 msgstr "Reverse scroll direction while zooming"
 
 msgid "Enable SSL(MQTT)"
-msgstr "Enable SSL(MQTT)"
+msgstr ""
 
 msgid "Enable SSL(FTP)"
-msgstr "Enable SSL(FTP)"
+msgstr ""
 
 msgid "Internal developer mode"
-msgstr "Internal developer mode"
+msgstr ""
 
 msgid "Log Level"
-msgstr "Log Level"
+msgstr ""
 
 msgid "fatal"
-msgstr "fatal"
+msgstr ""
 
 msgid "error"
-msgstr "error"
+msgstr ""
 
 msgid "warning"
-msgstr "warning"
+msgstr ""
 
 msgid "debug"
-msgstr "debug"
+msgstr ""
 
 msgid "trace"
-msgstr "trace"
+msgstr ""
 
 msgid "Host Setting"
-msgstr "Host Setting"
+msgstr ""
 
 msgid "DEV host: api-dev.bambu-lab.com/v1"
-msgstr "DEV host: api-dev.bambu-lab.com/v1"
+msgstr ""
 
 msgid "QA  host: api-qa.bambu-lab.com/v1"
-msgstr "QA  host: api-qa.bambu-lab.com/v1"
+msgstr ""
 
 msgid "PRE host: api-pre.bambu-lab.com/v1"
-msgstr "PRE host: api-pre.bambu-lab.com/v1"
+msgstr ""
 
 msgid "Product host"
-msgstr "Product host"
+msgstr ""
 
 msgid "debug save button"
 msgstr "Debug save button"
 
 msgid "save debug settings"
-msgstr "save debug settings"
+msgstr ""
 
 msgid "DEBUG settings have saved successfully!"
 msgstr "Debug settings have been saved successfully!"
@@ -6886,13 +6750,13 @@ msgid "Switch cloud environment, Please login again!"
 msgstr "Cloud environment switched; please login again!"
 
 msgid "System presets"
-msgstr "System presets"
+msgstr ""
 
 msgid "User presets"
-msgstr "User presets"
+msgstr ""
 
 msgid "Incompatible presets"
-msgstr "Incompatible presets"
+msgstr ""
 
 msgid "AMS filaments"
 msgstr "AMS filament"
@@ -6904,129 +6768,129 @@ msgid "Please choose the filament color"
 msgstr ""
 
 msgid "Add/Remove presets"
-msgstr "Add/Remove presets"
+msgstr ""
 
 msgid "Edit preset"
-msgstr "Edit preset"
+msgstr ""
 
 msgid "Project-inside presets"
-msgstr "Project-inside presets"
+msgstr ""
 
 msgid "Add/Remove filaments"
 msgstr "Add/Remove filament"
 
 msgid "Add/Remove materials"
-msgstr "Add/Remove materials"
+msgstr ""
 
 msgid "Select/Remove printers(system presets)"
-msgstr "Select/Remove printers(system presets)"
+msgstr ""
 
 msgid "Create printer"
-msgstr "Create printer"
+msgstr ""
 
 msgid "The selected preset is null!"
-msgstr "The selected preset is null!"
+msgstr ""
 
 msgid "End"
-msgstr "End"
+msgstr ""
 
 msgid "Customize"
-msgstr "Customize"
+msgstr ""
 
 msgid "Other layer filament sequence"
-msgstr "Other layer filament sequence"
+msgstr ""
 
 msgid "Please input layer value (>= 2)."
-msgstr "Please input layer value (>= 2)."
+msgstr ""
 
 msgid "Plate name"
-msgstr "Plate name"
+msgstr ""
 
 msgid "Same as Global Print Sequence"
-msgstr "Same as Global Print Sequence"
+msgstr ""
 
 msgid "Print sequence"
-msgstr "Print sequence"
+msgstr ""
 
 msgid "Same as Global"
-msgstr "Same as Global"
+msgstr ""
 
 msgid "Disable"
-msgstr "Disable"
+msgstr ""
 
 msgid "Spiral vase"
-msgstr "Spiral vase"
+msgstr ""
 
 msgid "First layer filament sequence"
-msgstr "First layer filament sequence"
+msgstr ""
 
 msgid "Same as Global Plate Type"
-msgstr "Same as Global Plate Type"
+msgstr ""
 
 msgid "Same as Global Bed Type"
 msgstr "Same as Global Plate Type"
 
 msgid "By Layer"
-msgstr "By Layer"
+msgstr ""
 
 msgid "By Object"
-msgstr "By Object"
+msgstr ""
 
 msgid "Accept"
-msgstr "Accept"
+msgstr ""
 
 msgid "Log Out"
-msgstr "Log Out"
+msgstr ""
 
 msgid "Slice all plate to obtain time and filament estimation"
 msgstr "Slice all plates to obtain time and filament estimation"
 
 msgid "Packing project data into 3mf file"
-msgstr "Packing project data into 3mf file"
+msgstr ""
 
 msgid "Uploading 3mf"
-msgstr "Uploading 3mf"
+msgstr ""
 
 msgid "Jump to model publish web page"
-msgstr "Jump to model publish web page"
+msgstr ""
 
 msgid "Note: The preparation may takes several minutes. Please be patient."
 msgstr "Note: The preparation may take several minutes. Please be patient."
 
 msgid "Publish"
-msgstr "Publish"
+msgstr ""
 
 msgid "Publish was canceled"
 msgstr ""
 
 msgid "Slicing Plate 1"
-msgstr "Slicing Plate 1"
+msgstr ""
 
 msgid "Packing data to 3mf"
-msgstr "Packing data to 3mf"
+msgstr ""
 
 msgid "Jump to webpage"
-msgstr "Jump to webpage"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Save %s as"
-msgstr "Save %s as"
+msgstr ""
 
 msgid "User Preset"
-msgstr "User Preset"
+msgstr ""
 
 msgid "Preset Inside Project"
-msgstr "Preset Inside Project"
+msgstr ""
 
 msgid "Name is unavailable."
-msgstr "Name is unavailable."
+msgstr ""
 
 msgid "Overwrite a system profile is not allowed"
 msgstr "Overwriting a system profile is not allowed."
 
 #, boost-format
 msgid "Preset \"%1%\" already exists."
-msgstr "Preset \"%1%\" already exists."
+msgstr ""
 
 #, boost-format
 msgid "Preset \"%1%\" already exists and is incompatible with current printer."
@@ -7037,106 +6901,106 @@ msgid "Please note that saving action will replace this preset"
 msgstr "Please note that saving will overwrite the current preset."
 
 msgid "The name cannot be the same as a preset alias name."
-msgstr "The name cannot be the same as a preset alias name."
+msgstr ""
 
 msgid "Save preset"
-msgstr "Save preset"
+msgstr ""
 
 msgctxt "PresetName"
 msgid "Copy"
-msgstr "Copy"
+msgstr ""
 
 #, boost-format
 msgid "Printer \"%1%\" is selected with preset \"%2%\""
-msgstr "Printer \"%1%\" is selected with preset \"%2%\""
+msgstr ""
 
 #, boost-format
 msgid "Please choose an action with \"%1%\" preset after saving."
-msgstr "Please choose an action with \"%1%\" preset after saving."
+msgstr ""
 
 #, boost-format
 msgid "For \"%1%\", change \"%2%\" to \"%3%\" "
-msgstr "For \"%1%\", change \"%2%\" to \"%3%\" "
+msgstr ""
 
 #, boost-format
 msgid "For \"%1%\", add \"%2%\" as a new preset"
-msgstr "For \"%1%\", add \"%2%\" as a new preset"
+msgstr ""
 
 #, boost-format
 msgid "Simply switch to \"%1%\""
-msgstr "Simply switch to \"%1%\""
+msgstr ""
 
 msgid "Task canceled"
-msgstr "Task canceled"
+msgstr ""
 
 msgid "(LAN)"
-msgstr "(LAN)"
+msgstr ""
 
 msgid "Search"
-msgstr "Search"
+msgstr ""
 
 msgid "My Device"
-msgstr "My Device"
+msgstr ""
 
 msgid "Other Device"
-msgstr "Other Device"
+msgstr ""
 
 msgid "Online"
-msgstr "Online"
+msgstr ""
 
 msgid "Input access code"
-msgstr "Input access code"
+msgstr ""
 
 msgid "Can't find my devices?"
 msgstr "Can't find devices?"
 
 msgid "Log out successful."
-msgstr "Log out successful."
+msgstr ""
 
 msgid "Busy"
-msgstr "Busy"
+msgstr ""
 
 msgid "Bambu Cool Plate"
-msgstr "Bambu Cool Plate"
+msgstr ""
 
 msgid "PLA Plate"
-msgstr "PLA Plate"
+msgstr ""
 
 msgid "Bambu Engineering Plate"
-msgstr "Bambu Engineering Plate"
+msgstr ""
 
 msgid "Bambu Smooth PEI Plate"
 msgstr ""
 
 msgid "High temperature Plate"
-msgstr "High temperature Plate"
+msgstr ""
 
 msgid "Bambu Textured PEI Plate"
 msgstr ""
 
 msgid "Send print job to"
-msgstr "Send print job to"
+msgstr ""
 
 msgid "Flow Dynamics Calibration"
-msgstr "Flow Dynamics Calibration"
+msgstr ""
 
 msgid "Click here if you can't connect to the printer"
-msgstr "Click here if you can't connect to the printer"
+msgstr ""
 
 msgid "send completed"
 msgstr "Send complete"
 
 msgid "Error code"
-msgstr "Error code"
+msgstr ""
 
 msgid "No login account, only printers in LAN mode are displayed"
-msgstr "No login account, only printers in LAN mode are displayed"
+msgstr ""
 
 msgid "Connecting to server"
-msgstr "Connecting to server"
+msgstr ""
 
 msgid "Synchronizing device information"
-msgstr "Synchronizing device information"
+msgstr ""
 
 msgid "Synchronizing device information time out"
 msgstr "Synchronizing device information timed out"
@@ -7147,7 +7011,6 @@ msgstr "Cannot send a print job while the printer is updating firmware"
 msgid ""
 "The printer is executing instructions. Please restart printing after it ends"
 msgstr ""
-"The printer is executing instructions. Please restart printing after it ends"
 
 msgid "The printer is busy on other print job"
 msgstr "The printer is busy with another print job."
@@ -7157,51 +7020,37 @@ msgid ""
 "Filament %s exceeds the number of AMS slots. Please update the printer "
 "firmware to support AMS slot assignment."
 msgstr ""
-"Filament %s exceeds the number of AMS slots. Please update the printer "
-"firmware to support AMS slot assignment."
 
 msgid ""
 "Filament exceeds the number of AMS slots. Please update the printer firmware "
 "to support AMS slot assignment."
 msgstr ""
-"Filament exceeds the number of AMS slots. Please update the printer firmware "
-"to support AMS slot assignment."
 
 msgid ""
 "Filaments to AMS slots mappings have been established. You can click a "
 "filament above to change its mapping AMS slot"
 msgstr ""
-"Filaments to AMS slots mappings have been established. You can click a "
-"filament above to change its mapping AMS slot"
 
 msgid ""
 "Please click each filament above to specify its mapping AMS slot before "
 "sending the print job"
 msgstr ""
-"Please click each filament above to specify its mapping AMS slot before "
-"sending the print job"
 
 #, c-format, boost-format
 msgid ""
 "Filament %s does not match the filament in AMS slot %s. Please update the "
 "printer firmware to support AMS slot assignment."
 msgstr ""
-"Filament %s does not match the filament in AMS slot %s. Please update the "
-"printer firmware to support AMS slot assignment."
 
 msgid ""
 "Filament does not match the filament in AMS slot. Please update the printer "
 "firmware to support AMS slot assignment."
 msgstr ""
-"Filament does not match the filament in AMS slot. Please update the printer "
-"firmware to support AMS slot assignment."
 
 msgid ""
 "The printer firmware only supports sequential mapping of filament => AMS "
 "slot."
 msgstr ""
-"The printer firmware only supports sequential mapping of filament => AMS "
-"slot."
 
 msgid "An SD card needs to be inserted before printing."
 msgstr "A MicroSD card needs to be inserted before printing."
@@ -7211,8 +7060,6 @@ msgid ""
 "The selected printer (%s) is incompatible with the chosen printer profile in "
 "the slicer (%s)."
 msgstr ""
-"The selected printer (%s) is incompatible with the chosen printer profile in "
-"the slicer (%s)."
 
 msgid "An SD card needs to be inserted to record timelapse."
 msgstr "A MicroSD card needs to be inserted to record a timelapse."
@@ -7226,7 +7073,7 @@ msgid "Cannot send the print job for empty plate"
 msgstr "Cannot send a print job for an empty plate."
 
 msgid "This printer does not support printing all plates"
-msgstr "This printer does not support printing all plates"
+msgstr ""
 
 msgid ""
 "When enable spiral vase mode, machines with I3 structure will not generate "
@@ -7238,13 +7085,12 @@ msgstr ""
 msgid ""
 "Timelapse is not supported because Print sequence is set to \"By object\"."
 msgstr ""
-"Timelapse is not supported because Print sequence is set to \"By object\"."
 
 msgid "Errors"
-msgstr "Errors"
+msgstr ""
 
 msgid "Please check the following:"
-msgstr "Please check the following:"
+msgstr ""
 
 msgid ""
 "The printer type selected when generating G-code is not consistent with the "
@@ -7263,11 +7109,11 @@ msgstr ""
 
 #, c-format, boost-format
 msgid "nozzle in preset: %s %s"
-msgstr "nozzle in preset: %s %s"
+msgstr ""
 
 #, c-format, boost-format
 msgid "nozzle memorized: %.2f %s"
-msgstr "nozzle memorized: %.2f %s"
+msgstr ""
 
 msgid ""
 "Your nozzle diameter in sliced file is not consistent with memorized nozzle. "
@@ -7283,37 +7129,31 @@ msgid ""
 "Printing high temperature material(%s material) with %s may cause nozzle "
 "damage"
 msgstr ""
-"Printing high temperature material(%s material) with %s may cause nozzle "
-"damage"
 
 msgid "Please fix the error above, otherwise printing cannot continue."
-msgstr "Please fix the error above, otherwise printing cannot continue."
+msgstr ""
 
 msgid ""
 "Please click the confirm button if you still want to proceed with printing."
 msgstr ""
-"Please click the confirm button if you still want to proceed with printing."
 
 msgid ""
 "Connecting to the printer. Unable to cancel during the connection process."
 msgstr ""
-"Connecting to the printer. Unable to cancel during the connection process."
 
 msgid ""
 "Caution to use! Flow calibration on Textured PEI Plate may fail due to the "
 "scattered surface."
 msgstr ""
-"Caution to use! Flow calibration on Textured PEI Plate may fail due to the "
-"scattered surface."
 
 msgid "Automatic flow calibration using Micro Lidar"
-msgstr "Automatic flow calibration using Micro Lidar"
+msgstr ""
 
 msgid "Modifying the device name"
-msgstr "Modifying the device name"
+msgstr ""
 
 msgid "Bind with Pin Code"
-msgstr "Bind with Pin Code"
+msgstr ""
 
 msgid "Bind with Access Code"
 msgstr ""
@@ -7325,7 +7165,7 @@ msgid "Cannot send the print task when the upgrade is in progress"
 msgstr "Cannot send print tasks when an update is in progress"
 
 msgid "The selected printer is incompatible with the chosen printer presets."
-msgstr "The selected printer is incompatible with the chosen printer presets."
+msgstr ""
 
 msgid "An SD card needs to be inserted before send to printer SD card."
 msgstr ""
@@ -7341,16 +7181,16 @@ msgid "Slice ok."
 msgstr "Slice complete"
 
 msgid "View all Daily tips"
-msgstr "View all Daily tips"
+msgstr ""
 
 msgid "Failed to create socket"
-msgstr "Failed to create socket"
+msgstr ""
 
 msgid "Failed to connect socket"
-msgstr "Failed to connect socket"
+msgstr ""
 
 msgid "Failed to publish login request"
-msgstr "Failed to publish login request"
+msgstr ""
 
 msgid "Get ticket from device timeout"
 msgstr "Timeout getting ticket from device"
@@ -7359,53 +7199,51 @@ msgid "Get ticket from server timeout"
 msgstr "Timeout getting ticket from server"
 
 msgid "Failed to post ticket to server"
-msgstr "Failed to post ticket to server"
+msgstr ""
 
 msgid "Failed to parse login report reason"
-msgstr "Failed to parse login report reason"
+msgstr ""
 
 msgid "Receive login report timeout"
-msgstr "Receive login report timeout"
+msgstr ""
 
 msgid "Unknown Failure"
-msgstr "Unknown Failure"
+msgstr ""
 
 msgid ""
 "Please Find the Pin Code in Account page on printer screen,\n"
 " and type in the Pin Code below."
 msgstr ""
-"Please Find the Pin Code in Account page on printer screen,\n"
-" and type in the Pin Code below."
 
 msgid "Can't find Pin Code?"
-msgstr "Can't find Pin Code?"
+msgstr ""
 
 msgid "Pin Code"
-msgstr "Pin Code"
+msgstr ""
 
 msgid "Binding..."
-msgstr "Binding..."
+msgstr ""
 
 msgid "Please confirm on the printer screen"
-msgstr "Please confirm on the printer screen"
+msgstr ""
 
 msgid "Log in failed. Please check the Pin Code."
-msgstr "Log in failed. Please check the Pin Code."
+msgstr ""
 
 msgid "Log in printer"
-msgstr "Log in printer"
+msgstr ""
 
 msgid "Would you like to log in this printer with current account?"
 msgstr "Would you like to log in this printer with the current account?"
 
 msgid "Check the reason"
-msgstr "Check the reason"
+msgstr ""
 
 msgid "Read and accept"
-msgstr "Read and accept"
+msgstr ""
 
 msgid "Terms and Conditions"
-msgstr "Terms and Conditions"
+msgstr ""
 
 msgid ""
 "Thank you for purchasing a Bambu Lab device.Before using your Bambu Lab "
@@ -7421,16 +7259,16 @@ msgstr ""
 "Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services."
 
 msgid "and"
-msgstr "and"
+msgstr ""
 
 msgid "Privacy Policy"
-msgstr "Privacy Policy"
+msgstr ""
 
 msgid "We ask for your help to improve everyone's printer"
-msgstr "We ask for your help to improve everyone's printer"
+msgstr ""
 
 msgid "Statement about User Experience Improvement Program"
-msgstr "Statement about User Experience Improvement Program"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -7446,52 +7284,41 @@ msgid ""
 "payment information, or phone numbers. By enabling this service, you agree "
 "to these terms and the statement about Privacy Policy."
 msgstr ""
-"In the 3D Printing community, we learn from each other's successes and "
-"failures to adjust our own slicing parameters and settings. %s follows the "
-"same principle and uses machine learning to improve its performance from the "
-"successes and failures of the vast number of prints by our users. We are "
-"training %s to be smarter by feeding them the real-world data. If you are "
-"willing, this service will access information from your error logs and usage "
-"logs, which may include information described in  Privacy Policy. We will "
-"not collect any Personal Data by which an individual can be identified "
-"directly or indirectly, including without limitation names, addresses, "
-"payment information, or phone numbers. By enabling this service, you agree "
-"to these terms and the statement about Privacy Policy."
 
 msgid "Statement on User Experience Improvement Plan"
-msgstr "Statement on User Experience Improvement Plan"
+msgstr ""
 
 msgid "Log in successful."
-msgstr "Log in successful."
+msgstr ""
 
 msgid "Log out printer"
-msgstr "Log out printer"
+msgstr ""
 
 msgid "Would you like to log out the printer?"
-msgstr "Would you like to log out the printer?"
+msgstr ""
 
 msgid "Please log in first."
-msgstr "Please log in first."
+msgstr ""
 
 msgid "There was a problem connecting to the printer. Please try again."
-msgstr "There was a problem connecting to the printer. Please try again."
+msgstr ""
 
 msgid "Failed to log out."
-msgstr "Failed to log out."
+msgstr ""
 
 #. TRN "Save current Settings"
 #, c-format, boost-format
 msgid "Save current %s"
-msgstr "Save current %s"
+msgstr ""
 
 msgid "Delete this preset"
-msgstr "Delete this preset"
+msgstr ""
 
 msgid "Search in preset"
-msgstr "Search in preset"
+msgstr ""
 
 msgid "Click to reset all settings to the last saved preset."
-msgstr "Click to reset all settings to the last saved preset."
+msgstr ""
 
 msgid ""
 "Prime tower is required for smooth timelapse. There may be flaws on the "
@@ -7509,7 +7336,7 @@ msgstr ""
 "the model without prime tower. Do you want to enable the prime tower?"
 
 msgid "Still print by object?"
-msgstr "Still print by object?"
+msgstr ""
 
 msgid ""
 "When using support material for the support interface, We recommend the "
@@ -7517,7 +7344,7 @@ msgid ""
 "0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
 "disable independent support layer height"
 msgstr ""
-"When using support material for the support interface, We recommend the "
+"When using support material for the support interface, we recommend the "
 "following settings:\n"
 "0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
 "disable independent support layer height"
@@ -7551,13 +7378,13 @@ msgid ""
 msgstr ""
 
 msgid "Adjust to the set range automatically? \n"
-msgstr "Adjust to the set range automatically? \n"
+msgstr ""
 
 msgid "Adjust"
-msgstr "Adjust"
+msgstr ""
 
 msgid "Ignore"
-msgstr "Ignore"
+msgstr ""
 
 msgid ""
 "Experimental feature: Retracting and cutting off the filament at a greater "
@@ -7587,10 +7414,6 @@ msgid ""
 "by right-click the empty position of build plate and choose \"Add "
 "Primitive\"->\"Timelapse Wipe Tower\"."
 msgstr ""
-"When recording timelapse without toolhead, it is recommended to add a "
-"\"Timelapse Wipe Tower\" \n"
-"by right-click the empty position of build plate and choose \"Add "
-"Primitive\"->\"Timelapse Wipe Tower\"."
 
 msgid ""
 "A copy of the current system preset will be created, which will be detached "
@@ -7662,16 +7485,16 @@ msgid "symbolic profile name"
 msgstr ""
 
 msgid "Line width"
-msgstr "Line width"
+msgstr ""
 
 msgid "Seam"
-msgstr "Seam"
+msgstr ""
 
 msgid "Precision"
-msgstr "Precision"
+msgstr ""
 
 msgid "Wall generator"
-msgstr "Wall generator"
+msgstr ""
 
 msgid "Walls and surfaces"
 msgstr ""
@@ -7683,46 +7506,43 @@ msgid "Overhangs"
 msgstr ""
 
 msgid "Walls"
-msgstr "Walls"
+msgstr ""
 
 msgid "Top/bottom shells"
-msgstr "Top/bottom shells"
+msgstr ""
 
 msgid "Initial layer speed"
 msgstr "First layer speed"
 
 msgid "Other layers speed"
-msgstr "Other layers speed"
+msgstr ""
 
 msgid "Overhang speed"
-msgstr "Overhang speed"
+msgstr ""
 
 msgid ""
 "This is the speed for various overhang degrees. Overhang degrees are "
 "expressed as a percentage of line width. 0 speed means no slowing down for "
 "the overhang degree range and wall speed is used"
 msgstr ""
-"This is the speed for various overhang degrees. Overhang degrees are "
-"expressed as a percentage of line width. 0 speed means no slowing down for "
-"the overhang degree range and wall speed is used"
 
 msgid "Bridge"
-msgstr "Bridge"
+msgstr ""
 
 msgid "Set speed for external and internal bridges"
 msgstr ""
 
 msgid "Travel speed"
-msgstr "Travel speed"
+msgstr ""
 
 msgid "Acceleration"
-msgstr "Acceleration"
+msgstr ""
 
 msgid "Jerk(XY)"
-msgstr "Jerk(XY)"
+msgstr ""
 
 msgid "Raft"
-msgstr "Raft"
+msgstr ""
 
 msgid "Support filament"
 msgstr "Filament for Supports"
@@ -7734,7 +7554,7 @@ msgid "Multimaterial"
 msgstr ""
 
 msgid "Prime tower"
-msgstr "Prime tower"
+msgstr ""
 
 msgid "Filament for Features"
 msgstr ""
@@ -7746,19 +7566,19 @@ msgid "Skirt"
 msgstr ""
 
 msgid "Special mode"
-msgstr "Special mode"
+msgstr ""
 
 msgid "G-code output"
 msgstr ""
 
 msgid "Post-processing Scripts"
-msgstr "Post-processing Scripts"
+msgstr ""
 
 msgid "Notes"
-msgstr "Notes"
+msgstr ""
 
 msgid "Frequent"
-msgstr "Frequent"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -7779,19 +7599,19 @@ msgstr[1] ""
 "be broken."
 
 msgid "Reserved keywords found"
-msgstr "Reserved keywords found"
+msgstr ""
 
 msgid "Setting Overrides"
-msgstr "Setting Overrides"
+msgstr ""
 
 msgid "Retraction"
-msgstr "Retraction"
+msgstr ""
 
 msgid "Basic information"
-msgstr "Basic information"
+msgstr ""
 
 msgid "Recommended nozzle temperature"
-msgstr "Recommended nozzle temperature"
+msgstr ""
 
 msgid "Recommended nozzle temperature range of this filament. 0 means no set"
 msgstr "Recommended nozzle temperature range of this filament. 0 means not set"
@@ -7803,13 +7623,13 @@ msgid "Print chamber temperature"
 msgstr ""
 
 msgid "Print temperature"
-msgstr "Print temperature"
+msgstr ""
 
 msgid "Nozzle"
-msgstr "Nozzle"
+msgstr ""
 
 msgid "Nozzle temperature when printing"
-msgstr "Nozzle temperature when printing"
+msgstr ""
 
 msgid "Cool Plate (SuperTack)"
 msgstr ""
@@ -7877,19 +7697,19 @@ msgstr ""
 "PEI Plate."
 
 msgid "Volumetric speed limitation"
-msgstr "Volumetric speed limitation"
+msgstr ""
 
 msgid "Cooling"
-msgstr "Cooling"
+msgstr ""
 
 msgid "Cooling for specific layer"
-msgstr "Cooling for specific layer"
+msgstr ""
 
 msgid "Part cooling fan"
-msgstr "Part cooling fan"
+msgstr ""
 
 msgid "Min fan speed threshold"
-msgstr "Min fan speed threshold"
+msgstr ""
 
 msgid ""
 "Part cooling fan speed will start to run at min speed when the estimated "
@@ -7903,7 +7723,7 @@ msgstr ""
 "minimum and maximum fan speed according to layer printing time."
 
 msgid "Max fan speed threshold"
-msgstr "Max fan speed threshold"
+msgstr ""
 
 msgid ""
 "Part cooling fan speed will be max when the estimated layer time is shorter "
@@ -7913,16 +7733,16 @@ msgstr ""
 "is shorter than the threshold value."
 
 msgid "Auxiliary part cooling fan"
-msgstr "Auxiliary part cooling fan"
+msgstr ""
 
 msgid "Exhaust fan"
-msgstr "Exhaust fan"
+msgstr ""
 
 msgid "During print"
-msgstr "During print"
+msgstr ""
 
 msgid "Complete print"
-msgstr "Complete print"
+msgstr ""
 
 msgid "Filament start G-code"
 msgstr ""
@@ -7949,7 +7769,7 @@ msgid "Profile dependencies"
 msgstr ""
 
 msgid "Printable space"
-msgstr "Printable space"
+msgstr ""
 
 #. TRN: First argument is parameter name, the second one is the value.
 #, boost-format
@@ -7966,13 +7786,13 @@ msgid "Fan speed-up time"
 msgstr ""
 
 msgid "Extruder Clearance"
-msgstr "Extruder Clearance"
+msgstr ""
 
 msgid "Adaptive bed mesh"
 msgstr ""
 
 msgid "Accessory"
-msgstr "Accessory"
+msgstr ""
 
 msgid "Machine G-code"
 msgstr ""
@@ -8008,19 +7828,19 @@ msgid "Template Custom G-code"
 msgstr ""
 
 msgid "Motion ability"
-msgstr "Motion ability"
+msgstr ""
 
 msgid "Normal"
-msgstr "Normal"
+msgstr ""
 
 msgid "Speed limitation"
-msgstr "Speed limitation"
+msgstr ""
 
 msgid "Acceleration limitation"
-msgstr "Acceleration limitation"
+msgstr ""
 
 msgid "Jerk limitation"
-msgstr "Jerk limitation"
+msgstr ""
 
 msgid "Single extruder multi-material setup"
 msgstr ""
@@ -8036,7 +7856,7 @@ msgid ""
 msgstr ""
 
 msgid "Nozzle diameter"
-msgstr "Nozzle diameter"
+msgstr ""
 
 msgid "Wipe tower"
 msgstr ""
@@ -8050,13 +7870,13 @@ msgid ""
 msgstr ""
 
 msgid "Layer height limits"
-msgstr "Layer height limits"
+msgstr ""
 
 msgid "Z-Hop"
 msgstr ""
 
 msgid "Retraction when switching material"
-msgstr "Retraction when switching material"
+msgstr ""
 
 msgid ""
 "The Wipe option is not available when using the Firmware Retraction mode.\n"
@@ -8068,18 +7888,16 @@ msgstr ""
 "Disable it in order to enable Firmware Retraction?"
 
 msgid "Firmware Retraction"
-msgstr "Firmware Retraction"
+msgstr ""
 
 msgid "Detached"
-msgstr "Detached"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "%d Filament Preset and %d Process Preset is attached to this printer. Those "
 "presets would be deleted if the printer is deleted."
 msgstr ""
-"%d Filament Preset and %d Process Preset is attached to this printer. Those "
-"presets would be deleted if the printer is deleted."
 
 msgid "Presets inherited by other presets cannot be deleted!"
 msgstr ""
@@ -8092,7 +7910,7 @@ msgstr[1] ""
 #. TRN  Remove/Delete
 #, boost-format
 msgid "%1% Preset"
-msgstr "%1% Preset"
+msgstr ""
 
 msgid "Following preset will be deleted too."
 msgid_plural "Following presets will be deleted too."
@@ -8104,28 +7922,25 @@ msgid ""
 "If the preset corresponds to a filament currently in use on your printer, "
 "please reset the filament information for that slot."
 msgstr ""
-"Are you sure to delete the selected preset? \n"
-"If the preset corresponds to a filament currently in use on your printer, "
-"please reset the filament information for that slot."
 
 #, boost-format
 msgid "Are you sure to %1% the selected preset?"
 msgstr "Are you sure you want to %1% the selected preset?"
 
 msgid "All"
-msgstr "All"
+msgstr ""
 
 msgid "Set"
-msgstr "Set"
+msgstr ""
 
 msgid "Click to reset current value and attach to the global value."
-msgstr "Click to reset current value and attach to the global value."
+msgstr ""
 
 msgid "Click to drop current modify and reset to saved value."
 msgstr "Click to drop current modifications and reset to saved value."
 
 msgid "Process Settings"
-msgstr "Process Settings"
+msgstr ""
 
 msgid "Undef"
 msgstr "Undefined"
@@ -8134,87 +7949,77 @@ msgid "Unsaved Changes"
 msgstr "unsaved changes"
 
 msgid "Transfer or discard changes"
-msgstr "Transfer or discard changes"
+msgstr ""
 
 msgid "Old Value"
 msgstr "Old value"
 
 msgid "New Value"
-msgstr "New Value"
+msgstr ""
 
 msgid "Transfer"
-msgstr "Transfer"
+msgstr ""
 
 msgid "Don't save"
-msgstr "Don't save"
+msgstr ""
 
 msgid "Discard"
-msgstr "Discard"
+msgstr ""
 
 msgid "Click the right mouse button to display the full text."
-msgstr "Click the right mouse button to display the full text."
+msgstr ""
 
 msgid "All changes will not be saved"
 msgstr "No changes will be saved."
 
 msgid "All changes will be discarded."
-msgstr "All changes will be discarded."
+msgstr ""
 
 msgid "Save the selected options."
-msgstr "Save the selected options."
+msgstr ""
 
 msgid "Keep the selected options."
-msgstr "Keep the selected options."
+msgstr ""
 
 msgid "Transfer the selected options to the newly selected preset."
-msgstr "Transfer the selected options to the newly selected preset."
+msgstr ""
 
 #, boost-format
 msgid ""
 "Save the selected options to preset \n"
 "\"%1%\"."
 msgstr ""
-"Save the selected options to preset \n"
-"\"%1%\"."
 
 #, boost-format
 msgid ""
 "Transfer the selected options to the newly selected preset \n"
 "\"%1%\"."
 msgstr ""
-"Transfer the selected options to the newly selected preset \n"
-"\"%1%\"."
 
 #, boost-format
 msgid "Preset \"%1%\" contains the following unsaved changes:"
-msgstr "Preset \"%1%\" contains the following unsaved changes:"
+msgstr ""
 
 #, boost-format
 msgid ""
 "Preset \"%1%\" is not compatible with the new printer profile and it "
 "contains the following unsaved changes:"
 msgstr ""
-"Preset \"%1%\" is not compatible with the new printer profile and it "
-"contains the following unsaved changes:"
 
 #, boost-format
 msgid ""
 "Preset \"%1%\" is not compatible with the new process profile and it "
 "contains the following unsaved changes:"
 msgstr ""
-"Preset \"%1%\" is not compatible with the new process profile and it "
-"contains the following unsaved changes:"
 
 #, boost-format
 msgid "You have changed some settings of preset \"%1%\"."
-msgstr "You have changed some settings of preset \"%1%\"."
+msgstr ""
 
 msgid ""
 "\n"
 "You can save or discard the preset values you have modified."
 msgstr ""
-"\n"
-"You can save or discard the preset values you have modified."
 
 msgid ""
 "\n"
@@ -8223,7 +8028,7 @@ msgid ""
 msgstr ""
 
 msgid "You have previously modified your settings."
-msgstr "You have previously modified your settings."
+msgstr ""
 
 msgid ""
 "\n"
@@ -8235,16 +8040,16 @@ msgid "Extruders count"
 msgstr "Extruder count"
 
 msgid "General"
-msgstr "General"
+msgstr ""
 
 msgid "Capabilities"
-msgstr "Capabilities"
+msgstr ""
 
 msgid "Show all presets (including incompatible)"
-msgstr "Show all presets (including incompatible)"
+msgstr ""
 
 msgid "Select presets to compare"
-msgstr "Select presets to compare"
+msgstr ""
 
 msgid ""
 "You can only transfer to current active profile because it has been modified."
@@ -8265,54 +8070,54 @@ msgid ""
 msgstr ""
 
 msgid "Add File"
-msgstr "Add File"
+msgstr ""
 
 msgid "Set as cover"
-msgstr "Set as cover"
+msgstr ""
 
 msgid "Cover"
-msgstr "Cover"
+msgstr ""
 
 #, boost-format
 msgid "The name \"%1%\" already exists."
-msgstr "The name \"%1%\" already exists."
+msgstr ""
 
 msgid "Basic Info"
-msgstr "Basic Info"
+msgstr ""
 
 msgid "Pictures"
-msgstr "Pictures"
+msgstr ""
 
 msgid "Bill of Materials"
-msgstr "Bill of Materials"
+msgstr ""
 
 msgid "Assembly Guide"
-msgstr "Assembly Guide"
+msgstr ""
 
 msgid "Author"
-msgstr "Author"
+msgstr ""
 
 msgid "Model Name"
-msgstr "Model Name"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s Update"
-msgstr "%s Update"
+msgstr ""
 
 msgid "A new version is available"
-msgstr "A new version is available"
+msgstr ""
 
 msgid "Configuration update"
-msgstr "Configuration update"
+msgstr ""
 
 msgid "A new configuration package available, Do you want to install it?"
 msgstr "A new configuration package is available. Do you want to install it?"
 
 msgid "Description:"
-msgstr "Description:"
+msgstr ""
 
 msgid "Configuration incompatible"
-msgstr "Configuration incompatible"
+msgstr ""
 
 msgid "the configuration package is incompatible with current application."
 msgstr ""
@@ -8328,7 +8133,7 @@ msgstr ""
 
 #, c-format, boost-format
 msgid "Exit %s"
-msgstr "Exit %s"
+msgstr ""
 
 msgid "the Configuration package is incompatible with current APP."
 msgstr ""
@@ -8336,60 +8141,58 @@ msgstr ""
 "Studio."
 
 msgid "Configuration updates"
-msgstr "Configuration updates"
+msgstr ""
 
 msgid "No updates available."
-msgstr "No updates available."
+msgstr ""
 
 msgid "The configuration is up to date."
-msgstr "The configuration is up to date."
+msgstr ""
 
 msgid "Obj file Import color"
-msgstr "Obj file Import color"
+msgstr ""
 
 msgid "Specify number of colors:"
-msgstr "Specify number of colors:"
+msgstr ""
 
 #, c-format, boost-format
 msgid "The color count should be in range [%d, %d]."
-msgstr "The color count should be in range [%d, %d]."
+msgstr ""
 
 msgid "Recommended "
-msgstr "Recommended "
+msgstr ""
 
 msgid "Current filament colors:"
-msgstr "Current filament colors:"
+msgstr ""
 
 msgid "Quick set:"
-msgstr "Quick set:"
+msgstr ""
 
 msgid "Color match"
-msgstr "Color match"
+msgstr ""
 
 msgid "Approximate color matching."
-msgstr "Approximate color matching."
+msgstr ""
 
 msgid "Append"
-msgstr "Append"
+msgstr ""
 
 msgid "Add consumable extruder after existing extruders."
-msgstr "Add consumable extruder after existing extruders."
+msgstr ""
 
 msgid "Reset mapped extruders."
-msgstr "Reset mapped extruders."
+msgstr ""
 
 msgid "Cluster colors"
-msgstr "Cluster colors"
+msgstr ""
 
 msgid "Map Filament"
-msgstr "Map Filament"
+msgstr ""
 
 msgid ""
 "Note:The color has been selected, you can choose OK \n"
 " to continue or manually adjust it."
 msgstr ""
-"Note:The color has been selected, you can choose OK \n"
-" to continue or manually adjust it."
 
 msgid ""
 "Waring:The count of newly added and \n"
@@ -8417,7 +8220,7 @@ msgid "Total ramming time"
 msgstr ""
 
 msgid "s"
-msgstr "s"
+msgstr ""
 
 msgid "Total rammed volume"
 msgstr ""
@@ -8429,13 +8232,13 @@ msgid "Ramming line spacing"
 msgstr ""
 
 msgid "Auto-Calc"
-msgstr "Auto-Calc"
+msgstr ""
 
 msgid "Re-calculate"
-msgstr "Re-calculate"
+msgstr ""
 
 msgid "Flushing volumes for filament change"
-msgstr "Flushing volumes for filament change"
+msgstr ""
 
 msgid ""
 "Orca would re-calculate your flushing volumes every time the filaments color "
@@ -8443,33 +8246,33 @@ msgid ""
 msgstr ""
 
 msgid "Flushing volume (mm³) for each filament pair."
-msgstr "Flushing volume (mm³) for each filament pair."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Suggestion: Flushing Volume in range [%d, %d]"
-msgstr "Suggestion: Flushing Volume in range [%d, %d]"
+msgstr ""
 
 #, c-format, boost-format
 msgid "The multiplier should be in range [%.2f, %.2f]."
-msgstr "The multiplier should be in range [%.2f, %.2f]."
+msgstr ""
 
 msgid "Multiplier"
-msgstr "Multiplier"
+msgstr ""
 
 msgid "unloaded"
-msgstr "unloaded"
+msgstr ""
 
 msgid "loaded"
-msgstr "loaded"
+msgstr ""
 
 msgid "Filament #"
-msgstr "Filament #"
+msgstr ""
 
 msgid "From"
-msgstr "From"
+msgstr ""
 
 msgid "To"
-msgstr "To"
+msgstr ""
 
 msgid ""
 "Windows Media Player is required for this task! Do you want to enable "
@@ -8498,67 +8301,67 @@ msgid ""
 msgstr ""
 
 msgid "Bambu Network plug-in not detected."
-msgstr "Bambu Network plug-in not detected."
+msgstr ""
 
 msgid "Click here to download it."
-msgstr "Click here to download it."
+msgstr ""
 
 msgid "Login"
-msgstr "Login"
+msgstr ""
 
 msgid "The configuration package is changed in previous Config Guide"
-msgstr "The configuration package is changed in previous Config Guide"
+msgstr ""
 
 msgid "Configuration package changed"
-msgstr "Configuration package changed"
+msgstr ""
 
 msgid "Toolbar"
-msgstr "Toolbar"
+msgstr ""
 
 msgid "Objects list"
-msgstr "Objects list"
+msgstr ""
 
 msgid "Import geometry data from STL/STEP/3MF/OBJ/AMF files"
-msgstr "Import geometry data from STL/STEP/3MF/OBJ/AMF files"
+msgstr ""
 
 msgid "⌘+Shift+G"
-msgstr "⌘+Shift+G"
+msgstr ""
 
 msgid "Ctrl+Shift+G"
-msgstr "Ctrl+Shift+G"
+msgstr ""
 
 msgid "Paste from clipboard"
-msgstr "Paste from clipboard"
+msgstr ""
 
 msgid "Show/Hide 3Dconnexion devices settings dialog"
-msgstr "Show/Hide 3Dconnexion devices settings dialog"
+msgstr ""
 
 msgid "Switch table page"
-msgstr "Switch table page"
+msgstr ""
 
 msgid "Show keyboard shortcuts list"
-msgstr "Show keyboard shortcuts list"
+msgstr ""
 
 msgid "Global shortcuts"
-msgstr "Global shortcuts"
+msgstr ""
 
 msgid "Rotate View"
-msgstr "Rotate View"
+msgstr ""
 
 msgid "Pan View"
-msgstr "Pan View"
+msgstr ""
 
 msgid "Mouse wheel"
-msgstr "Mouse wheel"
+msgstr ""
 
 msgid "Zoom View"
-msgstr "Zoom View"
+msgstr ""
 
 msgid "Shift+A"
-msgstr "Shift+A"
+msgstr ""
 
 msgid "Shift+R"
-msgstr "Shift+R"
+msgstr ""
 
 msgid ""
 "Auto orientates selected objects or all objects.If there are selected "
@@ -8570,70 +8373,70 @@ msgstr ""
 "objects in the current plate."
 
 msgid "Shift+Tab"
-msgstr "Shift+Tab"
+msgstr ""
 
 msgid "Collapse/Expand the sidebar"
-msgstr "Collapse/Expand the sidebar"
+msgstr ""
 
 msgid "⌘+Any arrow"
-msgstr "⌘+Any arrow"
+msgstr ""
 
 msgid "Movement in camera space"
-msgstr "Movement in camera space"
+msgstr ""
 
 msgid "⌥+Left mouse button"
-msgstr "⌥+Left mouse button"
+msgstr ""
 
 msgid "Select a part"
-msgstr "Select a part"
+msgstr ""
 
 msgid "⌘+Left mouse button"
-msgstr "⌘+Left mouse button"
+msgstr ""
 
 msgid "Select multiple objects"
-msgstr "Select multiple objects"
+msgstr ""
 
 msgid "Ctrl+Any arrow"
-msgstr "Ctrl+Any arrow"
+msgstr ""
 
 msgid "Alt+Left mouse button"
-msgstr "Alt+Left mouse button"
+msgstr ""
 
 msgid "Ctrl+Left mouse button"
-msgstr "Ctrl+Left mouse button"
+msgstr ""
 
 msgid "Shift+Left mouse button"
-msgstr "Shift+Left mouse button"
+msgstr ""
 
 msgid "Select objects by rectangle"
-msgstr "Select objects by rectangle"
+msgstr ""
 
 msgid "Arrow Up"
-msgstr "Arrow Up"
+msgstr ""
 
 msgid "Move selection 10 mm in positive Y direction"
 msgstr "Move selection 10mm in positive Y direction"
 
 msgid "Arrow Down"
-msgstr "Arrow Down"
+msgstr ""
 
 msgid "Move selection 10 mm in negative Y direction"
 msgstr "Move selection 10mm in negative Y direction"
 
 msgid "Arrow Left"
-msgstr "Arrow Left"
+msgstr ""
 
 msgid "Move selection 10 mm in negative X direction"
 msgstr "Move selection 10mm in negative X direction"
 
 msgid "Arrow Right"
-msgstr "Arrow Right"
+msgstr ""
 
 msgid "Move selection 10 mm in positive X direction"
 msgstr "Move selection 10mm in positive X direction"
 
 msgid "Shift+Any arrow"
-msgstr "Shift+Any arrow"
+msgstr ""
 
 msgid "Movement step set to 1 mm"
 msgstr "Movement step set to 1mm"
@@ -8642,49 +8445,49 @@ msgid "keyboard 1-9: set filament for object/part"
 msgstr "Keyboard 1-9: set filament for object/part"
 
 msgid "Camera view - Default"
-msgstr "Camera view - Default"
+msgstr ""
 
 msgid "Camera view - Top"
-msgstr "Camera view - Top"
+msgstr ""
 
 msgid "Camera view - Bottom"
-msgstr "Camera view - Bottom"
+msgstr ""
 
 msgid "Camera view - Front"
-msgstr "Camera view - Front"
+msgstr ""
 
 msgid "Camera view - Behind"
-msgstr "Camera view - Behind"
+msgstr ""
 
 msgid "Camera Angle - Left side"
-msgstr "Camera Angle - Left side"
+msgstr ""
 
 msgid "Camera Angle - Right side"
-msgstr "Camera Angle - Right side"
+msgstr ""
 
 msgid "Select all objects"
-msgstr "Select all objects"
+msgstr ""
 
 msgid "Gizmo move"
-msgstr "Gizmo move"
+msgstr ""
 
 msgid "Gizmo scale"
-msgstr "Gizmo scale"
+msgstr ""
 
 msgid "Gizmo rotate"
-msgstr "Gizmo rotate"
+msgstr ""
 
 msgid "Gizmo cut"
-msgstr "Gizmo cut"
+msgstr ""
 
 msgid "Gizmo Place face on bed"
-msgstr "Gizmo Place face on bed"
+msgstr ""
 
 msgid "Gizmo SLA support points"
-msgstr "Gizmo SLA support points"
+msgstr ""
 
 msgid "Gizmo FDM paint-on seam"
-msgstr "Gizmo FDM paint-on seam"
+msgstr ""
 
 msgid "Gizmo Text emboss / engrave"
 msgstr ""
@@ -8699,73 +8502,73 @@ msgid "Switch between Prepare/Preview"
 msgstr ""
 
 msgid "Plater"
-msgstr "Plater"
+msgstr ""
 
 msgid "Move: press to snap by 1mm"
-msgstr "Move: press to snap by 1mm"
+msgstr ""
 
 msgid "⌘+Mouse wheel"
-msgstr "⌘+Mouse wheel"
+msgstr ""
 
 msgid "Support/Color Painting: adjust pen radius"
-msgstr "Support/Color Painting: adjust pen radius"
+msgstr ""
 
 msgid "⌥+Mouse wheel"
-msgstr "⌥+Mouse wheel"
+msgstr ""
 
 msgid "Support/Color Painting: adjust section position"
-msgstr "Support/Color Painting: adjust section position"
+msgstr ""
 
 msgid "Ctrl+Mouse wheel"
-msgstr "Ctrl+Mouse wheel"
+msgstr ""
 
 msgid "Alt+Mouse wheel"
-msgstr "Alt+Mouse wheel"
+msgstr ""
 
 msgid "Gizmo"
-msgstr "Gizmo"
+msgstr ""
 
 msgid "Set extruder number for the objects and parts"
-msgstr "Set extruder number for the objects and parts"
+msgstr ""
 
 msgid "Delete objects, parts, modifiers  "
 msgstr "Delete objects, parts, modifiers"
 
 msgid "Select the object/part and press space to change the name"
-msgstr "Select the object/part and press space to change the name"
+msgstr ""
 
 msgid "Mouse click"
-msgstr "Mouse click"
+msgstr ""
 
 msgid "Select the object/part and mouse click to change the name"
-msgstr "Select the object/part and mouse click to change the name"
+msgstr ""
 
 msgid "Objects List"
-msgstr "Objects List"
+msgstr ""
 
 msgid "Vertical slider - Move active thumb Up"
-msgstr "Vertical slider - Move active thumb Up"
+msgstr ""
 
 msgid "Vertical slider - Move active thumb Down"
-msgstr "Vertical slider - Move active thumb Down"
+msgstr ""
 
 msgid "Horizontal slider - Move active thumb Left"
-msgstr "Horizontal slider - Move active thumb Left"
+msgstr ""
 
 msgid "Horizontal slider - Move active thumb Right"
-msgstr "Horizontal slider - Move active thumb Right"
+msgstr ""
 
 msgid "On/Off one layer mode of the vertical slider"
-msgstr "On/Off one layer mode of the vertical slider"
+msgstr ""
 
 msgid "On/Off G-code window"
 msgstr ""
 
 msgid "Move slider 5x faster"
-msgstr "Move slider 5x faster"
+msgstr ""
 
 msgid "Shift+Mouse wheel"
-msgstr "Shift+Mouse wheel"
+msgstr ""
 
 msgid "Horizontal slider - Move to start position"
 msgstr ""
@@ -8774,14 +8577,14 @@ msgid "Horizontal slider - Move to last position"
 msgstr ""
 
 msgid "Release Note"
-msgstr "Release Note"
+msgstr ""
 
 #, c-format, boost-format
 msgid "version %s update information :"
 msgstr "version %s update information:"
 
 msgid "Network plug-in update"
-msgstr "Network plug-in update"
+msgstr ""
 
 msgid ""
 "Click OK to update the Network plug-in when Orca Slicer launches next time."
@@ -8793,19 +8596,19 @@ msgid "A new Network plug-in(%s) available, Do you want to install it?"
 msgstr "A new network plug-in (%s) is available. Do you want to install it?"
 
 msgid "New version of Orca Slicer"
-msgstr "New version of Orca Slicer"
+msgstr ""
 
 msgid "Skip this Version"
-msgstr "Skip this Version"
+msgstr ""
 
 msgid "Done"
-msgstr "Done"
+msgstr ""
 
 msgid "resume"
-msgstr "resume"
+msgstr ""
 
 msgid "Resume Printing"
-msgstr "Resume Printing"
+msgstr ""
 
 msgid "Resume Printing(defects acceptable)"
 msgstr "Resume Printing (defects acceptable)"
@@ -8814,31 +8617,31 @@ msgid "Resume Printing(problem solved)"
 msgstr "Resume Printing (problem solved)"
 
 msgid "Stop Printing"
-msgstr "Stop Printing"
+msgstr ""
 
 msgid "Check Assistant"
-msgstr "Check Assistant"
+msgstr ""
 
 msgid "Filament Extruded, Continue"
-msgstr "Filament Extruded, Continue"
+msgstr ""
 
 msgid "Not Extruded Yet, Retry"
-msgstr "Not Extruded Yet, Retry"
+msgstr ""
 
 msgid "Finished, Continue"
-msgstr "Finished, Continue"
+msgstr ""
 
 msgid "Load Filament"
 msgstr "Load"
 
 msgid "Filament Loaded, Resume"
-msgstr "Filament Loaded, Resume"
+msgstr ""
 
 msgid "View Liveview"
-msgstr "View Liveview"
+msgstr ""
 
 msgid "Confirm and Update Nozzle"
-msgstr "Confirm and Update Nozzle"
+msgstr ""
 
 msgid "Connect the printer using IP and access code"
 msgstr ""
@@ -8858,10 +8661,10 @@ msgid ""
 msgstr ""
 
 msgid "IP"
-msgstr "IP"
+msgstr ""
 
 msgid "Access Code"
-msgstr "Access Code"
+msgstr ""
 
 msgid "Printer model"
 msgstr ""
@@ -8870,7 +8673,7 @@ msgid "Printer name"
 msgstr ""
 
 msgid "Where to find your printer's IP and Access Code?"
-msgstr "Where to find your printer's IP and Access Code?"
+msgstr ""
 
 msgid "Connect"
 msgstr ""
@@ -8897,38 +8700,36 @@ msgid "Connecting to printer... The dialog will close later"
 msgstr ""
 
 msgid "Connection failed, please double check IP and Access Code"
-msgstr "Connection failed, please double check IP and Access Code"
+msgstr ""
 
 msgid ""
 "Connection failed! If your IP and Access Code is correct, \n"
 "please move to step 3 for troubleshooting network issues"
 msgstr ""
-"Connection failed! If your IP and Access Code is correct, \n"
-"please move to step 3 for troubleshooting network issues"
 
 msgid "Model:"
-msgstr "Model:"
+msgstr ""
 
 msgid "Serial:"
-msgstr "Serial:"
+msgstr ""
 
 msgid "Version:"
-msgstr "Version:"
+msgstr ""
 
 msgid "Update firmware"
-msgstr "Update firmware"
+msgstr ""
 
 msgid "Beta version"
-msgstr "Beta version"
+msgstr ""
 
 msgid "Latest version"
-msgstr "Latest version"
+msgstr ""
 
 msgid "Updating"
-msgstr "Updating"
+msgstr ""
 
 msgid "Updating failed"
-msgstr "Updating failed"
+msgstr ""
 
 msgid "Updating successful"
 msgstr "Update successful"
@@ -8937,8 +8738,6 @@ msgid ""
 "Are you sure you want to update? This will take about 10 minutes. Do not "
 "turn off the power while the printer is updating."
 msgstr ""
-"Are you sure you want to update? This will take about 10 minutes. Do not "
-"turn off the power while the printer is updating."
 
 msgid ""
 "An important update was detected and needs to be run before printing can "
@@ -8959,37 +8758,37 @@ msgstr ""
 "printer or update next time you start Orca Slicer."
 
 msgid "Extension Board"
-msgstr "Extension Board"
+msgstr ""
 
 msgid "Saving objects into the 3mf failed."
-msgstr "Saving objects into the 3mf failed."
+msgstr ""
 
 msgid "Only Windows 10 is supported."
-msgstr "Only Windows 10 is supported."
+msgstr ""
 
 msgid "Failed to initialize the WinRT library."
-msgstr "Failed to initialize the WinRT library."
+msgstr ""
 
 msgid "Exporting objects"
-msgstr "Exporting objects"
+msgstr ""
 
 msgid "Failed loading objects."
-msgstr "Failed loading objects."
+msgstr ""
 
 msgid "Repairing object by Windows service"
-msgstr "Repairing object by Windows service"
+msgstr ""
 
 msgid "Repair failed."
-msgstr "Repair failed."
+msgstr ""
 
 msgid "Loading repaired objects"
-msgstr "Loading repaired objects"
+msgstr ""
 
 msgid "Exporting 3mf file failed"
-msgstr "Exporting 3mf file failed"
+msgstr ""
 
 msgid "Import 3mf file failed"
-msgstr "Import 3mf file failed"
+msgstr ""
 
 msgid "Repaired 3mf file does not contain any object"
 msgstr "The repaired 3mf file does not contain any objects."
@@ -9004,14 +8803,14 @@ msgid "Repaired 3mf file contains more than one volume"
 msgstr "The repaired 3mf file contains more than one volume."
 
 msgid "Repair finished"
-msgstr "Repair finished"
+msgstr ""
 
 msgid "Repair canceled"
-msgstr "Repair canceled"
+msgstr ""
 
 #, boost-format
 msgid "Copying of file %1% to %2% failed: %3%"
-msgstr "Copying of file %1% to %2% failed: %3%"
+msgstr ""
 
 msgid "Need to check the unsaved changes before configuration updates."
 msgstr "Please check any unsaved changes before updating the configuration."
@@ -9029,8 +8828,6 @@ msgid ""
 "One object has empty initial layer and can't be printed. Please Cut the "
 "bottom or enable supports."
 msgstr ""
-"One object has empty initial layer and can't be printed. Please Cut the "
-"bottom or enable supports."
 
 #, boost-format
 msgid "Object can't be printed for empty layer between %1% and %2%."
@@ -9038,7 +8835,7 @@ msgstr "The object has empty layers between %1% and %2% and can’t be printed."
 
 #, boost-format
 msgid "Object: %1%"
-msgstr "Object: %1%"
+msgstr ""
 
 msgid ""
 "Maybe parts of the object at these height are too thin, or the object has "
@@ -9068,40 +8865,40 @@ msgid "Generating G-code: layer %1%"
 msgstr ""
 
 msgid "Inner wall"
-msgstr "Inner wall"
+msgstr ""
 
 msgid "Outer wall"
-msgstr "Outer wall"
+msgstr ""
 
 msgid "Overhang wall"
-msgstr "Overhang wall"
+msgstr ""
 
 msgid "Sparse infill"
-msgstr "Sparse infill"
+msgstr ""
 
 msgid "Internal solid infill"
-msgstr "Internal solid infill"
+msgstr ""
 
 msgid "Top surface"
-msgstr "Top surface"
+msgstr ""
 
 msgid "Bottom surface"
-msgstr "Bottom surface"
+msgstr ""
 
 msgid "Internal Bridge"
 msgstr ""
 
 msgid "Gap infill"
-msgstr "Gap infill"
+msgstr ""
 
 msgid "Support interface"
-msgstr "Support interface"
+msgstr ""
 
 msgid "Support transition"
-msgstr "Support transition"
+msgstr ""
 
 msgid "Multiple"
-msgstr "Multiple"
+msgstr ""
 
 #, boost-format
 msgid "Failed to calculate line width of %1%. Cannot get value of \"%2%\" "
@@ -9113,97 +8910,97 @@ msgid ""
 msgstr ""
 
 msgid "undefined error"
-msgstr "undefined error"
+msgstr ""
 
 msgid "too many files"
-msgstr "too many files"
+msgstr ""
 
 msgid "file too large"
 msgstr "File too large"
 
 msgid "unsupported method"
-msgstr "unsupported method"
+msgstr ""
 
 msgid "unsupported encryption"
-msgstr "unsupported encryption"
+msgstr ""
 
 msgid "unsupported feature"
-msgstr "unsupported feature"
+msgstr ""
 
 msgid "failed finding central directory"
-msgstr "failed finding central directory"
+msgstr ""
 
 msgid "not a ZIP archive"
-msgstr "not a ZIP archive"
+msgstr ""
 
 msgid "invalid header or corrupted"
-msgstr "invalid header or corrupted"
+msgstr ""
 
 msgid "unsupported multidisk"
 msgstr "Saving to RAID is not supported."
 
 msgid "decompression failed"
-msgstr "decompression failed"
+msgstr ""
 
 msgid "compression failed"
-msgstr "compression failed"
+msgstr ""
 
 msgid "unexpected decompressed size"
-msgstr "unexpected decompressed size"
+msgstr ""
 
 msgid "CRC check failed"
-msgstr "CRC check failed"
+msgstr ""
 
 msgid "unsupported central directory size"
-msgstr "unsupported central directory size"
+msgstr ""
 
 msgid "allocation failed"
-msgstr "allocation failed"
+msgstr ""
 
 msgid "file open failed"
-msgstr "file open failed"
+msgstr ""
 
 msgid "file create failed"
-msgstr "file create failed"
+msgstr ""
 
 msgid "file write failed"
-msgstr "file write failed"
+msgstr ""
 
 msgid "file read failed"
-msgstr "file read failed"
+msgstr ""
 
 msgid "file close failed"
-msgstr "file close failed"
+msgstr ""
 
 msgid "file seek failed"
-msgstr "file seek failed"
+msgstr ""
 
 msgid "file stat failed"
-msgstr "file stat failed"
+msgstr ""
 
 msgid "invalid parameter"
-msgstr "invalid parameter"
+msgstr ""
 
 msgid "invalid filename"
-msgstr "invalid filename"
+msgstr ""
 
 msgid "buffer too small"
 msgstr "Buffer too small"
 
 msgid "internal error"
-msgstr "internal error"
+msgstr ""
 
 msgid "file not found"
-msgstr "file not found"
+msgstr ""
 
 msgid "archive too large"
 msgstr "Archive too large"
 
 msgid "validation failed"
-msgstr "validation failed"
+msgstr ""
 
 msgid "write callback failed"
-msgstr "write callback failed"
+msgstr ""
 
 #, boost-format
 msgid ""
@@ -9213,24 +9010,23 @@ msgstr ""
 
 #, boost-format
 msgid "%1% is too close to others, and collisions may be caused."
-msgstr "%1% is too close to others, and collisions may be caused."
+msgstr ""
 
 #, boost-format
 msgid "%1% is too tall, and collisions will be caused."
-msgstr "%1% is too tall, and collisions will be caused."
+msgstr ""
 
 msgid " is too close to others, there may be collisions when printing."
 msgstr " is too close to others; there may be collisions when printing."
 
 msgid " is too close to exclusion area, there may be collisions when printing."
 msgstr ""
-" is too close to exclusion area, there may be collisions when printing."
 
 msgid "Prime Tower"
-msgstr "Prime Tower"
+msgstr ""
 
 msgid " is too close to others, and collisions may be caused.\n"
-msgstr " is too close to others, and collisions may be caused.\n"
+msgstr ""
 
 msgid " is too close to exclusion area, and collisions will be caused.\n"
 msgstr " is too close to an exclusion area, and collisions will be caused.\n"
@@ -9245,21 +9041,17 @@ msgstr ""
 "during printing."
 
 msgid "No extrusions under current settings."
-msgstr "No extrusions under current settings."
+msgstr ""
 
 msgid ""
 "Smooth mode of timelapse is not supported when \"by object\" sequence is "
 "enabled."
 msgstr ""
-"Smooth mode of timelapse is not supported when \"by object\" sequence is "
-"enabled."
 
 msgid ""
 "Please select \"By object\" print sequence to print multiple objects in "
 "spiral vase mode."
 msgstr ""
-"Please select \"By object\" print sequence to print multiple objects in "
-"spiral vase mode."
 
 msgid ""
 "The spiral vase mode does not work when an object contains more than one "
@@ -9290,7 +9082,7 @@ msgid ""
 msgstr ""
 
 msgid "Variable layer height is not supported with Organic supports."
-msgstr "Variable layer height is not supported with Organic supports."
+msgstr ""
 
 msgid ""
 "Different nozzle diameters and different filament diameters may not work "
@@ -9302,8 +9094,6 @@ msgid ""
 "The Wipe Tower is currently only supported with the relative extruder "
 "addressing (use_relative_e_distances=1)."
 msgstr ""
-"The Wipe Tower is currently only supported with the relative extruder "
-"addressing (use_relative_e_distances=1)."
 
 msgid ""
 "Ooze prevention is only supported with the wipe tower when "
@@ -9355,8 +9145,6 @@ msgid ""
 "The prime tower is only supported if all objects have the same variable "
 "layer height"
 msgstr ""
-"The prime tower is only supported if all objects have the same variable "
-"layer height"
 
 msgid ""
 "One or more object were assigned an extruder that the printer does not have."
@@ -9398,7 +9186,6 @@ msgstr ""
 msgid ""
 "Support enforcers are used but support is not enabled. Please enable support."
 msgstr ""
-"Support enforcers are used but support is not enabled. Please enable support."
 
 msgid "Layer height cannot exceed nozzle diameter"
 msgstr "Layer height cannot exceed nozzle diameter."
@@ -9421,7 +9208,7 @@ msgstr ""
 
 #, c-format, boost-format
 msgid "Plate %d: %s does not support filament %s"
-msgstr "Plate %d: %s does not support filament %s"
+msgstr ""
 
 msgid ""
 "Setting the jerk speed too low could lead to artifacts on curved surfaces"
@@ -9460,7 +9247,7 @@ msgid ""
 msgstr ""
 
 msgid "Generating skirt & brim"
-msgstr "Generating skirt & brim"
+msgstr ""
 
 msgid "Exporting G-code"
 msgstr ""
@@ -9475,7 +9262,7 @@ msgid "Printer technology"
 msgstr ""
 
 msgid "Printable area"
-msgstr "Printable area"
+msgstr ""
 
 msgid "Bed exclude area"
 msgstr "Excluded bed area"
@@ -9485,18 +9272,15 @@ msgid ""
 "left corner to cut filament during filament change. The area is expressed as "
 "polygon by points in following format: \"XxY, XxY, ...\""
 msgstr ""
-"Unprintable area in XY plane. For example, X1 Series printers use the front "
-"left corner to cut filament during filament change. The area is expressed as "
-"polygon by points in following format: \"XxY, XxY, ...\""
 
 msgid "Bed custom texture"
-msgstr "Bed custom texture"
+msgstr ""
 
 msgid "Bed custom model"
-msgstr "Bed custom model"
+msgstr ""
 
 msgid "Elephant foot compensation"
-msgstr "Elephant foot compensation"
+msgstr ""
 
 msgid ""
 "Shrink the initial layer on build plate to compensate for elephant foot "
@@ -9516,7 +9300,7 @@ msgid ""
 msgstr ""
 
 msgid "layers"
-msgstr "layers"
+msgstr ""
 
 msgid ""
 "Slicing height for each layer. Smaller layer height means more accurate and "
@@ -9526,7 +9310,7 @@ msgstr ""
 "accuracy but longer printing time."
 
 msgid "Printable height"
-msgstr "Printable height"
+msgstr ""
 
 msgid "Maximum printable height which is limited by mechanism of printer"
 msgstr ""
@@ -9540,7 +9324,7 @@ msgid "Automatically orient stls on the Z-axis upon initial import"
 msgstr ""
 
 msgid "Printer preset names"
-msgstr "Printer preset names"
+msgstr ""
 
 msgid "Use 3rd-party print host"
 msgstr ""
@@ -9549,7 +9333,7 @@ msgid "Allow controlling BambuLab's printer through 3rd party print hosts"
 msgstr ""
 
 msgid "Hostname, IP or URL"
-msgstr "Hostname, IP or URL"
+msgstr ""
 
 msgid ""
 "Orca Slicer can upload G-code files to a printer host. This field should "
@@ -9560,15 +9344,14 @@ msgid ""
 msgstr ""
 
 msgid "Device UI"
-msgstr "Device UI"
+msgstr ""
 
 msgid ""
 "Specify the URL of your device user interface if it's not same as print_host"
 msgstr ""
-"Specify the URL of your device user interface if it's not same as print_host"
 
 msgid "API Key / Password"
-msgstr "API Key / Password"
+msgstr ""
 
 msgid ""
 "Orca Slicer can upload G-code files to a printer host. This field should "
@@ -9576,28 +9359,25 @@ msgid ""
 msgstr ""
 
 msgid "Name of the printer"
-msgstr "Name of the printer"
+msgstr ""
 
 msgid "HTTPS CA File"
-msgstr "HTTPS CA File"
+msgstr ""
 
 msgid ""
 "Custom CA certificate file can be specified for HTTPS OctoPrint connections, "
 "in crt/pem format. If left blank, the default OS CA certificate repository "
 "is used."
 msgstr ""
-"Custom CA certificate file can be specified for HTTPS OctoPrint connections, "
-"in crt/pem format. If left blank, the default OS CA certificate repository "
-"is used."
 
 msgid "User"
-msgstr "User"
+msgstr ""
 
 msgid "Password"
-msgstr "Password"
+msgstr ""
 
 msgid "Ignore HTTPS certificate revocation checks"
-msgstr "Ignore HTTPS certificate revocation checks"
+msgstr ""
 
 msgid ""
 "Ignore HTTPS certificate revocation checks in case of missing or offline "
@@ -9609,16 +9389,16 @@ msgstr ""
 "certificates if connection fails."
 
 msgid "Names of presets related to the physical printer"
-msgstr "Names of presets related to the physical printer"
+msgstr ""
 
 msgid "Authorization Type"
-msgstr "Authorization Type"
+msgstr ""
 
 msgid "API key"
-msgstr "API key"
+msgstr ""
 
 msgid "HTTP digest"
-msgstr "HTTP digest"
+msgstr ""
 
 msgid "Avoid crossing wall"
 msgstr "Avoid crossing walls"
@@ -9643,10 +9423,10 @@ msgstr ""
 "a direct travel path. A value of 0 will disable this."
 
 msgid "mm or %"
-msgstr "mm or %"
+msgstr ""
 
 msgid "Other layers"
-msgstr "Other layers"
+msgstr ""
 
 msgid ""
 "Bed temperature for layers except the initial one. A value of 0 means the "
@@ -9656,7 +9436,7 @@ msgstr ""
 "0 means the filament does not support printing on the Cool Plate."
 
 msgid "°C"
-msgstr "°C"
+msgstr ""
 
 msgid ""
 "Bed temperature for layers except the initial one. A value of 0 means the "
@@ -9744,34 +9524,31 @@ msgid "Smooth High Temp Plate"
 msgstr ""
 
 msgid "First layer print sequence"
-msgstr "First layer print sequence"
+msgstr ""
 
 msgid "Other layers print sequence"
-msgstr "Other layers print sequence"
+msgstr ""
 
 msgid "The number of other layers print sequence"
-msgstr "The number of other layers print sequence"
+msgstr ""
 
 msgid "Other layers filament sequence"
-msgstr "Other layers filament sequence"
+msgstr ""
 
 msgid "This G-code is inserted at every layer change before lifting z"
 msgstr "This G-code is inserted at every layer change before lifting z."
 
 msgid "Bottom shell layers"
-msgstr "Bottom shell layers"
+msgstr ""
 
 msgid ""
 "This is the number of solid layers of bottom shell, including the bottom "
 "surface layer. When the thickness calculated by this value is thinner than "
 "bottom shell thickness, the bottom shell layers will be increased"
 msgstr ""
-"This is the number of solid layers of bottom shell, including the bottom "
-"surface layer. When the thickness calculated by this value is thinner than "
-"bottom shell thickness, the bottom shell layers will be increased"
 
 msgid "Bottom shell thickness"
-msgstr "Bottom shell thickness"
+msgstr ""
 
 msgid ""
 "The number of bottom solid layers is increased when slicing if the thickness "
@@ -9917,7 +9694,7 @@ msgid ""
 msgstr ""
 
 msgid "Bridge flow ratio"
-msgstr "Bridge flow ratio"
+msgstr ""
 
 msgid ""
 "Decrease this value slightly(for example 0.9) to reduce the amount of "
@@ -9941,7 +9718,7 @@ msgid ""
 msgstr ""
 
 msgid "Top surface flow ratio"
-msgstr "Top surface flow ratio"
+msgstr ""
 
 msgid ""
 "This factor affects the amount of material for top solid infill. You can "
@@ -9970,7 +9747,7 @@ msgid ""
 msgstr ""
 
 msgid "Only one wall on top surfaces"
-msgstr "Only one wall on top surfaces"
+msgstr ""
 
 msgid ""
 "Use only one wall on flat top surface, to give more space to the top infill "
@@ -9995,7 +9772,7 @@ msgid ""
 msgstr ""
 
 msgid "Only one wall on first layer"
-msgstr "Only one wall on first layer"
+msgstr ""
 
 msgid ""
 "Use only one wall on first layer, to give more space to the bottom infill "
@@ -10114,7 +9891,7 @@ msgid ""
 msgstr ""
 
 msgid "mm/s or %"
-msgstr "mm/s or %"
+msgstr ""
 
 msgid "External"
 msgstr ""
@@ -10137,26 +9914,24 @@ msgid ""
 msgstr ""
 
 msgid "Brim width"
-msgstr "Brim width"
+msgstr ""
 
 msgid "Distance from model to the outermost brim line"
 msgstr "This is the distance from the model to the outermost brim line."
 
 msgid "Brim type"
-msgstr "Brim type"
+msgstr ""
 
 msgid ""
 "This controls the generation of the brim at outer and/or inner side of "
 "models. Auto means the brim width is analyzed and calculated automatically."
 msgstr ""
-"This controls the generation of the brim at outer and/or inner side of "
-"models. Auto means the brim width is analyzed and calculated automatically."
 
 msgid "Painted"
 msgstr ""
 
 msgid "Brim-object gap"
-msgstr "Brim-object gap"
+msgstr ""
 
 msgid ""
 "A gap between innermost brim line and object can make brim be removed more "
@@ -10190,13 +9965,13 @@ msgid ""
 msgstr ""
 
 msgid "Compatible machine"
-msgstr "Compatible machine"
+msgstr ""
 
 msgid "upward compatible machine"
-msgstr "upward compatible machine"
+msgstr ""
 
 msgid "Compatible machine condition"
-msgstr "Compatible machine condition"
+msgstr ""
 
 msgid ""
 "A boolean expression using the configuration values of an active printer "
@@ -10208,10 +9983,10 @@ msgstr ""
 "compatible with the active printer profile."
 
 msgid "Compatible process profiles"
-msgstr "Compatible process profiles"
+msgstr ""
 
 msgid "Compatible process profiles condition"
-msgstr "Compatible process profiles condition"
+msgstr ""
 
 msgid ""
 "A boolean expression using the configuration values of an active print "
@@ -10228,10 +10003,10 @@ msgstr ""
 "object-by-object."
 
 msgid "By layer"
-msgstr "By layer"
+msgstr ""
 
 msgid "By object"
-msgstr "By object"
+msgstr ""
 
 msgid "Intra-layer order"
 msgstr ""
@@ -10243,7 +10018,7 @@ msgid "As object list"
 msgstr ""
 
 msgid "Slow printing down for better layer cooling"
-msgstr "Slow printing down for better layer cooling"
+msgstr ""
 
 msgid ""
 "Enable this option to slow printing speed down to make the final layer time "
@@ -10257,7 +10032,7 @@ msgstr ""
 "improve the quality for small details."
 
 msgid "Normal printing"
-msgstr "Normal printing"
+msgstr ""
 
 msgid ""
 "The default acceleration of both normal printing and travel except initial "
@@ -10267,25 +10042,25 @@ msgstr ""
 "the first layer."
 
 msgid "Default filament profile"
-msgstr "Default filament profile"
+msgstr ""
 
 msgid "Default filament profile when switch to this machine profile"
 msgstr "Default filament profile when switching to this machine profile"
 
 msgid "Default process profile"
-msgstr "Default process profile"
+msgstr ""
 
 msgid "Default process profile when switch to this machine profile"
 msgstr "Default process profile when switching to this machine profile"
 
 msgid "Activate air filtration"
-msgstr "Activate air filtration"
+msgstr ""
 
 msgid "Activate for better air filtration. G-code command: M106 P3 S(0-255)"
 msgstr ""
 
 msgid "Fan speed"
-msgstr "Fan speed"
+msgstr ""
 
 msgid ""
 "Speed of exhaust fan during printing. This speed will override the speed in "
@@ -10296,7 +10071,7 @@ msgid "Speed of exhaust fan after printing completes"
 msgstr ""
 
 msgid "No cooling for the first"
-msgstr "No cooling for the first"
+msgstr ""
 
 msgid ""
 "Close all cooling fan for the first certain layers. Cooling fan of the first "
@@ -10306,7 +10081,7 @@ msgstr ""
 "improve bed adhesion."
 
 msgid "Don't support bridges"
-msgstr "Don't support bridges"
+msgstr ""
 
 msgid ""
 "Don't support the whole bridge area which make support very large. Bridges "
@@ -10429,7 +10204,7 @@ msgid "No filtering"
 msgstr ""
 
 msgid "Max bridge length"
-msgstr "Max bridge length"
+msgstr ""
 
 msgid ""
 "Max length of bridges that don't need support. Set it to 0 if you want all "
@@ -10458,7 +10233,7 @@ msgid "End G-code when finish the printing of this filament"
 msgstr "Add end G-code when finishing the printing of this filament."
 
 msgid "Ensure vertical shell thickness"
-msgstr "Ensure vertical shell thickness"
+msgstr ""
 
 msgid ""
 "Add solid infill near sloping surfaces to guarantee the vertical shell "
@@ -10478,37 +10253,37 @@ msgid "Moderate"
 msgstr ""
 
 msgid "Top surface pattern"
-msgstr "Top surface pattern"
+msgstr ""
 
 msgid "Line pattern of top surface infill"
 msgstr "This is the line pattern for top surface infill."
 
 msgid "Concentric"
-msgstr "Concentric"
+msgstr ""
 
 msgid "Rectilinear"
-msgstr "Rectilinear"
+msgstr ""
 
 msgid "Monotonic"
-msgstr "Monotonic"
+msgstr ""
 
 msgid "Monotonic line"
-msgstr "Monotonic line"
+msgstr ""
 
 msgid "Aligned Rectilinear"
-msgstr "Aligned Rectilinear"
+msgstr ""
 
 msgid "Hilbert Curve"
-msgstr "Hilbert Curve"
+msgstr ""
 
 msgid "Archimedean Chords"
-msgstr "Archimedean Chords"
+msgstr ""
 
 msgid "Octagram Spiral"
-msgstr "Octagram Spiral"
+msgstr ""
 
 msgid "Bottom surface pattern"
-msgstr "Bottom surface pattern"
+msgstr ""
 
 msgid "Line pattern of bottom surface infill, not bridge infill"
 msgstr ""
@@ -10516,7 +10291,7 @@ msgstr ""
 "infill."
 
 msgid "Internal solid infill pattern"
-msgstr "Internal solid infill pattern"
+msgstr ""
 
 msgid ""
 "Line pattern of internal solid infill. if the detect narrow internal solid "
@@ -10536,7 +10311,7 @@ msgstr ""
 "printed slower than inner walls for higher quality."
 
 msgid "Small perimeters"
-msgstr "Small perimeters"
+msgstr ""
 
 msgid ""
 "This separate setting will affect the speed of perimeters having radius <= "
@@ -10551,7 +10326,6 @@ msgstr ""
 msgid ""
 "This sets the threshold for small perimeter length. Default threshold is 0mm"
 msgstr ""
-"This sets the threshold for small perimeter length. Default threshold is 0mm"
 
 msgid "Walls printing order"
 msgstr ""
@@ -10591,7 +10365,7 @@ msgid "Inner/Outer/Inner"
 msgstr ""
 
 msgid "Print infill first"
-msgstr "Print infill first"
+msgstr ""
 
 msgid ""
 "Order of wall/infill. When the tickbox is unchecked the walls are printed "
@@ -10625,7 +10399,7 @@ msgid "Clockwise"
 msgstr ""
 
 msgid "Height to rod"
-msgstr "Height to rod"
+msgstr ""
 
 msgid ""
 "Distance of the nozzle tip to the lower rod. Used for collision avoidance in "
@@ -10635,7 +10409,7 @@ msgstr ""
 "in by-object printing."
 
 msgid "Height to lid"
-msgstr "Height to lid"
+msgstr ""
 
 msgid ""
 "Distance of the nozzle tip to the lid. Used for collision avoidance in by-"
@@ -10652,10 +10426,10 @@ msgstr ""
 "printing."
 
 msgid "Nozzle height"
-msgstr "Nozzle height"
+msgstr ""
 
 msgid "The height of nozzle tip."
-msgstr "The height of nozzle tip."
+msgstr ""
 
 msgid "Bed mesh min"
 msgstr ""
@@ -10702,16 +10476,16 @@ msgid ""
 msgstr ""
 
 msgid "Extruder Color"
-msgstr "Extruder Color"
+msgstr ""
 
 msgid "Only used as a visual help on UI"
-msgstr "Only used as a visual help on UI"
+msgstr ""
 
 msgid "Extruder offset"
-msgstr "Extruder offset"
+msgstr ""
 
 msgid "Flow ratio"
-msgstr "Flow ratio"
+msgstr ""
 
 msgid ""
 "The material may have volumetric change after switching between molten and "
@@ -10733,7 +10507,7 @@ msgid ""
 msgstr ""
 
 msgid "Enable pressure advance"
-msgstr "Enable pressure advance"
+msgstr ""
 
 msgid ""
 "Enable pressure advance, auto calibration result will be overwritten once "
@@ -10830,7 +10604,7 @@ msgid ""
 msgstr ""
 
 msgid "Keep fan always on"
-msgstr "Keep fan always on"
+msgstr ""
 
 msgid ""
 "If enable this setting, part cooling fan will never be stopped and will run "
@@ -10857,7 +10631,7 @@ msgid ""
 msgstr ""
 
 msgid "Layer time"
-msgstr "Layer time"
+msgstr ""
 
 msgid ""
 "Part cooling fan will be enabled for layers of which estimated time is "
@@ -10869,19 +10643,19 @@ msgstr ""
 "maximum fan speeds according to layer printing time."
 
 msgid "Default color"
-msgstr "Default color"
+msgstr ""
 
 msgid "Default filament color"
-msgstr "Default filament color"
+msgstr ""
 
 msgid "Filament notes"
-msgstr "Filament notes"
+msgstr ""
 
 msgid "You can put your notes regarding the filament here."
-msgstr "You can put your notes regarding the filament here."
+msgstr ""
 
 msgid "Required nozzle HRC"
-msgstr "Required nozzle HRC"
+msgstr ""
 
 msgid ""
 "Minimum HRC of nozzle required to print the filament. Zero means no checking "
@@ -10900,10 +10674,10 @@ msgstr ""
 "high and unreasonable speed setting. This value cannot be zero."
 
 msgid "mm³/s"
-msgstr "mm³/s"
+msgstr ""
 
 msgid "Filament load time"
-msgstr "Filament load time"
+msgstr ""
 
 msgid ""
 "Time to load new filament when switch filament. It's usually applicable for "
@@ -10912,7 +10686,7 @@ msgid ""
 msgstr ""
 
 msgid "Filament unload time"
-msgstr "Filament unload time"
+msgstr ""
 
 msgid ""
 "Time to unload old filament when switch filament. It's usually applicable "
@@ -11039,7 +10813,7 @@ msgid "Cooling moves are gradually accelerating beginning at this speed."
 msgstr ""
 
 msgid "Minimal purge on wipe tower"
-msgstr "Minimal purge on wipe tower"
+msgstr ""
 
 msgid ""
 "After a tool change, the exact position of the newly loaded filament inside "
@@ -11086,19 +10860,19 @@ msgid "Flow used for ramming the filament before the tool change."
 msgstr ""
 
 msgid "Density"
-msgstr "Density"
+msgstr ""
 
 msgid "Filament density. For statistics only"
 msgstr "Filament density, for statistical purposes only."
 
 msgid "g/cm³"
-msgstr "g/cm³"
+msgstr ""
 
 msgid "The material type of filament"
 msgstr "Filament material type"
 
 msgid "Soluble material"
-msgstr "Soluble material"
+msgstr ""
 
 msgid ""
 "Soluble material is commonly used to print support and support interface"
@@ -11106,7 +10880,7 @@ msgstr ""
 "Soluble material is commonly used to print support and support interfaces"
 
 msgid "Support material"
-msgstr "Support material"
+msgstr ""
 
 msgid ""
 "Support material is commonly used to print support and support interface"
@@ -11114,7 +10888,7 @@ msgstr ""
 "Support material is commonly used to print support and support interfaces."
 
 msgid "Softening temperature"
-msgstr "Softening temperature"
+msgstr ""
 
 msgid ""
 "The material softens at this temperature, so when the bed temperature is "
@@ -11126,22 +10900,22 @@ msgstr ""
 "door and/or remove the upper glass to avoid clogs."
 
 msgid "Price"
-msgstr "Price"
+msgstr ""
 
 msgid "Filament price. For statistics only"
 msgstr "Filament price, for statistical purposes only."
 
 msgid "money/kg"
-msgstr "money/kg"
+msgstr ""
 
 msgid "Vendor"
-msgstr "Vendor"
+msgstr ""
 
 msgid "Vendor of filament. For show only"
-msgstr "Vendor of filament. For show only"
+msgstr ""
 
 msgid "(Undefined)"
-msgstr "(Undefined)"
+msgstr ""
 
 msgid "Sparse infill direction"
 msgstr ""
@@ -11168,7 +10942,7 @@ msgid "Rotate the solid infill direction by 90° for each layer."
 msgstr ""
 
 msgid "Sparse infill density"
-msgstr "Sparse infill density"
+msgstr ""
 
 #, no-c-format, no-boost-format
 msgid ""
@@ -11177,46 +10951,46 @@ msgid ""
 msgstr ""
 
 msgid "Sparse infill pattern"
-msgstr "Sparse infill pattern"
+msgstr ""
 
 msgid "Line pattern for internal sparse infill"
 msgstr "This is the line pattern for internal sparse infill."
 
 msgid "Grid"
-msgstr "Grid"
+msgstr ""
 
 msgid "2D Lattice"
 msgstr ""
 
 msgid "Line"
-msgstr "Line"
+msgstr ""
 
 msgid "Cubic"
-msgstr "Cubic"
+msgstr ""
 
 msgid "Tri-hexagon"
-msgstr "Tri-hexagon"
+msgstr ""
 
 msgid "Gyroid"
-msgstr "Gyroid"
+msgstr ""
 
 msgid "Honeycomb"
-msgstr "Honeycomb"
+msgstr ""
 
 msgid "Adaptive Cubic"
-msgstr "Adaptive Cubic"
+msgstr ""
 
 msgid "3D Honeycomb"
-msgstr "3D Honeycomb"
+msgstr ""
 
 msgid "Support Cubic"
-msgstr "Support Cubic"
+msgstr ""
 
 msgid "Lightning"
-msgstr "Lightning"
+msgstr ""
 
 msgid "Cross Hatch"
-msgstr "Cross Hatch"
+msgstr ""
 
 msgid "Quarter Cubic"
 msgstr ""
@@ -11254,10 +11028,10 @@ msgid ""
 msgstr ""
 
 msgid "0 (no open anchors)"
-msgstr "0 (no open anchors)"
+msgstr ""
 
 msgid "1000 (unlimited)"
-msgstr "1000 (unlimited)"
+msgstr ""
 
 msgid "Maximum length of the infill anchor"
 msgstr ""
@@ -11303,14 +11077,12 @@ msgid ""
 msgstr ""
 
 msgid "mm/s² or %"
-msgstr "mm/s² or %"
+msgstr ""
 
 msgid ""
 "Acceleration of sparse infill. If the value is expressed as a percentage "
 "(e.g. 100%), it will be calculated based on the default acceleration."
 msgstr ""
-"Acceleration of sparse infill. If the value is expressed as a percentage "
-"(e.g. 100%), it will be calculated based on the default acceleration."
 
 msgid ""
 "Acceleration of internal solid infill. If the value is expressed as a "
@@ -11326,13 +11098,13 @@ msgstr ""
 "acceleration can improve build plate adhesion."
 
 msgid "Enable accel_to_decel"
-msgstr "Enable accel_to_decel"
+msgstr ""
 
 msgid "Klipper's max_accel_to_decel will be adjusted automatically"
-msgstr "Klipper's max_accel_to_decel will be adjusted automatically"
+msgstr ""
 
 msgid "accel_to_decel"
-msgstr "accel_to_decel"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -11340,10 +11112,10 @@ msgid ""
 msgstr ""
 
 msgid "Jerk of outer walls"
-msgstr "Jerk of outer walls"
+msgstr ""
 
 msgid "Jerk of inner walls"
-msgstr "Jerk of inner walls"
+msgstr ""
 
 msgid "Jerk for top surface"
 msgstr ""
@@ -11404,7 +11176,7 @@ msgid "Nozzle temperature for printing initial layer when using this filament"
 msgstr "Nozzle temperature for printing the first layer with this filament"
 
 msgid "Full fan speed at layer"
-msgstr "Full fan speed at layer"
+msgstr ""
 
 msgid ""
 "Fan speed will be ramped up linearly from zero at layer "
@@ -11450,16 +11222,16 @@ msgstr ""
 "position."
 
 msgid "Contour"
-msgstr "Contour"
+msgstr ""
 
 msgid "Contour and hole"
-msgstr "Contour and hole"
+msgstr ""
 
 msgid "All walls"
-msgstr "All walls"
+msgstr ""
 
 msgid "Fuzzy skin thickness"
-msgstr "Fuzzy skin thickness"
+msgstr ""
 
 msgid ""
 "The width within which to jitter. It's advised to be below outer wall line "
@@ -11469,14 +11241,12 @@ msgstr ""
 "wall line width."
 
 msgid "Fuzzy skin point distance"
-msgstr "Fuzzy skin point distance"
+msgstr ""
 
 msgid ""
 "The average distance between the random points introduced on each line "
 "segment"
 msgstr ""
-"The average distance between the random points introduced on each line "
-"segment"
 
 msgid "Apply fuzzy skin to first layer"
 msgstr ""
@@ -11499,7 +11269,7 @@ msgid ""
 msgstr ""
 
 msgid "Classic"
-msgstr "Classic"
+msgstr ""
 
 msgid "Perlin"
 msgstr ""
@@ -11538,10 +11308,10 @@ msgid ""
 msgstr ""
 
 msgid "Filter out tiny gaps"
-msgstr "Filter out tiny gaps"
+msgstr ""
 
 msgid "Layers and Perimeters"
-msgstr "Layers and Perimeters"
+msgstr ""
 
 msgid ""
 "Don't print gap fill with a length is smaller than the threshold specified "
@@ -11557,19 +11327,16 @@ msgstr ""
 "should be printed more slowly."
 
 msgid "Precise Z height"
-msgstr "Precise Z height"
+msgstr ""
 
 msgid ""
 "Enable this to get precise z height of object after slicing. It will get the "
 "precise object height by fine-tuning the layer heights of the last few "
 "layers. Note that this is an experimental parameter."
 msgstr ""
-"Enable this to get precise z height of object after slicing. It will get the "
-"precise object height by fine-tuning the layer heights of the last few "
-"layers. Note that this is an experimental parameter."
 
 msgid "Arc fitting"
-msgstr "Arc fitting"
+msgstr ""
 
 msgid ""
 "Enable this to get a G-code file which has G2 and G3 moves. The fitting "
@@ -11583,14 +11350,14 @@ msgid ""
 msgstr ""
 
 msgid "Add line number"
-msgstr "Add line number"
+msgstr ""
 
 msgid ""
 "Enable this to add line number(Nx) at the beginning of each G-code line."
 msgstr ""
 
 msgid "Scan first layer"
-msgstr "Scan first layer"
+msgstr ""
 
 msgid ""
 "Enable this to enable the camera on printer to check the quality of first "
@@ -11600,7 +11367,7 @@ msgstr ""
 "first layer."
 
 msgid "Nozzle type"
-msgstr "Nozzle type"
+msgstr ""
 
 msgid ""
 "The metallic material of nozzle. This determines the abrasive resistance of "
@@ -11613,16 +11380,16 @@ msgid "Undefine"
 msgstr "Undefined"
 
 msgid "Hardened steel"
-msgstr "Hardened steel"
+msgstr ""
 
 msgid "Stainless steel"
-msgstr "Stainless steel"
+msgstr ""
 
 msgid "Brass"
-msgstr "Brass"
+msgstr ""
 
 msgid "Nozzle HRC"
-msgstr "Nozzle HRC"
+msgstr ""
 
 msgid ""
 "The nozzle's hardness. Zero means no checking for nozzle's hardness during "
@@ -11632,13 +11399,13 @@ msgstr ""
 "slicing."
 
 msgid "HRC"
-msgstr "HRC"
+msgstr ""
 
 msgid "Printer structure"
-msgstr "Printer structure"
+msgstr ""
 
 msgid "The physical arrangement and components of a printing device"
-msgstr "The physical arrangement and components of a printing device"
+msgstr ""
 
 msgid "CoreXY"
 msgstr ""
@@ -11653,10 +11420,10 @@ msgid "Delta"
 msgstr ""
 
 msgid "Best object position"
-msgstr "Best object position"
+msgstr ""
 
 msgid "Best auto arranging position in range [0,1] w.r.t. bed shape."
-msgstr "Best auto arranging position in range [0,1] w.r.t. bed shape."
+msgstr ""
 
 msgid ""
 "Enable this option if machine has auxiliary part cooling fan. G-code "
@@ -11710,7 +11477,7 @@ msgid ""
 msgstr ""
 
 msgid "Support air filtration"
-msgstr "Support air filtration"
+msgstr ""
 
 msgid ""
 "Enable this if printer support air filtration\n"
@@ -11749,7 +11516,7 @@ msgid ""
 msgstr ""
 
 msgid "Exclude objects"
-msgstr "Exclude objects"
+msgstr ""
 
 msgid "Enable this option to add EXCLUDE OBJECT command in G-code."
 msgstr ""
@@ -11764,7 +11531,7 @@ msgid ""
 msgstr ""
 
 msgid "Infill combination"
-msgstr "Infill combination"
+msgstr ""
 
 msgid ""
 "Automatically Combine sparse infill of several layers to print together to "
@@ -11807,6 +11574,10 @@ msgid ""
 "value to ~10-15% to minimize potential over extrusion and accumulation of "
 "material resulting in rough top surfaces."
 msgstr ""
+"This allows the infill area to be enlarged slightly to overlap with walls "
+"for better bonding. The percentage value is relative to line width of "
+"sparse infill. Set this value to ~10-15% to minimize potential over "
+"extrusion and accumulation of material resulting in rough top surfaces."
 
 msgid "Top/Bottom solid infill/wall overlap"
 msgstr ""
@@ -11830,26 +11601,23 @@ msgid "Name of parent profile"
 msgstr ""
 
 msgid "Interface shells"
-msgstr "Interface shells"
+msgstr ""
 
 msgid ""
 "Force the generation of solid shells between adjacent materials/volumes. "
 "Useful for multi-extruder prints with translucent materials or manual "
 "soluble support material"
 msgstr ""
-"Force the generation of solid shells between adjacent materials/volumes. "
-"Useful for multi-extruder prints with translucent materials or manual "
-"soluble support material"
 
 msgid "Maximum width of a segmented region"
-msgstr "Maximum width of a segmented region"
+msgstr ""
 
 msgid "Maximum width of a segmented region. Zero disables this feature."
 msgstr ""
 "Maximum width of a segmented region. A value of 0 disables this feature."
 
 msgid "Interlocking depth of a segmented region"
-msgstr "Interlocking depth of a segmented region"
+msgstr ""
 
 msgid ""
 "Interlocking depth of a segmented region. It will be ignored if "
@@ -11914,7 +11682,7 @@ msgstr ""
 "flat surfaces smoother. This setting controls which layers are being ironed."
 
 msgid "No ironing"
-msgstr "No ironing"
+msgstr ""
 
 msgid "Top surfaces"
 msgstr "All top surfaces"
@@ -11926,13 +11694,13 @@ msgid "All solid layer"
 msgstr "All solid layers"
 
 msgid "Ironing Pattern"
-msgstr "Ironing Pattern"
+msgstr ""
 
 msgid "The pattern that will be used when ironing"
 msgstr ""
 
 msgid "Ironing flow"
-msgstr "Ironing flow"
+msgstr ""
 
 msgid ""
 "The amount of material to extrude during ironing. Relative to flow of normal "
@@ -11943,7 +11711,7 @@ msgstr ""
 "overextrusion on the surface."
 
 msgid "Ironing line spacing"
-msgstr "Ironing line spacing"
+msgstr ""
 
 msgid "The distance between the lines of ironing"
 msgstr "This is the distance between the lines used for ironing."
@@ -11957,7 +11725,7 @@ msgid ""
 msgstr ""
 
 msgid "Ironing speed"
-msgstr "Ironing speed"
+msgstr ""
 
 msgid "Print speed of ironing lines"
 msgstr "This is the print speed for ironing lines."
@@ -11987,7 +11755,7 @@ msgid "Emit limits to G-code"
 msgstr ""
 
 msgid "Machine limits"
-msgstr "Machine limits"
+msgstr ""
 
 msgid ""
 "If enabled, the machine limits will be emitted to G-code file.\n"
@@ -12019,103 +11787,103 @@ msgid ""
 msgstr ""
 
 msgid "Maximum speed X"
-msgstr "Maximum speed X"
+msgstr ""
 
 msgid "Maximum speed Y"
-msgstr "Maximum speed Y"
+msgstr ""
 
 msgid "Maximum speed Z"
-msgstr "Maximum speed Z"
+msgstr ""
 
 msgid "Maximum speed E"
-msgstr "Maximum speed E"
+msgstr ""
 
 msgid "Maximum X speed"
-msgstr "Maximum X speed"
+msgstr ""
 
 msgid "Maximum Y speed"
-msgstr "Maximum Y speed"
+msgstr ""
 
 msgid "Maximum Z speed"
-msgstr "Maximum Z speed"
+msgstr ""
 
 msgid "Maximum E speed"
-msgstr "Maximum E speed"
+msgstr ""
 
 msgid "Maximum acceleration X"
-msgstr "Maximum acceleration X"
+msgstr ""
 
 msgid "Maximum acceleration Y"
-msgstr "Maximum acceleration Y"
+msgstr ""
 
 msgid "Maximum acceleration Z"
-msgstr "Maximum acceleration Z"
+msgstr ""
 
 msgid "Maximum acceleration E"
-msgstr "Maximum acceleration E"
+msgstr ""
 
 msgid "Maximum acceleration of the X axis"
-msgstr "Maximum acceleration of the X axis"
+msgstr ""
 
 msgid "Maximum acceleration of the Y axis"
-msgstr "Maximum acceleration of the Y axis"
+msgstr ""
 
 msgid "Maximum acceleration of the Z axis"
-msgstr "Maximum acceleration of the Z axis"
+msgstr ""
 
 msgid "Maximum acceleration of the E axis"
-msgstr "Maximum acceleration of the E axis"
+msgstr ""
 
 msgid "Maximum jerk X"
-msgstr "Maximum jerk X"
+msgstr ""
 
 msgid "Maximum jerk Y"
-msgstr "Maximum jerk Y"
+msgstr ""
 
 msgid "Maximum jerk Z"
-msgstr "Maximum jerk Z"
+msgstr ""
 
 msgid "Maximum jerk E"
-msgstr "Maximum jerk E"
+msgstr ""
 
 msgid "Maximum jerk of the X axis"
-msgstr "Maximum jerk of the X axis"
+msgstr ""
 
 msgid "Maximum jerk of the Y axis"
-msgstr "Maximum jerk of the Y axis"
+msgstr ""
 
 msgid "Maximum jerk of the Z axis"
-msgstr "Maximum jerk of the Z axis"
+msgstr ""
 
 msgid "Maximum jerk of the E axis"
-msgstr "Maximum jerk of the E axis"
+msgstr ""
 
 msgid "Minimum speed for extruding"
-msgstr "Minimum speed for extruding"
+msgstr ""
 
 msgid "Minimum speed for extruding (M205 S)"
-msgstr "Minimum speed for extruding (M205 S)"
+msgstr ""
 
 msgid "Minimum travel speed"
-msgstr "Minimum travel speed"
+msgstr ""
 
 msgid "Minimum travel speed (M205 T)"
-msgstr "Minimum travel speed (M205 T)"
+msgstr ""
 
 msgid "Maximum acceleration for extruding"
-msgstr "Maximum acceleration for extruding"
+msgstr ""
 
 msgid "Maximum acceleration for extruding (M204 P)"
-msgstr "Maximum acceleration for extruding (M204 P)"
+msgstr ""
 
 msgid "Maximum acceleration for retracting"
-msgstr "Maximum acceleration for retracting"
+msgstr ""
 
 msgid "Maximum acceleration for retracting (M204 R)"
-msgstr "Maximum acceleration for retracting (M204 R)"
+msgstr ""
 
 msgid "Maximum acceleration for travel"
-msgstr "Maximum acceleration for travel"
+msgstr ""
 
 msgid "Maximum acceleration for travel (M204 T), it only applies to Marlin 2"
 msgstr ""
@@ -12128,7 +11896,7 @@ msgstr ""
 "This is the maximum speed for the part cooling fan."
 
 msgid "Max"
-msgstr "Max"
+msgstr ""
 
 msgid ""
 "The largest printable layer height for extruder. Used tp limits the maximum "
@@ -12156,8 +11924,8 @@ msgid ""
 "Voron) this value is usually not needed. However it can provide some "
 "marginal benefit in certain cases where feature speeds vary greatly. For "
 "example, when there are aggressive slowdowns due to overhangs. In these "
-"cases a high value of around 300-350mm3/s2 is recommended as this allows for "
-"just enough smoothing to assist pressure advance achieve a smoother flow "
+"cases a high value of around 300-350mm3/s2 is recommended as this allows "
+"for just enough smoothing to assist pressure advance achieve a smoother flow "
 "transition.\n"
 "\n"
 "For slower printers without pressure advance, the value should be set much "
@@ -12197,7 +11965,7 @@ msgid ""
 msgstr ""
 
 msgid "Minimum speed for part cooling fan"
-msgstr "Minimum speed for part cooling fan"
+msgstr ""
 
 msgid ""
 "Speed of auxiliary part cooling fan. Auxiliary fan will run at this speed "
@@ -12208,7 +11976,7 @@ msgid ""
 msgstr ""
 
 msgid "Min"
-msgstr "Min"
+msgstr ""
 
 msgid ""
 "The lowest printable layer height for extruder. Used tp limits the minimum "
@@ -12218,7 +11986,7 @@ msgstr ""
 "the minimum layer height when adaptive layer height is enabled."
 
 msgid "Min print speed"
-msgstr "Min print speed"
+msgstr ""
 
 msgid ""
 "The minimum print speed to which the printer slows down to maintain the "
@@ -12238,7 +12006,7 @@ msgid ""
 msgstr ""
 
 msgid "Host Type"
-msgstr "Host Type"
+msgstr ""
 
 msgid ""
 "Orca Slicer can upload G-code files to a printer host. This field must "
@@ -12246,7 +12014,7 @@ msgid ""
 msgstr ""
 
 msgid "Nozzle volume"
-msgstr "Nozzle volume"
+msgstr ""
 
 msgid "Volume of nozzle between the cutter and the end of nozzle"
 msgstr "Volume of nozzle between the filament cutter and the end of the nozzle"
@@ -12295,14 +12063,14 @@ msgstr ""
 "than unloading."
 
 msgid "Start end points"
-msgstr "Start end points"
+msgstr ""
 
 msgid "The start and end points which is from cutter area to garbage can."
 msgstr ""
 "The start and end points which are from the cutter area to the excess chute."
 
 msgid "Reduce infill retraction"
-msgstr "Reduce infill retraction"
+msgstr ""
 
 msgid ""
 "Don't retract when the travel is in infill area absolutely. That means the "
@@ -12319,7 +12087,7 @@ msgid ""
 msgstr ""
 
 msgid "Filename format"
-msgstr "Filename format"
+msgstr ""
 
 msgid "User can self-define the project file name when export"
 msgstr "Users can decide project file names when exporting."
@@ -12350,7 +12118,7 @@ msgstr ""
 "conical material. A value of 0 will fill all the holes in the model base."
 
 msgid "mm²"
-msgstr "mm²"
+msgstr ""
 
 msgid "Detect overhang wall"
 msgstr "Detect overhang walls"
@@ -12406,16 +12174,16 @@ msgid "Type of the printer"
 msgstr ""
 
 msgid "Printer notes"
-msgstr "Printer notes"
+msgstr ""
 
 msgid "You can put your notes regarding the printer here."
-msgstr "You can put your notes regarding the printer here."
+msgstr ""
 
 msgid "Printer variant"
 msgstr ""
 
 msgid "Raft contact Z distance"
-msgstr "Raft contact Z distance"
+msgstr ""
 
 msgid "Z gap between object and raft. Ignored for soluble interface"
 msgstr ""
@@ -12423,7 +12191,7 @@ msgstr ""
 "interfaces."
 
 msgid "Raft expansion"
-msgstr "Raft expansion"
+msgstr ""
 
 msgid "Expand all raft layers in XY plane"
 msgstr "This expands all raft layers in XY plane."
@@ -12441,7 +12209,7 @@ msgid "Expand the first raft or support layer to improve bed plate adhesion"
 msgstr "This expands the first raft or support layer to improve bed adhesion."
 
 msgid "Raft layers"
-msgstr "Raft layers"
+msgstr ""
 
 msgid ""
 "Object will be raised by this number of support layers. Use this function to "
@@ -12460,7 +12228,7 @@ msgstr ""
 "resolution and more time required to slice."
 
 msgid "Travel distance threshold"
-msgstr "Travel distance threshold"
+msgstr ""
 
 msgid ""
 "Only trigger retraction when the travel distance is longer than this "
@@ -12470,7 +12238,7 @@ msgstr ""
 "threshold."
 
 msgid "Retract amount before wipe"
-msgstr "Retract amount before wipe"
+msgstr ""
 
 msgid ""
 "The length of fast retraction before wipe, relative to retraction length"
@@ -12493,7 +12261,7 @@ msgid ""
 msgstr ""
 
 msgid "Retraction Length"
-msgstr "Retraction Length"
+msgstr ""
 
 msgid ""
 "Some amount of material in extruder is pulled back to avoid ooze during long "
@@ -12517,7 +12285,7 @@ msgstr ""
 "problems."
 
 msgid "Retraction distance when cut"
-msgstr "Retraction distance when cut"
+msgstr ""
 
 msgid ""
 "Experimental feature.Retraction length before cutting off during filament "
@@ -12559,10 +12327,10 @@ msgid "Z-hop type"
 msgstr ""
 
 msgid "Slope"
-msgstr "Slope"
+msgstr ""
 
 msgid "Spiral"
-msgstr "Spiral"
+msgstr ""
 
 msgid "Traveling angle"
 msgstr ""
@@ -12609,7 +12377,7 @@ msgid "Top and Bottom"
 msgstr ""
 
 msgid "Extra length on restart"
-msgstr "Extra length on restart"
+msgstr ""
 
 msgid ""
 "When the retraction is compensated after the travel move, the extruder will "
@@ -12638,7 +12406,7 @@ msgstr ""
 "setting this to 0 means that it will be the same speed as the retraction."
 
 msgid "Use firmware retraction"
-msgstr "Use firmware retraction"
+msgstr ""
 
 msgid ""
 "This experimental setting uses G10 and G11 commands to have the firmware "
@@ -12656,22 +12424,22 @@ msgid ""
 msgstr ""
 
 msgid "Seam position"
-msgstr "Seam position"
+msgstr ""
 
 msgid "The start position to print each part of outer wall"
 msgstr "This is the starting position for each part of the outer wall."
 
 msgid "Nearest"
-msgstr "Nearest"
+msgstr ""
 
 msgid "Aligned"
-msgstr "Aligned"
+msgstr ""
 
 msgid "Back"
-msgstr "Back"
+msgstr ""
 
 msgid "Random"
-msgstr "Random"
+msgstr ""
 
 msgid "Staggered inner seams"
 msgstr ""
@@ -12682,7 +12450,7 @@ msgid ""
 msgstr ""
 
 msgid "Seam gap"
-msgstr "Seam gap"
+msgstr ""
 
 msgid ""
 "In order to reduce the visibility of the seam in a closed loop extrusion, "
@@ -12696,20 +12464,17 @@ msgstr ""
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
 msgstr ""
-"Use scarf joint to minimize seam visibility and increase seam strength."
 
 msgid "Conditional scarf joint"
-msgstr "Conditional scarf joint"
+msgstr ""
 
 msgid ""
 "Apply scarf joints only to smooth perimeters where traditional seams do not "
 "conceal the seams at sharp corners effectively."
 msgstr ""
-"Apply scarf joints only to smooth perimeters where traditional seams do not "
-"conceal the seams at sharp corners effectively."
 
 msgid "Conditional angle threshold"
-msgstr "Conditional angle threshold"
+msgstr ""
 
 msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint "
@@ -12752,44 +12517,39 @@ msgid "This factor affects the amount of material for scarf joints."
 msgstr ""
 
 msgid "Scarf start height"
-msgstr "Scarf start height"
+msgstr ""
 
 msgid ""
 "Start height of the scarf.\n"
 "This amount can be specified in millimeters or as a percentage of the "
 "current layer height. The default value for this parameter is 0."
 msgstr ""
-"Start height of the scarf.\n"
-"This amount can be specified in millimeters or as a percentage of the "
-"current layer height. The default value for this parameter is 0."
 
 msgid "Scarf around entire wall"
-msgstr "Scarf around entire wall"
+msgstr ""
 
 msgid "The scarf extends to the entire length of the wall."
-msgstr "The scarf extends to the entire length of the wall."
+msgstr ""
 
 msgid "Scarf length"
-msgstr "Scarf length"
+msgstr ""
 
 msgid ""
 "Length of the scarf. Setting this parameter to zero effectively disables the "
 "scarf."
 msgstr ""
-"Length of the scarf. Setting this parameter to zero effectively disables the "
-"scarf."
 
 msgid "Scarf steps"
-msgstr "Scarf steps"
+msgstr ""
 
 msgid "Minimum number of segments of each scarf."
-msgstr "Minimum number of segments of each scarf."
+msgstr ""
 
 msgid "Scarf joint for inner walls"
-msgstr "Scarf joint for inner walls"
+msgstr ""
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "Use scarf joint for inner walls as well."
+msgstr ""
 
 msgid "Role base wipe speed"
 msgstr ""
@@ -12824,7 +12584,7 @@ msgid ""
 msgstr ""
 
 msgid "Wipe speed"
-msgstr "Wipe speed"
+msgstr ""
 
 msgid ""
 "The wipe speed is determined by the speed setting specified in this "
@@ -12838,7 +12598,7 @@ msgstr ""
 "this parameter is 80%"
 
 msgid "Skirt distance"
-msgstr "Skirt distance"
+msgstr ""
 
 msgid "Distance from skirt to brim or object"
 msgstr "This is the distance from the skirt to the brim or the object."
@@ -12852,7 +12612,7 @@ msgid ""
 msgstr ""
 
 msgid "Skirt height"
-msgstr "Skirt height"
+msgstr ""
 
 msgid "How many layers of skirt. Usually only one layer"
 msgstr "Number of skirt layers: usually only one"
@@ -12899,7 +12659,7 @@ msgid "Per object"
 msgstr ""
 
 msgid "Skirt loops"
-msgstr "Skirt loops"
+msgstr ""
 
 msgid "Number of loops for the skirt. Zero means disabling skirt"
 msgstr ""
@@ -12931,7 +12691,7 @@ msgid ""
 msgstr ""
 
 msgid "Minimum sparse infill threshold"
-msgstr "Minimum sparse infill threshold"
+msgstr ""
 
 msgid ""
 "Sparse infill area which is smaller than threshold value is replaced by "
@@ -12966,25 +12726,21 @@ msgstr ""
 "The final generated model has no seam."
 
 msgid "Smooth Spiral"
-msgstr "Smooth Spiral"
+msgstr ""
 
 msgid ""
 "Smooth Spiral smooths out X and Y moves as well, resulting in no visible "
 "seam at all, even in the XY directions on walls that are not vertical"
 msgstr ""
-"Smooth Spiral smooths out X and Y moves as well, resulting in no visible "
-"seam at all, even in the XY directions on walls that are not vertical"
 
 msgid "Max XY Smoothing"
-msgstr "Max XY Smoothing"
+msgstr ""
 
 #, no-c-format, no-boost-format
 msgid ""
 "Maximum distance to move points in XY to try to achieve a smooth spiral. If "
 "expressed as a %, it will be computed over nozzle diameter"
 msgstr ""
-"Maximum distance to move points in XY to try to achieve a smooth spiral. If "
-"expressed as a %, it will be computed over nozzle diameter"
 
 msgid "Spiral starting flow ratio"
 msgstr ""
@@ -13014,8 +12770,8 @@ msgid ""
 "timelapse video when printing completes. If smooth mode is selected, the "
 "toolhead will move to the excess chute after each layer is printed and then "
 "take a snapshot. Since the melt filament may leak from the nozzle during the "
-"process of taking a snapshot, prime tower is required for smooth mode to "
-"wipe nozzle."
+"process of taking a snapshot, prime tower is required for smooth mode to wipe "
+"nozzle."
 msgstr ""
 "If smooth or traditional mode is selected, a timelapse video will be "
 "generated for each print. After each layer is printed, a snapshot is taken "
@@ -13027,10 +12783,10 @@ msgstr ""
 "wipe the nozzle."
 
 msgid "Traditional"
-msgstr "Traditional"
+msgstr ""
 
 msgid "Temperature variation"
-msgstr "Temperature variation"
+msgstr ""
 
 #. TRN PrintSettings : "Ooze prevention" > "Temperature variation"
 msgid ""
@@ -13111,35 +12867,30 @@ msgid ""
 msgstr ""
 
 msgid "Slice gap closing radius"
-msgstr "Slice gap closing radius"
+msgstr ""
 
 msgid ""
 "Cracks smaller than 2x gap closing radius are being filled during the "
 "triangle mesh slicing. The gap closing operation may reduce the final print "
 "resolution, therefore it is advisable to keep the value reasonably low."
 msgstr ""
-"Cracks smaller than 2x gap closing radius are being filled during the "
-"triangle mesh slicing. The gap closing operation may reduce the final print "
-"resolution, therefore it is advisable to keep the value reasonably low."
 
 msgid "Slicing Mode"
-msgstr "Slicing Mode"
+msgstr ""
 
 msgid ""
 "Use \"Even-odd\" for 3DLabPrint airplane models. Use \"Close holes\" to "
 "close all holes in the model."
 msgstr ""
-"Use \"Even-odd\" for 3DLabPrint airplane models. Use \"Close holes\" to "
-"close all holes in the model."
 
 msgid "Regular"
-msgstr "Regular"
+msgstr ""
 
 msgid "Even-odd"
-msgstr "Even-odd"
+msgstr ""
 
 msgid "Close holes"
-msgstr "Close holes"
+msgstr ""
 
 msgid "Z offset"
 msgstr ""
@@ -13152,7 +12903,7 @@ msgid ""
 msgstr ""
 
 msgid "Enable support"
-msgstr "Enable support"
+msgstr ""
 
 msgid "Enable support generation."
 msgstr "This enables support generation."
@@ -13162,6 +12913,9 @@ msgid ""
 "Normal (manual) or Tree (manual) is selected, only support enforcers are "
 "generated"
 msgstr ""
+"Normal(auto) and Tree(auto) are used to generate support automatically. If "
+"Normal(manual) or Tree(manual) is selected, only support enforcers are "
+"generated"
 
 msgid "Normal (auto)"
 msgstr "Normal(auto)"
@@ -13176,60 +12930,57 @@ msgid "Tree (manual)"
 msgstr "Tree(manual)"
 
 msgid "Support/object xy distance"
-msgstr "Support/object xy distance"
+msgstr ""
 
 msgid "XY separation between an object and its support"
 msgstr "This controls the XY separation between an object and its support."
 
 msgid "Support/object first layer gap"
-msgstr "Support/object first layer gap"
+msgstr ""
 
 msgid "XY separation between an object and its support at the first layer."
-msgstr "XY separation between an object and its support at the first layer."
+msgstr ""
 
 msgid "Pattern angle"
-msgstr "Pattern angle"
+msgstr ""
 
 msgid "Use this setting to rotate the support pattern on the horizontal plane."
 msgstr ""
-"Use this setting to rotate the support pattern on the horizontal plane."
 
 msgid "On build plate only"
-msgstr "On build plate only"
+msgstr ""
 
 msgid "Don't create support on model surface, only on build plate"
 msgstr "This setting only generates supports that begin on the build plate."
 
 msgid "Support critical regions only"
-msgstr "Support critical regions only"
+msgstr ""
 
 msgid ""
 "Only create support for critical regions including sharp tail, cantilever, "
 "etc."
 msgstr ""
-"Only create support for critical regions including sharp tail, cantilever, "
-"etc."
 
 msgid "Remove small overhangs"
-msgstr "Remove small overhangs"
+msgstr ""
 
 msgid "Remove small overhangs that possibly need no supports."
-msgstr "Remove small overhangs that possibly need no supports."
+msgstr ""
 
 msgid "Top Z distance"
-msgstr "Top Z distance"
+msgstr ""
 
 msgid "The z gap between the top support interface and object"
 msgstr "This determines the Z gap between top support interfaces and objects."
 
 msgid "Bottom Z distance"
-msgstr "Bottom Z distance"
+msgstr ""
 
 msgid "The z gap between the bottom support interface and object"
-msgstr "The z gap between the bottom support interface and object"
+msgstr ""
 
 msgid "Support/raft base"
-msgstr "Support/raft base"
+msgstr ""
 
 msgid ""
 "Filament to print support base and raft. \"Default\" means no specific "
@@ -13239,12 +12990,11 @@ msgstr ""
 "filament for support, and current filament is used"
 
 msgid "Avoid interface filament for base"
-msgstr "Avoid interface filament for base"
+msgstr ""
 
 msgid ""
 "Avoid using support interface filament to print support base if possible."
 msgstr ""
-"Avoid using support interface filament to print support base if possible."
 
 msgid ""
 "Line width of support. If expressed as a %, it will be computed over the "
@@ -13261,7 +13011,7 @@ msgstr ""
 "by default."
 
 msgid "Support/raft interface"
-msgstr "Support/raft interface"
+msgstr ""
 
 msgid ""
 "Filament to print support interface. \"Default\" means no specific filament "
@@ -13271,28 +13021,28 @@ msgstr ""
 "for support interface, and current filament is used"
 
 msgid "Top interface layers"
-msgstr "Top interface layers"
+msgstr ""
 
 msgid "Number of top interface layers"
 msgstr "This is the number of top interface layers."
 
 msgid "Bottom interface layers"
-msgstr "Bottom interface layers"
+msgstr ""
 
 msgid "Number of bottom interface layers"
-msgstr "Number of bottom interface layers"
+msgstr ""
 
 msgid "Same as top"
-msgstr "Same as top"
+msgstr ""
 
 msgid "Top interface spacing"
-msgstr "Top interface spacing"
+msgstr ""
 
 msgid "Spacing of interface lines. Zero means solid interface"
 msgstr "This is the spacing of interface lines. 0 means solid interface."
 
 msgid "Bottom interface spacing"
-msgstr "Bottom interface spacing"
+msgstr ""
 
 msgid "Spacing of bottom interface lines. Zero means solid interface"
 msgstr ""
@@ -13302,19 +13052,19 @@ msgid "Speed of support interface"
 msgstr "This is the speed for support interfaces."
 
 msgid "Base pattern"
-msgstr "Base pattern"
+msgstr ""
 
 msgid "Line pattern of support"
 msgstr "This is the line pattern for support."
 
 msgid "Rectilinear grid"
-msgstr "Rectilinear grid"
+msgstr ""
 
 msgid "Hollow"
-msgstr "Hollow"
+msgstr ""
 
 msgid "Interface pattern"
-msgstr "Interface pattern"
+msgstr ""
 
 msgid ""
 "Line pattern of support interface. Default pattern for non-soluble support "
@@ -13326,10 +13076,10 @@ msgstr ""
 "soluble support interfaces is Concentric."
 
 msgid "Rectilinear Interlaced"
-msgstr "Rectilinear Interlaced"
+msgstr ""
 
 msgid "Base pattern spacing"
-msgstr "Base pattern spacing"
+msgstr ""
 
 msgid "Spacing between support lines"
 msgstr "This determines the spacing between support lines."
@@ -13338,7 +13088,7 @@ msgid "Normal Support expansion"
 msgstr "Normal support expansion"
 
 msgid "Expand (+) or shrink (-) the horizontal span of normal support"
-msgstr "Expand (+) or shrink (-) the horizontal span of normal support"
+msgstr ""
 
 msgid "Speed of support"
 msgstr "This is the speed for support."
@@ -13357,22 +13107,22 @@ msgid "Default (Grid/Organic)"
 msgstr ""
 
 msgid "Snug"
-msgstr "Snug"
+msgstr ""
 
 msgid "Organic"
 msgstr ""
 
 msgid "Tree Slim"
-msgstr "Tree Slim"
+msgstr ""
 
 msgid "Tree Strong"
-msgstr "Tree Strong"
+msgstr ""
 
 msgid "Tree Hybrid"
-msgstr "Tree Hybrid"
+msgstr ""
 
 msgid "Independent support layer height"
-msgstr "Independent support layer height"
+msgstr ""
 
 msgid ""
 "Support layer uses layer height independent with object layer. This is to "
@@ -13384,7 +13134,7 @@ msgstr ""
 "when the prime tower is enabled."
 
 msgid "Threshold angle"
-msgstr "Threshold angle"
+msgstr ""
 
 msgid ""
 "Support will be generated for overhangs whose slope angle is below the "
@@ -13403,7 +13153,7 @@ msgid ""
 msgstr ""
 
 msgid "Tree support branch angle"
-msgstr "Tree support branch angle"
+msgstr ""
 
 msgid ""
 "This setting determines the maximum overhang angle that t he branches of "
@@ -13425,12 +13175,11 @@ msgid ""
 msgstr ""
 
 msgid "Tree support branch distance"
-msgstr "Tree support branch distance"
+msgstr ""
 
 msgid ""
 "This setting determines the distance between neighboring tree support nodes."
 msgstr ""
-"This setting determines the distance between neighboring tree support nodes."
 
 msgid "Branch Density"
 msgstr ""
@@ -13445,7 +13194,7 @@ msgid ""
 msgstr ""
 
 msgid "Adaptive layer height"
-msgstr "Adaptive layer height"
+msgstr ""
 
 msgid ""
 "Enabling this option means the height of  tree support layer except the "
@@ -13461,7 +13210,7 @@ msgid ""
 msgstr ""
 
 msgid "Tree support brim width"
-msgstr "Tree support brim width"
+msgstr ""
 
 msgid "Distance from tree branch to the outermost brim line"
 msgstr ""
@@ -13474,10 +13223,10 @@ msgid "Branch tip diameter for organic supports."
 msgstr ""
 
 msgid "Tree support branch diameter"
-msgstr "Tree support branch diameter"
+msgstr ""
 
 msgid "This setting determines the initial diameter of support nodes."
-msgstr "This setting determines the initial diameter of support nodes."
+msgstr ""
 
 #. TRN PrintSettings: #lmFIXME
 msgid "Branch Diameter Angle"
@@ -13492,7 +13241,7 @@ msgid ""
 msgstr ""
 
 msgid "Support wall loops"
-msgstr "Support wall loops"
+msgstr ""
 
 msgid ""
 "This setting specifies the count of support walls in the range of [0,2]. 0 "
@@ -13500,7 +13249,7 @@ msgid ""
 msgstr ""
 
 msgid "Tree support with infill"
-msgstr "Tree support with infill"
+msgstr ""
 
 msgid ""
 "This setting specifies whether to add infill inside large hollows of tree "
@@ -13526,7 +13275,7 @@ msgid ""
 msgstr ""
 
 msgid "Chamber temperature"
-msgstr "Chamber temperature"
+msgstr ""
 
 msgid ""
 "For high-temperature materials like ABS, ASA, PC, and PA, a higher chamber "
@@ -13578,7 +13327,7 @@ msgid "Speed of top surface infill which is solid"
 msgstr "This is the speed for solid top surface infill."
 
 msgid "Top shell layers"
-msgstr "Top shell layers"
+msgstr ""
 
 msgid ""
 "This is the number of solid layers of top shell, including the top surface "
@@ -13590,10 +13339,10 @@ msgstr ""
 "shell thickness, the top shell layers will be increased"
 
 msgid "Top solid layers"
-msgstr "Top solid layers"
+msgstr ""
 
 msgid "Top shell thickness"
-msgstr "Top shell thickness"
+msgstr ""
 
 msgid ""
 "The number of top solid layers is increased when slicing if the thickness "
@@ -13612,7 +13361,7 @@ msgid "Speed of travel which is faster and without extrusion"
 msgstr "This is the speed at which traveling is done."
 
 msgid "Wipe while retracting"
-msgstr "Wipe while retracting"
+msgstr ""
 
 msgid ""
 "Move nozzle along the last extrusion path when retracting to clean any "
@@ -13648,10 +13397,10 @@ msgstr ""
 "when printing objects."
 
 msgid "Purging volumes"
-msgstr "Purging volumes"
+msgstr ""
 
 msgid "Flush multiplier"
-msgstr "Flush multiplier"
+msgstr ""
 
 msgid ""
 "The actual flushing volumes is equal to the flush multiplier multiplied by "
@@ -13661,7 +13410,7 @@ msgstr ""
 "multiplied by the flushing volumes in the table."
 
 msgid "Prime volume"
-msgstr "Prime volume"
+msgstr ""
 
 msgid "The volume of material to prime extruder on tower."
 msgstr ""
@@ -13783,7 +13532,7 @@ msgstr ""
 "Set to 0 to disable."
 
 msgid "X-Y hole compensation"
-msgstr "X-Y hole compensation"
+msgstr ""
 
 msgid ""
 "Holes of object will be grown or shrunk in XY plane by the configured value. "
@@ -13796,7 +13545,7 @@ msgstr ""
 "issues."
 
 msgid "X-Y contour compensation"
-msgstr "X-Y contour compensation"
+msgstr ""
 
 msgid ""
 "Contour of object will be grown or shrunk in XY plane by the configured "
@@ -13854,7 +13603,7 @@ msgid ""
 msgstr ""
 
 msgid "Use relative E distances"
-msgstr "Use relative E distances"
+msgstr ""
 
 msgid ""
 "Relative extrusion is recommended when using \"label_objects\" option.Some "
@@ -13877,10 +13626,10 @@ msgstr ""
 "with variable extrusion width."
 
 msgid "Arachne"
-msgstr "Arachne"
+msgstr ""
 
 msgid "Wall transition length"
-msgstr "Wall transition length"
+msgstr ""
 
 msgid ""
 "When transitioning between different numbers of walls as the part becomes "
@@ -13892,7 +13641,7 @@ msgstr ""
 "segments. It's expressed as a percentage over nozzle diameter."
 
 msgid "Wall transitioning filter margin"
-msgstr "Wall transitioning filter margin"
+msgstr ""
 
 msgid ""
 "Prevent transitioning back and forth between one extra wall and one less. "
@@ -13903,16 +13652,9 @@ msgid ""
 "variation can lead to under- or overextrusion problems. It's expressed as a "
 "percentage over nozzle diameter"
 msgstr ""
-"Prevent transitioning back and forth between one extra wall and one less. "
-"This margin extends the range of extrusion widths which follow to [Minimum "
-"wall width - margin, 2 * Minimum wall width + margin]. Increasing this "
-"margin reduces the number of transitions, which reduces the number of "
-"extrusion starts/stops and travel time. However, large extrusion width "
-"variation can lead to under- or overextrusion problems. It's expressed as a "
-"percentage over nozzle diameter"
 
 msgid "Wall transitioning threshold angle"
-msgstr "Wall transitioning threshold angle"
+msgstr ""
 
 msgid ""
 "When to create transitions between even and odd numbers of walls. A wedge "
@@ -13921,24 +13663,17 @@ msgid ""
 "this setting reduces the number and length of these center walls, but may "
 "leave gaps or overextrude"
 msgstr ""
-"When to create transitions between even and odd numbers of walls. A wedge "
-"shape with an angle greater than this setting will not have transitions and "
-"no walls will be printed in the center to fill the remaining space. Reducing "
-"this setting reduces the number and length of these center walls, but may "
-"leave gaps or overextrude"
 
 msgid "Wall distribution count"
-msgstr "Wall distribution count"
+msgstr ""
 
 msgid ""
 "The number of walls, counted from the center, over which the variation needs "
 "to be spread. Lower values mean that the outer walls don't change in width"
 msgstr ""
-"The number of walls, counted from the center, over which the variation needs "
-"to be spread. Lower values mean that the outer walls don't change in width"
 
 msgid "Minimum feature size"
-msgstr "Minimum feature size"
+msgstr ""
 
 msgid ""
 "Minimum thickness of thin features. Model features that are thinner than "
@@ -13975,7 +13710,7 @@ msgid ""
 msgstr ""
 
 msgid "Minimum wall width"
-msgstr "Minimum wall width"
+msgstr ""
 
 msgid ""
 "Width of the wall that will replace thin features (according to the Minimum "
@@ -13983,13 +13718,9 @@ msgid ""
 "thickness of the feature, the wall will become as thick as the feature "
 "itself. It's expressed as a percentage over nozzle diameter"
 msgstr ""
-"Width of the wall that will replace thin features (according to the Minimum "
-"feature size) of the model. If the Minimum wall width is thinner than the "
-"thickness of the feature, the wall will become as thick as the feature "
-"itself. It's expressed as a percentage over nozzle diameter"
 
 msgid "Detect narrow internal solid infill"
-msgstr "Detect narrow internal solid infill"
+msgstr ""
 
 msgid ""
 "This option will auto-detect narrow internal solid infill areas. If enabled, "
@@ -14001,16 +13732,16 @@ msgstr ""
 "Otherwise, the rectilinear pattern will be used by default."
 
 msgid "invalid value "
-msgstr "invalid value "
+msgstr ""
 
 msgid "Invalid value when spiral vase mode is enabled: "
-msgstr "Invalid value when spiral vase mode is enabled: "
+msgstr ""
 
 msgid "too large line width "
-msgstr "too large line width "
+msgstr ""
 
 msgid " not in range "
-msgstr " not in range "
+msgstr ""
 
 msgid "Export 3MF"
 msgstr "Export 3mf"
@@ -14019,19 +13750,19 @@ msgid "Export project as 3MF."
 msgstr "This exports the project as a 3mf file."
 
 msgid "Export slicing data"
-msgstr "Export slicing data"
+msgstr ""
 
 msgid "Export slicing data to a folder."
 msgstr "Export slicing data to a folder"
 
 msgid "Load slicing data"
-msgstr "Load slicing data"
+msgstr ""
 
 msgid "Load cached slicing data from directory"
-msgstr "Load cached slicing data from directory"
+msgstr ""
 
 msgid "Export STL"
-msgstr "Export STL"
+msgstr ""
 
 msgid "Export the objects as single STL."
 msgstr ""
@@ -14043,19 +13774,19 @@ msgid "Export the objects as multiple STLs to directory"
 msgstr ""
 
 msgid "Slice"
-msgstr "Slice"
+msgstr ""
 
 msgid "Slice the plates: 0-all plates, i-plate i, others-invalid"
-msgstr "Slice the plates: 0-all plates, i-plate i, others-invalid"
+msgstr ""
 
 msgid "Show command help."
 msgstr "This shows command help."
 
 msgid "UpToDate"
-msgstr "UpToDate"
+msgstr ""
 
 msgid "Update the configs values of 3mf to latest."
-msgstr "Update the configs values of 3mf to latest."
+msgstr ""
 
 msgid "downward machines check"
 msgstr ""
@@ -14066,10 +13797,10 @@ msgid ""
 msgstr ""
 
 msgid "Load default filaments"
-msgstr "Load default filaments"
+msgstr ""
 
 msgid "Load first filament as default for those not loaded"
-msgstr "Load first filament as default for those not loaded"
+msgstr ""
 
 msgid "Minimum save"
 msgstr ""
@@ -14078,52 +13809,52 @@ msgid "export 3mf with minimum size."
 msgstr ""
 
 msgid "mtcpp"
-msgstr "mtcpp"
+msgstr ""
 
 msgid "max triangle count per plate for slicing."
 msgstr "max triangle count per plate for slicing"
 
 msgid "mstpp"
-msgstr "mstpp"
+msgstr ""
 
 msgid "max slicing time per plate in seconds."
 msgstr "max slicing time per plate in seconds"
 
 msgid "No check"
-msgstr "No check"
+msgstr ""
 
 msgid "Do not run any validity checks, such as G-code path conflicts check."
 msgstr ""
 
 msgid "Normative check"
-msgstr "Normative check"
+msgstr ""
 
 msgid "Check the normative items."
-msgstr "Check the normative items."
+msgstr ""
 
 msgid "Output Model Info"
-msgstr "Output Model Info"
+msgstr ""
 
 msgid "Output the model's information."
 msgstr "This outputs the model’s information."
 
 msgid "Export Settings"
-msgstr "Export Settings"
+msgstr ""
 
 msgid "Export settings to a file."
 msgstr "This exports settings to a file."
 
 msgid "Send progress to pipe"
-msgstr "Send progress to pipe"
+msgstr ""
 
 msgid "Send progress to pipe."
-msgstr "Send progress to pipe."
+msgstr ""
 
 msgid "Arrange Options"
-msgstr "Arrange Options"
+msgstr ""
 
 msgid "Arrange options: 0-disable, 1-enable, others-auto"
-msgstr "Arrange options: 0-disable, 1-enable, others-auto"
+msgstr ""
 
 msgid "Repetions count"
 msgstr "Repetition count"
@@ -14144,10 +13875,10 @@ msgid ""
 msgstr ""
 
 msgid "Convert Unit"
-msgstr "Convert Unit"
+msgstr ""
 
 msgid "Convert the units of model"
-msgstr "Convert the units of model"
+msgstr ""
 
 msgid "Orient Options"
 msgstr ""
@@ -14165,25 +13896,25 @@ msgid "Rotation angle around the Y axis in degrees."
 msgstr ""
 
 msgid "Scale the model by a float factor"
-msgstr "Scale the model by a float factor"
+msgstr ""
 
 msgid "Load General Settings"
-msgstr "Load General Settings"
+msgstr ""
 
 msgid "Load process/machine settings from the specified file"
-msgstr "Load process/machine settings from the specified file"
+msgstr ""
 
 msgid "Load Filament Settings"
-msgstr "Load Filament Settings"
+msgstr ""
 
 msgid "Load filament settings from the specified file list"
-msgstr "Load filament settings from the specified file list"
+msgstr ""
 
 msgid "Skip Objects"
-msgstr "Skip Objects"
+msgstr ""
 
 msgid "Skip some objects in this print"
-msgstr "Skip some objects in this print"
+msgstr ""
 
 msgid "Clone Objects"
 msgstr ""
@@ -14192,7 +13923,7 @@ msgid "Clone objects in the load list"
 msgstr ""
 
 msgid "load uptodate process/machine settings when using uptodate"
-msgstr "load uptodate process/machine settings when using uptodate"
+msgstr ""
 
 msgid ""
 "load uptodate process/machine settings from the specified file when using "
@@ -14235,20 +13966,18 @@ msgid ""
 msgstr ""
 
 msgid "Output directory"
-msgstr "Output directory"
+msgstr ""
 
 msgid "Output directory for the exported files."
 msgstr "This is the output directory for exported files."
 
 msgid "Debug level"
-msgstr "Debug level"
+msgstr ""
 
 msgid ""
 "Sets debug logging level. 0:fatal, 1:error, 2:warning, 3:info, 4:debug, "
 "5:trace\n"
 msgstr ""
-"Sets debug logging level. 0:fatal, 1:error, 2:warning, 3:info, 4:debug, "
-"5:trace\n"
 
 msgid "Enable timelapse for print"
 msgstr ""
@@ -14581,55 +14310,51 @@ msgid "The current extruder ID. The same as current_extruder."
 msgstr ""
 
 msgid "Error in zip archive"
-msgstr "Error in zip archive"
+msgstr ""
 
 msgid "Generating walls"
-msgstr "Generating walls"
+msgstr ""
 
 msgid "Generating infill regions"
-msgstr "Generating infill regions"
+msgstr ""
 
 msgid "Generating infill toolpath"
-msgstr "Generating infill toolpath"
+msgstr ""
 
 msgid "Detect overhangs for auto-lift"
-msgstr "Detect overhangs for auto-lift"
+msgstr ""
 
 msgid "Checking support necessity"
-msgstr "Checking support necessity"
+msgstr ""
 
 msgid "floating regions"
-msgstr "floating regions"
+msgstr ""
 
 msgid "floating cantilever"
-msgstr "floating cantilever"
+msgstr ""
 
 msgid "large overhangs"
-msgstr "large overhangs"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "It seems object %s has %s. Please re-orient the object or enable support "
 "generation."
 msgstr ""
-"It seems object %s has %s. Please re-orient the object or enable support "
-"generation."
 
 msgid "Generating support"
-msgstr "Generating support"
+msgstr ""
 
 msgid "Optimizing toolpath"
-msgstr "Optimizing toolpath"
+msgstr ""
 
 msgid "Slicing mesh"
-msgstr "Slicing mesh"
+msgstr ""
 
 msgid ""
 "No layers were detected. You might want to repair your STL file(s) or check "
 "their size or thickness and retry.\n"
 msgstr ""
-"No layers were detected. You might want to repair your STL file(s) or check "
-"their size or thickness and retry.\n"
 
 msgid ""
 "An object's XY size compensation will not be used because it is also color-"
@@ -14638,7 +14363,7 @@ msgid ""
 msgstr ""
 
 msgid "Support: generate contact points"
-msgstr "Support: generate contact points"
+msgstr ""
 
 msgid ""
 "Unknown file format. Input file must have .stl, .obj, .amf(.xml) extension."
@@ -14656,55 +14381,55 @@ msgid "Unknown file format. Input file must have .3mf or .zip.amf extension."
 msgstr "Unknown file format: input file must have .3mf or .zip.amf extension."
 
 msgid "load_obj: failed to parse"
-msgstr "load_obj: failed to parse"
+msgstr ""
 
 msgid "load mtl in obj: failed to parse"
-msgstr "load mtl in obj: failed to parse"
+msgstr ""
 
 msgid "The file contains polygons with more than 4 vertices."
-msgstr "The file contains polygons with more than 4 vertices."
+msgstr ""
 
 msgid "The file contains polygons with less than 2 vertices."
-msgstr "The file contains polygons with less than 2 vertices."
+msgstr ""
 
 msgid "The file contains invalid vertex index."
-msgstr "The file contains invalid vertex index."
+msgstr ""
 
 msgid "This OBJ file couldn't be read because it's empty."
-msgstr "This OBJ file couldn't be read because it's empty."
+msgstr ""
 
 msgid "Flow Rate Calibration"
-msgstr "Flow Rate Calibration"
+msgstr ""
 
 msgid "Max Volumetric Speed Calibration"
-msgstr "Max Volumetric Speed Calibration"
+msgstr ""
 
 msgid "Manage Result"
-msgstr "Manage Result"
+msgstr ""
 
 msgid "Manual Calibration"
-msgstr "Manual Calibration"
+msgstr ""
 
 msgid "Result can be read by human eyes."
-msgstr "Result can be read by human eyes."
+msgstr ""
 
 msgid "Auto-Calibration"
-msgstr "Auto-Calibration"
+msgstr ""
 
 msgid "We would use Lidar to read the calibration result"
-msgstr "We would use Lidar to read the calibration result"
+msgstr ""
 
 msgid "Prev"
-msgstr "Prev"
+msgstr ""
 
 msgid "Recalibration"
-msgstr "Recalibration"
+msgstr ""
 
 msgid "Calibrate"
-msgstr "Calibrate"
+msgstr ""
 
 msgid "Finish"
-msgstr "Finish"
+msgstr ""
 
 msgid "How to use calibration result?"
 msgstr "How can I use calibration results?"
@@ -14712,32 +14437,29 @@ msgstr "How can I use calibration results?"
 msgid ""
 "You could change the Flow Dynamics Calibration Factor in material editing"
 msgstr ""
-"You could change the Flow Dynamics Calibration Factor in material editing"
 
 msgid ""
 "The current firmware version of the printer does not support calibration.\n"
 "Please upgrade the printer firmware."
 msgstr ""
-"The current firmware version of the printer does not support calibration.\n"
-"Please upgrade the printer firmware."
 
 msgid "Calibration not supported"
-msgstr "Calibration not supported"
+msgstr ""
 
 msgid "Error desc"
-msgstr "Error desc"
+msgstr ""
 
 msgid "Extra info"
-msgstr "Extra info"
+msgstr ""
 
 msgid "Flow Dynamics"
-msgstr "Flow Dynamics"
+msgstr ""
 
 msgid "Flow Rate"
-msgstr "Flow Rate"
+msgstr ""
 
 msgid "Max Volumetric Speed"
-msgstr "Max Volumetric Speed"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -14747,44 +14469,38 @@ msgid ""
 "End value: > Start value\n"
 "Value step: >= %.3f)"
 msgstr ""
-"Please input valid values:\n"
-"Start value: >= %.1f\n"
-"End value: <= %.1f\n"
-"End value: > Start value\n"
-"Value step: >= %.3f)"
 
 msgid "The name cannot be empty."
-msgstr "The name cannot be empty."
+msgstr ""
 
 #, c-format, boost-format
 msgid "The selected preset: %s was not found."
 msgstr ""
 
 msgid "The name cannot be the same as the system preset name."
-msgstr "The name cannot be the same as the system preset name."
+msgstr ""
 
 msgid "The name is the same as another existing preset name"
-msgstr "The name is the same as another existing preset name"
+msgstr ""
 
 msgid "create new preset failed."
-msgstr "create new preset failed."
+msgstr ""
 
 msgid ""
 "Are you sure to cancel the current calibration and return to the home page?"
 msgstr ""
-"Are you sure to cancel the current calibration and return to the home page?"
 
 msgid "No Printer Connected!"
-msgstr "No Printer Connected!"
+msgstr ""
 
 msgid "Printer is not connected yet."
-msgstr "Printer is not connected yet."
+msgstr ""
 
 msgid "Please select filament to calibrate."
-msgstr "Please select filament to calibrate."
+msgstr ""
 
 msgid "The input value size must be 3."
-msgstr "The input value size must be 3."
+msgstr ""
 
 msgid ""
 "This machine type can only hold 16 history results per nozzle. You can "
@@ -14800,13 +14516,13 @@ msgstr ""
 "Do you still want to continue the calibration?"
 
 msgid "Connecting to printer..."
-msgstr "Connecting to printer..."
+msgstr ""
 
 msgid "The failed test result has been dropped."
-msgstr "The failed test result has been dropped."
+msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
-msgstr "Flow Dynamics Calibration result has been saved to the printer"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -14827,19 +14543,19 @@ msgstr ""
 "result will not be saved."
 
 msgid "Internal Error"
-msgstr "Internal Error"
+msgstr ""
 
 msgid "Please select at least one filament for calibration"
-msgstr "Please select at least one filament for calibration"
+msgstr ""
 
 msgid "Flow rate calibration result has been saved to preset"
-msgstr "Flow rate calibration result has been saved to preset"
+msgstr ""
 
 msgid "Max volumetric speed calibration result has been saved to preset"
-msgstr "Max volumetric speed calibration result has been saved to preset"
+msgstr ""
 
 msgid "When do you need Flow Dynamics Calibration"
-msgstr "When do you need Flow Dynamics Calibration"
+msgstr ""
 
 msgid ""
 "We now have added the auto-calibration for different filaments, which is "
@@ -14851,17 +14567,9 @@ msgid ""
 "3. If the max volumetric speed or print temperature is changed in the "
 "filament setting."
 msgstr ""
-"We now have added the auto-calibration for different filaments, which is "
-"fully automated and the result will be saved into the printer for future "
-"use. You only need to do the calibration in the following limited cases:\n"
-"1. If you introduce a new filament of different brands/models or the "
-"filament is damp;\n"
-"2. if the nozzle is worn out or replaced with a new one;\n"
-"3. If the max volumetric speed or print temperature is changed in the "
-"filament setting."
 
 msgid "About this calibration"
-msgstr "About this calibration"
+msgstr ""
 
 msgid ""
 "Please find the details of Flow Dynamics Calibration from our wiki.\n"
@@ -14884,7 +14592,7 @@ msgid ""
 msgstr ""
 
 msgid "When to use Flow Rate Calibration"
-msgstr "When to use Flow Rate Calibration"
+msgstr ""
 
 msgid ""
 "After using Flow Dynamics Calibration, there might still be some extrusion "
@@ -14897,24 +14605,12 @@ msgid ""
 "4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as "
 "they should be."
 msgstr ""
-"After using Flow Dynamics Calibration, there might still be some extrusion "
-"issues, such as:\n"
-"1. Over-Extrusion: Excess material on your printed object, forming blobs or "
-"zits, or the layers seem thicker than expected and not uniform.\n"
-"2. Under-Extrusion: Very thin layers, weak infill strength, or gaps in the "
-"top layer of the model, even when printing slowly.\n"
-"3. Poor Surface Quality: The surface of your prints seems rough or uneven.\n"
-"4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as "
-"they should be."
 
 msgid ""
 "In addition, Flow Rate Calibration is crucial for foaming materials like LW-"
 "PLA used in RC planes. These materials expand greatly when heated, and "
 "calibration provides a useful reference flow rate."
 msgstr ""
-"In addition, Flow Rate Calibration is crucial for foaming materials like LW-"
-"PLA used in RC planes. These materials expand greatly when heated, and "
-"calibration provides a useful reference flow rate."
 
 msgid ""
 "Flow Rate Calibration measures the ratio of expected to actual extrusion "
@@ -14924,12 +14620,6 @@ msgid ""
 "you still see the listed defects after you have done other calibrations. For "
 "more details, please check out the wiki article."
 msgstr ""
-"Flow Rate Calibration measures the ratio of expected to actual extrusion "
-"volumes. The default setting works well in Bambu Lab printers and official "
-"filaments as they were pre-calibrated and fine-tuned. For a regular "
-"filament, you usually won't need to perform a Flow Rate Calibration unless "
-"you still see the listed defects after you have done other calibrations. For "
-"more details, please check out the wiki article."
 
 msgid ""
 "Auto Flow Rate Calibration utilizes Bambu Lab's Micro-Lidar technology, "
@@ -14966,45 +14656,41 @@ msgstr ""
 "read and understand the process before doing it."
 
 msgid "When you need Max Volumetric Speed Calibration"
-msgstr "When you need Max Volumetric Speed Calibration"
+msgstr ""
 
 msgid "Over-extrusion or under extrusion"
-msgstr "Over-extrusion or under extrusion"
+msgstr ""
 
 msgid "Max Volumetric Speed calibration is recommended when you print with:"
-msgstr "Max Volumetric Speed calibration is recommended when you print with:"
+msgstr ""
 
 msgid "material with significant thermal shrinkage/expansion, such as..."
-msgstr "material with significant thermal shrinkage/expansion, such as..."
+msgstr ""
 
 msgid "materials with inaccurate filament diameter"
-msgstr "materials with inaccurate filament diameter"
+msgstr ""
 
 msgid "We found the best Flow Dynamics Calibration Factor"
-msgstr "We found the best Flow Dynamics Calibration Factor"
+msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
 "failed test result would be dropped."
 msgstr ""
-"Part of the calibration failed! You may clean the plate and retry. The "
-"failed test result would be dropped."
 
 msgid ""
 "*We recommend you to add brand, materia, type, and even humidity level in "
 "the Name"
 msgstr ""
-"*We recommend you to add brand, materia, type, and even humidity level in "
-"the Name"
 
 msgid "Failed"
-msgstr "Failed"
+msgstr ""
 
 msgid "Please enter the name you want to save to printer."
-msgstr "Please enter the name you want to save to printer."
+msgstr ""
 
 msgid "The name cannot exceed 40 characters."
-msgstr "The name cannot exceed 40 characters."
+msgstr ""
 
 msgid ""
 "Only one of the results with the same name will be saved. Are you sure you "
@@ -15014,194 +14700,189 @@ msgstr ""
 "want to replace the other results?"
 
 msgid "Please find the best line on your plate"
-msgstr "Please find the best line on your plate"
+msgstr ""
 
 msgid "Please find the corner with perfect degree of extrusion"
 msgstr "Please find the corner with the perfect degree of extrusion"
 
 msgid "Input Value"
-msgstr "Input Value"
+msgstr ""
 
 msgid "Save to Filament Preset"
-msgstr "Save to Filament Preset"
+msgstr ""
 
 msgid "Preset"
-msgstr "Preset"
+msgstr ""
 
 msgid "Record Factor"
-msgstr "Record Factor"
+msgstr ""
 
 msgid "We found the best flow ratio for you"
-msgstr "We found the best flow ratio for you"
+msgstr ""
 
 msgid "Flow Ratio"
-msgstr "Flow Ratio"
+msgstr ""
 
 msgid "Please input a valid value (0.0 < flow ratio < 2.0)"
-msgstr "Please input a valid value (0.0 < flow ratio < 2.0)"
+msgstr ""
 
 msgid "Please enter the name of the preset you want to save."
-msgstr "Please enter the name of the preset you want to save."
+msgstr ""
 
 msgid "Calibration1"
-msgstr "Calibration1"
+msgstr ""
 
 msgid "Calibration2"
-msgstr "Calibration2"
+msgstr ""
 
 msgid "Please find the best object on your plate"
-msgstr "Please find the best object on your plate"
+msgstr ""
 
 msgid "Fill in the value above the block with smoothest top surface"
-msgstr "Fill in the value above the block with smoothest top surface"
+msgstr ""
 
 msgid "Skip Calibration2"
-msgstr "Skip Calibration2"
+msgstr ""
 
 #, c-format, boost-format
 msgid "flow ratio : %s "
-msgstr "flow ratio : %s "
+msgstr ""
 
 msgid "Please choose a block with smoothest top surface"
-msgstr "Please choose a block with smoothest top surface"
+msgstr ""
 
 msgid "Please choose a block with smoothest top surface."
-msgstr "Please choose a block with smoothest top surface."
+msgstr ""
 
 msgid "Please input a valid value (0 <= Max Volumetric Speed <= 60)"
-msgstr "Please input a valid value (0 <= Max Volumetric Speed <= 60)"
+msgstr ""
 
 msgid "Calibration Type"
-msgstr "Calibration Type"
+msgstr ""
 
 msgid "Complete Calibration"
-msgstr "Complete Calibration"
+msgstr ""
 
 msgid "Fine Calibration based on flow ratio"
-msgstr "Fine Calibration based on flow ratio"
+msgstr ""
 
 msgid "Title"
-msgstr "Title"
+msgstr ""
 
 msgid ""
 "A test model will be printed. Please clear the build plate and place it back "
 "to the hot bed before calibration."
 msgstr ""
-"A test model will be printed. Please clear the build plate and place it back "
-"to the hot bed before calibration."
 
 msgid "Printing Parameters"
-msgstr "Printing Parameters"
+msgstr ""
 
 msgid "Plate Type"
-msgstr "Plate Type"
+msgstr ""
 
 msgid "filament position"
-msgstr "filament position"
+msgstr ""
 
 msgid "External Spool"
-msgstr "External Spool"
+msgstr ""
 
 msgid "Filament For Calibration"
-msgstr "Filament For Calibration"
+msgstr ""
 
 msgid ""
 "Tips for calibration material: \n"
 "- Materials that can share same hot bed temperature\n"
 "- Different filament brand and family(Brand = Bambu, Family = Basic, Matte)"
 msgstr ""
-"Tips for calibration material: \n"
-"- Materials that can share same hot bed temperature\n"
-"- Different filament brand and family(Brand = Bambu, Family = Basic, Matte)"
 
 msgid "Pattern"
-msgstr "Pattern"
+msgstr ""
 
 msgid "Method"
-msgstr "Method"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s is not compatible with %s"
-msgstr "%s is not compatible with %s"
+msgstr ""
 
 msgid "TPU is not supported for Flow Dynamics Auto-Calibration."
-msgstr "TPU is not supported for Flow Dynamics Auto-Calibration."
+msgstr ""
 
 msgid "Connecting to printer"
-msgstr "Connecting to printer"
+msgstr ""
 
 msgid "From k Value"
-msgstr "From k Value"
+msgstr ""
 
 msgid "To k Value"
-msgstr "To k Value"
+msgstr ""
 
 msgid "Step value"
 msgstr ""
 
 msgid "The nozzle diameter has been synchronized from the printer Settings"
-msgstr "The nozzle diameter has been synchronized from the printer Settings"
+msgstr ""
 
 msgid "From Volumetric Speed"
-msgstr "From Volumetric Speed"
+msgstr ""
 
 msgid "To Volumetric Speed"
-msgstr "To Volumetric Speed"
+msgstr ""
 
 msgid "Flow Dynamics Calibration Result"
-msgstr "Flow Dynamics Calibration Result"
+msgstr ""
 
 msgid "New"
-msgstr "New"
+msgstr ""
 
 msgid "No History Result"
-msgstr "No History Result"
+msgstr ""
 
 msgid "Success to get history result"
-msgstr "Success to get history result"
+msgstr ""
 
 msgid "Refreshing the historical Flow Dynamics Calibration records"
 msgstr "Refreshing the previous Flow Dynamics Calibration records"
 
 msgid "Action"
-msgstr "Action"
+msgstr ""
 
 #, c-format, boost-format
 msgid "This machine type can only hold %d history results per nozzle."
 msgstr "This machine type can only hold %d historical results per nozzle."
 
 msgid "Edit Flow Dynamics Calibration"
-msgstr "Edit Flow Dynamics Calibration"
+msgstr ""
 
 msgid "New Flow Dynamic Calibration"
-msgstr "New Flow Dynamic Calibration"
+msgstr ""
 
 msgid "Ok"
-msgstr "Ok"
+msgstr ""
 
 msgid "The filament must be selected."
-msgstr "The filament must be selected."
+msgstr ""
 
 msgid "Network lookup"
-msgstr "Network lookup"
+msgstr ""
 
 msgid "Address"
-msgstr "Address"
+msgstr ""
 
 msgid "Hostname"
-msgstr "Hostname"
+msgstr ""
 
 msgid "Service name"
-msgstr "Service name"
+msgstr ""
 
 msgid "OctoPrint version"
-msgstr "OctoPrint version"
+msgstr ""
 
 msgid "Searching for devices"
-msgstr "Searching for devices"
+msgstr ""
 
 msgid "Finished"
-msgstr "Finished"
+msgstr ""
 
 msgid "Multiple resolved IP addresses"
 msgstr ""
@@ -15213,34 +14894,34 @@ msgid ""
 msgstr ""
 
 msgid "PA Calibration"
-msgstr "PA Calibration"
+msgstr ""
 
 msgid "DDE"
 msgstr ""
 
 msgid "Bowden"
-msgstr "Bowden"
+msgstr ""
 
 msgid "Extruder type"
 msgstr ""
 
 msgid "PA Tower"
-msgstr "PA Tower"
+msgstr ""
 
 msgid "PA Line"
-msgstr "PA Line"
+msgstr ""
 
 msgid "PA Pattern"
-msgstr "PA Pattern"
+msgstr ""
 
 msgid "Start PA: "
-msgstr "Start PA: "
+msgstr ""
 
 msgid "End PA: "
-msgstr "End PA: "
+msgstr ""
 
 msgid "PA step: "
-msgstr "PA step: "
+msgstr ""
 
 msgid "Accelerations: "
 msgstr ""
@@ -15249,7 +14930,7 @@ msgid "Speeds: "
 msgstr ""
 
 msgid "Print numbers"
-msgstr "Print numbers"
+msgstr ""
 
 msgid "Comma-separated list of printing accelerations"
 msgstr ""
@@ -15263,46 +14944,42 @@ msgid ""
 "End PA: > Start PA\n"
 "PA step: >= 0.001)"
 msgstr ""
-"Please input valid values:\n"
-"Start PA: >= 0.0\n"
-"End PA: > Start PA\n"
-"PA step: >= 0.001)"
 
 msgid "Temperature calibration"
-msgstr "Temperature calibration"
+msgstr ""
 
 msgid "PLA"
-msgstr "PLA"
+msgstr ""
 
 msgid "ABS/ASA"
-msgstr "ABS/ASA"
+msgstr ""
 
 msgid "PETG"
-msgstr "PETG"
+msgstr ""
 
 msgid "PCTG"
 msgstr ""
 
 msgid "TPU"
-msgstr "TPU"
+msgstr ""
 
 msgid "PA-CF"
-msgstr "PA-CF"
+msgstr ""
 
 msgid "PET-CF"
-msgstr "PET-CF"
+msgstr ""
 
 msgid "Filament type"
-msgstr "Filament type"
+msgstr ""
 
 msgid "Start temp: "
-msgstr "Start temp: "
+msgstr ""
 
 msgid "End temp: "
-msgstr "End temp: "
+msgstr ""
 
 msgid "Temp step: "
-msgstr "Temp step: "
+msgstr ""
 
 msgid ""
 "Please input valid values:\n"
@@ -15312,16 +14989,16 @@ msgid ""
 msgstr ""
 
 msgid "Max volumetric speed test"
-msgstr "Max volumetric speed test"
+msgstr ""
 
 msgid "Start volumetric speed: "
-msgstr "Start volumetric speed: "
+msgstr ""
 
 msgid "End volumetric speed: "
-msgstr "End volumetric speed: "
+msgstr ""
 
 msgid "step: "
-msgstr "step: "
+msgstr ""
 
 msgid ""
 "Please input valid values:\n"
@@ -15331,13 +15008,13 @@ msgid ""
 msgstr ""
 
 msgid "VFA test"
-msgstr "VFA test"
+msgstr ""
 
 msgid "Start speed: "
-msgstr "Start speed: "
+msgstr ""
 
 msgid "End speed: "
-msgstr "End speed: "
+msgstr ""
 
 msgid ""
 "Please input valid values:\n"
@@ -15347,22 +15024,22 @@ msgid ""
 msgstr ""
 
 msgid "Start retraction length: "
-msgstr "Start retraction length: "
+msgstr ""
 
 msgid "End retraction length: "
-msgstr "End retraction length: "
+msgstr ""
 
 msgid "mm/mm"
-msgstr "mm/mm"
+msgstr ""
 
 msgid "Send G-code to printer host"
 msgstr ""
 
 msgid "Upload to Printer Host with the following filename:"
-msgstr "Upload to Printer Host with the following filename:"
+msgstr ""
 
 msgid "Use forward slashes ( / ) as a directory separator if needed."
-msgstr "Use forward slashes ( / ) as a directory separator if needed."
+msgstr ""
 
 msgid "Upload to storage"
 msgstr ""
@@ -15372,44 +15049,44 @@ msgstr ""
 
 #, c-format, boost-format
 msgid "Upload filename doesn't end with \"%s\". Do you wish to continue?"
-msgstr "Upload filename doesn't end with \"%s\". Do you wish to continue?"
+msgstr ""
 
 msgid "Upload"
-msgstr "Upload"
+msgstr ""
 
 msgid "Print host upload queue"
-msgstr "Print host upload queue"
+msgstr ""
 
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 msgid "Progress"
-msgstr "Progress"
+msgstr ""
 
 msgid "Host"
-msgstr "Host"
+msgstr ""
 
 msgctxt "OfFile"
 msgid "Size"
-msgstr "Size"
+msgstr ""
 
 msgid "Filename"
-msgstr "Filename"
+msgstr ""
 
 msgid "Cancel selected"
-msgstr "Cancel selected"
+msgstr ""
 
 msgid "Show error message"
-msgstr "Show error message"
+msgstr ""
 
 msgid "Enqueued"
 msgstr "Queued"
 
 msgid "Uploading"
-msgstr "Uploading"
+msgstr ""
 
 msgid "Cancelling"
-msgstr "Cancelling"
+msgstr ""
 
 msgid "Error uploading to print host"
 msgstr ""
@@ -15432,64 +15109,64 @@ msgid "Smooth Build Plate (Side B)"
 msgstr ""
 
 msgid "Unable to perform boolean operation on selected parts"
-msgstr "Unable to perform boolean operation on selected parts"
+msgstr ""
 
 msgid "Mesh Boolean"
-msgstr "Mesh Boolean"
+msgstr ""
 
 msgid "Union"
-msgstr "Union"
+msgstr ""
 
 msgid "Difference"
-msgstr "Difference"
+msgstr ""
 
 msgid "Intersection"
-msgstr "Intersection"
+msgstr ""
 
 msgid "Source Volume"
-msgstr "Source Volume"
+msgstr ""
 
 msgid "Tool Volume"
-msgstr "Tool Volume"
+msgstr ""
 
 msgid "Subtract from"
-msgstr "Subtract from"
+msgstr ""
 
 msgid "Subtract with"
-msgstr "Subtract with"
+msgstr ""
 
 msgid "selected"
-msgstr "selected"
+msgstr ""
 
 msgid "Part 1"
-msgstr "Part 1"
+msgstr ""
 
 msgid "Part 2"
-msgstr "Part 2"
+msgstr ""
 
 msgid "Delete input"
-msgstr "Delete input"
+msgstr ""
 
 msgid "Network Test"
-msgstr "Network Test"
+msgstr ""
 
 msgid "Start Test Multi-Thread"
-msgstr "Start Test Multi-Thread"
+msgstr ""
 
 msgid "Start Test Single-Thread"
-msgstr "Start Test Single-Thread"
+msgstr ""
 
 msgid "Export Log"
-msgstr "Export Log"
+msgstr ""
 
 msgid "OrcaSlicer Version:"
 msgstr ""
 
 msgid "System Version:"
-msgstr "System Version:"
+msgstr ""
 
 msgid "DNS Server:"
-msgstr "DNS Server:"
+msgstr ""
 
 msgid "Test OrcaSlicer(GitHub)"
 msgstr ""
@@ -15498,61 +15175,61 @@ msgid "Test OrcaSlicer(GitHub):"
 msgstr ""
 
 msgid "Test Bing.com"
-msgstr "Test Bing.com"
+msgstr ""
 
 msgid "Test bing.com:"
-msgstr "Test bing.com:"
+msgstr ""
 
 msgid "Log Info"
-msgstr "Log Info"
+msgstr ""
 
 msgid "Select filament preset"
-msgstr "Select filament preset"
+msgstr ""
 
 msgid "Create Filament"
-msgstr "Create Filament"
+msgstr ""
 
 msgid "Create Based on Current Filament"
-msgstr "Create Based on Current Filament"
+msgstr ""
 
 msgid "Copy Current Filament Preset "
-msgstr "Copy Current Filament Preset "
+msgstr ""
 
 msgid "Basic Information"
-msgstr "Basic Information"
+msgstr ""
 
 msgid "Add Filament Preset under this filament"
-msgstr "Add Filament Preset under this filament"
+msgstr ""
 
 msgid "We could create the filament presets for your following printer:"
-msgstr "We could create the filament presets for your following printer:"
+msgstr ""
 
 msgid "Select Vendor"
-msgstr "Select Vendor"
+msgstr ""
 
 msgid "Input Custom Vendor"
-msgstr "Input Custom Vendor"
+msgstr ""
 
 msgid "Can't find vendor I want"
-msgstr "Can't find vendor I want"
+msgstr ""
 
 msgid "Select Type"
-msgstr "Select Type"
+msgstr ""
 
 msgid "Select Filament Preset"
-msgstr "Select Filament Preset"
+msgstr ""
 
 msgid "Serial"
-msgstr "Serial"
+msgstr ""
 
 msgid "e.g. Basic, Matte, Silk, Marble"
-msgstr "e.g. Basic, Matte, Silk, Marble"
+msgstr ""
 
 msgid "Filament Preset"
-msgstr "Filament Preset"
+msgstr ""
 
 msgid "Create"
-msgstr "Create"
+msgstr ""
 
 msgid "Vendor is not selected, please reselect vendor."
 msgstr "Vendor is not selected; please reselect vendor."
@@ -15565,7 +15242,7 @@ msgid ""
 msgstr ""
 
 msgid "Filament type is not selected, please reselect type."
-msgstr "Filament type is not selected, please reselect type."
+msgstr ""
 
 msgid "Filament serial is not entered, please enter serial."
 msgstr "Filament serial missing; please input serial."
@@ -15578,7 +15255,7 @@ msgstr ""
 "filament. Please delete and re-enter."
 
 msgid "All inputs in the custom vendor or serial are spaces. Please re-enter."
-msgstr "All inputs in the custom vendor or serial are spaces. Please re-enter."
+msgstr ""
 
 msgid "The vendor cannot be a number. Please re-enter."
 msgstr "The vendor cannot be a number; please re-enter."
@@ -15586,7 +15263,6 @@ msgstr "The vendor cannot be a number; please re-enter."
 msgid ""
 "You have not selected a printer or preset yet. Please select at least one."
 msgstr ""
-"You have not selected a printer or preset yet. Please select at least one."
 
 #, c-format, boost-format
 msgid ""
@@ -15599,14 +15275,12 @@ msgstr ""
 "you want to continue?"
 
 msgid "Some existing presets have failed to be created, as follows:\n"
-msgstr "Some existing presets have failed to be created, as follows:\n"
+msgstr ""
 
 msgid ""
 "\n"
 "Do you want to rewrite it?"
 msgstr ""
-"\n"
-"Do you want to rewrite it?"
 
 msgid ""
 "We would rename the presets as \"Vendor Type Serial @printer you "
@@ -15615,74 +15289,74 @@ msgid ""
 msgstr ""
 
 msgid "Create Printer/Nozzle"
-msgstr "Create Printer/Nozzle"
+msgstr ""
 
 msgid "Create Printer"
-msgstr "Create Printer"
+msgstr ""
 
 msgid "Create Nozzle for Existing Printer"
-msgstr "Create Nozzle for Existing Printer"
+msgstr ""
 
 msgid "Create from Template"
-msgstr "Create from Template"
+msgstr ""
 
 msgid "Create Based on Current Printer"
-msgstr "Create Based on Current Printer"
+msgstr ""
 
 msgid "Import Preset"
-msgstr "Import Preset"
+msgstr ""
 
 msgid "Create Type"
-msgstr "Create Type"
+msgstr ""
 
 msgid "The model was not found, please reselect vendor."
 msgstr "The model was not found; please reselect vendor."
 
 msgid "Select Model"
-msgstr "Select Model"
+msgstr ""
 
 msgid "Select Printer"
-msgstr "Select Printer"
+msgstr ""
 
 msgid "Input Custom Model"
-msgstr "Input Custom Model"
+msgstr ""
 
 msgid "Can't find my printer model"
-msgstr "Can't find my printer model"
+msgstr ""
 
 msgid "Rectangle"
-msgstr "Rectangle"
+msgstr ""
 
 msgid "Printable Space"
-msgstr "Printable Space"
+msgstr ""
 
 msgid "Hot Bed STL"
-msgstr "Hot Bed STL"
+msgstr ""
 
 msgid "Load stl"
-msgstr "Load stl"
+msgstr ""
 
 msgid "Hot Bed SVG"
-msgstr "Hot Bed SVG"
+msgstr ""
 
 msgid "Load svg"
-msgstr "Load svg"
+msgstr ""
 
 msgid "Max Print Height"
-msgstr "Max Print Height"
+msgstr ""
 
 #, c-format, boost-format
 msgid "The file exceeds %d MB, please import again."
-msgstr "The file exceeds %d MB, please import again."
+msgstr ""
 
 msgid "Exception in obtaining file size, please import again."
-msgstr "Exception in obtaining file size, please import again."
+msgstr ""
 
 msgid "Preset path was not found, please reselect vendor."
 msgstr "Preset path was not found; please reselect vendor."
 
 msgid "The printer model was not found, please reselect."
-msgstr "The printer model was not found, please reselect."
+msgstr ""
 
 msgid "The nozzle diameter was not found, please reselect."
 msgstr "The nozzle diameter was not found; please reselect."
@@ -15691,26 +15365,24 @@ msgid "The printer preset was not found, please reselect."
 msgstr "The printer preset was not found; please reselect."
 
 msgid "Printer Preset"
-msgstr "Printer Preset"
+msgstr ""
 
 msgid "Filament Preset Template"
-msgstr "Filament Preset Template"
+msgstr ""
 
 msgid "Deselect All"
-msgstr "Deselect All"
+msgstr ""
 
 msgid "Process Preset Template"
-msgstr "Process Preset Template"
+msgstr ""
 
 msgid "Back Page 1"
-msgstr "Back Page 1"
+msgstr ""
 
 msgid ""
 "You have not yet chosen which printer preset to create based on. Please "
 "choose the vendor and model of the printer"
 msgstr ""
-"You have not yet chosen which printer preset to create based on. Please "
-"choose the vendor and model of the printer"
 
 msgid ""
 "You have entered an illegal input in the printable area section on the first "
@@ -15740,22 +15412,22 @@ msgstr ""
 "\tCancel: Do not create a preset; return to the creation interface."
 
 msgid "You need to select at least one filament preset."
-msgstr "You need to select at least one filament preset."
+msgstr ""
 
 msgid "You need to select at least one process preset."
-msgstr "You need to select at least one process preset."
+msgstr ""
 
 msgid "Create filament presets failed. As follows:\n"
-msgstr "Create filament presets failed. As follows:\n"
+msgstr ""
 
 msgid "Create process presets failed. As follows:\n"
-msgstr "Create process presets failed. As follows:\n"
+msgstr ""
 
 msgid "Vendor was not found, please reselect."
 msgstr "Vendor was not found; please reselect."
 
 msgid "Current vendor has no models, please reselect."
-msgstr "Current vendor has no models, please reselect."
+msgstr ""
 
 msgid ""
 "You have not selected the vendor and model or entered the custom vendor and "
@@ -15768,16 +15440,13 @@ msgid ""
 "There may be escape characters in the custom printer vendor or model. Please "
 "delete and re-enter."
 msgstr ""
-"There may be escape characters in the custom printer vendor or model. Please "
-"delete and re-enter."
 
 msgid ""
 "All inputs in the custom printer vendor or model are spaces. Please re-enter."
 msgstr ""
-"All inputs in the custom printer vendor or model are spaces. Please re-enter."
 
 msgid "Please check bed printable shape and origin input."
-msgstr "Please check bed printable shape and origin input."
+msgstr ""
 
 msgid ""
 "You have not yet selected the printer to replace the nozzle, please choose."
@@ -15786,19 +15455,19 @@ msgstr ""
 "choose a printer."
 
 msgid "Create Printer Successful"
-msgstr "Create Printer Successful"
+msgstr ""
 
 msgid "Create Filament Successful"
 msgstr "Filament Created Successfully"
 
 msgid "Printer Created"
-msgstr "Printer Created"
+msgstr ""
 
 msgid "Please go to printer settings to edit your presets"
-msgstr "Please go to printer settings to edit your presets"
+msgstr ""
 
 msgid "Filament Created"
-msgstr "Filament Created"
+msgstr ""
 
 msgid ""
 "Please go to filament setting to edit your presets if you need.\n"
@@ -15821,7 +15490,7 @@ msgid ""
 msgstr ""
 
 msgid "Printer Setting"
-msgstr "Printer Setting"
+msgstr ""
 
 msgid "Printer config bundle(.orca_printer)"
 msgstr ""
@@ -15830,31 +15499,31 @@ msgid "Filament bundle(.orca_filament)"
 msgstr ""
 
 msgid "Printer presets(.zip)"
-msgstr "Printer presets(.zip)"
+msgstr ""
 
 msgid "Filament presets(.zip)"
-msgstr "Filament presets(.zip)"
+msgstr ""
 
 msgid "Process presets(.zip)"
-msgstr "Process presets(.zip)"
+msgstr ""
 
 msgid "initialize fail"
-msgstr "initialize fail"
+msgstr ""
 
 msgid "add file fail"
-msgstr "add file fail"
+msgstr ""
 
 msgid "add bundle structure file fail"
-msgstr "add bundle structure file fail"
+msgstr ""
 
 msgid "finalize fail"
-msgstr "finalize fail"
+msgstr ""
 
 msgid "open zip written fail"
-msgstr "open zip written fail"
+msgstr ""
 
 msgid "Export successful"
-msgstr "Export successful"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -15877,8 +15546,6 @@ msgid ""
 "User's filament preset set. \n"
 "Can be shared with others."
 msgstr ""
-"User's filament preset set. \n"
-"Can be shared with others."
 
 msgid ""
 "Only display printer names with changes to printer, filament, and process "
@@ -15888,54 +15555,44 @@ msgstr ""
 "are displayed."
 
 msgid "Only display the filament names with changes to filament presets."
-msgstr "Only display the filament names with changes to filament presets."
+msgstr ""
 
 msgid ""
 "Only printer names with user printer presets will be displayed, and each "
 "preset you choose will be exported as a zip."
 msgstr ""
-"Only printer names with user printer presets will be displayed, and each "
-"preset you choose will be exported as a zip."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
 "and all user filament presets in each filament name you select will be "
 "exported as a zip."
 msgstr ""
-"Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be "
-"exported as a zip."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
 "and all user process presets in each printer name you select will be "
 "exported as a zip."
 msgstr ""
-"Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be "
-"exported as a zip."
 
 msgid "Please select at least one printer or filament."
-msgstr "Please select at least one printer or filament."
+msgstr ""
 
 msgid "Please select a type you want to export"
 msgstr "Please select a preset type you want to export"
 
 msgid "Failed to create temporary folder, please try Export Configs again."
-msgstr "Failed to create temporary folder, please try Export Configs again."
+msgstr ""
 
 msgid "Edit Filament"
-msgstr "Edit Filament"
+msgstr ""
 
 msgid "Filament presets under this filament"
-msgstr "Filament presets under this filament"
+msgstr ""
 
 msgid ""
 "Note: If the only preset under this filament is deleted, the filament will "
 "be deleted after exiting the dialog."
 msgstr ""
-"Note: If the only preset under this filament is deleted, the filament will "
-"be deleted after exiting the dialog."
 
 msgid "Presets inherited by other presets cannot be deleted"
 msgstr ""
@@ -15946,62 +15603,59 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Delete Preset"
-msgstr "Delete Preset"
+msgstr ""
 
 msgid "Are you sure to delete the selected preset?"
-msgstr "Are you sure to delete the selected preset?"
+msgstr ""
 
 msgid "Delete preset"
-msgstr "Delete preset"
+msgstr ""
 
 msgid "+ Add Preset"
-msgstr "+ Add Preset"
+msgstr ""
 
 msgid "Delete Filament"
-msgstr "Delete Filament"
+msgstr ""
 
 msgid ""
 "All the filament presets belong to this filament would be deleted. \n"
 "If you are using this filament on your printer, please reset the filament "
 "information for that slot."
 msgstr ""
-"All the filament presets belong to this filament would be deleted. \n"
-"If you are using this filament on your printer, please reset the filament "
-"information for that slot."
 
 msgid "Delete filament"
-msgstr "Delete filament"
+msgstr ""
 
 msgid "Add Preset"
-msgstr "Add Preset"
+msgstr ""
 
 msgid "Add preset for new printer"
-msgstr "Add preset for new printer"
+msgstr ""
 
 msgid "Copy preset from filament"
-msgstr "Copy preset from filament"
+msgstr ""
 
 msgid "The filament choice not find filament preset, please reselect it"
-msgstr "The filament choice not find filament preset, please reselect it"
+msgstr ""
 
 msgid "[Delete Required]"
-msgstr "[Delete Required]"
+msgstr ""
 
 msgid "Edit Preset"
-msgstr "Edit Preset"
+msgstr ""
 
 msgid "For more information, please check out Wiki"
 msgstr "For more information, please check out our Wiki"
 
 msgid "Collapse"
-msgstr "Collapse"
+msgstr ""
 
 msgid "Daily Tips"
-msgstr "Daily Tips"
+msgstr ""
 
 #, c-format, boost-format
 msgid "nozzle memorized: %.1f %s"
-msgstr "nozzle memorized: %.1f %s"
+msgstr ""
 
 msgid ""
 "Your nozzle diameter in preset is not consistent with memorized nozzle "
@@ -16012,42 +15666,40 @@ msgstr ""
 
 #, c-format, boost-format
 msgid "*Printing %s material with %s may cause nozzle damage"
-msgstr "*Printing %s material with %s may cause nozzle damage"
+msgstr ""
 
 msgid "Need select printer"
-msgstr "Need select printer"
+msgstr ""
 
 msgid "The start, end or step is not valid value."
-msgstr "The start, end or step is not valid value."
+msgstr ""
 
 msgid ""
 "Unable to calibrate: maybe because the set calibration value range is too "
 "large, or the step is too small"
 msgstr ""
-"Unable to calibrate: maybe because the set calibration value range is too "
-"large, or the step is too small"
 
 #, fuzzy
 msgid "Physical Printer"
 msgstr "Printer"
 
 msgid "Print Host upload"
-msgstr "Print Host upload"
+msgstr ""
 
 msgid "Test"
-msgstr "Test"
+msgstr ""
 
 msgid "Could not get a valid Printer Host reference"
-msgstr "Could not get a valid Printer Host reference"
+msgstr ""
 
 msgid "Success!"
-msgstr "Success!"
+msgstr ""
 
 msgid "Are you sure to log out?"
 msgstr ""
 
 msgid "Refresh Printers"
-msgstr "Refresh Printers"
+msgstr ""
 
 msgid "View print host webui in Device tab"
 msgstr ""
@@ -16059,39 +15711,33 @@ msgid ""
 "HTTPS CA file is optional. It is only needed if you use HTTPS with a self-"
 "signed certificate."
 msgstr ""
-"HTTPS CA file is optional. It is only needed if you use HTTPS with a self-"
-"signed certificate."
 
 msgid "Certificate files (*.crt, *.pem)|*.crt;*.pem|All files|*.*"
-msgstr "Certificate files (*.crt, *.pem)|*.crt;*.pem|All files|*.*"
+msgstr ""
 
 msgid "Open CA certificate file"
-msgstr "Open CA certificate file"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "On this system, %s uses HTTPS certificates from the system Certificate Store "
 "or Keychain."
 msgstr ""
-"On this system, %s uses HTTPS certificates from the system Certificate Store "
-"or Keychain."
 
 msgid ""
 "To use a custom CA file, please import your CA file into Certificate Store / "
 "Keychain."
 msgstr ""
-"To use a custom CA file, please import your CA file into Certificate Store / "
-"Keychain."
 
 msgid "Login/Test"
 msgstr ""
 
 msgid "Connection to printers connected via the print host failed."
-msgstr "Connection to printers connected via the print host failed."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Mismatched type of print host: %s"
-msgstr "Mismatched type of print host: %s"
+msgstr ""
 
 msgid "Connection to AstroBox is working correctly."
 msgstr ""
@@ -16109,13 +15755,13 @@ msgid "Could not connect to Duet"
 msgstr ""
 
 msgid "Unknown error occurred"
-msgstr "Unknown error occurred"
+msgstr ""
 
 msgid "Wrong password"
-msgstr "Wrong password"
+msgstr ""
 
 msgid "Could not get resources to create a new connection"
-msgstr "Could not get resources to create a new connection"
+msgstr ""
 
 msgid "Upload not enabled on FlashAir card."
 msgstr ""
@@ -16196,8 +15842,6 @@ msgid ""
 "HTTP status: %1%\n"
 "Message body: \"%2%\""
 msgstr ""
-"HTTP status: %1%\n"
-"Message body: \"%2%\""
 
 #, boost-format
 msgid ""
@@ -16205,9 +15849,6 @@ msgid ""
 "Message body: \"%1%\"\n"
 "Error: \"%2%\""
 msgstr ""
-"Parsing of host response failed.\n"
-"Message body: \"%1%\"\n"
-"Error: \"%2%\""
 
 #, boost-format
 msgid ""
@@ -16215,9 +15856,6 @@ msgid ""
 "Message body: \"%1%\"\n"
 "Error: \"%2%\""
 msgstr ""
-"Enumeration of host printers failed.\n"
-"Message body: \"%1%\"\n"
-"Error: \"%2%\""
 
 msgid ""
 "It has a small layer height. This results in almost negligible layer lines "
@@ -16474,7 +16112,7 @@ msgid "Brim Ears"
 msgstr ""
 
 msgid "Please select single object."
-msgstr "Please select single object."
+msgstr ""
 
 #: resources/data/hints.ini: [hint:Precise wall]
 msgid ""
@@ -16549,9 +16187,6 @@ msgid ""
 "Did you know that you can cut a model at any angle and position with the "
 "cutting tool?"
 msgstr ""
-"Cut Tool\n"
-"Did you know that you can cut a model at any angle and position with the "
-"cutting tool?"
 
 #: resources/data/hints.ini: [hint:Fix Model]
 msgid ""
@@ -16559,17 +16194,12 @@ msgid ""
 "Did you know that you can fix a corrupted 3D model to avoid a lot of slicing "
 "problems on the Windows system?"
 msgstr ""
-"Fix Model\n"
-"Did you know that you can fix a corrupted 3D model to avoid a lot of slicing "
-"problems on the Windows system?"
 
 #: resources/data/hints.ini: [hint:Timelapse]
 msgid ""
 "Timelapse\n"
 "Did you know that you can generate a timelapse video during each print?"
 msgstr ""
-"Timelapse\n"
-"Did you know that you can generate a timelapse video during each print?"
 
 #: resources/data/hints.ini: [hint:Auto-Arrange]
 msgid ""
@@ -16596,10 +16226,6 @@ msgid ""
 "sits on the print bed? Select the \"Place on face\" function or press the "
 "<b>F</b> key."
 msgstr ""
-"Lay on Face\n"
-"Did you know that you can quickly orient a model so that one of its faces "
-"sits on the print bed? Select the \"Place on face\" function or press the "
-"<b>F</b> key."
 
 #: resources/data/hints.ini: [hint:Object List]
 msgid ""
@@ -16607,9 +16233,6 @@ msgid ""
 "Did you know that you can view all objects/parts in a list and change "
 "settings for each object/part?"
 msgstr ""
-"Object List\n"
-"Did you know that you can view all objects/parts in a list and change "
-"settings for each object/part?"
 
 #: resources/data/hints.ini: [hint:Search Functionality]
 msgid ""
@@ -16631,9 +16254,6 @@ msgid ""
 "Did you know that you can view all objects/parts on a table and change "
 "settings for each object/part?"
 msgstr ""
-"Slicing Parameter Table\n"
-"Did you know that you can view all objects/parts on a table and change "
-"settings for each object/part?"
 
 #: resources/data/hints.ini: [hint:Split to Objects/Parts]
 msgid ""
@@ -16641,9 +16261,6 @@ msgid ""
 "Did you know that you can split a big object into small ones for easy "
 "colorizing or printing?"
 msgstr ""
-"Split to Objects/Parts\n"
-"Did you know that you can split a big object into small ones for easy "
-"colorizing or printing?"
 
 #: resources/data/hints.ini: [hint:Subtract a Part]
 msgid ""
@@ -16669,10 +16286,6 @@ msgid ""
 "paint it on your print, to have it in a less visible location? This improves "
 "the overall look of your model. Check it out!"
 msgstr ""
-"Z seam location\n"
-"Did you know that you can customize the location of the Z seam, and even "
-"paint it on your print, to have it in a less visible location? This improves "
-"the overall look of your model. Check it out!"
 
 #: resources/data/hints.ini: [hint:Fine-tuning for flow rate]
 msgid ""
@@ -16681,10 +16294,6 @@ msgid ""
 "prints? Depending on the material, you can improve the overall finish of the "
 "printed model by doing some fine-tuning."
 msgstr ""
-"Fine-tuning for flow rate\n"
-"Did you know that flow rate can be fine-tuned for even better-looking "
-"prints? Depending on the material, you can improve the overall finish of the "
-"printed model by doing some fine-tuning."
 
 #: resources/data/hints.ini: [hint:Split your prints into plates]
 msgid ""
@@ -16693,10 +16302,6 @@ msgid ""
 "individual plates ready to print? This will simplify the process of keeping "
 "track of all the parts."
 msgstr ""
-"Split your prints into plates\n"
-"Did you know that you can split a model that has a lot of parts into "
-"individual plates ready to print? This will simplify the process of keeping "
-"track of all the parts."
 
 #: resources/data/hints.ini: [hint:Speed up your print with Adaptive Layer
 #: Height]
@@ -16716,10 +16321,6 @@ msgid ""
 "makes it easy to place the support material only on the sections of the "
 "model that actually need it."
 msgstr ""
-"Support painting\n"
-"Did you know that you can paint the location of your supports? This feature "
-"makes it easy to place the support material only on the sections of the "
-"model that actually need it."
 
 #: resources/data/hints.ini: [hint:Different types of supports]
 msgid ""
@@ -16767,8 +16368,6 @@ msgid ""
 "Stack objects\n"
 "Did you know that you can stack objects as a whole one?"
 msgstr ""
-"Stack objects\n"
-"Did you know that you can stack objects as a whole one?"
 
 #: resources/data/hints.ini: [hint:Flush into support/objects/infill]
 msgid ""
@@ -16786,9 +16385,6 @@ msgid ""
 "Did you know that you can use more wall loops and higher sparse infill "
 "density to improve the strength of the model?"
 msgstr ""
-"Improve strength\n"
-"Did you know that you can use more wall loops and higher sparse infill "
-"density to improve the strength of the model?"
 
 #: resources/data/hints.ini: [hint:When need to print with the printer door
 #: opened]
@@ -16815,72 +16411,6 @@ msgstr ""
 "ABS, appropriately increasing the heatbed temperature can reduce the "
 "probability of warping?"
 
-#~ msgid ""
-#~ "We have added an experimental style \"Tree Slim\" that features smaller "
-#~ "support volume but weaker strength.\n"
-#~ "We recommend using it with: 0 interface layers, 0 top distance, 2 walls."
-#~ msgstr ""
-#~ "We have added an experimental style \"Tree Slim\" that features smaller "
-#~ "support volume but weaker strength.\n"
-#~ "We recommend using it with: 0 interface layers, 0 top distance, 2 walls."
-
-#~ msgid ""
-#~ "For \"Tree Strong\" and \"Tree Hybrid\" styles, we recommend the "
-#~ "following settings: at least 2 interface layers, at least 0.1mm top z "
-#~ "distance or using support materials on interface."
-#~ msgstr ""
-#~ "For \"Tree Strong\" and \"Tree Hybrid\" styles, we recommend the "
-#~ "following settings: at least 2 interface layers, at least 0.1mm top z "
-#~ "distance or using support materials on interface."
-
-#~ msgid ""
-#~ "When using support material for the support interface, We recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-#~ msgstr ""
-#~ "When using support material for the support interface, we recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-
-#~ msgid "This setting specify the count of walls around support"
-#~ msgstr "This setting specify the count of walls around support"
-
-#, c-format, boost-format
-#~ msgid "Support: generate toolpath at layer %d"
-#~ msgstr "Support: generate toolpath at layer %d"
-
-#~ msgid "Support: detect overhangs"
-#~ msgstr "Support: detect overhangs"
-
-#~ msgid "Support: propagate branches"
-#~ msgstr "Support: propagate branches"
-
-#~ msgid "Support: draw polygons"
-#~ msgstr "Support: draw polygons"
-
-#~ msgid "Support: generate toolpath"
-#~ msgstr "Support: generate toolpath"
-
-#, c-format, boost-format
-#~ msgid "Support: generate polygons at layer %d"
-#~ msgstr "Support: generate polygons at layer %d"
-
-#, c-format, boost-format
-#~ msgid "Support: fix holes at layer %d"
-#~ msgstr "Support: fix holes at layer %d"
-
-#, c-format, boost-format
-#~ msgid "Support: propagate branches at layer %d"
-#~ msgstr "Support: propagate branches at layer %d"
-
-#~ msgid "Current Cabin humidity"
-#~ msgstr "Current Cabin humidity"
-
-#~ msgid "Stopped."
-#~ msgstr "Stopped."
-
 #, c-format, boost-format
 #~ msgid "Connect failed [%d]!"
 #~ msgstr "Connection failed [%d]!"
@@ -16892,27 +16422,11 @@ msgstr ""
 #~ msgid "Initialize failed (%s)!"
 #~ msgstr "Initialization failed (%s)!"
 
-#~ msgid "LAN Connection Failed (Sending print file)"
-#~ msgstr "LAN Connection Failed (Sending print file)"
-
 #~ msgid ""
 #~ "Step 1, please confirm Orca Slicer and your printer are in the same LAN."
 #~ msgstr ""
 #~ "Step 1, please confirm that Orca Slicer and your printer are on the same "
 #~ "LAN."
-
-#~ msgid ""
-#~ "Step 2, if the IP and Access Code below are different from the actual "
-#~ "values on your printer, please correct them."
-#~ msgstr ""
-#~ "Step 2, if the IP and Access Code below are different from the actual "
-#~ "values on your printer, please correct them."
-
-#~ msgid "Step 3: Ping the IP address to check for packet loss and latency."
-#~ msgstr "Step 3: Ping the IP address to check for packet loss and latency."
-
-#~ msgid "IP and Access Code Verified! You may close the window"
-#~ msgstr "IP and Access Code Verified! You may close the window"
 
 #~ msgid "Force cooling for overhang and bridge"
 #~ msgstr "Force cooling for overhangs and bridges"
@@ -16936,9 +16450,6 @@ msgstr ""
 #~ "walls which have a large overhang degree. Forcing cooling for overhangs "
 #~ "and bridges can achieve better quality for these parts."
 
-#~ msgid "Cooling overhang threshold"
-#~ msgstr "Cooling overhang threshold"
-
 #, c-format
 #~ msgid ""
 #~ "Force cooling fan to be specific speed when overhang degree of printed "
@@ -16950,25 +16461,6 @@ msgstr ""
 #~ "part exceeds this value. This is expressed as a percentage which "
 #~ "indicates how much width of the line without support from lower layer. "
 #~ "0% means forcing cooling for all outer wall no matter the overhang degree."
-
-#~ msgid "Thick bridges"
-#~ msgstr "Thick bridges"
-
-#~ msgid ""
-#~ "normal(auto) and tree(auto) is used to generate support automatically. If "
-#~ "normal(manual) or tree(manual) is selected, only support enforcers are "
-#~ "generated"
-#~ msgstr ""
-#~ "Normal(auto) and Tree(auto) are used to generate support automatically. "
-#~ "If normal(manual) or tree(manual) is selected, only support enforcers are "
-#~ "generated"
-
-#~ msgctxt "Verb"
-#~ msgid "Scale"
-#~ msgstr "Scale"
-
-#~ msgid "Cool plate"
-#~ msgstr "Cool plate"
 
 #~ msgid "Z-hop when retract"
 #~ msgstr "Z-hop when retracting"
@@ -16986,13 +16478,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Decrease this value slightly (for example 0.9) to reduce the amount of "
 #~ "material extruded for bridges to avoid sagging."
-
-#~ msgid ""
-#~ "This factor affects the amount of material for top solid infill. You can "
-#~ "decrease it slightly to have smooth surface finish"
-#~ msgstr ""
-#~ "This factor affects the amount of material for top solid infill. You can "
-#~ "decrease it slightly to have smooth surface finish"
 
 #~ msgid "Speed of bridge and completely overhang wall"
 #~ msgstr "This is the speed for bridges and 100% overhang walls."
@@ -17024,29 +16509,6 @@ msgstr ""
 #~ "TPU, PVA and other low temperature materials, the actual chamber "
 #~ "temperature should not be high to avoid clogs, so 0 (turned off) is "
 #~ "highly recommended."
-
-#~ msgid ""
-#~ "Different nozzle diameters and different filament diameters is not "
-#~ "allowed when prime tower is enabled."
-#~ msgstr ""
-#~ "Different nozzle diameters and different filament diameters is not "
-#~ "allowed when prime tower is enabled."
-
-#~ msgid ""
-#~ "Ooze prevention is currently not supported with the prime tower enabled."
-#~ msgstr ""
-#~ "Ooze prevention is currently not supported with the prime tower enabled."
-
-#~ msgid ""
-#~ "Interlocking depth of a segmented region. Zero disables this feature."
-#~ msgstr ""
-#~ "Interlocking depth of a segmented region. Zero disables this feature."
-
-#~ msgid "Please input a valid value (K in 0~0.3)"
-#~ msgstr "Please input a valid value (K in 0~0.3)"
-
-#~ msgid "Please input a valid value (K in 0~0.3, N in 0.6~2.0)"
-#~ msgstr "Please input a valid value (K in 0~0.3, N in 0.6~2.0)"
 
 #~ msgid "Printer local connection failed, please try again."
 #~ msgstr "Printer local connection failed; please try again."
@@ -17090,34 +16552,8 @@ msgstr ""
 #~ "may cause the result not exactly the same in each calibration. We are "
 #~ "still investigating the root cause to do improvements with new updates."
 
-#~ msgid ""
-#~ "Only one of the results with the same name will be saved. Are you sure "
-#~ "you want to overrides the other results?"
-#~ msgstr ""
-#~ "Only one of the results with the same name will be saved. Are you sure "
-#~ "you want to replace the other results?"
-
-#, c-format, boost-format
-#~ msgid ""
-#~ "There is already a historical calibration result with the same name: %s. "
-#~ "Only one of the results with the same name is saved. Are you sure you "
-#~ "want to overrides the historical result?"
-#~ msgstr ""
-#~ "There is already a previous calibration result with the same name: %s. "
-#~ "Only one of the results with the same name is saved. Are you sure you "
-#~ "want to replace the previous result?"
-
 #~ msgid "Please find the cornor with perfect degree of extrusion"
 #~ msgstr "Please find the corner with the perfect degree of extrusion"
-
-#~ msgid "V"
-#~ msgstr "V"
-
-#~ msgid "Export &Configs"
-#~ msgstr "Export &Configs"
-
-#~ msgid "Infill direction"
-#~ msgstr "Infill direction"
 
 #~ msgid ""
 #~ "Enable this to get a G-code file which has G2 and G3 moves. And the "
@@ -17126,47 +16562,8 @@ msgstr ""
 #~ "Enable this to get a G-code file with G2 and G3 moves. The fitting "
 #~ "tolerance is the same as the resolution."
 
-#~ msgid ""
-#~ "Infill area is enlarged slightly to overlap with wall for better bonding. "
-#~ "The percentage value is relative to line width of sparse infill"
-#~ msgstr ""
-#~ "This allows the infill area to be enlarged slightly to overlap with walls "
-#~ "for better bonding. The percentage value is relative to line width of "
-#~ "sparse infill."
-
 #~ msgid "Unload Filament"
 #~ msgstr "Unload"
-
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" to automatically "
-#~ "load or unload filament."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
-#~ msgid "MainBoard"
-#~ msgstr "MainBoard"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
-
-#~ msgid "active"
-#~ msgstr "active"
-
-#~ msgid "Jump to layer"
-#~ msgstr "Jump to layer"
-
-#~ msgid "Cabin humidity"
-#~ msgstr "Cabin humidity"
 
 #~ msgid ""
 #~ "Green means that AMS humidity is normal, orange represent humidity is "
@@ -17176,33 +16573,12 @@ msgstr ""
 #~ "high, and red means that humidity is too high. (Hygrometer: the lower, "
 #~ "the better.)"
 
-#~ msgid "Desiccant status"
-#~ msgstr "Desiccant status"
-
 #~ msgid ""
 #~ "A desiccant status lower than two bars indicates that desiccant may be "
 #~ "inactive. Please change the desiccant.(The bars: higher the better.)"
 #~ msgstr ""
 #~ "A desiccant status lower than two bars indicates that desiccant may be "
 #~ "inactive. Please change the desiccant. (The higher, the better.)"
-
-#~ msgid ""
-#~ "Note: When the lid is open or the desiccant pack is changed, it can take "
-#~ "hours or a night to absorb the moisture. Low temperatures also slow down "
-#~ "the process. During this time, the indicator may not represent the "
-#~ "chamber accurately."
-#~ msgstr ""
-#~ "Note: When the lid is open or the desiccant pack is changed, it can take "
-#~ "hours or a night to absorb the moisture. Low temperatures also slow down "
-#~ "the process. During this time, the indicator may not represent the "
-#~ "chamber accurately."
-
-#~ msgid ""
-#~ "Note: if new filament is inserted during  printing, the AMS will not "
-#~ "automatically read any information until printing is completed."
-#~ msgstr ""
-#~ "Note: if new filament is inserted during  printing, the AMS will not "
-#~ "automatically read any information until printing has finished."
 
 #, boost-format
 #~ msgid "Succeed to export G-code to %1%"
@@ -17226,20 +16602,8 @@ msgstr ""
 #~ msgstr "Initialization failed (Missing LAN IP of printer)!"
 
 #, c-format, boost-format
-#~ msgid "Stopped [%d]!"
-#~ msgstr "Stopped [%d]!"
-
-#, c-format, boost-format
 #~ msgid "Load failed [%d]!"
 #~ msgstr "Loading failed [%d]!"
-
-#, c-format, boost-format
-#~ msgid "No files [%d]"
-#~ msgstr "No files [%d]"
-
-#, c-format, boost-format
-#~ msgid "Load failed [%d]"
-#~ msgstr "Load failed [%d]"
 
 #~ msgid "Failed to fetching model informations from printer."
 #~ msgstr "Failed to fetch model information from printer."
@@ -17266,40 +16630,6 @@ msgstr ""
 #~ "Would you like to keep these changed settings (new value) after switching "
 #~ "presets?"
 
-#~ msgid ""
-#~ "Add solid infill near sloping surfaces to guarantee the vertical shell "
-#~ "thickness (top+bottom solid layers)"
-#~ msgstr ""
-#~ "Add solid infill near sloping surfaces to guarantee the vertical shell "
-#~ "thickness (top+bottom solid layers)."
-
-#~ msgid "Configuration package updated to "
-#~ msgstr "Configuration package updated to "
-
-#~ msgid "Movement:"
-#~ msgstr "Movement:"
-
-#~ msgid "Movement"
-#~ msgstr "Movement"
-
-#~ msgid "Auto Segment"
-#~ msgstr "Auto Segment"
-
-#~ msgid "Depth ratio"
-#~ msgstr "Depth ratio"
-
-#~ msgid "Prizm"
-#~ msgstr "Prizm"
-
-#~ msgid "connector is out of cut contour"
-#~ msgstr "connector is out of cut contour"
-
-#~ msgid "connectors are out of cut contour"
-#~ msgstr "connectors are out of cut contour"
-
-#~ msgid "connector is out of object"
-#~ msgstr "connector is out of object"
-
 #~ msgid "connectors is out of object"
 #~ msgstr "Connectors must be on object surface."
 
@@ -17310,51 +16640,14 @@ msgstr ""
 #~ "Invalid state. \n"
 #~ "No one part is selected to keep after cut"
 
-#~ msgid "Edit Text"
-#~ msgstr "Edit Text"
-
 #~ msgid "Error! Unable to create thread!"
 #~ msgstr "Error. Unable to create thread."
-
-#~ msgid "Exception"
-#~ msgstr "Exception"
-
-#~ msgid "Choose SLA archive:"
-#~ msgstr "Choose SLA archive:"
-
-#~ msgid "Import file"
-#~ msgstr "Import file"
-
-#~ msgid "Import model and profile"
-#~ msgstr "Import model and profile"
-
-#~ msgid "Import profile only"
-#~ msgstr "Import profile only"
-
-#~ msgid "Import model only"
-#~ msgstr "Import model only"
-
-#~ msgid "Accurate"
-#~ msgstr "Accurate"
-
-#~ msgid "Balanced"
-#~ msgstr "Balanced"
-
-#~ msgid "Quick"
-#~ msgstr "Quick"
 
 #~ msgid ""
 #~ "Discribe how long the nozzle will move along the last path when retracting"
 #~ msgstr ""
 #~ "This describes how long the nozzle will move along the last path while "
 #~ "retracting."
-
-#~ msgid "Filling bed "
-#~ msgstr "Filling bed"
-
-#, boost-format
-#~ msgid "%1% infill pattern doesn't support 100%% density."
-#~ msgstr "%1% infill pattern doesn't support 100%% density."
 
 #~ msgid ""
 #~ "Switch to rectilinear pattern?\n"
@@ -17365,55 +16658,20 @@ msgstr ""
 #~ "Yes - Switch to rectilinear pattern automatically\n"
 #~ "No  - Reset density to default non 100% value automatically"
 
-#~ msgid "Please heat the nozzle to above 170 degree before loading filament."
-#~ msgstr ""
-#~ "Please heat the nozzle to above 170 degrees before loading filament."
-
 #, c-format
 #~ msgid "Density of internal sparse infill, 100% means solid throughout"
 #~ msgstr ""
 #~ "This is the density of internal sparse infill. 100% means that the object "
 #~ "will be solid throughout."
 
-#~ msgid "Tree support wall loops"
-#~ msgstr "Tree support wall loops"
-
 #~ msgid "This setting specify the count of walls around tree support"
 #~ msgstr "This setting specifies the wall count around tree support."
-
-#, c-format, boost-format
-#~ msgid " doesn't work at 100%% density "
-#~ msgstr " doesn't work at 100%% density "
-
-#~ msgid "Ctrl + Shift + Enter"
-#~ msgstr "Ctrl + Shift + Enter"
-
-#~ msgid "Tool-Lay on Face"
-#~ msgstr "Tool-Lay on Face"
-
-#~ msgid "Export as STL"
-#~ msgstr "Export as STL"
-
-#~ msgid "Check cloud service status"
-#~ msgstr "Check cloud service status"
-
-#~ msgid "Please input a valid value (K in 0~0.5)"
-#~ msgstr "Please input a valid value (K in 0~0.5)"
-
-#~ msgid "Please input a valid value (K in 0~0.5, N in 0.6~2.0)"
-#~ msgstr "Please input a valid value (K in 0~0.5, N in 0.6~2.0)"
 
 #~ msgid "Export all objects as STL"
 #~ msgstr "Export All Objects as STL"
 
 #~ msgid "The 3mf is not compatible, load geometry data only!"
 #~ msgstr "The 3mf is not compatible, loading geometry data only!"
-
-#~ msgid "Incompatible 3mf"
-#~ msgstr "Incompatible 3mf"
-
-#~ msgid "Add/Remove printers"
-#~ msgstr "Add/Remove printers"
 
 #, c-format, boost-format
 #~ msgid "%s is not supported by AMS."
@@ -17422,51 +16680,11 @@ msgstr ""
 #~ msgid "Don't remind me of this version again"
 #~ msgstr "Don't remind me about this version again."
 
-#~ msgid "Error: IP or Access Code are not correct"
-#~ msgstr "Error: IP or Access Code are not correct"
-
-#~ msgid "Order of inner wall/outer wall/infil"
-#~ msgstr "Order of inner wall/outer wall/infill"
-
 #~ msgid "Print sequence of inner wall, outer wall and infill. "
 #~ msgstr "This is the print sequence of inner walls, outer walls, and infill."
 
-#~ msgid "inner/outer/infill"
-#~ msgstr "inner/outer/infill"
-
-#~ msgid "outer/inner/infill"
-#~ msgstr "outer/inner/infill"
-
-#~ msgid "infill/inner/outer"
-#~ msgstr "infill/inner/outer"
-
-#~ msgid "infill/outer/inner"
-#~ msgstr "infill/outer/inner"
-
-#~ msgid "inner-outer-inner/infill"
-#~ msgstr "inner-outer-inner/infill"
-
-#~ msgid "Embeded"
-#~ msgstr "Embedded"
-
-#~ msgid "Online Models"
-#~ msgstr "Online Models"
-
-#~ msgid "Show online staff-picked models on the home page"
-#~ msgstr "Show online staff-picked models on the home page"
-
 #~ msgid "The minimum printing speed when slow down for cooling"
 #~ msgstr "The minimum printing speed when slowing down for cooling."
-
-#~ msgid ""
-#~ "The bed temperature exceeds filament's vitrification temperature. Please "
-#~ "open the front door of printer before printing to avoid nozzle clog."
-#~ msgstr ""
-#~ "The bed temperature exceeds filament's vitrification temperature. Please "
-#~ "open the front door of printer before printing to avoid nozzle clogs."
-
-#~ msgid "Temperature of vitrificaiton"
-#~ msgstr "Temperature of vitrification"
 
 #~ msgid ""
 #~ "Material becomes soft at this temperature. Thus the heatbed cannot be "
@@ -17474,9 +16692,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Material becomes soft at this temperature. Thus, the heat bed cannot be "
 #~ "hotter than this temperature."
-
-#~ msgid "Enable this option if machine has auxiliary part cooling fan"
-#~ msgstr "Enable this option if the machine has an auxiliary part cooling fan"
 
 #~ msgid ""
 #~ "Speed of auxiliary part cooling fan. Auxiliary fan will run at this speed "
@@ -17486,21 +16701,6 @@ msgstr ""
 #~ "This is the speed of auxiliary part cooling fan. The auxiliary fan will "
 #~ "run at this speed during printing except for during the first several "
 #~ "layers which may be set to have no part cooling."
-
-#~ msgid "Empty layers around bottom are replaced by nearest normal layers."
-#~ msgstr "Empty layers around bottom are replaced by nearest normal layers."
-
-#~ msgid "The model has too many empty layers."
-#~ msgstr "The model has too many empty layers."
-
-#~ msgid "Cali"
-#~ msgstr "Cali"
-
-#~ msgid "Calibration of extrusion"
-#~ msgstr "Calibration of extrusion"
-
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "Push new filament into the extruder"
 
 #, c-format, boost-format
 #~ msgid ""
@@ -17525,30 +16725,6 @@ msgstr ""
 #~ "Please keep the printer open during the printing process to ensure air "
 #~ "circulation or reduce the temperature of the hot bed."
 
-#~ msgid "Total Time Estimation"
-#~ msgstr "Total Time Estimation"
-
-#~ msgid "Resonance frequency identification"
-#~ msgstr "Resonance frequency identification"
-
-#~ msgid "Immediately score"
-#~ msgstr "Immediately score"
-
-#~ msgid "Please give a score for your favorite Bambu Market model."
-#~ msgstr "Please give a score for your favorite Bambu Market model."
-
-#~ msgid "Score"
-#~ msgstr "Score"
-
-#~ msgid "Bambu High Temperature Plate"
-#~ msgstr "Bambu High Temperature Plate"
-
-#~ msgid "Can't connect to the printer"
-#~ msgstr "Can't connect to the printer"
-
-#~ msgid "Recommended temperature range"
-#~ msgstr "Recommended temperature range"
-
 #~ msgid ""
 #~ "Bed temperature when high temperature plate is installed. A value of 0 "
 #~ "means the filament does not support printing on the High Temp Plate"
@@ -17557,9 +16733,6 @@ msgstr ""
 #~ "A value of 0 means the filament does not support printing on the High "
 #~ "Temp Plate."
 
-#~ msgid "Internal bridge support thickness"
-#~ msgstr "Internal bridge support thickness"
-
 #~ msgid ""
 #~ "Style and shape of the support. For normal support, projecting the "
 #~ "supports into a regular grid will create more stable supports (default), "
@@ -17574,9 +16747,6 @@ msgstr ""
 #~ "For tree support, slim style will merge branches more aggressively and "
 #~ "save a lot of material (default), while hybrid style will create similar "
 #~ "structure to normal support under large flat overhangs."
-
-#~ msgid "Bed temperature difference"
-#~ msgstr "Bed temperature difference"
 
 #~ msgid ""
 #~ "Do not recommend bed temperature of other layer to be lower than initial "
@@ -17586,6 +16756,3 @@ msgstr ""
 #~ "It is not recommend for bed temperature of other layers to be lower than "
 #~ "the first layer by more than this threshold. Too low bed temperature of "
 #~ "other layer may cause the model to break free from the build plate."
-
-#~ msgid "Orient the model"
-#~ msgstr "Orient the model"

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -5388,8 +5388,6 @@ msgid ""
 "File: %s\n"
 "Title: %s\n"
 msgstr ""
-"File: %s\n"
-"Title: %s\n"
 
 msgid "Download waiting..."
 msgstr "Descarga esperando..."
@@ -6636,8 +6634,6 @@ msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
 "will be exported."
 msgstr ""
-"Unable to perform boolean operation on model meshes. Only positive parts "
-"will be exported."
 
 msgid ""
 "Are you sure you want to store original SVGs with their local paths into the "
@@ -7113,13 +7109,13 @@ msgid "Mouse wheel reverses when zooming"
 msgstr "La rueda del ratón se invierte al hacer zoom"
 
 msgid "Enable SSL(MQTT)"
-msgstr "Enable SSL(MQTT)"
+msgstr ""
 
 msgid "Enable SSL(FTP)"
-msgstr "Enable SSL(FTP)"
+msgstr ""
 
 msgid "Internal developer mode"
-msgstr "Internal developer mode"
+msgstr ""
 
 msgid "Log Level"
 msgstr "Nivel de registro"
@@ -7822,10 +7818,6 @@ msgid ""
 "0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
 "disable independent support layer height"
 msgstr ""
-"When using support material for the support interface, We recommend the "
-"following settings:\n"
-"0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
-"disable independent support layer height"
 
 msgid ""
 "Change these settings automatically? \n"
@@ -14395,10 +14387,10 @@ msgid "XY separation between an object and its support"
 msgstr "Separación XY entre un objeto y su soporte"
 
 msgid "Support/object first layer gap"
-msgstr "Support/object first layer gap"
+msgstr ""
 
 msgid "XY separation between an object and its support at the first layer."
-msgstr "XY separation between an object and its support at the first layer."
+msgstr ""
 
 msgid "Pattern angle"
 msgstr "Ángulo del patrón"
@@ -18118,7 +18110,7 @@ msgid "Brim Ears"
 msgstr ""
 
 msgid "Please select single object."
-msgstr "Please select single object."
+msgstr ""
 
 #: resources/data/hints.ini: [hint:Precise wall]
 msgid ""
@@ -18815,12 +18807,6 @@ msgstr ""
 #~ msgid "Scale"
 #~ msgstr "Escala"
 
-#~ msgid "Orca Slicer "
-#~ msgstr "Orca Slicer "
-
-#~ msgid "Cool plate"
-#~ msgstr "Bandeja Fría"
-
 #~ msgid "Lift Z Enforcement"
 #~ msgstr "Forzar elevación Z"
 
@@ -19290,9 +19276,6 @@ msgstr ""
 #~ msgid "PrintingPause"
 #~ msgstr "Impresión Pausada"
 
-#~ msgid "Printer local connection failed, please try again."
-#~ msgstr "Printer local connection failed; please try again."
-
 #~ msgid ""
 #~ "Please find the details of Flow Dynamics Calibration from our wiki.\n"
 #~ "\n"
@@ -19357,12 +19340,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Por favor, encuentre la esquina con ángulo perfecto para la extrusión"
 
-#~ msgid "X"
-#~ msgstr "X"
-
-#~ msgid "Y"
-#~ msgstr "Y"
-
 #~ msgid ""
 #~ "Order of wall/infill. When the tickbox is unchecked the walls are printed "
 #~ "first, which works best in most cases.\n"
@@ -19383,9 +19360,6 @@ msgstr ""
 #~ "ellos, lo que resulta en un peor acabado de la superficie exterior. "
 #~ "También puede hacer que el relleno brille a través de las superficies "
 #~ "externas de la pieza."
-
-#~ msgid "V"
-#~ msgstr "V"
 
 #~ msgid ""
 #~ "Orca Slicer is based on BambuStudio by Bambulab, which is from "
@@ -19423,36 +19397,8 @@ msgstr ""
 #~ msgid "Unload Filament"
 #~ msgstr "Descargar"
 
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "Elija una ranura AMS y pulse el botón \"Cargar\" o \"Descargar\" para "
-#~ "cargar o descargar automáticamente el filamento."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
 #~ msgid "MainBoard"
 #~ msgstr "Placa Base"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
-
-#~ msgid "- ℃"
-#~ msgstr "- ℃"
-
-#~ msgid "0.5"
-#~ msgstr "0.5"
-
-#~ msgid "0.005"
-#~ msgstr "0.005"
 
 #~ msgid "active"
 #~ msgstr "activo"
@@ -19533,20 +19479,6 @@ msgstr ""
 #, c-format, boost-format
 #~ msgid "Load failed [%d]!"
 #~ msgstr "¡La carga ha fallado [%d]!"
-
-#, c-format, boost-format
-#~ msgid "No files [%d]"
-#~ msgstr "No files [%d]"
-
-#, c-format, boost-format
-#~ msgid "Load failed [%d]"
-#~ msgstr "Load failed [%d]"
-
-#~ msgid "Failed to fetching model information from printer."
-#~ msgstr "Failed to fetch model information from printer."
-
-#~ msgid "Failed to parse model informations."
-#~ msgstr "Fallo al analizar la información de modelado."
 
 #~ msgid "Connection lost. Please retry."
 #~ msgstr "Conexión perdida. Por favor, reinténtelo."
@@ -19669,9 +19601,6 @@ msgstr ""
 #~ "Añadir relleno sólido al lado de capas inclinadas para garantizar el "
 #~ "grosor de carcasa vertical (capas sólidas superior+inferior)"
 
-#~ msgid " "
-#~ msgstr " "
-
 #~ msgid "Text-Rotate"
 #~ msgstr "Rotación de texto"
 
@@ -19701,18 +19630,6 @@ msgstr ""
 #~ msgstr ""
 #~ "El 3mf está generado por un Orca Slicer antiguo, cargar solo datos de "
 #~ "geometría."
-
-#~ msgid ""
-#~ "Relative extrusion is recommended when using \"label_objects\" "
-#~ "option.Some extruders work better with this option unchecked (absolute "
-#~ "extrusion mode). Wipe tower is only compatible with relative mode. It is "
-#~ "always enabled on BambuLab printers. Default is checked"
-#~ msgstr ""
-#~ "Se recomienda la extrusión relativa cuando se utiliza la opción "
-#~ "\"label_objects\". Algunos extrusores funcionan mejor con esta opción "
-#~ "desactivada (modo de extrusión absoluta). La torre de purga sólo es "
-#~ "compatible con el modo relativo. Siempre activa en las impresoras "
-#~ "BambuLab. Marcada por defecto"
 
 #~ msgid "Fan Speed: "
 #~ msgstr "Velocidad del ventilador:"
@@ -19846,9 +19763,6 @@ msgstr ""
 #~ msgid "Choose SLA archive:"
 #~ msgstr "Elige el archivo SLA:"
 
-#~ msgid "Import file"
-#~ msgstr "Importar archivo"
-
 #~ msgid "Import model and profile"
 #~ msgstr "Importar modelo y perfil"
 
@@ -19941,17 +19855,11 @@ msgstr ""
 #~ msgid " doesn't work at 100%% density "
 #~ msgstr " no funciona con una densidad del 100%% "
 
-#~ msgid "Ctrl + Shift + Enter"
-#~ msgstr "Ctrl + Shift + Enter"
-
 #~ msgid "Tool-Lay on Face"
 #~ msgstr "Herramienta-Tumbar Boca Abajo"
 
 #~ msgid "Export as STL"
 #~ msgstr "Exportar como STL"
-
-#~ msgid "Check cloud service status"
-#~ msgstr "Check cloud service status"
 
 #~ msgid "Please input a valid value (K in 0~0.5)"
 #~ msgstr "Por favor, introduce un valor válido (K en 0~0.5)"
@@ -20034,15 +19942,6 @@ msgstr ""
 #~ "Operaciones de la escena 3D\n"
 #~ "¿Sabías cómo controlar la vista y la selección de objetos/partes con el "
 #~ "ratón y el panel táctil en la escena 3D?"
-
-#~ msgid ""
-#~ "Fix Model\n"
-#~ "Did you know that you can fix a corrupted 3D model to avoid a lot of "
-#~ "slicing problems?"
-#~ msgstr ""
-#~ "Fijar modelo\n"
-#~ "¿Sabías que puedes arreglar un modelo 3D dañado para evitar muchos "
-#~ "problemas de corte?"
 
 #~ msgid ""
 #~ "When need to print with the printer door opened\n"
@@ -20131,14 +20030,8 @@ msgstr ""
 #~ "funcionará a esta velocidad durante la impresión, excepto en las primeras "
 #~ "capas, que se define por la ausencia de capas de refrigeración"
 
-#~ msgid "Cali"
-#~ msgstr "Cali"
-
 #~ msgid "Calibration of extrusion"
 #~ msgstr "Calibración de extrusión"
-
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "Push new filament into the extruder"
 
 #, c-format, boost-format
 #~ msgid ""
@@ -20170,15 +20063,6 @@ msgstr ""
 
 #~ msgid "Resonance frequency identification"
 #~ msgstr "Identificación de frecuencia de resonancia"
-
-#~ msgid "Immediately score"
-#~ msgstr "Immediately score"
-
-#~ msgid "Please give a score for your favorite Bambu Market model."
-#~ msgstr "Please give a score for your favorite Bambu Market model."
-
-#~ msgid "Score"
-#~ msgstr "Score"
 
 #~ msgid "Bambu High Temperature Plate"
 #~ msgstr "Bandeja de Alta Temperatura Bambú"
@@ -20216,12 +20100,6 @@ msgstr ""
 #~ "especialmente cuando la densidad de relleno es baja. Este valor determina "
 #~ "el grosor de los bucles de soporte. 0 significa deshabilitar esta "
 #~ "característica"
-
-#, c-format, boost-format
-#~ msgid ""
-#~ "Klipper's max_accel_to_decel will be adjusted to this % of acceleration"
-#~ msgstr ""
-#~ "El max_accel_to_decel de Klipper se ajustará a este % o de aceleración"
 
 #~ msgid ""
 #~ "Style and shape of the support. For normal support, projecting the "
@@ -20326,13 +20204,6 @@ msgstr ""
 #~ msgstr ""
 #~ "No se ha encontrado el archivo de impresión, por favor, vuelva a "
 #~ "procesarlo"
-
-#~ msgid ""
-#~ "The print file exceeds the maximum allowable size (1GB). Please simplify "
-#~ "the model and slice again"
-#~ msgstr ""
-#~ "El archivo de impresión supera el tamaño máximo permitido (1GB). Por "
-#~ "favor, simplifique el modelo y vuelva a procesarlo"
 
 #~ msgid "Failed uploading print file"
 #~ msgstr "Fallo al cargar el archivo de impresión"
@@ -20537,24 +20408,8 @@ msgstr ""
 #~ "Si se activa, ajusta BambuStudio como aplicación por defecto para abrir "
 #~ "archivos .step"
 
-#~ msgid "Post-processing scripts"
-#~ msgstr "Post-processing scripts"
-
-#~ msgid "Cool Plate / PLA Plate"
-#~ msgstr "Cool Plate / PLA Plate"
-
-#~ msgid ""
-#~ "The following object(s) have empty initial layer and can't be printed. "
-#~ "Please Cut the bottom or enable supports."
-#~ msgstr ""
-#~ "The following object(s) have an empty initial layer and can't be printed. "
-#~ "Please cut the bottom or enable supports."
-
 #~ msgid "Bridge direction"
 #~ msgstr "Dirección del puente"
-
-#~ msgid "Use only one wall on the first layer of model"
-#~ msgstr "Use only one wall on the first layer of models"
 
 #~ msgid "Max Radius"
 #~ msgstr "Radio máximo"
@@ -20566,78 +20421,8 @@ msgstr ""
 #~ "Radio máximo de separación alrededor del extrusor. Se utiliza para evitar "
 #~ "colisiones en la impresión por objetos."
 
-#~ msgid "Object flow ratio"
-#~ msgstr "Object flow ratio"
-
-#~ msgid "The flow ratio set by object, the meaning is the same as flow ratio."
-#~ msgstr ""
-#~ "The flow ratio set by object; the meaning is the same as flow ratio."
-
-#~ msgid "Length of sparse infill anchor"
-#~ msgstr "Length of sparse infill anchor"
-
-#~ msgid ""
-#~ "Connect a sparse infill line to an internal perimeter with a short "
-#~ "segment of an additional perimeter. If expressed as percentage (example: "
-#~ "15%) it is calculated over sparse infill line width. Slicer tries to "
-#~ "connect two close infill lines to a short perimeter segment. If no such "
-#~ "perimeter segment shorter than infill_anchor_max is found, the infill "
-#~ "line is connected to a perimeter segment at just one side and the length "
-#~ "of the perimeter segment taken is limited to this parameter, but no "
-#~ "longer than anchor_length_max. Set this parameter to zero to disable "
-#~ "anchoring perimeters connected to a single infill line."
-#~ msgstr ""
-#~ "This connects a sparse infill line to an internal perimeter with a short "
-#~ "segment of an additional perimeter. If expressed as percentage (example: "
-#~ "15%) it is calculated over sparse infill line width. Bambu Studio tries "
-#~ "to connect two close infill lines to a short perimeter segment. If no "
-#~ "such perimeter segment shorter than infill_anchor_max is found, the "
-#~ "infill line is connected to a perimeter segment at just one side and the "
-#~ "length of the perimeter segment taken is limited to this parameter, but "
-#~ "no longer than anchor_length_max. Set this parameter to zero to disable "
-#~ "anchoring perimeters connected to a single infill line."
-
-#~ msgid "Maximum length of sparse infill anchor"
-#~ msgstr "Maximum length of sparse infill anchor"
-
-#~ msgid ""
-#~ "Connect a sparse infill line to an internal perimeter with a short "
-#~ "segment of an additional perimeter. If expressed as percentage (example: "
-#~ "15%) it is calculated over sparse infill line width. Slicer tries to "
-#~ "connect two close infill lines to a short perimeter segment. If no such "
-#~ "perimeter segment shorter than this parameter is found, the infill line "
-#~ "is connected to a perimeter segment at just one side and the length of "
-#~ "the perimeter segment taken is limited to infill_anchor, but no longer "
-#~ "than this parameter. Set this parameter to zero to disable anchoring."
-#~ msgstr ""
-#~ "This connects a sparse infill line to an internal perimeter with a short "
-#~ "segment of an additional perimeter. If expressed as percentage (example: "
-#~ "15%) it is calculated over sparse infill line width. Bambu Studio tries "
-#~ "to connect two close infill lines to a short perimeter segment. If no "
-#~ "such perimeter segment shorter than this parameter is found, the infill "
-#~ "line is connected to a perimeter segment at just one side and the length "
-#~ "of the perimeter segment taken is limited to infill_anchor, but no longer "
-#~ "than this parameter. Set this parameter to zero to disable anchoring."
-
-#~ msgid "0 (not anchored)"
-#~ msgstr "0 (not anchored)"
-
-#~ msgid ""
-#~ "If you want to process the output G-code through custom scripts, just "
-#~ "list their absolute paths here. Separate multiple scripts with a "
-#~ "semicolon. Scripts will be passed the absolute path to the G-code file as "
-#~ "the first argument, and variables of settings also can be read"
-#~ msgstr ""
-#~ "If you want to process the output G-code through custom scripts, just "
-#~ "list their absolute paths here. Separate multiple scripts with a "
-#~ "semicolon. Scripts will be passed via the absolute path to the G-code "
-#~ "file as the first argument, and variables of settings can also be read"
-
 #~ msgid "Z-Hop Type"
 #~ msgstr "Tipo de salto Z"
-
-#~ msgid "The brim width around tree support. 0 means auto."
-#~ msgstr "The brim width around tree support. 0 means auto."
 
 #~ msgid ""
 #~ "Subtract a Part\n"
@@ -20663,9 +20448,6 @@ msgstr ""
 #~ "STEP en lugar de un STL?\n"
 #~ "Bambu Studio admite el corte de archivos STEP, lo que proporciona "
 #~ "resultados más suaves que un archivo STL de menor resolución. ¡Pruébalo!"
-
-#~ msgid "ERROR:"
-#~ msgstr "ERROR:"
 
 #~ msgid "Bed temperatures for the used filaments differ significantly."
 #~ msgstr ""
@@ -20736,10 +20518,6 @@ msgstr ""
 
 #~ msgid "Export."
 #~ msgstr "Exportar."
-
-#~ msgid "Import geometry data from STL/STEP/3MF/OBJ/AMF files."
-#~ msgstr ""
-#~ "Importación de datos geométricos desde archivos STL/STEP/3MF/OBJ/AMF."
 
 #, boost-format
 #~ msgid "Copying directory %1% to %2% failed: %3%"
@@ -21214,16 +20992,6 @@ msgstr ""
 #~ "%s s"
 
 #~ msgid ""
-#~ "Support layer uses layer height independent with object layer. This is to "
-#~ "support custom support gap,but may cause extra filament switches if "
-#~ "support is specified as different extruder with object"
-#~ msgstr ""
-#~ "La capa de soporte utiliza la altura de la capa independientemente de la "
-#~ "capa del objeto. Esto es para soportar la brecha de soporte "
-#~ "personalizada, pero puede causar cambios de filamento adicionales si el "
-#~ "soporte se especifica como un extrusor diferente con el objeto"
-
-#~ msgid ""
 #~ "Switch to rectilinear pattern?\n"
 #~ "Yes - switch to rectilinear pattern automaticlly\n"
 #~ "No  - reset density to default non 100% value automaticlly\n"
@@ -21321,9 +21089,6 @@ msgstr ""
 #~ "Has cambiado algunos ajustes de preajuste. \n"
 #~ "¿Desea mantener estos ajustes cambiados después de cambiar de preajuste?"
 
-#~ msgid "Zig zag"
-#~ msgstr "Zig zag"
-
 #~ msgid " Object:"
 #~ msgstr "Objeto"
 
@@ -21337,17 +21102,11 @@ msgstr ""
 #~ " está demasiado cerca del área de exclusión, habrá colisiones al "
 #~ "imprimir.\n"
 
-#~ msgid " is too close to others, there may be collisions when printing.\n"
-#~ msgstr "\n"
-
 #~ msgid " is too close to others, there will be collisions when printing.\n"
 #~ msgstr " está demasiado cerca de otros, habrá colisiones al imprimir.\n"
 
 #~ msgid "hybrid(auto)"
 #~ msgstr "híbrido(auto)"
-
-#~ msgid "normal"
-#~ msgstr "normal"
 
 #~ msgid ""
 #~ "normal(auto) and tree(auto) is used to generate support automatically. If "
@@ -21362,24 +21121,6 @@ msgstr ""
 
 #~ msgid "tree"
 #~ msgstr "árbol"
-
-#~ msgid "Pause Print"
-#~ msgstr "Pause Print"
-
-#~ msgid "Edit Pause Print Message"
-#~ msgstr "Edit Pause Print Message"
-
-#~ msgid "Delete Pause Print"
-#~ msgstr "Delete Pause Print"
-
-#~ msgid "\\u2103"
-#~ msgstr "\\ u2103"
-
-#~ msgid "mm\\u00B3"
-#~ msgstr "mm\\ u00b3"
-
-#~ msgid "&Edit"
-#~ msgstr "Editar"
 
 #~ msgid "AMSMaterialsSetting"
 #~ msgstr "Configuración de materiales AMS"
@@ -21412,9 +21153,6 @@ msgstr ""
 #~ "desactivada.\n"
 #~ "Esto puede provocar una disminución en la calidad de los voladizos al "
 #~ "imprimir rápidamente."
-
-#~ msgid "Auto refill"
-#~ msgstr "Auto refill"
 
 #~ msgid ""
 #~ "Bed exclude area that can't used as printable area in X-Y plane. For "
@@ -21471,9 +21209,6 @@ msgstr ""
 #~ msgid "Downloading Bambu Network plug-in"
 #~ msgstr "Descargando el complemento Bambu Network"
 
-#~ msgid "Edit plate setitngs"
-#~ msgstr "Edit plate settings"
-
 #~ msgid ""
 #~ "Extrusion compensation calibration is not supported when using Textured "
 #~ "PEI Plate"
@@ -21487,9 +21222,6 @@ msgstr ""
 #~ msgstr ""
 #~ "No se pudo conectar a la impresora a través de LAN. Introduzca la "
 #~ "dirección IP de la impresora y el código de acceso correctos."
-
-#~ msgid "Failed to parse login report reason111"
-#~ msgstr "Failed to parse login report reason"
 
 #~ msgid "Failed uploading print file. Please enter ip address again."
 #~ msgstr ""
@@ -21533,12 +21265,6 @@ msgstr ""
 #~ "Filamento para imprimir soportes y balsas. «Predeterminado» significa que "
 #~ "no se utiliza un filamento específico como soporte y se utiliza un "
 #~ "filamento actual"
-
-#~ msgid "Filaments Auto refill"
-#~ msgstr "Filament Auto-refill"
-
-#~ msgid "G-code"
-#~ msgstr "G-code"
 
 #~ msgid ""
 #~ "Green represents that AMS humidity is normal, orange and red represent "
@@ -21599,9 +21325,6 @@ msgstr ""
 #~ msgid "Modify"
 #~ msgstr "Modificar"
 
-#~ msgid "NO AMS"
-#~ msgstr "NO AMS"
-
 #~ msgid "Not supported."
 #~ msgstr "No soportado"
 
@@ -21618,12 +21341,6 @@ msgstr ""
 
 #~ msgid "Plate %d: %s does not support filament %s (%s)."
 #~ msgstr "Placa %d: %s no admite el filamento %s (%s)."
-
-#~ msgid "Plate type"
-#~ msgstr "Plate type"
-
-#~ msgid "Plate types supported by the printer"
-#~ msgstr "Plate types supported by the printer"
 
 #~ msgid "Please Fill Task Report."
 #~ msgstr "Por favor rellene el informe de tareas."
@@ -21698,14 +21415,6 @@ msgstr ""
 #~ msgid "Support base"
 #~ msgstr "Base de soporte"
 
-#~ msgid ""
-#~ "Support layer uses layer height independent with object layer. This is to "
-#~ "support customizing z-gap and save print time."
-#~ msgstr ""
-#~ "La capa de soporte utiliza la altura de la capa independientemente de la "
-#~ "capa de objetos. Esto es para permitir la personalización de z-gap y "
-#~ "ahorrar tiempo de impresión."
-
 #~ msgid "Sync material list from AMS"
 #~ msgstr "Sincronizar la lista de materiales de AMS"
 
@@ -21771,13 +21480,6 @@ msgstr ""
 #~ "los puentes internos. 0 significa desactivar esta función"
 
 #~ msgid ""
-#~ "When the current material run out,the printer will continue to print in "
-#~ "the following order."
-#~ msgstr ""
-#~ "When the current material runs out, the printer will continue to print in "
-#~ "the following order."
-
-#~ msgid ""
 #~ "When using support material for the support interface, We recommend the "
 #~ "following settings:\n"
 #~ "0 top z distance, 0 interface spacing, concentric pattern."
@@ -21791,12 +21493,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Configuración general de X1: configuración de red en la barra lateral de "
 #~ "la pantalla principal del X1."
-
-#~ msgid ""
-#~ "You are going to delete %u files from printer. Are you sure to continue?"
-#~ msgstr ""
-#~ "You are going to delete %u files from the printer. Are you sure you want "
-#~ "to continue?"
 
 #~ msgid "(Sort)"
 #~ msgstr "Ordenar"

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -5014,7 +5014,7 @@ msgid "Flow rate"
 msgstr "Débit"
 
 msgid "Pressure advance"
-msgstr "Pressure Advance"
+msgstr ""
 
 msgid "Retraction test"
 msgstr "Test de rétraction"
@@ -7427,16 +7427,16 @@ msgid "PLA Plate"
 msgstr "Plaque PLA"
 
 msgid "Bambu Engineering Plate"
-msgstr "Bambu Engineering Plate"
+msgstr ""
 
 msgid "Bambu Smooth PEI Plate"
-msgstr "Bambu Smooth PEI Plate"
+msgstr ""
 
 msgid "High temperature Plate"
 msgstr "Plateau haute température"
 
 msgid "Bambu Textured PEI Plate"
-msgstr "Bambu Textured PEI Plate"
+msgstr ""
 
 msgid "Send print job to"
 msgstr "Envoyer le travail d'impression à"
@@ -7880,10 +7880,6 @@ msgid ""
 "0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
 "disable independent support layer height"
 msgstr ""
-"When using support material for the support interface, We recommend the "
-"following settings:\n"
-"0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
-"disable independent support layer height"
 
 msgid ""
 "Change these settings automatically? \n"
@@ -8772,58 +8768,54 @@ msgid "The configuration is up to date."
 msgstr "La configuration est à jour."
 
 msgid "Obj file Import color"
-msgstr "Obj file Import color"
+msgstr ""
 
 msgid "Specify number of colors:"
-msgstr "Specify number of colors:"
+msgstr ""
 
 #, c-format, boost-format
 msgid "The color count should be in range [%d, %d]."
-msgstr "The color count should be in range [%d, %d]."
+msgstr ""
 
 msgid "Recommended "
-msgstr "Recommended "
+msgstr ""
 
 msgid "Current filament colors:"
-msgstr "Current filament colors:"
+msgstr ""
 
 msgid "Quick set:"
-msgstr "Quick set:"
+msgstr ""
 
 msgid "Color match"
-msgstr "Color match"
+msgstr ""
 
 msgid "Approximate color matching."
-msgstr "Approximate color matching."
+msgstr ""
 
 msgid "Append"
-msgstr "Append"
+msgstr ""
 
 msgid "Add consumable extruder after existing extruders."
-msgstr "Add consumable extruder after existing extruders."
+msgstr ""
 
 msgid "Reset mapped extruders."
-msgstr "Reset mapped extruders."
+msgstr ""
 
 msgid "Cluster colors"
-msgstr "Cluster colors"
+msgstr ""
 
 msgid "Map Filament"
-msgstr "Map Filament"
+msgstr ""
 
 msgid ""
 "Note:The color has been selected, you can choose OK \n"
 " to continue or manually adjust it."
 msgstr ""
-"Note:The color has been selected, you can choose OK \n"
-" to continue or manually adjust it."
 
 msgid ""
 "Waring:The count of newly added and \n"
 " current extruders exceeds 16."
 msgstr ""
-"Warning: The count of newly added and \n"
-" current extruders exceeds 16."
 
 msgid "Ramming customization"
 msgstr "Personnalisation du pilonnage"
@@ -12434,7 +12426,7 @@ msgstr ""
 "extérieure."
 
 msgid "mm/s² or %"
-msgstr "mm/s² or %"
+msgstr "mm/s² ou %"
 
 msgid ""
 "Acceleration of sparse infill. If the value is expressed as a percentage "
@@ -14725,10 +14717,10 @@ msgid "XY separation between an object and its support"
 msgstr "Séparation XY entre un objet et ses supports"
 
 msgid "Support/object first layer gap"
-msgstr "Support/object first layer gap"
+msgstr ""
 
 msgid "XY separation between an object and its support at the first layer."
-msgstr "XY separation between an object and its support at the first layer."
+msgstr ""
 
 msgid "Pattern angle"
 msgstr "Angle du motif"
@@ -18514,7 +18506,7 @@ msgid "Brim Ears"
 msgstr "Bordure à oreilles"
 
 msgid "Please select single object."
-msgstr "Please select single object."
+msgstr ""
 
 #: resources/data/hints.ini: [hint:Precise wall]
 msgid ""
@@ -19205,12 +19197,6 @@ msgstr ""
 #~ msgid "Scale"
 #~ msgstr "Redimensionner"
 
-#~ msgid "Orca Slicer "
-#~ msgstr "Orca Slicer "
-
-#~ msgid "Cool plate"
-#~ msgstr "Plaque Cool plate"
-
 #~ msgid "Lift Z Enforcement"
 #~ msgstr "Exécution du décalage en Z"
 
@@ -19827,12 +19813,6 @@ msgstr ""
 #~ msgid "Please find the cornor with perfect degree of extrusion"
 #~ msgstr "Veuillez trouver le coin avec un degré d’extrusion parfait"
 
-#~ msgid "X"
-#~ msgstr "X"
-
-#~ msgid "Y"
-#~ msgstr "Y"
-
 #~ msgid ""
 #~ "Associate OrcaSlicer with prusaslicer:// links so that Orca can open "
 #~ "PrusaSlicer links from Printable.com"
@@ -19860,9 +19840,6 @@ msgstr ""
 #~ "imprimées à l’endroit où il est fixé, ce qui se traduira par une moins "
 #~ "bonne finition de la surface extérieure. Cela peut également faire "
 #~ "briller le remplissage à travers les surfaces externes de la pièce."
-
-#~ msgid "V"
-#~ msgstr "V"
 
 #~ msgid "Maximum print speed when purging"
 #~ msgstr "Vitesse d’impression maximale lors de la purge"
@@ -20014,36 +19991,8 @@ msgstr ""
 #~ msgid "Unload Filament"
 #~ msgstr "Déchargement"
 
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "Choisissez un emplacement AMS puis appuyez sur le bouton correspondant "
-#~ "pour Charger ou Décharger le filament."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
 #~ msgid "MainBoard"
 #~ msgstr "Carte mère"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
-
-#~ msgid "- ℃"
-#~ msgstr "- ℃"
-
-#~ msgid "0.5"
-#~ msgstr "0.5"
-
-#~ msgid "0.005"
-#~ msgstr "0.005"
 
 #~ msgid "New Flow Dynamics Calibration"
 #~ msgstr "Nouvelle calibration de la dynamique du flux"
@@ -20148,9 +20097,6 @@ msgstr ""
 #~ msgid "Failed to fetching model information from printer."
 #~ msgstr ""
 #~ "Impossible de récupérer les informations du modèle depuis l'imprimante."
-
-#~ msgid "Failed to parse model informations."
-#~ msgstr "Impossible d'analyser les informations du modèle."
 
 #~ msgid "Connection lost. Please retry."
 #~ msgstr "Connexion perdue. Veuillez réessayer."
@@ -20313,9 +20259,6 @@ msgstr ""
 #~ "surplombs et lorsque les fonctionnalités de vitesses ne sont pas "
 #~ "spécifiées explicitement."
 
-#~ msgid " "
-#~ msgstr " "
-
 #~ msgid "Small Area Infill Flow Compensation (beta)"
 #~ msgstr ""
 #~ "Compensation des débits de remplissage des petites zones (expérimental)"
@@ -20336,18 +20279,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Le fichier 3mf a été généré par une ancienne version de Orca Slicer, "
 #~ "chargement des données de géométrie uniquement."
-
-#~ msgid ""
-#~ "Relative extrusion is recommended when using \"label_objects\" "
-#~ "option.Some extruders work better with this option unchecked (absolute "
-#~ "extrusion mode). Wipe tower is only compatible with relative mode. It is "
-#~ "always enabled on BambuLab printers. Default is checked"
-#~ msgstr ""
-#~ "L’extrusion relative est recommandée lors de l’utilisation de l’option "
-#~ "\"label_objects\". Certains extrudeurs fonctionnent mieux avec cette "
-#~ "option décochée (mode d’extrusion absolu). La tour d’essuyage n’est "
-#~ "compatible qu’avec le mode relatif. Il est toujours activé sur les "
-#~ "imprimantes BambuLab. La valeur par défaut est cochée"
 
 #~ msgid "Movement:"
 #~ msgstr "Mouvement:"
@@ -20418,9 +20349,6 @@ msgstr ""
 
 #~ msgid "Choose SLA archive:"
 #~ msgstr "Choisissez l'archive SLA:"
-
-#~ msgid "Import file"
-#~ msgstr "Importer un fichier"
 
 #~ msgid "Import model and profile"
 #~ msgstr "Importer modèle et profil"
@@ -20588,15 +20516,6 @@ msgstr ""
 #~ "Savez-vous comment contrôler la vue et la sélection des objets/pièces "
 #~ "avec la souris et l'écran tactile dans la scène 3D ?"
 
-#~ msgid ""
-#~ "Fix Model\n"
-#~ "Did you know that you can fix a corrupted 3D model to avoid a lot of "
-#~ "slicing problems?"
-#~ msgstr ""
-#~ "Réparer le Modèle\n"
-#~ "Saviez-vous que vous pouvez réparer un modèle 3D corrompu pour éviter de "
-#~ "nombreux problèmes de découpage ?"
-
 #~ msgid "Embedded"
 #~ msgstr "Intégré"
 
@@ -20688,9 +20607,6 @@ msgstr ""
 #~ msgid "Calibration of extrusion"
 #~ msgstr "Calibration de l'extrusion"
 
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "Poussez le nouveau filament dans l'extrudeur"
-
 #, c-format, boost-format
 #~ msgid ""
 #~ "Bed temperature of other layer is lower than bed temperature of initial "
@@ -20753,13 +20669,6 @@ msgstr ""
 
 #~ msgid "Internal bridge support thickness"
 #~ msgstr "Épaisseur du support interne du pont"
-
-#, fuzzy, c-format, boost-format
-#~ msgid ""
-#~ "Klipper's max_accel_to_decel will be adjusted to this % of acceleration"
-#~ msgstr ""
-#~ "Le paramètre max_accel_to_decel de Klipper sera ajusté à ce pourcentage "
-#~ "d’accélération"
 
 #~ msgid ""
 #~ "Style and shape of the support. For normal support, projecting the "

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -281,10 +281,10 @@ msgid "Manual"
 msgstr "Manuális"
 
 msgid "Plug"
-msgstr "Plug"
+msgstr ""
 
 msgid "Dowel"
-msgstr "Dowel"
+msgstr ""
 
 msgid "Snap"
 msgstr "Csatlakoztatás"
@@ -296,22 +296,22 @@ msgid "Frustum"
 msgstr "Frustum"
 
 msgid "Square"
-msgstr "Square"
+msgstr ""
 
 msgid "Hexagon"
-msgstr "Hexagon"
+msgstr ""
 
 msgid "Keep orientation"
 msgstr "Tájolás megtartása"
 
 msgid "Place on cut"
-msgstr "Place on cut"
+msgstr ""
 
 msgid "Flip upside down"
 msgstr ""
 
 msgid "Connectors"
-msgstr "Connectors"
+msgstr ""
 
 msgid "Type"
 msgstr "Típus"
@@ -367,7 +367,7 @@ msgid "Change cut mode"
 msgstr ""
 
 msgid "Tolerance"
-msgstr "Tolerance"
+msgstr ""
 
 msgid "Drag"
 msgstr "Drag"
@@ -376,28 +376,28 @@ msgid "Draw cut line"
 msgstr ""
 
 msgid "Left click"
-msgstr "Left click"
+msgstr ""
 
 msgid "Add connector"
-msgstr "Add connector"
+msgstr ""
 
 msgid "Right click"
-msgstr "Right click"
+msgstr ""
 
 msgid "Remove connector"
-msgstr "Remove connector"
+msgstr ""
 
 msgid "Move connector"
-msgstr "Move connector"
+msgstr ""
 
 msgid "Add connector to selection"
-msgstr "Add connector to selection"
+msgstr ""
 
 msgid "Remove connector from selection"
-msgstr "Remove connector from selection"
+msgstr ""
 
 msgid "Select all connectors"
-msgstr "Select all connectors"
+msgstr ""
 
 msgid "Cut"
 msgstr "Vágás"
@@ -406,7 +406,7 @@ msgid "Rotate cut plane"
 msgstr ""
 
 msgid "Remove connectors"
-msgstr "Remove connectors"
+msgstr ""
 
 msgid "Bulge"
 msgstr "Kidudorodás"
@@ -421,7 +421,7 @@ msgid "Space proportion related to radius"
 msgstr ""
 
 msgid "Confirm connectors"
-msgstr "Confirm connectors"
+msgstr ""
 
 msgid "Cancel"
 msgstr "Mégse"
@@ -449,10 +449,10 @@ msgid "Reset cutting plane"
 msgstr ""
 
 msgid "Edit connectors"
-msgstr "Edit connectors"
+msgstr ""
 
 msgid "Add connectors"
-msgstr "Add connectors"
+msgstr ""
 
 msgid "Reset cut"
 msgstr ""
@@ -461,10 +461,10 @@ msgid "Reset cutting plane and remove connectors"
 msgstr ""
 
 msgid "Upper part"
-msgstr "Upper part"
+msgstr ""
 
 msgid "Lower part"
-msgstr "Lower part"
+msgstr ""
 
 msgid "Keep"
 msgstr "Keep"
@@ -473,7 +473,7 @@ msgid "Flip"
 msgstr "Flip"
 
 msgid "After cut"
-msgstr "After cut"
+msgstr ""
 
 msgid "Cut to parts"
 msgstr "Részekre darabolás"
@@ -485,7 +485,7 @@ msgid "Warning"
 msgstr "Figyelmeztetés"
 
 msgid "Invalid connectors detected"
-msgstr "Invalid connectors detected"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%1$d connector is out of cut contour"
@@ -500,7 +500,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Some connectors are overlapped"
-msgstr "Some connectors are overlapped"
+msgstr ""
 
 msgid "Select at least one object to keep after cutting."
 msgstr ""
@@ -635,30 +635,30 @@ msgid "Thickness"
 msgstr "Vastagság"
 
 msgid "Text Gap"
-msgstr "Text Gap"
+msgstr ""
 
 msgid "Angle"
-msgstr "Angle"
+msgstr ""
 
 msgid ""
 "Embedded\n"
 "depth"
-msgstr "Embedded depth"
+msgstr ""
 
 msgid "Input text"
 msgstr "Szöveg"
 
 msgid "Surface"
-msgstr "Surface"
+msgstr ""
 
 msgid "Horizontal text"
-msgstr "Horizontal text"
+msgstr ""
 
 msgid "Shift + Mouse move up or down"
-msgstr "Shift + Mouse move up or down"
+msgstr ""
 
 msgid "Rotate text"
-msgstr "Rotate text"
+msgstr ""
 
 msgid "Text shape"
 msgstr "Szöveg alakja"
@@ -1244,64 +1244,63 @@ msgid "No feature"
 msgstr ""
 
 msgid "Vertex"
-msgstr "Vertex"
+msgstr ""
 
 msgid "Edge"
-msgstr "Edge"
+msgstr ""
 
 msgid "Plane"
-msgstr "Plane"
+msgstr ""
 
 msgid "Point on edge"
-msgstr "Point on edge"
+msgstr ""
 
 msgid "Point on circle"
-msgstr "Point on circle"
+msgstr ""
 
 msgid "Point on plane"
-msgstr "Point on plane"
+msgstr ""
 
 msgid "Center of edge"
-msgstr "Center of edge"
+msgstr ""
 
 msgid "Center of circle"
-msgstr "Center of circle"
+msgstr ""
 
 msgid "Select feature"
-msgstr "Select feature"
+msgstr ""
 
 msgid "Select point"
-msgstr "Select point"
+msgstr ""
 
 msgid "Delete"
 msgstr "Törlés"
 
 msgid "Restart selection"
-msgstr "Restart selection"
+msgstr ""
 
 msgid "Esc"
 msgstr "Esc"
 
 msgid "Cancel a feature until exit"
-msgstr "Cancel a feature until exit"
+msgstr ""
 
 msgid "Measure"
-msgstr "Measure"
+msgstr ""
 
 msgid ""
 "Please confirm explosion ratio = 1,and please select at least one object"
 msgstr ""
-"Please confirm explosion ratio = 1, and please select at least one object"
 
 msgid "Please select at least one object."
-msgstr "Please select at least one object."
+msgstr ""
 
 msgid "Edit to scale"
-msgstr "Edit to scale"
+msgstr ""
 
 msgctxt "Verb"
 msgid "Scale all"
-msgstr "Scale all"
+msgstr ""
 
 msgid "None"
 msgstr "Sehol"
@@ -1313,24 +1312,20 @@ msgid "Length"
 msgstr "Hossz"
 
 msgid "Selection"
-msgstr "Selection"
+msgstr ""
 
 msgid " (Moving)"
-msgstr " (Moving)"
+msgstr ""
 
 msgid ""
 "Select 2 faces on objects and \n"
 " make objects assemble together."
 msgstr ""
-"Select 2 faces on objects and \n"
-" make objects assemble together."
 
 msgid ""
 "Select 2 points or circles on objects and \n"
 " specify distance between them."
 msgstr ""
-"Select 2 points or circles on objects and \n"
-" specify distance between them."
 
 msgid "Face"
 msgstr "Face"
@@ -1345,53 +1340,51 @@ msgid ""
 "Feature 1 has been reset, \n"
 "feature 2 has been feature 1"
 msgstr ""
-"Feature 1 has been reset, \n"
-"feature 2 has been feature 1"
 
 msgid "Warning:please select Plane's feature."
-msgstr "Warning: please select Plane's feature."
+msgstr ""
 
 msgid "Warning:please select Point's or Circle's feature."
-msgstr "Warning: please select Point's or Circle's feature."
+msgstr ""
 
 msgid "Warning:please select two different mesh."
-msgstr "Warning: please select two different meshes."
+msgstr ""
 
 msgid "Copy to clipboard"
 msgstr "Másolás a vágólapra"
 
 msgid "Perpendicular distance"
-msgstr "Perpendicular distance"
+msgstr ""
 
 msgid "Distance"
-msgstr "Distance"
+msgstr ""
 
 msgid "Direct distance"
-msgstr "Direct distance"
+msgstr ""
 
 msgid "Distance XYZ"
-msgstr "Distance XYZ"
+msgstr ""
 
 msgid "Parallel"
-msgstr "Parallel"
+msgstr ""
 
 msgid "Center coincidence"
-msgstr "Center coincidence"
+msgstr ""
 
 msgid "Featue 1"
 msgstr "Feature 1"
 
 msgid "Reverse rotation"
-msgstr "Reverse rotation"
+msgstr ""
 
 msgid "Rotate around center:"
-msgstr "Rotate around center:"
+msgstr ""
 
 msgid "Parallel distance:"
 msgstr ""
 
 msgid "Flip by Face 2"
-msgstr "Flip by Face 2"
+msgstr ""
 
 msgid "Ctrl+"
 msgstr "Ctrl+"
@@ -1565,7 +1558,7 @@ msgstr ""
 "frissíteni, mielőtt rendesen használható lenne"
 
 msgid "Privacy Policy Update"
-msgstr "Privacy Policy Update"
+msgstr ""
 
 msgid ""
 "The number of user presets cached in the cloud has exceeded the upper limit, "
@@ -1610,16 +1603,16 @@ msgid ""
 msgstr ""
 
 msgid "Import File"
-msgstr "Import File"
+msgstr ""
 
 msgid "Choose files"
 msgstr "Fájlok kiválasztása"
 
 msgid "New Folder"
-msgstr "New Folder"
+msgstr ""
 
 msgid "Open"
-msgstr "Open"
+msgstr ""
 
 msgid "Rename"
 msgstr "Átnevezés"
@@ -1778,7 +1771,7 @@ msgid "Text"
 msgstr ""
 
 msgid "Height range Modifier"
-msgstr "Height Range Modifier"
+msgstr ""
 
 msgid "Add settings"
 msgstr "Beállítások hozzáadása"
@@ -1793,10 +1786,10 @@ msgid "Set as individual objects"
 msgstr "Beállítás különálló objektumokként"
 
 msgid "Fill bed with copies"
-msgstr "Fill bed with copies"
+msgstr ""
 
 msgid "Fill the remaining area of bed with copies of the selected object"
-msgstr "Fill the remaining area of bed with copies of the selected object"
+msgstr ""
 
 msgid "Printable"
 msgstr "Nyomtatható"
@@ -1923,7 +1916,7 @@ msgid "Change SVG source file, projection, size, ..."
 msgstr ""
 
 msgid "Invalidate cut info"
-msgstr "Invalidate cut info"
+msgstr ""
 
 msgid "Add Primitive"
 msgstr "Primitív hozzáadása"
@@ -1993,7 +1986,7 @@ msgid "auto rotate current plate"
 msgstr "aktuális tálca automatikus forgatása"
 
 msgid "Delete Plate"
-msgstr "Delete Plate"
+msgstr ""
 
 msgid "Remove the selected plate"
 msgstr "Kiválasztott tálca eltávolítása"
@@ -2083,7 +2076,7 @@ msgid "Click the icon to edit color painting of the object"
 msgstr "Kattints az ikonra az objektum színfestésének szerkesztéséhez"
 
 msgid "Click the icon to shift this object to the bed"
-msgstr "Click the icon to shift this object to the bed"
+msgstr ""
 
 msgid "Loading file"
 msgstr "Fájl betöltése"
@@ -2113,20 +2106,18 @@ msgstr ""
 "folyamatbeállításainak szerkesztéséhez."
 
 msgid "Delete connector from object which is a part of cut"
-msgstr "Delete connector from object which is a part of cut"
+msgstr ""
 
 msgid "Delete solid part from object which is a part of cut"
-msgstr "Delete solid part from object which is a part of cut"
+msgstr ""
 
 msgid "Delete negative volume from object which is a part of cut"
-msgstr "Delete negative volume from object which is a part of cut"
+msgstr ""
 
 msgid ""
 "To save cut correspondence you can delete all connectors from all related "
 "objects."
 msgstr ""
-"To save cut correspondence you can delete all connectors from all related "
-"objects."
 
 msgid ""
 "This action will break a cut correspondence.\n"
@@ -2135,14 +2126,9 @@ msgid ""
 "To manipulate with solid parts or negative volumes you have to invalidate "
 "cut information first."
 msgstr ""
-"This action will break a cut correspondence.\n"
-"After that, model consistency can't be guaranteed .\n"
-"\n"
-"To manipulate with solid parts or negative volumes you have to invalidate "
-"cut information first."
 
 msgid "Delete all connectors"
-msgstr "Delete all connectors"
+msgstr ""
 
 msgid "Deleting the last solid part is not allowed."
 msgstr "Az utolsó szilárd rész törlése nem megengedett."
@@ -2156,34 +2142,34 @@ msgid "Assembly"
 msgstr "Összeállítás"
 
 msgid "Cut Connectors information"
-msgstr "Cut Connectors information"
+msgstr ""
 
 msgid "Object manipulation"
-msgstr "Object manipulation"
+msgstr ""
 
 msgid "Group manipulation"
-msgstr "Group manipulation"
+msgstr ""
 
 msgid "Object Settings to modify"
-msgstr "Object Settings to Modify"
+msgstr ""
 
 msgid "Part Settings to modify"
-msgstr "Part Settings to Modify"
+msgstr ""
 
 msgid "Layer range Settings to modify"
-msgstr "Layer Range Settings to Modify"
+msgstr ""
 
 msgid "Part manipulation"
-msgstr "Part manipulation"
+msgstr ""
 
 msgid "Instance manipulation"
-msgstr "Instance manipulation"
+msgstr ""
 
 msgid "Height ranges"
-msgstr "Height ranges"
+msgstr ""
 
 msgid "Settings for height range"
-msgstr "Settings for height range"
+msgstr ""
 
 msgid "Layer"
 msgstr "Réteg"
@@ -2251,10 +2237,10 @@ msgid "to"
 msgstr "eddig"
 
 msgid "Remove height range"
-msgstr "Remove height range"
+msgstr ""
 
 msgid "Add height range"
-msgstr "Add height range"
+msgstr ""
 
 msgid "Invalid numeric."
 msgstr "Érvénytelen számjegy."
@@ -2286,13 +2272,13 @@ msgid "Mouse ear"
 msgstr ""
 
 msgid "Outer brim only"
-msgstr "Outer brim only"
+msgstr ""
 
 msgid "Inner brim only"
-msgstr "Inner brim only"
+msgstr ""
 
 msgid "Outer and inner brim"
-msgstr "Outer and inner brim"
+msgstr ""
 
 msgid "No-brim"
 msgstr "Nincs perem"
@@ -2343,13 +2329,13 @@ msgid "Custom"
 msgstr "Egyéni"
 
 msgid "Pause:"
-msgstr "Pause:"
+msgstr ""
 
 msgid "Custom Template:"
-msgstr "Custom Template:"
+msgstr ""
 
 msgid "Custom G-code:"
-msgstr "Custom G-code:"
+msgstr ""
 
 msgid "Custom G-code"
 msgstr "Egyedi G-kód"
@@ -2367,40 +2353,40 @@ msgid "Add Pause"
 msgstr "Szünet hozzáadása"
 
 msgid "Insert a pause command at the beginning of this layer."
-msgstr "Insert a pause command at the beginning of this layer."
+msgstr ""
 
 msgid "Add Custom G-code"
 msgstr "Egyedi G-kód hozzáadása"
 
 msgid "Insert custom G-code at the beginning of this layer."
-msgstr "Insert custom G-code at the beginning of this layer."
+msgstr ""
 
 msgid "Add Custom Template"
 msgstr "Egyéni sablon hozzáadása"
 
 msgid "Insert template custom G-code at the beginning of this layer."
-msgstr "Insert template custom G-code at the beginning of this layer."
+msgstr ""
 
 msgid "Filament "
 msgstr "Filament "
 
 msgid "Change filament at the beginning of this layer."
-msgstr "Change filament at the beginning of this layer."
+msgstr ""
 
 msgid "Delete Pause"
 msgstr "Szünet törlése"
 
 msgid "Delete Custom Template"
-msgstr "Delete Custom Template"
+msgstr ""
 
 msgid "Edit Custom G-code"
-msgstr "Edit Custom G-code"
+msgstr ""
 
 msgid "Delete Custom G-code"
-msgstr "Delete Custom G-code"
+msgstr ""
 
 msgid "Delete Filament Change"
-msgstr "Delete Filament Change"
+msgstr ""
 
 msgid "No printer"
 msgstr "Nincs nyomtató"
@@ -2412,25 +2398,25 @@ msgid "Failed to connect to the server"
 msgstr "Nem sikerült csatlakozni a szerverhez"
 
 msgid "Check the status of current system services"
-msgstr "Check the status of current system services"
+msgstr ""
 
 msgid "code"
-msgstr "code"
+msgstr ""
 
 msgid "Failed to connect to cloud service"
-msgstr "Failed to connect to cloud service"
+msgstr ""
 
 msgid "Please click on the hyperlink above to view the cloud service status"
-msgstr "Please click on the hyperlink above to view the cloud service status"
+msgstr ""
 
 msgid "Failed to connect to the printer"
 msgstr "Nem sikerült csatlakozni a nyomtatóhoz"
 
 msgid "Connection to printer failed"
-msgstr "Connection to printer failed"
+msgstr ""
 
 msgid "Please check the network connection of the printer and Orca."
-msgstr "Please check the network connection of the printer and Orca."
+msgstr ""
 
 msgid "Connecting..."
 msgstr "Csatlakozás..."
@@ -2448,13 +2434,13 @@ msgid "AMS"
 msgstr "AMS"
 
 msgid "Auto Refill"
-msgstr "Auto Refill"
+msgstr ""
 
 msgid "AMS not connected"
 msgstr "Az AMS nincs csatlakoztatva"
 
 msgid "Load"
-msgstr "Load"
+msgstr ""
 
 msgid "Unload"
 msgstr "Kitöltés"
@@ -2513,7 +2499,7 @@ msgid "Check filament location"
 msgstr "Ellenőrizd a filament helyzetét"
 
 msgid "Grab new filament"
-msgstr "Grab new filament"
+msgstr ""
 
 msgid ""
 "Choose an AMS slot then press \"Load\" or \"Unload\" button to automatically "
@@ -2603,10 +2589,10 @@ msgid "Filling"
 msgstr "Kitöltés"
 
 msgid "Bed filling canceled."
-msgstr "Bed filling canceled."
+msgstr ""
 
 msgid "Bed filling done."
-msgstr "Bed filling done."
+msgstr ""
 
 msgid "Searching for optimal orientation"
 msgstr "Az optimális tájolás keresése"
@@ -2627,56 +2613,48 @@ msgid "Please check the printer network connection."
 msgstr "Kérjük, ellenőrizd a nyomtató hálózati kapcsolatát."
 
 msgid "Abnormal print file data. Please slice again."
-msgstr "Abnormal print file data: please slice again."
+msgstr ""
 
 msgid "Task canceled."
-msgstr "Task canceled."
+msgstr ""
 
 msgid "Upload task timed out. Please check the network status and try again."
-msgstr "Upload task timed out. Please check the network status and try again."
+msgstr ""
 
 msgid "Cloud service connection failed. Please try again."
 msgstr ""
 "A felhőszolgáltatáshoz való csatlakozás sikertelen. Kérjük, próbáld újra."
 
 msgid "Print file not found. please slice again."
-msgstr "Print file not found; please slice again."
+msgstr ""
 
 msgid ""
 "The print file exceeds the maximum allowable size (1GB). Please simplify the "
 "model and slice again."
 msgstr ""
-"The print file exceeds the maximum allowable size (1GB). Please simplify the "
-"model and slice again."
 
 msgid "Failed to send the print job. Please try again."
 msgstr "Nem sikerült elküldeni a nyomtatási feladatot. Kérlek próbáld újra."
 
 msgid "Failed to upload file to ftp. Please try again."
-msgstr "Failed to upload file to ftp. Please try again."
+msgstr ""
 
 msgid ""
 "Check the current status of the bambu server by clicking on the link above."
 msgstr ""
-"Check the current status of the Bambu Lab server by clicking on the link "
-"above."
 
 msgid ""
 "The size of the print file is too large. Please adjust the file size and try "
 "again."
 msgstr ""
-"The size of the print file is too large. Please adjust the file size and try "
-"again."
 
 msgid "Print file not found, Please slice it again and send it for printing."
-msgstr "Print file not found; please slice it again and send it for printing."
+msgstr ""
 
 msgid ""
 "Failed to upload print file to FTP. Please check the network status and try "
 "again."
 msgstr ""
-"Failed to upload print file via FTP. Please check the network status and try "
-"again."
 
 msgid "Sending print job over LAN"
 msgstr "Nyomtatási munka küldése LAN-on keresztül"
@@ -2723,33 +2701,29 @@ msgid "An SD card needs to be inserted before sending to printer."
 msgstr "A nyomtatóra való küldés előtt be kell helyezned egy MicroSD-kártyát."
 
 msgid "Importing SLA archive"
-msgstr "Importing SLA archive"
+msgstr ""
 
 msgid ""
 "The SLA archive doesn't contain any presets. Please activate some SLA "
 "printer preset first before importing that SLA archive."
 msgstr ""
-"The SLA archive doesn't contain any presets. Please activate some SLA "
-"printer presets first before importing that SLA archive."
 
 msgid "Importing canceled."
-msgstr "Importing canceled."
+msgstr ""
 
 msgid "Importing done."
-msgstr "Importing done."
+msgstr ""
 
 msgid ""
 "The imported SLA archive did not contain any presets. The current SLA "
 "presets were used as fallback."
 msgstr ""
-"The imported SLA archive did not contain any presets. The current SLA "
-"presets were used as fallback."
 
 msgid "You cannot load SLA project with a multi-part object on the bed"
-msgstr "You cannot load an SLA project with a multi-part object on the bed"
+msgstr ""
 
 msgid "Please check your object list before preset changing."
-msgstr "Please check your object list before preset changing."
+msgstr ""
 
 msgid "Attention!"
 msgstr "Figyelem!"
@@ -2785,7 +2759,7 @@ msgid "Orca Slicer is licensed under "
 msgstr "A Orca Slicer a következő licencet használja "
 
 msgid "GNU Affero General Public License, version 3"
-msgstr "GNU Affero General Public License, version 3"
+msgstr ""
 
 msgid "Orca Slicer is based on PrusaSlicer and BambuStudio"
 msgstr ""
@@ -2870,13 +2844,13 @@ msgid "Setting AMS slot information while printing is not supported"
 msgstr "Nyomtatás közben nem változtathatóak meg a AMS férőhelyek adatai"
 
 msgid "Setting Virtual slot information while printing is not supported"
-msgstr "Setting Virtual slot information while printing is not supported"
+msgstr ""
 
 msgid "Are you sure you want to clear the filament information?"
-msgstr "Are you sure you want to clear the filament information?"
+msgstr ""
 
 msgid "You need to select the material type and color first."
-msgstr "You need to select the material type and color first."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Please input a valid value (K in %.1f~%.1f)"
@@ -2887,10 +2861,10 @@ msgid "Please input a valid value (K in %.1f~%.1f, N in %.1f~%.1f)"
 msgstr ""
 
 msgid "Other Color"
-msgstr "Other Color"
+msgstr ""
 
 msgid "Custom Color"
-msgstr "Custom Color"
+msgstr ""
 
 msgid "Dynamic flow calibration"
 msgstr "Dinamikus anyagáramlás kalibráció"
@@ -3000,10 +2974,6 @@ msgid ""
 "desiccant pack is changed. it take hours to absorb the moisture, low "
 "temperatures also slow down the process."
 msgstr ""
-"Please change the desiccant when it is too wet. The indicator may not "
-"represent accurately in following cases: when the lid is open or the "
-"desiccant pack is changed. It takes a few hours to absorb the moisture, and "
-"low temperatures also slow down the process."
 
 msgid ""
 "Config which AMS slot should be used for a filament used in the print job"
@@ -3048,7 +3018,6 @@ msgstr "A nyomtató jelenleg nem támogatja az automatikus újratöltést."
 msgid ""
 "AMS filament backup is not enabled, please enable it in the AMS settings."
 msgstr ""
-"AMS filament backup is not enabled; please enable it in the AMS settings."
 
 msgid ""
 "If there are two identical filaments in AMS, AMS filament backup will be "
@@ -3056,10 +3025,6 @@ msgid ""
 "(Currently supporting automatic supply of consumables with the same brand, "
 "material type, and color)"
 msgstr ""
-"If there are two identical filaments in an AMS, AMS filament backup will be "
-"enabled. \n"
-"(This currently supports automatic supply of consumables with the same "
-"brand, material type, and color)"
 
 msgid "DRY"
 msgstr "DRY"
@@ -3128,7 +3093,7 @@ msgstr ""
 "maradék mennyiség automatikusan frissül."
 
 msgid "AMS filament backup"
-msgstr "AMS filament backup"
+msgstr ""
 
 msgid ""
 "AMS will continue to another spool with the same properties of filament "
@@ -3138,14 +3103,12 @@ msgstr ""
 "aktuális filament kifogy."
 
 msgid "Air Printing Detection"
-msgstr "Air Printing Detection"
+msgstr ""
 
 msgid ""
 "Detects clogging and filament grinding, halting printing immediately to "
 "conserve time and filament."
 msgstr ""
-"Detects clogging and filament grinding, halting printing immediately to "
-"conserve time and filament."
 
 msgid "File"
 msgstr "Fájl"
@@ -3227,7 +3190,7 @@ msgid "Running post-processing scripts"
 msgstr "Utófeldolgozási szkriptek futtatása"
 
 msgid "Successfully executed post-processing script"
-msgstr "Successfully executed post-processing script"
+msgstr ""
 
 msgid "Unknown error occurred during exporting G-code."
 msgstr "Ismeretlen hiba történt a G-kód exportálása közben."
@@ -3305,10 +3268,10 @@ msgid "Device"
 msgstr "Nyomtató"
 
 msgid "Task Sending"
-msgstr "Task Sending"
+msgstr ""
 
 msgid "Task Sent"
-msgstr "Task Sent"
+msgstr ""
 
 msgid "Edit multiple printers"
 msgstr ""
@@ -3325,10 +3288,10 @@ msgid "The maximum number of printers that can be selected is %d"
 msgstr ""
 
 msgid "Offline"
-msgstr "Offline"
+msgstr ""
 
 msgid "No task"
-msgstr "No task"
+msgstr ""
 
 msgid "View"
 msgstr "Nézet"
@@ -3340,16 +3303,16 @@ msgid "Edit Printers"
 msgstr ""
 
 msgid "Device Name"
-msgstr "Device Name"
+msgstr ""
 
 msgid "Task Name"
-msgstr "Task Name"
+msgstr ""
 
 msgid "Device Status"
-msgstr "Device Status"
+msgstr ""
 
 msgid "Actions"
-msgstr "Actions"
+msgstr ""
 
 msgid ""
 "Please select the devices you would like to manage here (up to 6 devices)"
@@ -3368,7 +3331,7 @@ msgid "Upgrading"
 msgstr ""
 
 msgid "Incompatible"
-msgstr "Incompatible"
+msgstr ""
 
 msgid "syncing"
 msgstr ""
@@ -3419,25 +3382,25 @@ msgid "Stop"
 msgstr "Állj"
 
 msgid "Task Status"
-msgstr "Task Status"
+msgstr ""
 
 msgid "Sent Time"
-msgstr "Sent Time"
+msgstr ""
 
 msgid "There are no tasks to be sent!"
-msgstr "There are no tasks to be sent!"
+msgstr ""
 
 msgid "No historical tasks!"
-msgstr "No historical tasks!"
+msgstr ""
 
 msgid "Loading..."
 msgstr "Betöltés…"
 
 msgid "No AMS"
-msgstr "No AMS"
+msgstr ""
 
 msgid "Send to Multi-device"
-msgstr "Send to Multi-device"
+msgstr ""
 
 msgid "Preparing print job"
 msgstr "Nyomtatási feladat előkészítése"
@@ -3452,19 +3415,19 @@ msgid "The number of printers in use simultaneously cannot be equal to 0."
 msgstr ""
 
 msgid "Use External Spool"
-msgstr "Use External Spool"
+msgstr ""
 
 msgid "Use AMS"
-msgstr "Use AMS"
+msgstr ""
 
 msgid "Select Printers"
-msgstr "Select Printers"
+msgstr ""
 
 msgid "Ams Status"
-msgstr "AMS Status"
+msgstr ""
 
 msgid "Printing Options"
-msgstr "Printing Options"
+msgstr ""
 
 msgid "Bed Leveling"
 msgstr "Asztalszintezés"
@@ -3476,7 +3439,7 @@ msgid "Flow Dynamic Calibration"
 msgstr ""
 
 msgid "Send Options"
-msgstr "Send Options"
+msgstr ""
 
 msgid "Send to"
 msgstr ""
@@ -3485,16 +3448,13 @@ msgid ""
 "printers at the same time.(It depends on how many devices can undergo "
 "heating at the same time.)"
 msgstr ""
-"printers at the same time. (It depends on how many devices can undergo "
-"heating at the same time.)"
 
 msgid "Wait"
-msgstr "Wait"
+msgstr ""
 
 msgid ""
 "minute each batch.(It depends on how long it takes to complete the heating.)"
 msgstr ""
-"minute each batch. (It depends on how long it takes to complete heating.)"
 
 msgid "Send"
 msgstr "Küldés"
@@ -3518,7 +3478,7 @@ msgid "The name is not allowed to end with space character."
 msgstr "A név nem végződhet szóközzel."
 
 msgid "The name length exceeds the limit."
-msgstr "The name length exceeds the limit."
+msgstr ""
 
 msgid "Origin"
 msgstr "Origó"
@@ -3599,8 +3559,6 @@ msgid ""
 "The recommended minimum temperature cannot be higher than the recommended "
 "maximum temperature.\n"
 msgstr ""
-"The recommended minimum temperature cannot be higher than the recommended "
-"maximum temperature.\n"
 
 msgid "Please check.\n"
 msgstr "Kérjük, ellenőrizd.\n"
@@ -3635,9 +3593,6 @@ msgid ""
 "temperature,it may result in material softening and clogging.The maximum "
 "safe temperature for the material is %d"
 msgstr ""
-"Current chamber temperature is higher than the material's safe temperature; "
-"this may result in material softening and nozzle clogs.The maximum safe "
-"temperature for the material is %d"
 
 msgid ""
 "Too small layer height.\n"
@@ -3747,8 +3702,6 @@ msgid ""
 "Spiral mode only works when wall loops is 1, support is disabled, top shell "
 "layers is 0, sparse infill density is 0 and timelapse type is traditional."
 msgstr ""
-"Spiral mode only works when wall loops is 1, support is disabled, top shell "
-"layers is 0, sparse infill density is 0 and timelapse type is traditional."
 
 msgid " But machines with I3 structure will not generate timelapse videos."
 msgstr ""
@@ -3898,27 +3851,18 @@ msgid ""
 "45℃.In order to avoid extruder clogging,low temperature filament(PLA/PETG/"
 "TPU) is not allowed to be loaded."
 msgstr ""
-"The current chamber temperature or the target chamber temperature exceeds "
-"45℃. In order to avoid extruder clogging, low temperature filament (PLA/PETG/"
-"TPU) is not allowed to be loaded."
 
 msgid ""
 "Low temperature filament(PLA/PETG/TPU) is loaded in the extruder.In order to "
 "avoid extruder clogging,it is not allowed to set the chamber temperature "
 "above 45℃."
 msgstr ""
-"Low temperature filament (PLA/PETG/TPU) is loaded in the extruder. In order "
-"to avoid extruder clogging, it is not allowed to set the chamber temperature "
-"above 45℃."
 
 msgid ""
 "When you set the chamber temperature below 40℃, the chamber temperature "
 "control will not be activated. And the target chamber temperature will "
 "automatically be set to 0℃."
 msgstr ""
-"When you set the chamber temperature below 40℃, the chamber temperature "
-"control will not be activated, and the target chamber temperature will "
-"automatically be set to 0℃."
 
 msgid "Failed to start print job"
 msgstr "Nem sikerült elindítani a nyomtatási feladatot"
@@ -4010,7 +3954,7 @@ msgid "Specific for %1%"
 msgstr ""
 
 msgid "Presets"
-msgstr "Presets"
+msgstr ""
 
 msgid "Print settings"
 msgstr "Nyomtatási beállítások"
@@ -4040,7 +3984,7 @@ msgstr "Paraméter validáció"
 
 #, c-format, boost-format
 msgid "Value %s is out of range. The valid range is from %d to %d."
-msgstr "Value %s is out of range. The valid range is from %d to %d."
+msgstr ""
 
 msgid "Value is out of range."
 msgstr "Az érték tartományon kívül esik."
@@ -4128,7 +4072,7 @@ msgid "Generating geometry index data"
 msgstr "Geometriai index adatok generálása"
 
 msgid "Statistics of All Plates"
-msgstr "Statistics of All Plates"
+msgstr ""
 
 msgid "Display"
 msgstr "Megjelenítés"
@@ -4149,7 +4093,7 @@ msgid "Total time"
 msgstr "Teljes idő"
 
 msgid "Total cost"
-msgstr "Total cost"
+msgstr ""
 
 msgid "up to"
 msgstr "legfeljebb"
@@ -4215,7 +4159,7 @@ msgid "travel"
 msgstr "mozgás"
 
 msgid "Extruder"
-msgstr "Extruder"
+msgstr ""
 
 msgid "Filament change times"
 msgstr "Filamentcserék száma"
@@ -4242,10 +4186,10 @@ msgid "Normal mode"
 msgstr "Normál mód"
 
 msgid "Total Filament"
-msgstr "Total Filament"
+msgstr ""
 
 msgid "Model Filament"
-msgstr "Model Filament"
+msgstr ""
 
 msgid "Prepare time"
 msgstr "Előkészítési idő"
@@ -4317,7 +4261,7 @@ msgid "Tool Move"
 msgstr "Fej mozgatása"
 
 msgid "Tool Rotate"
-msgstr "Tool Rotate"
+msgstr ""
 
 msgid "Move Object"
 msgstr "Objektum mozgatása"
@@ -4341,7 +4285,7 @@ msgid "Spacing"
 msgstr "Térköz"
 
 msgid "0 means auto spacing."
-msgstr "0 means auto spacing."
+msgstr ""
 
 msgid "Auto rotate for arrangement"
 msgstr "Automatikus forgatás az elrendezéshez"
@@ -4556,7 +4500,7 @@ msgid "No"
 msgstr "Nem"
 
 msgid "will be closed before creating a new model. Do you want to continue?"
-msgstr "will be closed before creating a new model. Do you want to continue?"
+msgstr ""
 
 msgid "Slice plate"
 msgstr "Tálca szeletelése"
@@ -4697,13 +4641,13 @@ msgid "Load models contained within a zip archive"
 msgstr ""
 
 msgid "Import Configs"
-msgstr "Import Configs"
+msgstr ""
 
 msgid "Load configs"
-msgstr "Load configs"
+msgstr ""
 
 msgid "Import"
-msgstr "Import"
+msgstr ""
 
 msgid "Export all objects as one STL"
 msgstr "Az összes objektum exportálása egy STL-ként"
@@ -4712,10 +4656,10 @@ msgid "Export all objects as STLs"
 msgstr "Az összes objektum exportálása STL-ként"
 
 msgid "Export Generic 3MF"
-msgstr "Export Generic 3MF"
+msgstr ""
 
 msgid "Export 3mf file without using some 3mf-extensions"
-msgstr "Export 3mf file without using some 3mf-extensions"
+msgstr ""
 
 msgid "Export current sliced file"
 msgstr "Aktuális szeletelt fájl exportálása"
@@ -4837,10 +4781,10 @@ msgid "Show object labels in 3D scene"
 msgstr "Objektumcímkék megjelenítése a 3D-térben"
 
 msgid "Show &Overhang"
-msgstr "Show &Overhang"
+msgstr ""
 
 msgid "Show object overhang highlight in 3D scene"
-msgstr "Show object overhang highlight in 3D scene"
+msgstr ""
 
 msgid "Show Selected Outline (beta)"
 msgstr ""
@@ -4891,7 +4835,7 @@ msgid "Retraction test"
 msgstr "Visszahúzás teszt"
 
 msgid "Orca Tolerance Test"
-msgstr "Orca Tolerance Test"
+msgstr ""
 
 msgid "Max flowrate"
 msgstr "Max. anyagáramlás"
@@ -4966,10 +4910,10 @@ msgid "Overwrite config"
 msgstr ""
 
 msgid "Yes to All"
-msgstr "Yes to All"
+msgstr ""
 
 msgid "No to All"
-msgstr "No to All"
+msgstr ""
 
 msgid "Choose a directory"
 msgstr "Válassz egy mappát"
@@ -4981,7 +4925,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Export result"
-msgstr "Export Result"
+msgstr ""
 
 msgid "Select profile to load:"
 msgstr "Válaszd ki a betölteni kívánt profilt:"
@@ -5000,7 +4944,7 @@ msgid ""
 msgstr ""
 
 msgid "Import result"
-msgstr "Import result"
+msgstr ""
 
 msgid "File is missing"
 msgstr "Hiányzik a fájl"
@@ -5059,7 +5003,6 @@ msgstr ""
 msgid ""
 "LAN Only Liveview is off. Please turn on the liveview on printer screen."
 msgstr ""
-"LAN Only Liveview is off. Please turn on the liveview on printer screen."
 
 msgid "Please enter the IP of printer to connect."
 msgstr "A csatlakozáshoz add meg a nyomtató IP-címét."
@@ -5120,10 +5063,10 @@ msgid "Playing..."
 msgstr "Lejátszás..."
 
 msgid "Year"
-msgstr "Year"
+msgstr ""
 
 msgid "Month"
-msgstr "Month"
+msgstr ""
 
 msgid "All Files"
 msgstr "Minden fájl"
@@ -5147,7 +5090,7 @@ msgid "Switch to video files."
 msgstr "Váltás a videófájlokra."
 
 msgid "Switch to 3mf model files."
-msgstr "Switch to 3mf model files."
+msgstr ""
 
 msgid "Delete selected files from printer."
 msgstr "Kijelölt fájlok törlése a nyomtatóról."
@@ -5168,26 +5111,24 @@ msgid "Refresh"
 msgstr "Frissítés"
 
 msgid "Reload file list from printer."
-msgstr "Reload file list from printer."
+msgstr ""
 
 msgid "No printers."
-msgstr "No printers."
+msgstr ""
 
 msgid "Loading file list..."
-msgstr "Loading file list..."
+msgstr ""
 
 msgid "No files"
 msgstr "Nincs fájl"
 
 msgid "Load failed"
-msgstr "Load failed"
+msgstr ""
 
 msgid ""
 "Browsing file in SD card is not supported in current firmware. Please update "
 "the printer firmware."
 msgstr ""
-"Browsing file in SD card is not supported in current firmware. Please update "
-"the printer firmware."
 
 msgid ""
 "Please check if the SD card is inserted into the printer.\n"
@@ -5197,10 +5138,10 @@ msgstr ""
 "Ha továbbra sem olvasható, próbáld meg formázni az SD-kártyát."
 
 msgid "LAN Connection Failed (Failed to view sdcard)"
-msgstr "LAN Connection Failed (Failed to view sdcard)"
+msgstr ""
 
 msgid "Browsing file in SD card is not supported in LAN Only Mode."
-msgstr "Browsing file in SD card is not supported in LAN Only Mode."
+msgstr ""
 
 #, c-format, boost-format
 msgid "You are going to delete %u file from printer. Are you sure to continue?"
@@ -5210,17 +5151,17 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Delete files"
-msgstr "Delete files"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Do you want to delete the file '%s' from printer?"
-msgstr "Do you want to delete the file '%s' from printer?"
+msgstr ""
 
 msgid "Delete file"
-msgstr "Delete file"
+msgstr ""
 
 msgid "Fetching model information..."
-msgstr "Fetching model information..."
+msgstr ""
 
 msgid "Failed to fetch model information from printer."
 msgstr "Nem sikerült letölteni a modellinfomációt a nyomtatóról."
@@ -5242,8 +5183,6 @@ msgid ""
 "File: %s\n"
 "Title: %s\n"
 msgstr ""
-"File: %s\n"
-"Title: %s\n"
 
 msgid "Download waiting..."
 msgstr "Várakozás letöltésre..."
@@ -5265,8 +5204,6 @@ msgid ""
 "Reconnecting the printer, the operation cannot be completed immediately, "
 "please try again later."
 msgstr ""
-"Reconnecting the printer, the operation cannot be completed immediately, "
-"please try again later."
 
 msgid "File does not exist."
 msgstr "A fájl nem létezik."
@@ -5330,7 +5267,7 @@ msgid "0"
 msgstr "0"
 
 msgid "Layer: N/A"
-msgstr "Layer: N/A"
+msgstr ""
 
 msgid "Clear"
 msgstr "Törlés"
@@ -5339,8 +5276,6 @@ msgid ""
 "You have completed printing the mall model, \n"
 "but the synchronization of rating information has failed."
 msgstr ""
-"You have completed printing the mall model, \n"
-"but synchronizing rating information has failed."
 
 msgid "How do you like this printing file?"
 msgstr "Hogy tetszik ez a nyomtatási fájl?"
@@ -5369,7 +5304,7 @@ msgid "Control"
 msgstr "Vezérlés"
 
 msgid "Printer Parts"
-msgstr "Printer Parts"
+msgstr ""
 
 msgid "Print Options"
 msgstr "Nyomtatási lehetőségek"
@@ -5416,11 +5351,11 @@ msgstr "In Cloud Slicing Queue, there are %s tasks ahead of you."
 
 #, c-format, boost-format
 msgid "Layer: %s"
-msgstr "Layer: %s"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Layer: %d/%d"
-msgstr "Layer: %d/%d"
+msgstr ""
 
 msgid ""
 "Please heat the nozzle to above 170 degree before loading or unloading "
@@ -5491,7 +5426,7 @@ msgid "Get oss config failed."
 msgstr "OSS-konfiguráció letöltése sikertelen."
 
 msgid "Upload Pictures"
-msgstr "Upload Pictures"
+msgstr ""
 
 msgid "Number of images successfully uploaded"
 msgstr "Sikeresen feltöltött képek száma"
@@ -5500,13 +5435,13 @@ msgid " upload failed"
 msgstr " feltöltés sikertelen"
 
 msgid " upload config prase failed\n"
-msgstr " upload config prase failed\n"
+msgstr ""
 
 msgid " No corresponding storage bucket\n"
 msgstr " Nincs megfelelő tárolóhely\n"
 
 msgid " cannot be opened\n"
-msgstr " cannot be opened\n"
+msgstr ""
 
 msgid ""
 "The following issues occurred during the process of uploading images. Do you "
@@ -5534,9 +5469,6 @@ msgid ""
 "\n"
 "  error code: "
 msgstr ""
-"Your comment result cannot be uploaded due to the following reasons:\n"
-"\n"
-"  error code: "
 
 msgid "error message: "
 msgstr "hibaüzenet: "
@@ -5546,9 +5478,6 @@ msgid ""
 "\n"
 "Would you like to redirect to the webpage for rating?"
 msgstr ""
-"\n"
-"\n"
-"Would you like to redirect to the webpage to give a rating?"
 
 msgid ""
 "Some of your images failed to upload. Would you like to redirect to the "
@@ -5630,7 +5559,7 @@ msgid "Latest Version: "
 msgstr "Legújabb verzió: "
 
 msgid "Not for now"
-msgstr "Not for now"
+msgstr ""
 
 msgid "Server Exception"
 msgstr ""
@@ -5697,7 +5626,7 @@ msgid "Open Folder."
 msgstr "Mappa megnyitása."
 
 msgid "Safely remove hardware."
-msgstr "Safely remove hardware."
+msgstr ""
 
 #, c-format, boost-format
 msgid "%1$d Object has custom supports."
@@ -5770,7 +5699,7 @@ msgid "Color painting"
 msgstr "Színfestés"
 
 msgid "Cut connectors"
-msgstr "Cut connectors"
+msgstr ""
 
 msgid "Layers"
 msgstr "Rétegek"
@@ -5836,16 +5765,16 @@ msgid "Allow Prompt Sound"
 msgstr "Hangjelzés engedélyezése"
 
 msgid "Filament Tangle Detect"
-msgstr "Filament Tangle Detection"
+msgstr ""
 
 msgid "Nozzle Clumping Detection"
-msgstr "Nozzle Clumping Detection"
+msgstr ""
 
 msgid "Check if the nozzle is clumping by filament or other foreign objects."
-msgstr "Check if the nozzle is clumping by filament or other foreign objects."
+msgstr ""
 
 msgid "Nozzle Type"
-msgstr "Nozzle Type"
+msgstr "Fúvóka Típus"
 
 msgid "Stainless Steel"
 msgstr "Rozsdamentes acél"
@@ -5977,8 +5906,6 @@ msgid ""
 "Already did a synchronization, do you want to sync only changes or resync "
 "all?"
 msgstr ""
-"Already did a synchronization; do you want to sync only changes or resync "
-"all?"
 
 msgid "Sync"
 msgstr "Sync"
@@ -6078,10 +6005,10 @@ msgstr ""
 "frissítése."
 
 msgid "Invalid values found in the 3mf:"
-msgstr "Invalid values found in the 3mf:"
+msgstr ""
 
 msgid "Please correct them in the param tabs"
-msgstr "Please correct them in the Param tabs"
+msgstr ""
 
 msgid "The 3mf has following modified G-codes in filament or printer presets:"
 msgstr ""
@@ -6118,7 +6045,7 @@ msgstr ""
 "A nem támogatott szövegkódolás miatt helytelen karakterek jelenhetnek meg!"
 
 msgid "Remember my choice."
-msgstr "Remember my choice."
+msgstr ""
 
 #, boost-format
 msgid "Failed loading file \"%1%\". An invalid configuration was found."
@@ -6195,16 +6122,13 @@ msgid "Confirm Save As"
 msgstr "Mentés másként megerősítése"
 
 msgid "Delete object which is a part of cut object"
-msgstr "Delete object which is a part of cut object"
+msgstr ""
 
 msgid ""
 "You try to delete an object which is a part of a cut object.\n"
 "This action will break a cut correspondence.\n"
 "After that model consistency can't be guaranteed."
 msgstr ""
-"You are trying to delete an object which is a part of a cut object.\n"
-"This action will break a cut correspondence.\n"
-"After that, model consistency can't be guaranteed."
 
 msgid "The selected object couldn't be split."
 msgstr "A kijelölt objektumot nem lehet feldarabolni."
@@ -6307,13 +6231,13 @@ msgid "prepare 3mf file..."
 msgstr "3mf fájl előkészítése..."
 
 msgid "Download failed, unknown file format."
-msgstr "Download failed; unknown file format."
+msgstr ""
 
 msgid "downloading project ..."
 msgstr "projekt letöltése ..."
 
 msgid "Download failed, File size exception."
-msgstr "Download failed; File size exception."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Project downloaded %d%%"
@@ -6434,31 +6358,27 @@ msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
 "will be kept. You may fix the meshes and try again."
 msgstr ""
-"Unable to perform boolean operation on model meshes. Only positive parts "
-"will be kept. You may fix the meshes and try again."
 
 #, boost-format
 msgid "Reason: part \"%1%\" is empty."
-msgstr "Reason: part \"%1%\" is empty."
+msgstr ""
 
 #, boost-format
 msgid "Reason: part \"%1%\" does not bound a volume."
-msgstr "Reason: part \"%1%\" does not bound a volume."
+msgstr ""
 
 #, boost-format
 msgid "Reason: part \"%1%\" has self intersection."
-msgstr "Reason: part \"%1%\" has self intersection."
+msgstr ""
 
 #, boost-format
 msgid "Reason: \"%1%\" and another part have no intersection."
-msgstr "Reason: \"%1%\" and another part have no intersection."
+msgstr ""
 
 msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
 "will be exported."
 msgstr ""
-"Unable to perform boolean operation on model meshes. Only positive parts "
-"will be exported."
 
 msgid ""
 "Are you sure you want to store original SVGs with their local paths into the "
@@ -6500,11 +6420,11 @@ msgid "Invalid number"
 msgstr "Érvénytelen szám"
 
 msgid "Plate Settings"
-msgstr "Plate Settings"
+msgstr ""
 
 #, boost-format
 msgid "Number of currently selected parts: %1%\n"
-msgstr "Number of currently selected parts: %1%\n"
+msgstr ""
 
 #, boost-format
 msgid "Number of currently selected objects: %1%\n"
@@ -6683,14 +6603,12 @@ msgid ""
 msgstr ""
 
 msgid "Zoom to mouse position"
-msgstr "Zoom to mouse position"
+msgstr ""
 
 msgid ""
 "Zoom in towards the mouse pointer's position in the 3D view, rather than the "
 "2D window center."
 msgstr ""
-"Zoom in towards the mouse pointer's position in the 3D view, rather than the "
-"2D window center."
 
 msgid "Use free camera"
 msgstr "Szabad kamera használata"
@@ -6749,8 +6667,6 @@ msgid ""
 "With this option enabled, you can send a task to multiple devices at the "
 "same time and manage multiple devices."
 msgstr ""
-"With this option enabled, you can send a task to multiple devices at the "
-"same time and manage multiple devices."
 
 msgid "Auto arrange plate after cloning"
 msgstr ""
@@ -6770,13 +6686,13 @@ msgid "User Sync"
 msgstr "Felhasználó szinkronizálás"
 
 msgid "Update built-in Presets automatically."
-msgstr "Update built-in presets automatically."
+msgstr ""
 
 msgid "System Sync"
-msgstr "System Sync"
+msgstr ""
 
 msgid "Clear my choice on the unsaved presets."
-msgstr "Clear my choice on the unsaved presets."
+msgstr ""
 
 msgid "Associate files to OrcaSlicer"
 msgstr "Fájlok társítása a OrcaSlicerhoz"
@@ -6830,16 +6746,16 @@ msgid "Should printer/filament/process settings be loaded when opening a .3mf?"
 msgstr ""
 
 msgid "Maximum recent projects"
-msgstr "Maximum recent projects"
+msgstr ""
 
 msgid "Maximum count of recent projects"
-msgstr "Maximum count of recent projects"
+msgstr ""
 
 msgid "Clear my choice on the unsaved projects."
-msgstr "Clear my choice on the unsaved projects."
+msgstr ""
 
 msgid "No warnings when loading 3MF with modified G-code"
-msgstr "No warnings when loading 3MF with modified G-code"
+msgstr ""
 
 msgid "Auto-Backup"
 msgstr "Automatikus biztonsági mentés"
@@ -6847,14 +6763,12 @@ msgstr "Automatikus biztonsági mentés"
 msgid ""
 "Backup your project periodically for restoring from the occasional crash."
 msgstr ""
-"Backup your project periodically to help with restoring from an occasional "
-"crash."
 
 msgid "every"
-msgstr "every"
+msgstr ""
 
 msgid "The period of backup in seconds."
-msgstr "The period of backup in seconds."
+msgstr ""
 
 msgid "Downloads"
 msgstr "Letöltések"
@@ -6869,7 +6783,7 @@ msgid "Develop mode"
 msgstr "Fejlesztői mód"
 
 msgid "Skip AMS blacklist check"
-msgstr "Skip AMS blacklist check"
+msgstr ""
 
 msgid "Home page and daily tips"
 msgstr "Kezdőoldal és napi tippek"
@@ -6908,13 +6822,13 @@ msgid "Mouse wheel reverses when zooming"
 msgstr "Görgetési irány megfordítása nagyítás közben"
 
 msgid "Enable SSL(MQTT)"
-msgstr "Enable SSL(MQTT)"
+msgstr ""
 
 msgid "Enable SSL(FTP)"
-msgstr "Enable SSL(FTP)"
+msgstr ""
 
 msgid "Internal developer mode"
-msgstr "Internal developer mode"
+msgstr ""
 
 msgid "Log Level"
 msgstr "Naplózási szint"
@@ -6977,7 +6891,7 @@ msgid "Click to select filament color"
 msgstr "Kattints a filament szín kiválasztásához"
 
 msgid "Please choose the filament color"
-msgstr "Please choose the filament color"
+msgstr ""
 
 msgid "Add/Remove presets"
 msgstr "Beállítások hozzáadása/eltávolítása"
@@ -7004,31 +6918,31 @@ msgid "The selected preset is null!"
 msgstr "A kiválasztott beállítás nulla!"
 
 msgid "End"
-msgstr "End"
+msgstr ""
 
 msgid "Customize"
 msgstr "Testreszabás"
 
 msgid "Other layer filament sequence"
-msgstr "Other layer filament sequence"
+msgstr ""
 
 msgid "Please input layer value (>= 2)."
-msgstr "Please input layer value (>= 2)."
+msgstr ""
 
 msgid "Plate name"
-msgstr "Plate name"
+msgstr ""
 
 msgid "Same as Global Print Sequence"
-msgstr "Same as Global Print Sequence"
+msgstr ""
 
 msgid "Print sequence"
 msgstr "Nyomtatás sorrendje"
 
 msgid "Same as Global"
-msgstr "Same as Global"
+msgstr ""
 
 msgid "Disable"
-msgstr "Disable"
+msgstr ""
 
 msgid "Spiral vase"
 msgstr "Spirál (váza)"
@@ -7037,7 +6951,7 @@ msgid "First layer filament sequence"
 msgstr "Kezdőréteg filament sorrendje"
 
 msgid "Same as Global Plate Type"
-msgstr "Same as Global Plate Type"
+msgstr ""
 
 msgid "Same as Global Bed Type"
 msgstr "Ugyanaz, mint a globális tálca típusa"
@@ -7172,19 +7086,19 @@ msgid "Busy"
 msgstr "Elfoglalt"
 
 msgid "Bambu Cool Plate"
-msgstr "Bambu Cool Plate"
+msgstr ""
 
 msgid "PLA Plate"
-msgstr "PLA Plate"
+msgstr ""
 
 msgid "Bambu Engineering Plate"
-msgstr "Bambu Engineering Plate"
+msgstr ""
 
 msgid "Bambu Smooth PEI Plate"
 msgstr ""
 
 msgid "High temperature Plate"
-msgstr "High Temperature Plate"
+msgstr ""
 
 msgid "Bambu Textured PEI Plate"
 msgstr ""
@@ -7202,7 +7116,7 @@ msgid "send completed"
 msgstr "küldés befejezve"
 
 msgid "Error code"
-msgstr "Error code"
+msgstr ""
 
 msgid "No login account, only printers in LAN mode are displayed"
 msgstr ""
@@ -7290,8 +7204,6 @@ msgid ""
 "The selected printer (%s) is incompatible with the chosen printer profile in "
 "the slicer (%s)."
 msgstr ""
-"The selected printer (%s) is incompatible with the chosen printer profile in "
-"the slicer (%s)."
 
 msgid "An SD card needs to be inserted to record timelapse."
 msgstr "A timelapse rögzítéséhez egy microSD kártyára van szükség."
@@ -7326,16 +7238,13 @@ msgid "Errors"
 msgstr "Hibák"
 
 msgid "Please check the following:"
-msgstr "Please check the following:"
+msgstr ""
 
 msgid ""
 "The printer type selected when generating G-code is not consistent with the "
 "currently selected printer. It is recommended that you use the same printer "
 "type for slicing."
 msgstr ""
-"The printer type selected when generating G-code is not consistent with the "
-"currently selected printer. It is recommended that you use the same printer "
-"type for slicing."
 
 msgid ""
 "There are some unknown filaments in the AMS mappings. Please check whether "
@@ -7359,25 +7268,19 @@ msgid ""
 "If you changed your nozzle lately, please go to Device > Printer Parts to "
 "change settings."
 msgstr ""
-"Your nozzle diameter in sliced file is not consistent with the saved nozzle. "
-"If you changed your nozzle lately, please go to Device > Printer Parts to "
-"change settings."
 
 #, c-format, boost-format
 msgid ""
 "Printing high temperature material(%s material) with %s may cause nozzle "
 "damage"
 msgstr ""
-"Printing high temperature material(%s material) with %s may cause nozzle "
-"damage"
 
 msgid "Please fix the error above, otherwise printing cannot continue."
-msgstr "Please fix the error above, otherwise printing cannot continue."
+msgstr ""
 
 msgid ""
 "Please click the confirm button if you still want to proceed with printing."
 msgstr ""
-"Please click the confirm button if you still want to proceed with printing."
 
 msgid ""
 "Connecting to the printer. Unable to cancel during the connection process."
@@ -7393,13 +7296,13 @@ msgstr ""
 "miatt hamis eredményeket adhat."
 
 msgid "Automatic flow calibration using Micro Lidar"
-msgstr "Automatic flow calibration using the Micro Lidar"
+msgstr ""
 
 msgid "Modifying the device name"
 msgstr "Eszköz nevének módosítása"
 
 msgid "Bind with Pin Code"
-msgstr "Bind with Pin Code"
+msgstr ""
 
 msgid "Bind with Access Code"
 msgstr ""
@@ -7417,7 +7320,6 @@ msgstr "A nyomtató nem kompatibilis a kiválasztott nyomtatóbeállításokkal.
 
 msgid "An SD card needs to be inserted before send to printer SD card."
 msgstr ""
-"A MicroSD card needs to be inserted before sending to the printer SD card."
 
 msgid "The printer is required to be in the same LAN as Orca Slicer."
 msgstr ""
@@ -7433,28 +7335,28 @@ msgid "View all Daily tips"
 msgstr "Napi tippek megtekintése"
 
 msgid "Failed to create socket"
-msgstr "Failed to create socket"
+msgstr ""
 
 msgid "Failed to connect socket"
-msgstr "Failed to connect socket"
+msgstr ""
 
 msgid "Failed to publish login request"
-msgstr "Failed to publish login request"
+msgstr ""
 
 msgid "Get ticket from device timeout"
-msgstr "Timeout getting ticket from device"
+msgstr ""
 
 msgid "Get ticket from server timeout"
-msgstr "Timeout getting ticket from server"
+msgstr ""
 
 msgid "Failed to post ticket to server"
-msgstr "Failed to post ticket to server"
+msgstr ""
 
 msgid "Failed to parse login report reason"
-msgstr "Failed to parse login report reason"
+msgstr ""
 
 msgid "Receive login report timeout"
-msgstr "Receive login report timeout"
+msgstr ""
 
 msgid "Unknown Failure"
 msgstr "Ismeretlen hiba"
@@ -7463,23 +7365,21 @@ msgid ""
 "Please Find the Pin Code in Account page on printer screen,\n"
 " and type in the Pin Code below."
 msgstr ""
-"Please Find the Pin Code in Account page on printer screen,\n"
-" and type in the Pin Code below."
 
 msgid "Can't find Pin Code?"
-msgstr "Can't find Pin Code?"
+msgstr ""
 
 msgid "Pin Code"
-msgstr "Pin Code"
+msgstr ""
 
 msgid "Binding..."
-msgstr "Binding..."
+msgstr ""
 
 msgid "Please confirm on the printer screen"
-msgstr "Please confirm on the printer screen"
+msgstr ""
 
 msgid "Log in failed. Please check the Pin Code."
-msgstr "Log in failed. Please check the Pin Code."
+msgstr ""
 
 msgid "Log in printer"
 msgstr "Bejelentkezés a nyomtatóra"
@@ -7488,13 +7388,13 @@ msgid "Would you like to log in this printer with current account?"
 msgstr "Szeretnél bejelentkezni a nyomtatóra a jelenlegi fiókkal?"
 
 msgid "Check the reason"
-msgstr "Check the reason"
+msgstr ""
 
 msgid "Read and accept"
-msgstr "Read and accept"
+msgstr ""
 
 msgid "Terms and Conditions"
-msgstr "Terms and Conditions"
+msgstr ""
 
 msgid ""
 "Thank you for purchasing a Bambu Lab device.Before using your Bambu Lab "
@@ -7503,23 +7403,18 @@ msgid ""
 "Use(collectively, the \"Terms\"). If you do not comply with or agree to the "
 "Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services."
 msgstr ""
-"Thank you for purchasing a Bambu Lab device. Before using your Bambu Lab "
-"device, please read the terms and conditions. By clicking to agree to use "
-"your Bambu Lab device, you agree to abide by the Privacy Policy and Terms of "
-"Use (collectively, the \"Terms\"). If you do not comply with or agree to the "
-"Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services."
 
 msgid "and"
-msgstr "and"
+msgstr ""
 
 msgid "Privacy Policy"
-msgstr "Privacy Policy"
+msgstr ""
 
 msgid "We ask for your help to improve everyone's printer"
-msgstr "We ask for your help to improve everyone's printer"
+msgstr ""
 
 msgid "Statement about User Experience Improvement Program"
-msgstr "Statement about User Experience Improvement Program"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -7535,20 +7430,9 @@ msgid ""
 "payment information, or phone numbers. By enabling this service, you agree "
 "to these terms and the statement about Privacy Policy."
 msgstr ""
-"In the 3D Printing community, we learn from each other's successes and "
-"failures to adjust our own slicing parameters and settings. %s follows the "
-"same principle and uses machine learning to improve its performance from the "
-"successes and failures of the vast number of prints by our users. We are "
-"training %s to be smarter by feeding them the real-world data. If you are "
-"willing, this service will access information from your error logs and usage "
-"logs, which may include information described in  Privacy Policy. We will "
-"not collect any Personal Data by which an individual can be identified "
-"directly or indirectly, including without limitation names, addresses, "
-"payment information, or phone numbers. By enabling this service, you agree "
-"to these terms and the statement about Privacy Policy."
 
 msgid "Statement on User Experience Improvement Plan"
-msgstr "Statement on User Experience Improvement Plan"
+msgstr ""
 
 msgid "Log in successful."
 msgstr "Sikeres bejelentkezés."
@@ -7606,10 +7490,6 @@ msgid ""
 "0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
 "disable independent support layer height"
 msgstr ""
-"When using support material for the support interface, We recommend the "
-"following settings:\n"
-"0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
-"disable independent support layer height"
 
 msgid ""
 "Change these settings automatically? \n"
@@ -7850,10 +7730,10 @@ msgid "G-code output"
 msgstr "G-kód kimenet"
 
 msgid "Post-processing Scripts"
-msgstr "Post-processing Scripts"
+msgstr ""
 
 msgid "Notes"
-msgstr "Notes"
+msgstr ""
 
 msgid "Frequent"
 msgstr "Gyakori"
@@ -8307,14 +8187,12 @@ msgstr ""
 
 #, boost-format
 msgid "You have changed some settings of preset \"%1%\"."
-msgstr "You have changed some settings of preset \"%1%\"."
+msgstr ""
 
 msgid ""
 "\n"
 "You can save or discard the preset values you have modified."
 msgstr ""
-"\n"
-"You can save or discard the preset values you have modified."
 
 msgid ""
 "\n"
@@ -8323,7 +8201,7 @@ msgid ""
 msgstr ""
 
 msgid "You have previously modified your settings."
-msgstr "You have previously modified your settings."
+msgstr ""
 
 msgid ""
 "\n"
@@ -8344,7 +8222,7 @@ msgid "Show all presets (including incompatible)"
 msgstr "Minden beállítás megjelenítése (beleértve az inkompatibiliseket is)"
 
 msgid "Select presets to compare"
-msgstr "Select presets to compare"
+msgstr ""
 
 msgid ""
 "You can only transfer to current active profile because it has been modified."
@@ -8443,58 +8321,54 @@ msgid "The configuration is up to date."
 msgstr "A konfiguráció naprakész."
 
 msgid "Obj file Import color"
-msgstr "Obj file Import color"
+msgstr ""
 
 msgid "Specify number of colors:"
-msgstr "Specify number of colors:"
+msgstr ""
 
 #, c-format, boost-format
 msgid "The color count should be in range [%d, %d]."
-msgstr "The color count should be in range [%d, %d]."
+msgstr ""
 
 msgid "Recommended "
-msgstr "Recommended "
+msgstr ""
 
 msgid "Current filament colors:"
-msgstr "Current filament colors:"
+msgstr ""
 
 msgid "Quick set:"
-msgstr "Quick set:"
+msgstr ""
 
 msgid "Color match"
-msgstr "Color match"
+msgstr ""
 
 msgid "Approximate color matching."
-msgstr "Approximate color matching."
+msgstr ""
 
 msgid "Append"
-msgstr "Append"
+msgstr ""
 
 msgid "Add consumable extruder after existing extruders."
-msgstr "Add consumable extruder after existing extruders."
+msgstr ""
 
 msgid "Reset mapped extruders."
-msgstr "Reset mapped extruders."
+msgstr ""
 
 msgid "Cluster colors"
-msgstr "Cluster colors"
+msgstr ""
 
 msgid "Map Filament"
-msgstr "Map Filament"
+msgstr ""
 
 msgid ""
 "Note:The color has been selected, you can choose OK \n"
 " to continue or manually adjust it."
 msgstr ""
-"Note:The color has been selected, you can choose OK \n"
-" to continue or manually adjust it."
 
 msgid ""
 "Waring:The count of newly added and \n"
 " current extruders exceeds 16."
 msgstr ""
-"Warning: The count of newly added and \n"
-" current extruders exceeds 16."
 
 msgid "Ramming customization"
 msgstr "Tömörítés testreszabása"
@@ -8627,7 +8501,7 @@ msgid "Objects list"
 msgstr "Objektumok listája"
 
 msgid "Import geometry data from STL/STEP/3MF/OBJ/AMF files"
-msgstr "Import geometry data from STL/STEP/3MF/OBJ/AMF files"
+msgstr ""
 
 msgid "⌘+Shift+G"
 msgstr "⌘+Shift+G"
@@ -8774,25 +8648,25 @@ msgid "Select all objects"
 msgstr "Összes objektum kijelölése"
 
 msgid "Gizmo move"
-msgstr "Gizmo move"
+msgstr ""
 
 msgid "Gizmo scale"
-msgstr "Gizmo scale"
+msgstr ""
 
 msgid "Gizmo rotate"
-msgstr "Gizmo rotate"
+msgstr ""
 
 msgid "Gizmo cut"
-msgstr "Gizmo cut"
+msgstr ""
 
 msgid "Gizmo Place face on bed"
-msgstr "Gizmo Place face on bed"
+msgstr ""
 
 msgid "Gizmo SLA support points"
-msgstr "Gizmo SLA support points"
+msgstr ""
 
 msgid "Gizmo FDM paint-on seam"
-msgstr "Gizmo FDM paint-on seam"
+msgstr ""
 
 msgid "Gizmo Text emboss / engrave"
 msgstr ""
@@ -8807,10 +8681,10 @@ msgid "Switch between Prepare/Preview"
 msgstr ""
 
 msgid "Plater"
-msgstr "Plater"
+msgstr ""
 
 msgid "Move: press to snap by 1mm"
-msgstr "Move: press to snap by 1mm"
+msgstr ""
 
 msgid "⌘+Mouse wheel"
 msgstr "⌘+Egérgörgő"
@@ -8912,43 +8786,43 @@ msgid "Skip this Version"
 msgstr "Verzió kihagyása"
 
 msgid "Done"
-msgstr "Done"
+msgstr ""
 
 msgid "resume"
-msgstr "resume"
+msgstr ""
 
 msgid "Resume Printing"
-msgstr "Resume Printing"
+msgstr ""
 
 msgid "Resume Printing(defects acceptable)"
-msgstr "Resume Printing (defects acceptable)"
+msgstr ""
 
 msgid "Resume Printing(problem solved)"
-msgstr "Resume Printing (problem solved)"
+msgstr ""
 
 msgid "Stop Printing"
-msgstr "Stop Printing"
+msgstr ""
 
 msgid "Check Assistant"
-msgstr "Check Assistant"
+msgstr ""
 
 msgid "Filament Extruded, Continue"
-msgstr "Filament Extruded, Continue"
+msgstr ""
 
 msgid "Not Extruded Yet, Retry"
-msgstr "Not Extruded Yet, Retry"
+msgstr ""
 
 msgid "Finished, Continue"
-msgstr "Finished, Continue"
+msgstr ""
 
 msgid "Load Filament"
 msgstr "Filament betöltés"
 
 msgid "Filament Loaded, Resume"
-msgstr "Filament Loaded, Resume"
+msgstr ""
 
 msgid "View Liveview"
-msgstr "View Liveview"
+msgstr ""
 
 msgid "Confirm and Update Nozzle"
 msgstr "Fúvóka lecserélésének megerősítése"
@@ -9884,13 +9758,13 @@ msgid "First layer print sequence"
 msgstr "Az első réteg nyomtatási sorrendje"
 
 msgid "Other layers print sequence"
-msgstr "Other layers print sequence"
+msgstr ""
 
 msgid "The number of other layers print sequence"
-msgstr "The number of other layers print sequence"
+msgstr ""
 
 msgid "Other layers filament sequence"
-msgstr "Other layers filament sequence"
+msgstr ""
 
 msgid "This G-code is inserted at every layer change before lifting z"
 msgstr "Ez a G-kód minden rétegváltáshoz bekerül a Z tengely emelése előtt."
@@ -10133,7 +10007,7 @@ msgid ""
 msgstr ""
 
 msgid "Only one wall on first layer"
-msgstr "Only one wall on first layer"
+msgstr ""
 
 msgid ""
 "Use only one wall on first layer, to give more space to the bottom infill "
@@ -10287,8 +10161,6 @@ msgid ""
 "This controls the generation of the brim at outer and/or inner side of "
 "models. Auto means the brim width is analyzed and calculated automatically."
 msgstr ""
-"This controls the generation of the brim at outer and/or inner side of "
-"models. Auto means the brim width is analyzed and calculated automatically."
 
 msgid "Painted"
 msgstr ""
@@ -10416,7 +10288,7 @@ msgid "Default process profile when switch to this machine profile"
 msgstr "Alapértelmezett folyamat profil, ha erre a gép profilra váltasz"
 
 msgid "Activate air filtration"
-msgstr "Activate air filtration"
+msgstr ""
 
 msgid "Activate for better air filtration. G-code command: M106 P3 S(0-255)"
 msgstr ""
@@ -11022,10 +10894,10 @@ msgid "Default filament color"
 msgstr "Alapértelmezett filament szín"
 
 msgid "Filament notes"
-msgstr "Filament notes"
+msgstr ""
 
 msgid "You can put your notes regarding the filament here."
-msgstr "You can put your notes regarding the filament here."
+msgstr ""
 
 msgid "Required nozzle HRC"
 msgstr "Szükséges fúvóka HRC-érték"
@@ -11278,9 +11150,6 @@ msgid ""
 "equal to or greater than it, it's highly recommended to open the front door "
 "and/or remove the upper glass to avoid clogging."
 msgstr ""
-"The material softens at this temperature, so when the bed temperature is "
-"equal to or greater than this, it's highly recommended to open the front "
-"door and/or remove the upper glass to avoid clogs."
 
 msgid "Price"
 msgstr "Költség"
@@ -11411,10 +11280,10 @@ msgid ""
 msgstr ""
 
 msgid "0 (no open anchors)"
-msgstr "0 (no open anchors)"
+msgstr ""
 
 msgid "1000 (unlimited)"
-msgstr "1000 (unlimited)"
+msgstr ""
 
 msgid "Maximum length of the infill anchor"
 msgstr "A kitöltőhorgony maximális hossza"
@@ -11462,7 +11331,7 @@ msgid ""
 msgstr ""
 
 msgid "mm/s² or %"
-msgstr "mm/s² or %"
+msgstr "mm/s² vagy %"
 
 msgid ""
 "Acceleration of sparse infill. If the value is expressed as a percentage "
@@ -11607,10 +11476,10 @@ msgstr ""
 "durva megjelenésű lesz"
 
 msgid "Contour"
-msgstr "Contour"
+msgstr ""
 
 msgid "Contour and hole"
-msgstr "Contour and hole"
+msgstr ""
 
 msgid "All walls"
 msgstr "Összes fal"
@@ -11713,16 +11582,13 @@ msgstr ""
 "vonalszélességű, és lassabban kell nyomtatni"
 
 msgid "Precise Z height"
-msgstr "Precise Z height"
+msgstr ""
 
 msgid ""
 "Enable this to get precise z height of object after slicing. It will get the "
 "precise object height by fine-tuning the layer heights of the last few "
 "layers. Note that this is an experimental parameter."
 msgstr ""
-"Enable this to get precise z height of object after slicing. It will get the "
-"precise object height by fine-tuning the layer heights of the last few "
-"layers. Note that this is an experimental parameter."
 
 msgid "Arc fitting"
 msgstr "Íves illesztés"
@@ -11995,16 +11861,13 @@ msgid "Name of parent profile"
 msgstr ""
 
 msgid "Interface shells"
-msgstr "Interface shells"
+msgstr ""
 
 msgid ""
 "Force the generation of solid shells between adjacent materials/volumes. "
 "Useful for multi-extruder prints with translucent materials or manual "
 "soluble support material"
 msgstr ""
-"Force the generation of solid shells between adjacent materials/volumes. "
-"Useful for multi-extruder prints with translucent materials or manual "
-"soluble support material"
 
 msgid "Maximum width of a segmented region"
 msgstr "Szegmentált régió maximális szélessége"
@@ -12091,7 +11954,7 @@ msgid "All solid layer"
 msgstr "Összes szilárd réteg"
 
 msgid "Ironing Pattern"
-msgstr "Ironing Pattern"
+msgstr ""
 
 msgid "The pattern that will be used when ironing"
 msgstr ""
@@ -12587,10 +12450,10 @@ msgid "Type of the printer"
 msgstr ""
 
 msgid "Printer notes"
-msgstr "Printer notes"
+msgstr ""
 
 msgid "You can put your notes regarding the printer here."
-msgstr "You can put your notes regarding the printer here."
+msgstr ""
 
 msgid "Printer variant"
 msgstr "Nyomtató változat"
@@ -12685,7 +12548,7 @@ msgstr ""
 "állítsd nullára"
 
 msgid "Long retraction when cut(beta)"
-msgstr "Long retraction when cut (beta)"
+msgstr ""
 
 msgid ""
 "Experimental feature.Retracting and cutting off the filament at a longer "
@@ -12693,20 +12556,14 @@ msgid ""
 "significantly, it may also raise the risk of nozzle clogs or other printing "
 "problems."
 msgstr ""
-"Experimental feature: Retracting and cutting off the filament at a longer "
-"distance during changes to minimize purge.While this reduces flush "
-"significantly, it may also raise the risk of nozzle clogs or other printing "
-"problems."
 
 msgid "Retraction distance when cut"
-msgstr "Retraction distance when cut"
+msgstr ""
 
 msgid ""
 "Experimental feature.Retraction length before cutting off during filament "
 "change"
 msgstr ""
-"Experimental feature. Retraction length before cutting off during filament "
-"change"
 
 msgid "Z-hop height"
 msgstr ""
@@ -12887,20 +12744,17 @@ msgstr ""
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
 msgstr ""
-"Use scarf joint to minimize seam visibility and increase seam strength."
 
 msgid "Conditional scarf joint"
-msgstr "Conditional scarf joint"
+msgstr ""
 
 msgid ""
 "Apply scarf joints only to smooth perimeters where traditional seams do not "
 "conceal the seams at sharp corners effectively."
 msgstr ""
-"Apply scarf joints only to smooth perimeters where traditional seams do not "
-"conceal the seams at sharp corners effectively."
 
 msgid "Conditional angle threshold"
-msgstr "Conditional angle threshold"
+msgstr ""
 
 msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint "
@@ -12943,44 +12797,39 @@ msgid "This factor affects the amount of material for scarf joints."
 msgstr ""
 
 msgid "Scarf start height"
-msgstr "Scarf start height"
+msgstr ""
 
 msgid ""
 "Start height of the scarf.\n"
 "This amount can be specified in millimeters or as a percentage of the "
 "current layer height. The default value for this parameter is 0."
 msgstr ""
-"Start height of the scarf.\n"
-"This amount can be specified in millimeters or as a percentage of the "
-"current layer height. The default value for this parameter is 0."
 
 msgid "Scarf around entire wall"
-msgstr "Scarf around entire wall"
+msgstr ""
 
 msgid "The scarf extends to the entire length of the wall."
-msgstr "The scarf extends to the entire length of the wall."
+msgstr ""
 
 msgid "Scarf length"
-msgstr "Scarf length"
+msgstr ""
 
 msgid ""
 "Length of the scarf. Setting this parameter to zero effectively disables the "
 "scarf."
 msgstr ""
-"Length of the scarf. Setting this parameter to zero effectively disables the "
-"scarf."
 
 msgid "Scarf steps"
-msgstr "Scarf steps"
+msgstr ""
 
 msgid "Minimum number of segments of each scarf."
-msgstr "Minimum number of segments of each scarf."
+msgstr ""
 
 msgid "Scarf joint for inner walls"
-msgstr "Scarf joint for inner walls"
+msgstr ""
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "Use scarf joint for inner walls as well."
+msgstr ""
 
 msgid "Role base wipe speed"
 msgstr ""
@@ -13043,10 +12892,10 @@ msgid ""
 msgstr ""
 
 msgid "Skirt height"
-msgstr "Skirt height"
+msgstr ""
 
 msgid "How many layers of skirt. Usually only one layer"
-msgstr "Number of skirt layers: usually only one"
+msgstr ""
 
 msgid "Single loop draft shield"
 msgstr ""
@@ -13165,17 +13014,15 @@ msgstr ""
 "varratok"
 
 msgid "Smooth Spiral"
-msgstr "Smooth Spiral"
+msgstr ""
 
 msgid ""
 "Smooth Spiral smooths out X and Y moves as well, resulting in no visible "
 "seam at all, even in the XY directions on walls that are not vertical"
 msgstr ""
-"Smooth Spiral smooths out X and Y moves as well, resulting in no visible "
-"seam at all, even in the XY directions on walls that are not vertical"
 
 msgid "Max XY Smoothing"
-msgstr "Max XY Smoothing"
+msgstr ""
 
 #, no-c-format, no-boost-format
 msgid ""
@@ -13391,10 +13238,10 @@ msgid "XY separation between an object and its support"
 msgstr "Ez szabályozza a tárgy és a támasz közötti XY elválasztás távolságát."
 
 msgid "Support/object first layer gap"
-msgstr "Support/object first layer gap"
+msgstr ""
 
 msgid "XY separation between an object and its support at the first layer."
-msgstr "XY separation between an object and its support at the first layer."
+msgstr ""
 
 msgid "Pattern angle"
 msgstr "Mintázat szöge"
@@ -13442,7 +13289,7 @@ msgid "The z gap between the bottom support interface and object"
 msgstr "A Z távolság az alsó támasz érintkező rétege és az objektum között."
 
 msgid "Support/raft base"
-msgstr "Support/raft base"
+msgstr ""
 
 msgid ""
 "Filament to print support base and raft. \"Default\" means no specific "
@@ -13476,7 +13323,7 @@ msgstr ""
 "letiltva."
 
 msgid "Support/raft interface"
-msgstr "Support/raft interface"
+msgstr ""
 
 msgid ""
 "Filament to print support interface. \"Default\" means no specific filament "
@@ -13542,7 +13389,7 @@ msgstr ""
 "alapértelmezett mintázata koncentrikus"
 
 msgid "Rectilinear Interlaced"
-msgstr "Rectilinear Interlaced"
+msgstr ""
 
 msgid "Base pattern spacing"
 msgstr "Alap mintázatának térköze"
@@ -13595,9 +13442,6 @@ msgid ""
 "support customizing z-gap and save print time.This option will be invalid "
 "when the prime tower is enabled."
 msgstr ""
-"Support layer uses layer height independent with object layer. This is to "
-"support customizing z-gap and save print time.This option will be invalid "
-"when the prime tower is enabled."
 
 msgid "Threshold angle"
 msgstr "Dőlésszög küszöbértéke"
@@ -13678,7 +13522,7 @@ msgid ""
 msgstr ""
 
 msgid "Tree support brim width"
-msgstr "Tree support brim width"
+msgstr ""
 
 msgid "Distance from tree branch to the outermost brim line"
 msgstr ""
@@ -14219,16 +14063,16 @@ msgstr ""
 "alapértelmezés szerint az egyenes vonalú mintát használja."
 
 msgid "invalid value "
-msgstr "invalid value "
+msgstr ""
 
 msgid "Invalid value when spiral vase mode is enabled: "
-msgstr "Invalid value when spiral vase mode is enabled: "
+msgstr ""
 
 msgid "too large line width "
-msgstr "too large line width "
+msgstr ""
 
 msgid " not in range "
-msgstr " not in range "
+msgstr ""
 
 msgid "Export 3MF"
 msgstr "3MF exportálása"
@@ -14300,25 +14144,25 @@ msgid "mtcpp"
 msgstr "mtcpp"
 
 msgid "max triangle count per plate for slicing."
-msgstr "max triangle count per plate for slicing"
+msgstr ""
 
 msgid "mstpp"
 msgstr "mstpp"
 
 msgid "max slicing time per plate in seconds."
-msgstr "max slicing time per plate in seconds"
+msgstr ""
 
 msgid "No check"
-msgstr "No check"
+msgstr ""
 
 msgid "Do not run any validity checks, such as G-code path conflicts check."
 msgstr ""
 
 msgid "Normative check"
-msgstr "Normative check"
+msgstr ""
 
 msgid "Check the normative items."
-msgstr "Check the normative items."
+msgstr ""
 
 msgid "Output Model Info"
 msgstr "Kimeneti modell információ"
@@ -14401,10 +14245,10 @@ msgid "Load filament settings from the specified file list"
 msgstr "Filamentbeállítások betöltése a megadott fájllistából"
 
 msgid "Skip Objects"
-msgstr "Skip Objects"
+msgstr ""
 
 msgid "Skip some objects in this print"
-msgstr "Skip some objects in this print"
+msgstr ""
 
 msgid "Clone Objects"
 msgstr ""
@@ -14413,14 +14257,12 @@ msgid "Clone objects in the load list"
 msgstr ""
 
 msgid "load uptodate process/machine settings when using uptodate"
-msgstr "load uptodate process/machine settings when using uptodate"
+msgstr ""
 
 msgid ""
 "load uptodate process/machine settings from the specified file when using "
 "uptodate"
 msgstr ""
-"load up-to-date process/machine settings from the specified file when using "
-"up-to-date"
 
 msgid "load uptodate filament settings when using uptodate"
 msgstr ""
@@ -14823,21 +14665,19 @@ msgid "Checking support necessity"
 msgstr "Támasz szükségességének ellenőrzése"
 
 msgid "floating regions"
-msgstr "floating regions"
+msgstr ""
 
 msgid "floating cantilever"
-msgstr "floating cantilever"
+msgstr ""
 
 msgid "large overhangs"
-msgstr "large overhangs"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "It seems object %s has %s. Please re-orient the object or enable support "
 "generation."
 msgstr ""
-"It seems object %s has %s. Please re-orient the object or enable support "
-"generation."
 
 msgid "Generating support"
 msgstr "Támaszok generálása"
@@ -14852,8 +14692,6 @@ msgid ""
 "No layers were detected. You might want to repair your STL file(s) or check "
 "their size or thickness and retry.\n"
 msgstr ""
-"No layers were detected. You might want to repair your STL file(s) or check "
-"their size or thickness and retry.\n"
 
 msgid ""
 "An object's XY size compensation will not be used because it is also color-"
@@ -14867,35 +14705,33 @@ msgstr "Támasz: érintkezési pontok generálása"
 msgid ""
 "Unknown file format. Input file must have .stl, .obj, .amf(.xml) extension."
 msgstr ""
-"Unknown file format: input file must have .stl, .obj, or .amf(.xml) "
-"extension."
 
 msgid "Loading of a model file failed."
-msgstr "Loading of model file failed."
+msgstr ""
 
 msgid "The supplied file couldn't be read because it's empty"
-msgstr "The supplied file couldn't be read because it's empty."
+msgstr ""
 
 msgid "Unknown file format. Input file must have .3mf or .zip.amf extension."
-msgstr "Unknown file format: input file must have .3mf or .zip.amf extension."
+msgstr ""
 
 msgid "load_obj: failed to parse"
-msgstr "load_obj: failed to parse"
+msgstr ""
 
 msgid "load mtl in obj: failed to parse"
-msgstr "load mtl in obj: failed to parse"
+msgstr ""
 
 msgid "The file contains polygons with more than 4 vertices."
-msgstr "The file contains polygons with more than 4 vertices."
+msgstr ""
 
 msgid "The file contains polygons with less than 2 vertices."
-msgstr "The file contains polygons with less than 2 vertices."
+msgstr ""
 
 msgid "The file contains invalid vertex index."
-msgstr "The file contains invalid vertex index."
+msgstr ""
 
 msgid "This OBJ file couldn't be read because it's empty."
-msgstr "This OBJ file couldn't be read because it's empty."
+msgstr ""
 
 msgid "Flow Rate Calibration"
 msgstr "Anyagáramlás kalibrálása"
@@ -14995,8 +14831,6 @@ msgstr "Új beállítás létrehozása sikertelen."
 msgid ""
 "Are you sure to cancel the current calibration and return to the home page?"
 msgstr ""
-"Are you sure you want to cancel the current calibration and return to the "
-"home page?"
 
 msgid "No Printer Connected!"
 msgstr "Nincs nyomtató csatlakoztatva!"
@@ -15017,11 +14851,6 @@ msgid ""
 "historical results. \n"
 "Do you still want to continue the calibration?"
 msgstr ""
-"This machine type can only hold 16 historical results per nozzle. You can "
-"delete the existing historical results and then start calibration. Or you "
-"can continue the calibration, but you cannot create new calibration "
-"historical results. \n"
-"Do you still want to continue the calibration?"
 
 msgid "Connecting to printer..."
 msgstr "Csatlakozás a nyomtatóhoz..."
@@ -15047,8 +14876,6 @@ msgid ""
 "This machine type can only hold %d history results per nozzle. This result "
 "will not be saved."
 msgstr ""
-"This machine type can only hold %d historical results per nozzle. This "
-"result will not be saved."
 
 msgid "Internal Error"
 msgstr "Belső hiba"
@@ -15123,15 +14950,6 @@ msgid ""
 "4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as "
 "they should be."
 msgstr ""
-"After using Flow Dynamics Calibration, there might still be some extrusion "
-"issues, such as:\n"
-"1. Over-Extrusion: Excess material on your printed object, forming blobs or "
-"zits, or the layers seem thicker than expected and not uniform.\n"
-"2. Under-Extrusion: Very thin layers, weak infill strength, or gaps in the "
-"top layer of the model, even when printing slowly.\n"
-"3. Poor Surface Quality: The surface of your prints seems rough or uneven.\n"
-"4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as "
-"they should be."
 
 msgid ""
 "In addition, Flow Rate Calibration is crucial for foaming materials like LW-"
@@ -15176,22 +14994,6 @@ msgid ""
 "can lead to sub-par prints or printer damage. Please make sure to carefully "
 "read and understand the process before doing it."
 msgstr ""
-"Auto Flow Rate Calibration utilizes Bambu Lab's Micro-Lidar technology, "
-"directly measuring the calibration patterns. However, please be advised that "
-"the efficacy and accuracy of this method may be compromised with specific "
-"types of materials. Particularly, filaments that are transparent or semi-"
-"transparent, sparkling-particled, or have a high-reflective finish may not "
-"be suitable for this calibration and can produce less-than-desirable "
-"results.\n"
-"\n"
-"The calibration results may vary between each calibration or filament. We "
-"are still improving the accuracy and compatibility of this calibration "
-"through firmware updates over time.\n"
-"\n"
-"Caution: Flow Rate Calibration is an advanced process, to be attempted only "
-"by those who fully understand its purpose and implications. Incorrect usage "
-"can lead to sub-par prints or printer damage. Please make sure to carefully "
-"read and understand the process before performing it."
 
 msgid "When you need Max Volumetric Speed Calibration"
 msgstr "Mikor van szükség a max. volumetrikus sebesség kalibrálására"
@@ -15260,7 +15062,7 @@ msgid "Preset"
 msgstr "Beállítás"
 
 msgid "Record Factor"
-msgstr "Record Factor"
+msgstr ""
 
 msgid "We found the best flow ratio for you"
 msgstr "Megtaláltuk a legjobb anyagáramlást"
@@ -15326,7 +15128,7 @@ msgid "Printing Parameters"
 msgstr "Nyomtatási paraméterek"
 
 msgid "Plate Type"
-msgstr "Plate Type"
+msgstr ""
 
 msgid "filament position"
 msgstr "filamentpozíció"
@@ -15385,7 +15187,7 @@ msgid "Flow Dynamics Calibration Result"
 msgstr "Áramlásdinamikai kalibrációs eredmény"
 
 msgid "New"
-msgstr "New"
+msgstr ""
 
 msgid "No History Result"
 msgstr "Nincs előzmény"
@@ -15401,25 +15203,25 @@ msgstr "Művelet"
 
 #, c-format, boost-format
 msgid "This machine type can only hold %d history results per nozzle."
-msgstr "This machine type can only hold %d historical results per nozzle."
+msgstr ""
 
 msgid "Edit Flow Dynamics Calibration"
 msgstr "Áramlásdinamikai kalibráció szerkesztése"
 
 msgid "New Flow Dynamic Calibration"
-msgstr "New Flow Dynamic Calibration"
+msgstr ""
 
 msgid "Ok"
 msgstr "Ok"
 
 msgid "The filament must be selected."
-msgstr "The filament must be selected."
+msgstr ""
 
 msgid "Network lookup"
 msgstr "Hálózati keresés"
 
 msgid "Address"
-msgstr "Address"
+msgstr ""
 
 msgid "Hostname"
 msgstr "Host név:"
@@ -16158,7 +15960,7 @@ msgid "Please select a type you want to export"
 msgstr "Válaszd ki az exportálandó beállítás típusát"
 
 msgid "Failed to create temporary folder, please try Export Configs again."
-msgstr "Failed to create temporary folder, please try Export Configs again."
+msgstr ""
 
 msgid "Edit Filament"
 msgstr "Filament szerkesztése"
@@ -16331,16 +16133,16 @@ msgid "Mismatched type of print host: %s"
 msgstr "A nyomtatóállomás típusa nem egyezik: %s"
 
 msgid "Connection to AstroBox is working correctly."
-msgstr "Connection to AstroBox is working correctly."
+msgstr ""
 
 msgid "Could not connect to AstroBox"
 msgstr "Nem sikerült csatlakozni az AstroBoxhoz"
 
 msgid "Note: AstroBox version 1.1.0 or higher is required."
-msgstr "Note: AstroBox version 1.1.0 or higher is required."
+msgstr ""
 
 msgid "Connection to Duet is working correctly."
-msgstr "Connection to Duet is working correctly."
+msgstr ""
 
 msgid "Could not connect to Duet"
 msgstr "Nem sikerült csatlakozni a Duethez"
@@ -16358,7 +16160,7 @@ msgid "Upload not enabled on FlashAir card."
 msgstr "A feltöltés nincs engedélyezve a FlashAir kártyán."
 
 msgid "Connection to FlashAir is working correctly and upload is enabled."
-msgstr "Connection to FlashAir is working correctly and upload is enabled."
+msgstr ""
 
 msgid "Could not connect to FlashAir"
 msgstr "Nem sikerült csatlakozni a FlashAirhez"
@@ -16371,28 +16173,28 @@ msgstr ""
 "funkció szükséges."
 
 msgid "Connection to MKS is working correctly."
-msgstr "Connection to MKS is working correctly."
+msgstr ""
 
 msgid "Could not connect to MKS"
 msgstr "Nem sikerült csatlakozni az MKS-hez"
 
 msgid "Connection to OctoPrint is working correctly."
-msgstr "Connection to OctoPrint is working correctly."
+msgstr ""
 
 msgid "Could not connect to OctoPrint"
 msgstr "Nem sikerült csatlakozni az OctoPrinthez"
 
 msgid "Note: OctoPrint version 1.1.0 or higher is required."
-msgstr "Note: OctoPrint version 1.1.0 or higher is required."
+msgstr ""
 
 msgid "Connection to Prusa SL1 / SL1S is working correctly."
-msgstr "Connection to Prusa SL1 / SL1S is working correctly."
+msgstr ""
 
 msgid "Could not connect to Prusa SLA"
 msgstr "Nem sikerült csatlakozni a Prusa SLA-hoz"
 
 msgid "Connection to PrusaLink is working correctly."
-msgstr "Connection to PrusaLink is working correctly."
+msgstr ""
 
 msgid "Could not connect to PrusaLink"
 msgstr "Nem sikerült csatlakozni a PrusaLinkhez"
@@ -16422,13 +16224,13 @@ msgid "Could not connect to Prusa Connect"
 msgstr ""
 
 msgid "Connection to Repetier is working correctly."
-msgstr "Connection to Repetier is working correctly."
+msgstr ""
 
 msgid "Could not connect to Repetier"
 msgstr "Nem sikerült csatlakozni a Repetierhez"
 
 msgid "Note: Repetier version 0.90.0 or higher is required."
-msgstr "Note: Repetier version 0.90.0 or higher is required."
+msgstr ""
 
 #, boost-format
 msgid ""
@@ -16705,7 +16507,7 @@ msgid "Brim Ears"
 msgstr ""
 
 msgid "Please select single object."
-msgstr "Please select single object."
+msgstr ""
 
 #: resources/data/hints.ini: [hint:Precise wall]
 msgid ""
@@ -17067,17 +16869,6 @@ msgstr ""
 #~ "javasoljuk: legalább 2 érintkező réteg, legalább 0,1 mm felső Z-távolság "
 #~ "vagy támaszanyag használata."
 
-#~ msgid ""
-#~ "When using support material for the support interface, We recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-#~ msgstr ""
-#~ "When using support material for the support interface, we recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-
 #~ msgid "This setting specify the count of walls around support"
 #~ msgstr "A támasz körüli falak száma"
 
@@ -17109,15 +16900,8 @@ msgstr ""
 #~ msgid "Support: propagate branches at layer %d"
 #~ msgstr "Támasz: ágak kiterjesztése %d. réteg"
 
-#~ msgid "Current Cabin humidity"
-#~ msgstr "Current Cabin humidity"
-
 #~ msgid "Stopped."
 #~ msgstr "Megállítva."
-
-#, c-format, boost-format
-#~ msgid "Connect failed [%d]!"
-#~ msgstr "Connection failed [%d]!"
 
 #~ msgid "Initialize failed (Device connection not ready)!"
 #~ msgstr "Initialization failed (Device connection not ready)!"
@@ -17205,18 +16989,8 @@ msgstr ""
 #~ msgid "Scale"
 #~ msgstr "Átméretezés"
 
-#~ msgid "Cool plate"
-#~ msgstr "Cool plate"
-
 #~ msgid "Z-hop when retract"
 #~ msgstr "Z-tengely emelés visszahúzáskor"
-
-#~ msgid ""
-#~ "While printing by Object, the extruder may collide skirt.\n"
-#~ "Thus, reset the skirt layer to 1 to avoid that."
-#~ msgstr ""
-#~ "While printing by object, the extruder may collide with a skirt.\n"
-#~ "Thus, reset the skirt layer to 1 to avoid collisions."
 
 #~ msgid "Limited"
 #~ msgstr "Korlátozott"
@@ -17270,23 +17044,6 @@ msgstr ""
 #~ "nyomtatási időhöz."
 
 #~ msgid ""
-#~ "Higher chamber temperature can help suppress or reduce warping and "
-#~ "potentially lead to higher interlayer bonding strength for high "
-#~ "temperature materials like ABS, ASA, PC, PA and so on.At the same time, "
-#~ "the air filtration of ABS and ASA will get worse.While for PLA, PETG, "
-#~ "TPU, PVA and other low temperature materials,the actual chamber "
-#~ "temperature should not be high to avoid cloggings, so 0 which stands for "
-#~ "turning off is highly recommended"
-#~ msgstr ""
-#~ "Higher chamber temperature can help suppress or reduce warping and "
-#~ "potentially lead to higher interlayer bonding strength for high "
-#~ "temperature materials like ABS, ASA, PC, PA and so on. At the same time, "
-#~ "the air filtration of ABS and ASA will get worse.While for PLA, PETG, "
-#~ "TPU, PVA and other low temperature materials, the actual chamber "
-#~ "temperature should not be high to avoid clogs, so 0 (turned off) is "
-#~ "highly recommended."
-
-#~ msgid ""
 #~ "Different nozzle diameters and different filament diameters is not "
 #~ "allowed when prime tower is enabled."
 #~ msgstr ""
@@ -17309,9 +17066,6 @@ msgstr ""
 
 #~ msgid "Please input a valid value (K in 0~0.3, N in 0.6~2.0)"
 #~ msgstr "Kérjük, adj meg egy érvényes értéket (K 0-0,3; N 0,6-2,0)"
-
-#~ msgid "Printer local connection failed, please try again."
-#~ msgstr "Printer local connection failed; please try again."
 
 #~ msgid ""
 #~ "Please find the details of Flow Dynamics Calibration from our wiki.\n"
@@ -17373,12 +17127,6 @@ msgstr ""
 #~ msgid "Please find the cornor with perfect degree of extrusion"
 #~ msgstr "Keresd meg a tökéletesen extrudált sarkot"
 
-#~ msgid "V"
-#~ msgstr "V"
-
-#~ msgid "Export &Configs"
-#~ msgstr "Export &Configs"
-
 #~ msgid "Infill direction"
 #~ msgstr "Kitöltés iránya"
 
@@ -17399,28 +17147,6 @@ msgstr ""
 
 #~ msgid "Unload Filament"
 #~ msgstr "Filament kitöltése"
-
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "Válassz egy AMS rekeszt, majd nyomd meg a \"Load\" vagy \"Unload\" gombot "
-#~ "a filament automatikus be- vagy kitöltéséhez."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
-#~ msgid "MainBoard"
-#~ msgstr "MainBoard"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
 
 #~ msgid "active"
 #~ msgstr "aktív"
@@ -17498,20 +17224,6 @@ msgstr ""
 #~ msgid "Load failed [%d]!"
 #~ msgstr "A betöltés sikertelen [%d]!"
 
-#, c-format, boost-format
-#~ msgid "No files [%d]"
-#~ msgstr "No files [%d]"
-
-#, c-format, boost-format
-#~ msgid "Load failed [%d]"
-#~ msgstr "Load failed [%d]"
-
-#~ msgid "Failed to fetching model information from printer."
-#~ msgstr "Failed to fetch model information from printer."
-
-#~ msgid "Failed to parse model informations."
-#~ msgstr "Failed to parse model information"
-
 #, boost-format
 #~ msgid ""
 #~ "You have changed some settings of preset \"%1%\". \n"
@@ -17552,63 +17264,14 @@ msgstr ""
 #~ msgid "Auto Segment"
 #~ msgstr "Automatikus szegmentálás"
 
-#~ msgid "Depth ratio"
-#~ msgstr "Depth ratio"
-
 #~ msgid "Prizm"
 #~ msgstr "Prizm"
-
-#~ msgid "connector is out of cut contour"
-#~ msgstr "connector is out of cut contour"
-
-#~ msgid "connectors are out of cut contour"
-#~ msgstr "connectors are out of cut contour"
-
-#~ msgid "connector is out of object"
-#~ msgstr "connector is out of object"
-
-#~ msgid "connectors is out of object"
-#~ msgstr "Connectors must be on object surface."
-
-#~ msgid ""
-#~ "Invalid state. \n"
-#~ "No one part is selected for keep after cut"
-#~ msgstr ""
-#~ "Invalid state. \n"
-#~ "No one part is selected to keep after cut"
-
-#~ msgid "Edit Text"
-#~ msgstr "Edit Text"
 
 #~ msgid "Error! Unable to create thread!"
 #~ msgstr "Hiba. Nem sikerült létrehozni a szálat."
 
 #~ msgid "Exception"
 #~ msgstr "Kivétel"
-
-#~ msgid "Choose SLA archive:"
-#~ msgstr "Choose SLA archive:"
-
-#~ msgid "Import file"
-#~ msgstr "Import file"
-
-#~ msgid "Import model and profile"
-#~ msgstr "Import model and profile"
-
-#~ msgid "Import profile only"
-#~ msgstr "Import profile only"
-
-#~ msgid "Import model only"
-#~ msgstr "Import model only"
-
-#~ msgid "Accurate"
-#~ msgstr "Accurate"
-
-#~ msgid "Balanced"
-#~ msgstr "Balanced"
-
-#~ msgid "Quick"
-#~ msgstr "Quick"
 
 #~ msgid ""
 #~ "Discribe how long the nozzle will move along the last path when retracting"
@@ -17628,9 +17291,6 @@ msgstr ""
 #~ "egyszerűsítése lehetőséget. További információ a dokumentációban "
 #~ "található."
 
-#~ msgid "Filling bed "
-#~ msgstr "Filling bed"
-
 #, boost-format
 #~ msgid "%1% infill pattern doesn't support 100%% density."
 #~ msgstr "%1% kitöltési mintázat nem támogatja a 100%%-os kitöltés."
@@ -17644,9 +17304,6 @@ msgstr ""
 #~ "Igen - Váltás a vonalak mintázatra\n"
 #~ "Nem - Sűrűség visszaállítása az alapértelmezett, nem 100%-os értékre"
 
-#~ msgid "Please heat the nozzle to above 170 degree before loading filament."
-#~ msgstr "A filament betöltése előtt melegítsd fel a fúvókát 170 fok fölé."
-
 #, c-format
 #~ msgid "Density of internal sparse infill, 100% means solid throughout"
 #~ msgstr ""
@@ -17659,21 +17316,11 @@ msgstr ""
 #~ msgid "This setting specify the count of walls around tree support"
 #~ msgstr "Ez a beállítás határozza meg a falak számát a fa támasz körül."
 
-#, c-format, boost-format
-#~ msgid " doesn't work at 100%% density "
-#~ msgstr " doesn't work at 100%% density "
-
-#~ msgid "Ctrl + Shift + Enter"
-#~ msgstr "Ctrl + Shift + Enter"
-
 #~ msgid "Tool-Lay on Face"
 #~ msgstr "Eszköz-Felületre fektetés"
 
 #~ msgid "Export as STL"
 #~ msgstr "Exportálás STL-ként"
-
-#~ msgid "Check cloud service status"
-#~ msgstr "Check cloud service status"
 
 #~ msgid "Please input a valid value (K in 0~0.5)"
 #~ msgstr "Adj meg egy érvényes értéket (K 0-0,5 között)"
@@ -17692,10 +17339,6 @@ msgstr ""
 
 #~ msgid "Add/Remove printers"
 #~ msgstr "Nyomtatók hozzáadása/eltávolítása"
-
-#, c-format, boost-format
-#~ msgid "%s is not supported by AMS."
-#~ msgstr "%s is not supported by the AMS."
 
 #~ msgid "Don't remind me of this version again"
 #~ msgstr "Ne emlékeztessen újra erre a verzióra."
@@ -17732,24 +17375,6 @@ msgstr ""
 #~ "3D-jelenettel kapcsolatos műveletek\n"
 #~ "Tudod, hogyan változtathatod meg a nézetet és hogyan választhatod ki az "
 #~ "objektumot/tárgyat egérrel és érintőképernyővel a 3D-jelenetben?"
-
-#~ msgid ""
-#~ "Fix Model\n"
-#~ "Did you know that you can fix a corrupted 3D model to avoid a lot of "
-#~ "slicing problems?"
-#~ msgstr ""
-#~ "Modell javítása\n"
-#~ "Tudtad, hogy a sérült 3D-modelleket megjavíthatod, amivel elkerülhetsz "
-#~ "sok szeletelési problémát?"
-
-#~ msgid "Embedded"
-#~ msgstr "Embedded"
-
-#~ msgid "Online Models"
-#~ msgstr "Online Models"
-
-#~ msgid "Show online staff-picked models on the home page"
-#~ msgstr "Show online staff-picked models on the home page"
 
 #~ msgid "The minimum printing speed when slow down for cooling"
 #~ msgstr "A minimum nyomtatási sebesség hűtés miatti lassításkor."
@@ -17798,9 +17423,6 @@ msgstr ""
 #~ msgid "Calibration of extrusion"
 #~ msgstr "Extrudálás kalibrálása"
 
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "Push new filament into the extruder"
-
 #, c-format, boost-format
 #~ msgid ""
 #~ "Bed temperature of other layer is lower than bed temperature of initial "
@@ -17823,20 +17445,8 @@ msgstr ""
 #~ "Kérjük, hogy a nyomtatás során tartsd nyitva a nyomtatót, vagy csökkentsd "
 #~ "az asztalhőmérsékletet."
 
-#~ msgid "Total Time Estimation"
-#~ msgstr "Total Time Estimation"
-
 #~ msgid "Resonance frequency identification"
 #~ msgstr "Rezonanciafrekvencia meghatározása"
-
-#~ msgid "Immediately score"
-#~ msgstr "Immediately score"
-
-#~ msgid "Please give a score for your favorite Bambu Market model."
-#~ msgstr "Please give a score for your favorite Bambu Market model."
-
-#~ msgid "Score"
-#~ msgstr "Score"
 
 #~ msgid "Can't connect to the printer"
 #~ msgstr "Nem lehet csatlakozni a nyomtatóhoz"

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -18873,9 +18873,6 @@ msgstr ""
 #~ msgid "Support: propagate branches at layer %d"
 #~ msgstr "Supporto: propagazione rami allo strato %d"
 
-#~ msgid "Current Cabin humidity"
-#~ msgstr "Current Cabin humidity"
-
 #~ msgid "Stopped."
 #~ msgstr "Interrotto."
 
@@ -19019,12 +19016,6 @@ msgstr ""
 #~ msgctxt "Verb"
 #~ msgid "Scale"
 #~ msgstr "Ridimensiona"
-
-#~ msgid "Orca Slicer "
-#~ msgstr "Orca Slicer "
-
-#~ msgid "Cool plate"
-#~ msgstr "Cool plate"
 
 #~ msgid "Lift Z Enforcement"
 #~ msgstr "Applicazione dell'ascensore Z"
@@ -19445,12 +19436,6 @@ msgstr ""
 #~ msgid "Please find the cornor with perfect degree of extrusion"
 #~ msgstr "Si prega di trovare il cornor con il perfetto grado di estrusione"
 
-#~ msgid "X"
-#~ msgstr "X"
-
-#~ msgid "Y"
-#~ msgstr "Y"
-
 #~ msgid ""
 #~ "Order of wall/infill. When the tickbox is unchecked the walls are printed "
 #~ "first, which works best in most cases.\n"
@@ -19471,9 +19456,6 @@ msgstr ""
 #~ "con conseguente peggioramento della finitura superficiale esterna. Può "
 #~ "anche far brillare il riempimento attraverso le superfici esterne della "
 #~ "parte."
-
-#~ msgid "V"
-#~ msgstr "V"
 
 #~ msgid ""
 #~ "Orca Slicer is based on BambuStudio by Bambulab, which is from "
@@ -19511,37 +19493,6 @@ msgstr ""
 
 #~ msgid "Unload Filament"
 #~ msgstr "Scarica Filamento"
-
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "Seleziona uno slot AMS, premi \"Carica\" o \"Scarica\" per caricare o "
-#~ "scaricare automaticamente il filamento."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
-#~ msgid "MainBoard"
-#~ msgstr "MainBoard"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
-
-#~ msgid "- ℃"
-#~ msgstr "- °C"
-
-#~ msgid "0.5"
-#~ msgstr "0.5"
-
-#~ msgid "0.005"
-#~ msgstr "0.005"
 
 #~ msgid "active"
 #~ msgstr "attivo"
@@ -19627,10 +19578,6 @@ msgstr ""
 #~ msgstr "Caricamento non riuscito [%d]!"
 
 #, c-format, boost-format
-#~ msgid "No files [%d]"
-#~ msgstr "No files [%d]"
-
-#, c-format, boost-format
 #~ msgid "Load failed [%d]"
 #~ msgstr "Caricamento non riuscito [%d]"
 
@@ -19663,9 +19610,6 @@ msgstr ""
 #~ "Sono stati modificati alcuni preset preimpostati. \n"
 #~ "Vuoi mantenere le impostazioni (nuovo valore) dopo aver cambiato i preset?"
 
-#~ msgid " ℃"
-#~ msgstr " °C"
-
 #~ msgid ""
 #~ "Please go to filament setting to edit your presets if you need.\n"
 #~ "Please note that nozzle temperature, hot bed temperature, and maximum "
@@ -19680,15 +19624,6 @@ msgstr ""
 
 #~ msgid "Studio Version:"
 #~ msgstr "Versione Studio:"
-
-#~ msgid "Test BambuLab"
-#~ msgstr "Test BambuLab"
-
-#~ msgid "Test BambuLab:"
-#~ msgstr "Test BambuLab:"
-
-#~ msgid "Test HTTP"
-#~ msgstr "Test HTTP"
 
 #~ msgid "Test HTTP Service:"
 #~ msgstr "Test servizio HTTP:"
@@ -19710,12 +19645,6 @@ msgstr ""
 
 #~ msgid "Test Storage Download:"
 #~ msgstr "Test Download dell'archiviazione:"
-
-#~ msgid "Test plugin download"
-#~ msgstr "Test plugin download"
-
-#~ msgid "Test Plugin Download:"
-#~ msgstr "Test Plugin Download:"
 
 #~ msgid "Test Storage Upload"
 #~ msgstr "Test Caricamento dell'archiviazione"
@@ -19765,9 +19694,6 @@ msgstr ""
 #~ "Per superfici fortemente inclinate, questa opzione non è adatta in quanto "
 #~ "genererebbe uno strato superiore troppo sottile e dovrebbe essere "
 #~ "disabilitata."
-
-#~ msgid " "
-#~ msgstr " "
 
 #~ msgid "Text-Rotate"
 #~ msgstr "Ruota testo"
@@ -19827,9 +19753,6 @@ msgstr ""
 #~ "compatibile solo con la modalità relativa. È sempre abilitato sulle "
 #~ "stampanti BambuLab. Il valore predefinito è selezionato"
 
-#~ msgid "Movement:"
-#~ msgstr "Movement:"
-
 #~ msgid "Movement"
 #~ msgstr "Movimento"
 
@@ -19838,9 +19761,6 @@ msgstr ""
 
 #~ msgid "Depth ratio"
 #~ msgstr "Rapporto di profondità"
-
-#~ msgid "Prizm"
-#~ msgstr "Prizm"
 
 #~ msgid "connector is out of cut contour"
 #~ msgstr "Connettore fuori dal contorno"
@@ -20023,9 +19943,6 @@ msgstr ""
 #~ msgid "The 3mf is not compatible, load geometry data only!"
 #~ msgstr "Il 3mf non è compatibile, carica solo i dati della geometria!"
 
-#~ msgid "Incompatible 3mf"
-#~ msgstr "Incompatible 3mf"
-
 #~ msgid "Add/Remove printers"
 #~ msgstr "Aggiungi/Rimuovi stampanti"
 
@@ -20077,10 +19994,6 @@ msgstr ""
 
 #~ msgid "inner-outer-inner/infill"
 #~ msgstr "interno-esterno-interno/riempimento"
-
-#, c-format, boost-format
-#~ msgid "%%"
-#~ msgstr "%%"
 
 #~ msgid "Export the objects as multiple STL."
 #~ msgstr "Esportare gli oggetti come STL multipli."
@@ -20134,9 +20047,6 @@ msgstr ""
 #~ msgid "Online Models"
 #~ msgstr "Modelli Online"
 
-#~ msgid "The minimum printing speed when slow down for cooling"
-#~ msgstr "The minimum printing speed when slowing down for cooling."
-
 #~ msgid ""
 #~ "The bed temperature exceeds filament's vitrification temperature. Please "
 #~ "open the front door of printer before printing to avoid nozzle clog."
@@ -20144,31 +20054,6 @@ msgstr ""
 #~ "La temperatura del piano supera la temperatura di vetrificazione del "
 #~ "filamento. Aprire lo sportello anteriore della stampante prima di "
 #~ "stampare per evitare l'intasamento del nozzle."
-
-#~ msgid "Temperature of vitrificaiton"
-#~ msgstr "Temperature of vitrification"
-
-#~ msgid ""
-#~ "Material becomes soft at this temperature. Thus the heatbed cannot be "
-#~ "hotter than this tempature"
-#~ msgstr ""
-#~ "Material becomes soft at this temperature. Thus, the heat bed cannot be "
-#~ "hotter than this temperature."
-
-#~ msgid "Enable this option if machine has auxiliary part cooling fan"
-#~ msgstr "Enable this option if the machine has an auxiliary part cooling fan"
-
-#~ msgid ""
-#~ "Speed of auxiliary part cooling fan. Auxiliary fan will run at this speed "
-#~ "during printing except the first several layers which is defined by no "
-#~ "cooling layers"
-#~ msgstr ""
-#~ "This is the speed of auxiliary part cooling fan. The auxiliary fan will "
-#~ "run at this speed during printing except for during the first several "
-#~ "layers which may be set to have no part cooling."
-
-#~ msgid "Empty layers around bottom are replaced by nearest normal layers."
-#~ msgstr "Empty layers around bottom are replaced by nearest normal layers."
 
 #~ msgid "The model has too many empty layers."
 #~ msgstr "Il modello ha troppi layers vuoti."
@@ -20220,9 +20105,6 @@ msgstr ""
 #~ msgid "Score"
 #~ msgstr "Punteggio"
 
-#~ msgid "Bambu High Temperature Plate"
-#~ msgstr "Bambu High Temperature Plate"
-
 #~ msgid "Can't connect to the printer"
 #~ msgstr "Impossibile connettersi alla stampante"
 
@@ -20254,9 +20136,6 @@ msgstr ""
 #~ "mentre lo stile ibrido creerà una struttura simile a quella dei sostegni "
 #~ "normali sotto grandi sporgenze piatte."
 
-#~ msgid "Bed temperature difference"
-#~ msgstr "Bed temperature difference"
-
 #~ msgid ""
 #~ "Do not recommend bed temperature of other layer to be lower than initial "
 #~ "layer for more than this threshold. Too low bed temperature of other "
@@ -20266,6 +20145,3 @@ msgstr ""
 #~ "inferiore a quella del primo layer di oltre questa soglia. Una "
 #~ "temperatura del piano troppo bassa degli altri layer può causare il "
 #~ "distacco dell'oggetto dal piatto."
-
-#~ msgid "Orient the model"
-#~ msgstr "Orient the model"

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -167,10 +167,10 @@ msgid "Height Range"
 msgstr "高さ範囲"
 
 msgid "Vertical"
-msgstr "Vertical"
+msgstr ""
 
 msgid "Horizontal"
-msgstr "Horizontal"
+msgstr ""
 
 msgid "Remove painted color"
 msgstr "塗った色を消去"
@@ -271,10 +271,10 @@ msgid "uniform scale"
 msgstr "スケール"
 
 msgid "Planar"
-msgstr "Planar"
+msgstr ""
 
 msgid "Dovetail"
-msgstr "Dovetail"
+msgstr ""
 
 msgid "Auto"
 msgstr "自動"
@@ -283,10 +283,10 @@ msgid "Manual"
 msgstr "手動"
 
 msgid "Plug"
-msgstr "Plug"
+msgstr ""
 
 msgid "Dowel"
-msgstr "Dowel"
+msgstr ""
 
 msgid "Snap"
 msgstr "スナップ"
@@ -295,25 +295,25 @@ msgid "Prism"
 msgstr "プリズム"
 
 msgid "Frustum"
-msgstr "Frustum"
+msgstr ""
 
 msgid "Square"
-msgstr "Square"
+msgstr ""
 
 msgid "Hexagon"
-msgstr "Hexagon"
+msgstr ""
 
 msgid "Keep orientation"
-msgstr "Keep orientation"
+msgstr ""
 
 msgid "Place on cut"
-msgstr "Place on cut"
+msgstr ""
 
 msgid "Flip upside down"
 msgstr "上下反転"
 
 msgid "Connectors"
-msgstr "Connectors"
+msgstr ""
 
 msgid "Type"
 msgstr "タイプ"
@@ -328,19 +328,19 @@ msgstr "形状"
 #. Size in emboss direction
 #. TRN - Input label. Be short as possible
 msgid "Depth"
-msgstr "Depth"
+msgstr ""
 
 msgid "Groove"
-msgstr "Groove"
+msgstr ""
 
 msgid "Width"
 msgstr "幅"
 
 msgid "Flap Angle"
-msgstr "Flap Angle"
+msgstr ""
 
 msgid "Groove Angle"
-msgstr "Groove Angle"
+msgstr ""
 
 msgid "Part"
 msgstr "パーツ"
@@ -368,7 +368,7 @@ msgid "Move cut plane"
 msgstr "カット面の移動"
 
 msgid "Mode"
-msgstr "Mode"
+msgstr ""
 
 msgid "Change cut mode"
 msgstr "カットモード変更"
@@ -377,7 +377,7 @@ msgid "Tolerance"
 msgstr "公差"
 
 msgid "Drag"
-msgstr "Drag"
+msgstr ""
 
 msgid "Draw cut line"
 msgstr ""
@@ -386,25 +386,25 @@ msgid "Left click"
 msgstr "左クリック"
 
 msgid "Add connector"
-msgstr "Add connector"
+msgstr ""
 
 msgid "Right click"
 msgstr "右クリック"
 
 msgid "Remove connector"
-msgstr "Remove connector"
+msgstr ""
 
 msgid "Move connector"
-msgstr "Move connector"
+msgstr ""
 
 msgid "Add connector to selection"
-msgstr "Add connector to selection"
+msgstr ""
 
 msgid "Remove connector from selection"
-msgstr "Remove connector from selection"
+msgstr ""
 
 msgid "Select all connectors"
-msgstr "Select all connectors"
+msgstr ""
 
 msgid "Cut"
 msgstr "カット"
@@ -413,10 +413,10 @@ msgid "Rotate cut plane"
 msgstr "カット面の回転"
 
 msgid "Remove connectors"
-msgstr "Remove connectors"
+msgstr ""
 
 msgid "Bulge"
-msgstr "Bulge"
+msgstr ""
 
 msgid "Bulge proportion related to radius"
 msgstr "バルジの比率と半径の関係"
@@ -428,7 +428,7 @@ msgid "Space proportion related to radius"
 msgstr "半径に関係する空間の割合"
 
 msgid "Confirm connectors"
-msgstr "Confirm connectors"
+msgstr ""
 
 msgid "Cancel"
 msgstr "取消し"
@@ -456,10 +456,10 @@ msgid "Reset cutting plane"
 msgstr "カット面をリセット"
 
 msgid "Edit connectors"
-msgstr "Edit connectors"
+msgstr ""
 
 msgid "Add connectors"
-msgstr "Add connectors"
+msgstr ""
 
 msgid "Reset cut"
 msgstr "カットをリセット"
@@ -477,10 +477,10 @@ msgid "Keep"
 msgstr "残す"
 
 msgid "Flip"
-msgstr "Flip"
+msgstr ""
 
 msgid "After cut"
-msgstr "After cut"
+msgstr ""
 
 msgid "Cut to parts"
 msgstr "パーツに割り切る"
@@ -492,7 +492,7 @@ msgid "Warning"
 msgstr "警告"
 
 msgid "Invalid connectors detected"
-msgstr "Invalid connectors detected"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%1$d connector is out of cut contour"
@@ -505,7 +505,7 @@ msgid_plural "%1$d connectors are out of object"
 msgstr[0] ""
 
 msgid "Some connectors are overlapped"
-msgstr "Some connectors are overlapped"
+msgstr ""
 
 msgid "Select at least one object to keep after cutting."
 msgstr "カットした後に残すものを1つ以上選んでください。"
@@ -517,7 +517,7 @@ msgid "Cut plane with groove is invalid"
 msgstr "溝のあるカット面は無効"
 
 msgid "Connector"
-msgstr "Connector"
+msgstr ""
 
 msgid "Cut by Plane"
 msgstr "面でカット"
@@ -637,30 +637,30 @@ msgid "Thickness"
 msgstr "太さ"
 
 msgid "Text Gap"
-msgstr "Text Gap"
+msgstr ""
 
 msgid "Angle"
-msgstr "Angle"
+msgstr ""
 
 msgid ""
 "Embedded\n"
 "depth"
-msgstr "Embedded depth"
+msgstr ""
 
 msgid "Input text"
 msgstr "テキスト"
 
 msgid "Surface"
-msgstr "Surface"
+msgstr ""
 
 msgid "Horizontal text"
-msgstr "Horizontal text"
+msgstr ""
 
 msgid "Shift + Mouse move up or down"
-msgstr "Shift + Mouse move up or down"
+msgstr ""
 
 msgid "Rotate text"
-msgstr "Rotate text"
+msgstr ""
 
 msgid "Text shape"
 msgstr "文字形状"
@@ -1264,60 +1264,59 @@ msgid "No feature"
 msgstr ""
 
 msgid "Vertex"
-msgstr "Vertex"
+msgstr ""
 
 msgid "Edge"
-msgstr "Edge"
+msgstr ""
 
 msgid "Plane"
-msgstr "Plane"
+msgstr ""
 
 msgid "Point on edge"
-msgstr "Point on edge"
+msgstr ""
 
 msgid "Point on circle"
-msgstr "Point on circle"
+msgstr ""
 
 msgid "Point on plane"
-msgstr "Point on plane"
+msgstr ""
 
 msgid "Center of edge"
-msgstr "Center of edge"
+msgstr ""
 
 msgid "Center of circle"
 msgstr "円の中心"
 
 msgid "Select feature"
-msgstr "Select feature"
+msgstr ""
 
 msgid "Select point"
-msgstr "Select point"
+msgstr ""
 
 msgid "Delete"
 msgstr "削除"
 
 msgid "Restart selection"
-msgstr "Restart selection"
+msgstr ""
 
 msgid "Esc"
 msgstr "Esc"
 
 msgid "Cancel a feature until exit"
-msgstr "Cancel a feature until exit"
+msgstr ""
 
 msgid "Measure"
-msgstr "Measure"
+msgstr ""
 
 msgid ""
 "Please confirm explosion ratio = 1,and please select at least one object"
 msgstr ""
-"Please confirm explosion ratio = 1, and please select at least one object"
 
 msgid "Please select at least one object."
 msgstr "最低１つのオブジェクトを選択してください。"
 
 msgid "Edit to scale"
-msgstr "Edit to scale"
+msgstr ""
 
 msgctxt "Verb"
 msgid "Scale all"
@@ -1333,7 +1332,7 @@ msgid "Length"
 msgstr "長さ"
 
 msgid "Selection"
-msgstr "Selection"
+msgstr ""
 
 msgid " (Moving)"
 msgstr " (移動中)"
@@ -1351,7 +1350,7 @@ msgstr ""
 "その間の距離を特定する。"
 
 msgid "Face"
-msgstr "Face"
+msgstr ""
 
 msgid " (Fixed)"
 msgstr "（固定）"
@@ -1363,38 +1362,36 @@ msgid ""
 "Feature 1 has been reset, \n"
 "feature 2 has been feature 1"
 msgstr ""
-"Feature 1 has been reset, \n"
-"feature 2 has been feature 1"
 
 msgid "Warning:please select Plane's feature."
-msgstr "Warning: please select Plane's feature."
+msgstr ""
 
 msgid "Warning:please select Point's or Circle's feature."
-msgstr "Warning: please select Point's or Circle's feature."
+msgstr ""
 
 msgid "Warning:please select two different mesh."
-msgstr "Warning: please select two different meshes."
+msgstr ""
 
 msgid "Copy to clipboard"
 msgstr "コピー"
 
 msgid "Perpendicular distance"
-msgstr "Perpendicular distance"
+msgstr ""
 
 msgid "Distance"
-msgstr "Distance"
+msgstr ""
 
 msgid "Direct distance"
-msgstr "Direct distance"
+msgstr ""
 
 msgid "Distance XYZ"
-msgstr "Distance XYZ"
+msgstr ""
 
 msgid "Parallel"
 msgstr "平行"
 
 msgid "Center coincidence"
-msgstr "Center coincidence"
+msgstr ""
 
 msgid "Featue 1"
 msgstr "フィーチャー1"
@@ -1409,7 +1406,7 @@ msgid "Parallel distance:"
 msgstr ""
 
 msgid "Flip by Face 2"
-msgstr "Flip by Face 2"
+msgstr ""
 
 msgid "Ctrl+"
 msgstr "Ctrl+"
@@ -1576,17 +1573,15 @@ msgstr ""
 "い。"
 
 msgid "Privacy Policy Update"
-msgstr "Privacy Policy Update"
+msgstr ""
 
 msgid ""
 "The number of user presets cached in the cloud has exceeded the upper limit, "
 "newly created user presets can only be used locally."
 msgstr ""
-"The number of user presets cached in the cloud has exceeded the upper limit, "
-"newly created user presets can only be used locally."
 
 msgid "Sync user presets"
-msgstr "Sync user presets"
+msgstr ""
 
 msgid "Loading user preset"
 msgstr "ユーザープリセットを読込み中"
@@ -1623,13 +1618,13 @@ msgstr ""
 "設定ウィザードで保存先フォルダーを選択してください。"
 
 msgid "Import File"
-msgstr "Import File"
+msgstr "ファイルインポート"
 
 msgid "Choose files"
 msgstr "ファイルを選択"
 
 msgid "New Folder"
-msgstr "New Folder"
+msgstr ""
 
 msgid "Open"
 msgstr "開く"
@@ -1791,7 +1786,7 @@ msgid "Text"
 msgstr "テキスト"
 
 msgid "Height range Modifier"
-msgstr "Height Range Modifier"
+msgstr ""
 
 msgid "Add settings"
 msgstr "設定を追加"
@@ -1821,7 +1816,7 @@ msgid "Export as one STL"
 msgstr "1つのSTLとしてエクスポート"
 
 msgid "Export as STLs"
-msgstr "Export as STLs"
+msgstr ""
 
 msgid "Reload from disk"
 msgstr "ディスクから再読込み"
@@ -1894,10 +1889,10 @@ msgid "Assemble the selected objects to an object with single part"
 msgstr "選択したオブジェクトを一つオブジェクトに組み立てます（単パーツ）"
 
 msgid "Mesh boolean"
-msgstr "Mesh boolean"
+msgstr ""
 
 msgid "Mesh boolean operations including union and subtraction"
-msgstr "Mesh boolean operations including union and subtraction"
+msgstr ""
 
 msgid "Along X axis"
 msgstr "X軸方向"
@@ -1933,7 +1928,7 @@ msgid "Change SVG source file, projection, size, ..."
 msgstr "SVG ソース ファイル、プロジェクション、サイズなどを変更します。"
 
 msgid "Invalidate cut info"
-msgstr "Invalidate cut info"
+msgstr ""
 
 msgid "Add Primitive"
 msgstr "プリミティブを追加"
@@ -2002,7 +1997,7 @@ msgid "auto rotate current plate"
 msgstr "現在のプレートを自動回転させる"
 
 msgid "Delete Plate"
-msgstr "Delete Plate"
+msgstr ""
 
 msgid "Remove the selected plate"
 msgstr "選択したプレートを削除"
@@ -2038,13 +2033,13 @@ msgid "Lock"
 msgstr "ロック"
 
 msgid "Edit Plate Name"
-msgstr "Edit Plate Name"
+msgstr ""
 
 msgid "Name"
 msgstr "名称"
 
 msgid "Fila."
-msgstr "Fila."
+msgstr ""
 
 #, c-format, boost-format
 msgid "%1$d error repaired"
@@ -2074,7 +2069,7 @@ msgid "Click the icon to reset all settings of the object"
 msgstr "オブジェクトへの編集をリセットします"
 
 msgid "Right button click the icon to drop the object printable property"
-msgstr "Right click the icon to drop the object printable property"
+msgstr ""
 
 msgid "Click the icon to toggle printable property of the object"
 msgstr "オブジェクトの造形属性を切り替えます"
@@ -2086,7 +2081,7 @@ msgid "Click the icon to edit color painting of the object"
 msgstr "オブジェクトに色塗りをします"
 
 msgid "Click the icon to shift this object to the bed"
-msgstr "Click the icon to shift this object to the bed"
+msgstr ""
 
 msgid "Loading file"
 msgstr "ファイルを読み込み中"
@@ -2095,7 +2090,7 @@ msgid "Error!"
 msgstr "エラー！"
 
 msgid "Failed to get the model data in the current file."
-msgstr "Failed to get the model data in the current file."
+msgstr ""
 
 msgid "Generic"
 msgstr "一般"
@@ -2113,20 +2108,18 @@ msgid ""
 msgstr "オブジェクト設定で、各オブジェクトの造形設定を指定できます。"
 
 msgid "Delete connector from object which is a part of cut"
-msgstr "Delete connector from object which is a part of cut"
+msgstr ""
 
 msgid "Delete solid part from object which is a part of cut"
-msgstr "Delete solid part from object which is a part of cut"
+msgstr ""
 
 msgid "Delete negative volume from object which is a part of cut"
-msgstr "Delete negative volume from object which is a part of cut"
+msgstr ""
 
 msgid ""
 "To save cut correspondence you can delete all connectors from all related "
 "objects."
 msgstr ""
-"To save cut correspondence you can delete all connectors from all related "
-"objects."
 
 msgid ""
 "This action will break a cut correspondence.\n"
@@ -2135,11 +2128,6 @@ msgid ""
 "To manipulate with solid parts or negative volumes you have to invalidate "
 "cut information first."
 msgstr ""
-"This action will break a cut correspondence.\n"
-"After that, model consistency can't be guaranteed .\n"
-"\n"
-"To manipulate with solid parts or negative volumes you have to invalidate "
-"cut information first."
 
 msgid "Delete all connectors"
 msgstr "全てのコネクターを削除"
@@ -2154,34 +2142,34 @@ msgid "Assembly"
 msgstr "アセンブリ"
 
 msgid "Cut Connectors information"
-msgstr "Cut Connectors information"
+msgstr ""
 
 msgid "Object manipulation"
-msgstr "Object manipulation"
+msgstr ""
 
 msgid "Group manipulation"
-msgstr "Group manipulation"
+msgstr ""
 
 msgid "Object Settings to modify"
-msgstr "Object Settings to Modify"
+msgstr ""
 
 msgid "Part Settings to modify"
-msgstr "Part Settings to Modify"
+msgstr ""
 
 msgid "Layer range Settings to modify"
-msgstr "Layer Range Settings to Modify"
+msgstr ""
 
 msgid "Part manipulation"
-msgstr "Part manipulation"
+msgstr ""
 
 msgid "Instance manipulation"
-msgstr "Instance manipulation"
+msgstr ""
 
 msgid "Height ranges"
-msgstr "Height ranges"
+msgstr ""
 
 msgid "Settings for height range"
-msgstr "Settings for height range"
+msgstr ""
 
 msgid "Layer"
 msgstr "積層"
@@ -2246,10 +2234,10 @@ msgid "to"
 msgstr "→"
 
 msgid "Remove height range"
-msgstr "Remove height range"
+msgstr ""
 
 msgid "Add height range"
-msgstr "Add height range"
+msgstr ""
 
 msgid "Invalid numeric."
 msgstr "無効な数値"
@@ -2330,19 +2318,19 @@ msgid "Pause"
 msgstr "一時停止"
 
 msgid "Template"
-msgstr "Template"
+msgstr ""
 
 msgid "Custom"
 msgstr "カスタム"
 
 msgid "Pause:"
-msgstr "Pause:"
+msgstr ""
 
 msgid "Custom Template:"
-msgstr "Custom Template:"
+msgstr ""
 
 msgid "Custom G-code:"
-msgstr "Custom G-code:"
+msgstr ""
 
 msgid "Custom G-code"
 msgstr "カスタム G-code"
@@ -2366,7 +2354,7 @@ msgid "Add Custom G-code"
 msgstr "カスタムG-codeを追加"
 
 msgid "Insert custom G-code at the beginning of this layer."
-msgstr "Insert custom G-code at the beginning of this layer."
+msgstr ""
 
 msgid "Add Custom Template"
 msgstr "カスタムテンプレートを追加"
@@ -2381,19 +2369,19 @@ msgid "Change filament at the beginning of this layer."
 msgstr "このレイヤーの先頭でフィラメントを交換"
 
 msgid "Delete Pause"
-msgstr "Delete Pause"
+msgstr ""
 
 msgid "Delete Custom Template"
-msgstr "Delete Custom Template"
+msgstr ""
 
 msgid "Edit Custom G-code"
-msgstr "Edit Custom G-code"
+msgstr ""
 
 msgid "Delete Custom G-code"
-msgstr "Delete Custom G-code"
+msgstr ""
 
 msgid "Delete Filament Change"
-msgstr "Delete Filament Change"
+msgstr ""
 
 msgid "No printer"
 msgstr "プリンタ無し"
@@ -2405,7 +2393,7 @@ msgid "Failed to connect to the server"
 msgstr "サーバーに接続できませんでした"
 
 msgid "Check the status of current system services"
-msgstr "Check the status of current system services"
+msgstr ""
 
 msgid "code"
 msgstr "code"
@@ -2443,13 +2431,13 @@ msgid "AMS"
 msgstr "AMS"
 
 msgid "Auto Refill"
-msgstr "Auto Refill"
+msgstr ""
 
 msgid "AMS not connected"
 msgstr "AMS が接続されていません"
 
 msgid "Load"
-msgstr "Load"
+msgstr ""
 
 msgid "Unload"
 msgstr "ｱﾝﾛｰﾄﾞ"
@@ -2481,7 +2469,7 @@ msgid "Cancel calibration"
 msgstr "キャリブレーションを取消し"
 
 msgid "Idling..."
-msgstr "Idling..."
+msgstr ""
 
 msgid "Heat the nozzle"
 msgstr "ノズルを加熱"
@@ -2499,23 +2487,21 @@ msgid "Purge old filament"
 msgstr "古いフィラメントを排出"
 
 msgid "Feed Filament"
-msgstr "Feed Filament"
+msgstr ""
 
 msgid "Confirm extruded"
-msgstr "Confirm that filament has been extruded"
+msgstr ""
 
 msgid "Check filament location"
-msgstr "Check filament location"
+msgstr ""
 
 msgid "Grab new filament"
-msgstr "Grab new filament"
+msgstr ""
 
 msgid ""
 "Choose an AMS slot then press \"Load\" or \"Unload\" button to automatically "
 "load or unload filaments."
 msgstr ""
-"Choose an AMS slot then press \"Load\" or \"Unload\" button to automatically "
-"load or unload filament."
 
 msgid "Edit"
 msgstr "編集"
@@ -2590,13 +2576,13 @@ msgid "Orienting canceled."
 msgstr ""
 
 msgid "Filling"
-msgstr "Filling"
+msgstr ""
 
 msgid "Bed filling canceled."
-msgstr "Bed filling canceled."
+msgstr ""
 
 msgid "Bed filling done."
-msgstr "Bed filling done."
+msgstr ""
 
 msgid "Searching for optimal orientation"
 msgstr "最適方向を探す"
@@ -2617,55 +2603,47 @@ msgid "Please check the printer network connection."
 msgstr "プリンターとのネットワーク接続をご確認ください"
 
 msgid "Abnormal print file data. Please slice again."
-msgstr "Abnormal print file data: please slice again."
+msgstr ""
 
 msgid "Task canceled."
-msgstr "Task canceled."
+msgstr ""
 
 msgid "Upload task timed out. Please check the network status and try again."
-msgstr "Upload task timed out. Please check the network status and try again."
+msgstr ""
 
 msgid "Cloud service connection failed. Please try again."
 msgstr "クラウドサービス接続できませんでした、もう一度お試しください"
 
 msgid "Print file not found. please slice again."
-msgstr "Print file not found; please slice again."
+msgstr ""
 
 msgid ""
 "The print file exceeds the maximum allowable size (1GB). Please simplify the "
 "model and slice again."
 msgstr ""
-"The print file exceeds the maximum allowable size (1GB). Please simplify the "
-"model and slice again."
 
 msgid "Failed to send the print job. Please try again."
 msgstr "造形タスクを送信できませんでした、もう一度お試しください。"
 
 msgid "Failed to upload file to ftp. Please try again."
-msgstr "Failed to upload file to ftp. Please try again."
+msgstr ""
 
 msgid ""
 "Check the current status of the bambu server by clicking on the link above."
 msgstr ""
-"Check the current status of the Bambu Lab server by clicking on the link "
-"above."
 
 msgid ""
 "The size of the print file is too large. Please adjust the file size and try "
 "again."
 msgstr ""
-"The size of the print file is too large. Please adjust the file size and try "
-"again."
 
 msgid "Print file not found, Please slice it again and send it for printing."
-msgstr "Print file not found; please slice it again and send it for printing."
+msgstr ""
 
 msgid ""
 "Failed to upload print file to FTP. Please check the network status and try "
 "again."
 msgstr ""
-"Failed to upload print file via FTP. Please check the network status and try "
-"again."
 
 msgid "Sending print job over LAN"
 msgstr "LAN経由で造形タスクを送信"
@@ -2674,7 +2652,7 @@ msgid "Sending print job through cloud service"
 msgstr "クラウド経由で造形タスクを送信"
 
 msgid "Print task sending times out."
-msgstr "Print task sending times out."
+msgstr ""
 
 msgid "Service Unavailable"
 msgstr "サービスは利用できません"
@@ -2691,7 +2669,7 @@ msgstr "送信しました、%s秒後デバイスページへ移動します"
 
 #, c-format, boost-format
 msgid "Successfully sent. Will automatically jump to the next page in %ss"
-msgstr "Successfully sent. Automatically jumping to the next page in %ss"
+msgstr ""
 
 msgid "An SD card needs to be inserted before printing via LAN."
 msgstr "SDカードが必要です"
@@ -2710,33 +2688,29 @@ msgid "An SD card needs to be inserted before sending to printer."
 msgstr "SDカードが必要です"
 
 msgid "Importing SLA archive"
-msgstr "Importing SLA archive"
+msgstr ""
 
 msgid ""
 "The SLA archive doesn't contain any presets. Please activate some SLA "
 "printer preset first before importing that SLA archive."
 msgstr ""
-"The SLA archive doesn't contain any presets. Please activate some SLA "
-"printer presets first before importing that SLA archive."
 
 msgid "Importing canceled."
-msgstr "Importing canceled."
+msgstr ""
 
 msgid "Importing done."
-msgstr "Importing done."
+msgstr ""
 
 msgid ""
 "The imported SLA archive did not contain any presets. The current SLA "
 "presets were used as fallback."
 msgstr ""
-"The imported SLA archive did not contain any presets. The current SLA "
-"presets were used as fallback."
 
 msgid "You cannot load SLA project with a multi-part object on the bed"
-msgstr "You cannot load an SLA project with a multi-part object on the bed"
+msgstr ""
 
 msgid "Please check your object list before preset changing."
-msgstr "Please check your object list before preset changing."
+msgstr ""
 
 msgid "Attention!"
 msgstr "注意！"
@@ -2772,7 +2746,7 @@ msgid "Orca Slicer is licensed under "
 msgstr "Orca Slicerのライセンス"
 
 msgid "GNU Affero General Public License, version 3"
-msgstr "GNU Affero General Public License, version 3"
+msgstr ""
 
 msgid "Orca Slicer is based on PrusaSlicer and BambuStudio"
 msgstr ""
@@ -2805,8 +2779,6 @@ msgid ""
 "Slic3r was created by Alessandro Ranellucci with the help of many other "
 "contributors."
 msgstr ""
-"Slic3r was created by Alessandro Ranellucci with the help of many other "
-"contributors."
 
 msgid "Version"
 msgstr "バージョン"
@@ -2839,10 +2811,10 @@ msgid "SN"
 msgstr "シリアル番号"
 
 msgid "Factors of Flow Dynamics Calibration"
-msgstr "Factors of Flow Dynamics Calibration"
+msgstr ""
 
 msgid "PA Profile"
-msgstr "PA Profile"
+msgstr ""
 
 msgid "Factor K"
 msgstr "係数K"
@@ -2854,13 +2826,13 @@ msgid "Setting AMS slot information while printing is not supported"
 msgstr "造形中に、AMSスロットを設定できません。"
 
 msgid "Setting Virtual slot information while printing is not supported"
-msgstr "Setting Virtual slot information while printing is not supported"
+msgstr ""
 
 msgid "Are you sure you want to clear the filament information?"
-msgstr "Are you sure you want to clear the filament information?"
+msgstr ""
 
 msgid "You need to select the material type and color first."
-msgstr "You need to select the material type and color first."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Please input a valid value (K in %.1f~%.1f)"
@@ -2871,10 +2843,10 @@ msgid "Please input a valid value (K in %.1f~%.1f, N in %.1f~%.1f)"
 msgstr ""
 
 msgid "Other Color"
-msgstr "Other Color"
+msgstr ""
 
 msgid "Custom Color"
-msgstr "Custom Color"
+msgstr ""
 
 msgid "Dynamic flow calibration"
 msgstr "流量キャリブレーション"
@@ -2977,10 +2949,6 @@ msgid ""
 "desiccant pack is changed. it take hours to absorb the moisture, low "
 "temperatures also slow down the process."
 msgstr ""
-"Please change the desiccant when it is too wet. The indicator may not "
-"represent accurately in following cases: when the lid is open or the "
-"desiccant pack is changed. It takes a few hours to absorb the moisture, and "
-"low temperatures also slow down the process."
 
 msgid ""
 "Config which AMS slot should be used for a filament used in the print job"
@@ -3011,19 +2979,16 @@ msgid ""
 "When the current material run out, the printer will continue to print in the "
 "following order."
 msgstr ""
-"When the current material runs out, the printer will continue to print "
-"materials in the following order."
 
 msgid "Group"
-msgstr "Group"
+msgstr ""
 
 msgid "The printer does not currently support auto refill."
-msgstr "The printer does not currently support auto refill."
+msgstr ""
 
 msgid ""
 "AMS filament backup is not enabled, please enable it in the AMS settings."
 msgstr ""
-"AMS filament backup is not enabled; please enable it in the AMS settings."
 
 msgid ""
 "If there are two identical filaments in AMS, AMS filament backup will be "
@@ -3031,10 +2996,6 @@ msgid ""
 "(Currently supporting automatic supply of consumables with the same brand, "
 "material type, and color)"
 msgstr ""
-"If there are two identical filaments in an AMS, AMS filament backup will be "
-"enabled. \n"
-"(This currently supports automatic supply of consumables with the same "
-"brand, material type, and color)"
 
 msgid "DRY"
 msgstr "DRY"
@@ -3059,8 +3020,6 @@ msgid ""
 "Note: if a new filament is inserted during  printing, the AMS will not "
 "automatically read any information until printing is completed."
 msgstr ""
-"Note: if a new filament is inserted during  printing, the AMS will not "
-"automatically read any information until printing is completed."
 
 msgid ""
 "When inserting a new filament, the AMS will not automatically read its "
@@ -3096,7 +3055,7 @@ msgstr ""
 "更新します。"
 
 msgid "AMS filament backup"
-msgstr "AMS filament backup"
+msgstr ""
 
 msgid ""
 "AMS will continue to another spool with the same properties of filament "
@@ -3104,14 +3063,12 @@ msgid ""
 msgstr "使用中のフィラメントが切れた時に、同じ属性のフィラメントに切り替えます"
 
 msgid "Air Printing Detection"
-msgstr "Air Printing Detection"
+msgstr ""
 
 msgid ""
 "Detects clogging and filament grinding, halting printing immediately to "
 "conserve time and filament."
 msgstr ""
-"Detects clogging and filament grinding, halting printing immediately to "
-"conserve time and filament."
 
 msgid "File"
 msgstr "ファイル"
@@ -3181,16 +3138,16 @@ msgid "Underflow"
 msgstr "アンダーフロー"
 
 msgid "Floating reserved operand"
-msgstr "Floating reserved operand"
+msgstr ""
 
 msgid "Stack overflow"
-msgstr "Stack Overflow"
+msgstr ""
 
 msgid "Running post-processing scripts"
 msgstr "後処理スクリプトを実行"
 
 msgid "Successfully executed post-processing script"
-msgstr "Successfully executed post-processing script"
+msgstr ""
 
 msgid "Unknown error occurred during exporting G-code."
 msgstr "Gコードのエクスポート中に不明なエラーが発生しました。"
@@ -3269,10 +3226,10 @@ msgid "Device"
 msgstr "デバイス"
 
 msgid "Task Sending"
-msgstr "Task Sending"
+msgstr ""
 
 msgid "Task Sent"
-msgstr "Task Sent"
+msgstr ""
 
 msgid "Edit multiple printers"
 msgstr ""
@@ -3292,7 +3249,7 @@ msgid "Offline"
 msgstr "オフライン"
 
 msgid "No task"
-msgstr "No task"
+msgstr ""
 
 msgid "View"
 msgstr "表示"
@@ -3304,16 +3261,16 @@ msgid "Edit Printers"
 msgstr ""
 
 msgid "Device Name"
-msgstr "Device Name"
+msgstr ""
 
 msgid "Task Name"
-msgstr "Task Name"
+msgstr ""
 
 msgid "Device Status"
-msgstr "Device Status"
+msgstr ""
 
 msgid "Actions"
-msgstr "Actions"
+msgstr ""
 
 msgid ""
 "Please select the devices you would like to manage here (up to 6 devices)"
@@ -3332,7 +3289,7 @@ msgid "Upgrading"
 msgstr ""
 
 msgid "Incompatible"
-msgstr "Incompatible"
+msgstr ""
 
 msgid "syncing"
 msgstr ""
@@ -3383,25 +3340,25 @@ msgid "Stop"
 msgstr "中止"
 
 msgid "Task Status"
-msgstr "Task Status"
+msgstr ""
 
 msgid "Sent Time"
-msgstr "Sent Time"
+msgstr ""
 
 msgid "There are no tasks to be sent!"
-msgstr "There are no tasks to be sent!"
+msgstr ""
 
 msgid "No historical tasks!"
-msgstr "No historical tasks!"
+msgstr ""
 
 msgid "Loading..."
 msgstr "読込み中"
 
 msgid "No AMS"
-msgstr "No AMS"
+msgstr ""
 
 msgid "Send to Multi-device"
-msgstr "Send to Multi-device"
+msgstr ""
 
 msgid "Preparing print job"
 msgstr "造形タスクを準備"
@@ -3416,19 +3373,19 @@ msgid "The number of printers in use simultaneously cannot be equal to 0."
 msgstr ""
 
 msgid "Use External Spool"
-msgstr "Use External Spool"
+msgstr ""
 
 msgid "Use AMS"
-msgstr "Use AMS"
+msgstr ""
 
 msgid "Select Printers"
-msgstr "Select Printers"
+msgstr ""
 
 msgid "Ams Status"
-msgstr "AMS Status"
+msgstr ""
 
 msgid "Printing Options"
-msgstr "Printing Options"
+msgstr ""
 
 msgid "Bed Leveling"
 msgstr "ベッドレベリング"
@@ -3440,7 +3397,7 @@ msgid "Flow Dynamic Calibration"
 msgstr ""
 
 msgid "Send Options"
-msgstr "Send Options"
+msgstr ""
 
 msgid "Send to"
 msgstr ""
@@ -3449,16 +3406,13 @@ msgid ""
 "printers at the same time.(It depends on how many devices can undergo "
 "heating at the same time.)"
 msgstr ""
-"printers at the same time. (It depends on how many devices can undergo "
-"heating at the same time.)"
 
 msgid "Wait"
-msgstr "Wait"
+msgstr ""
 
 msgid ""
 "minute each batch.(It depends on how long it takes to complete the heating.)"
 msgstr ""
-"minute each batch. (It depends on how long it takes to complete heating.)"
 
 msgid "Send"
 msgstr "送信"
@@ -3482,7 +3436,7 @@ msgid "The name is not allowed to end with space character."
 msgstr "名前の最後にスペースを入れないでください"
 
 msgid "The name length exceeds the limit."
-msgstr "The name length exceeds the limit."
+msgstr ""
 
 msgid "Origin"
 msgstr "原点"
@@ -3553,18 +3507,14 @@ msgid ""
 "The recommended minimum temperature is less than 190 degree or the "
 "recommended maximum temperature is greater than 300 degree.\n"
 msgstr ""
-"The recommended minimum temperature is less than 190 degree or the "
-"recommended maximum temperature is greater than 300 degree.\n"
 
 msgid ""
 "The recommended minimum temperature cannot be higher than the recommended "
 "maximum temperature.\n"
 msgstr ""
-"The recommended minimum temperature cannot be higher than the recommended "
-"maximum temperature.\n"
 
 msgid "Please check.\n"
-msgstr "Please check.\n"
+msgstr ""
 
 msgid ""
 "Nozzle may be blocked when the temperature is out of recommended range.\n"
@@ -3591,9 +3541,6 @@ msgid ""
 "temperature,it may result in material softening and clogging.The maximum "
 "safe temperature for the material is %d"
 msgstr ""
-"Current chamber temperature is higher than the material's safe temperature; "
-"this may result in material softening and nozzle clogs.The maximum safe "
-"temperature for the material is %d"
 
 msgid ""
 "Too small layer height.\n"
@@ -3693,11 +3640,9 @@ msgid ""
 "Spiral mode only works when wall loops is 1, support is disabled, top shell "
 "layers is 0, sparse infill density is 0 and timelapse type is traditional."
 msgstr ""
-"Spiral mode only works when wall loops is 1, support is disabled, top shell "
-"layers is 0, sparse infill density is 0 and timelapse type is traditional."
 
 msgid " But machines with I3 structure will not generate timelapse videos."
-msgstr " But machines with I3 structure will not generate timelapse videos."
+msgstr ""
 
 msgid ""
 "Change these settings automatically? \n"
@@ -3772,46 +3717,46 @@ msgid "Paused due to heat bed temperature malfunction"
 msgstr "ベッド温度異常により一時停止"
 
 msgid "Filament unloading"
-msgstr "Filament unloading"
+msgstr ""
 
 msgid "Skip step pause"
-msgstr "Skip step pause"
+msgstr ""
 
 msgid "Filament loading"
-msgstr "Filament loading"
+msgstr ""
 
 msgid "Motor noise calibration"
-msgstr "Motor noise calibration"
+msgstr ""
 
 msgid "Paused due to AMS lost"
-msgstr "Paused due to AMS lost"
+msgstr ""
 
 msgid "Paused due to low speed of the heat break fan"
-msgstr "Paused due to low speed of the heat break fan"
+msgstr ""
 
 msgid "Paused due to chamber temperature control error"
-msgstr "Paused due to chamber temperature control error"
+msgstr ""
 
 msgid "Cooling chamber"
-msgstr "Cooling chamber"
+msgstr ""
 
 msgid "Paused by the G-code inserted by user"
 msgstr ""
 
 msgid "Motor noise showoff"
-msgstr "Motor noise showoff"
+msgstr ""
 
 msgid "Nozzle filament covered detected pause"
-msgstr "Nozzle filament covered detected pause"
+msgstr ""
 
 msgid "Cutter error pause"
-msgstr "Cutter error pause"
+msgstr ""
 
 msgid "First layer error pause"
-msgstr "First layer error pause"
+msgstr ""
 
 msgid "Nozzle clog pause"
-msgstr "Nozzle clog pause"
+msgstr ""
 
 msgid "Unknown"
 msgstr "不明"
@@ -3842,27 +3787,18 @@ msgid ""
 "45℃.In order to avoid extruder clogging,low temperature filament(PLA/PETG/"
 "TPU) is not allowed to be loaded."
 msgstr ""
-"The current chamber temperature or the target chamber temperature exceeds "
-"45℃. In order to avoid extruder clogging, low temperature filament (PLA/PETG/"
-"TPU) is not allowed to be loaded."
 
 msgid ""
 "Low temperature filament(PLA/PETG/TPU) is loaded in the extruder.In order to "
 "avoid extruder clogging,it is not allowed to set the chamber temperature "
 "above 45℃."
 msgstr ""
-"Low temperature filament (PLA/PETG/TPU) is loaded in the extruder. In order "
-"to avoid extruder clogging, it is not allowed to set the chamber temperature "
-"above 45℃."
 
 msgid ""
 "When you set the chamber temperature below 40℃, the chamber temperature "
 "control will not be activated. And the target chamber temperature will "
 "automatically be set to 0℃."
 msgstr ""
-"When you set the chamber temperature below 40℃, the chamber temperature "
-"control will not be activated, and the target chamber temperature will "
-"automatically be set to 0℃."
 
 msgid "Failed to start print job"
 msgstr "造形タスクを開始できませんでした"
@@ -3870,39 +3806,34 @@ msgstr "造形タスクを開始できませんでした"
 msgid ""
 "This calibration does not support the currently selected nozzle diameter"
 msgstr ""
-"This calibration does not support the currently selected nozzle diameter"
 
 msgid "Current flowrate cali param is invalid"
-msgstr "Current flowrate cali param is invalid"
+msgstr ""
 
 msgid "Selected diameter and machine diameter do not match"
-msgstr "Selected diameter and machine diameter do not match"
+msgstr ""
 
 msgid "Failed to generate cali G-code"
 msgstr ""
 
 msgid "Calibration error"
-msgstr "Calibration error"
+msgstr ""
 
 msgid "TPU is not supported by AMS."
-msgstr "TPU is not supported by the AMS."
+msgstr ""
 
 msgid "Bambu PET-CF/PA6-CF is not supported by AMS."
-msgstr "Bambu PET-CF/PA6-CF is not supported by the AMS."
+msgstr ""
 
 msgid ""
 "Damp PVA will become flexible and get stuck inside AMS,please take care to "
 "dry it before use."
 msgstr ""
-"Damp PVA will become flexible and get stuck inside the AMS; please take care "
-"to dry it well before use."
 
 msgid ""
 "CF/GF filaments are hard and brittle, It's easy to break or get stuck in "
 "AMS, please use with caution."
 msgstr ""
-"CF/GF filaments are hard and brittle, so they can easily break or get stuck "
-"in an AMS; please use with caution."
 
 msgid "default"
 msgstr "デフォルト"
@@ -3955,7 +3886,7 @@ msgid "Specific for %1%"
 msgstr "%1%に固有"
 
 msgid "Presets"
-msgstr "Presets"
+msgstr ""
 
 msgid "Print settings"
 msgstr "造形設定"
@@ -3985,7 +3916,7 @@ msgstr "パラメータ検証"
 
 #, c-format, boost-format
 msgid "Value %s is out of range. The valid range is from %d to %d."
-msgstr "Value %s is out of range. The valid range is from %d to %d."
+msgstr ""
 
 msgid "Value is out of range."
 msgstr "値が範囲外です。"
@@ -4070,7 +4001,7 @@ msgid "Generating geometry index data"
 msgstr "ジオメトリ・インデックス・データを生成"
 
 msgid "Statistics of All Plates"
-msgstr "Statistics of All Plates"
+msgstr ""
 
 msgid "Display"
 msgstr "表示"
@@ -4079,7 +4010,7 @@ msgid "Flushed"
 msgstr "フラッシュ"
 
 msgid "Tower"
-msgstr "Tower"
+msgstr ""
 
 msgid "Total"
 msgstr "合計"
@@ -4091,7 +4022,7 @@ msgid "Total time"
 msgstr "総時間"
 
 msgid "Total cost"
-msgstr "Total cost"
+msgstr ""
 
 msgid "up to"
 msgstr "最大"
@@ -4100,7 +4031,7 @@ msgid "above"
 msgstr "以上"
 
 msgid "from"
-msgstr "from"
+msgstr ""
 
 msgid "Color Scheme"
 msgstr "配色スキーム"
@@ -4184,10 +4115,10 @@ msgid "Normal mode"
 msgstr "通常モード"
 
 msgid "Total Filament"
-msgstr "Total Filament"
+msgstr ""
 
 msgid "Model Filament"
-msgstr "Model Filament"
+msgstr ""
 
 msgid "Prepare time"
 msgstr "準備時間"
@@ -4259,7 +4190,7 @@ msgid "Tool Move"
 msgstr "ツール 移動"
 
 msgid "Tool Rotate"
-msgstr "Tool Rotate"
+msgstr ""
 
 msgid "Move Object"
 msgstr "オブジェクトを移動"
@@ -4283,7 +4214,7 @@ msgid "Spacing"
 msgstr "間隔"
 
 msgid "0 means auto spacing."
-msgstr "0 means auto spacing."
+msgstr ""
 
 msgid "Auto rotate for arrangement"
 msgstr "自動回転"
@@ -4295,7 +4226,7 @@ msgid "Avoid extrusion calibration region"
 msgstr "押出しキャリブレーション領域を避ける"
 
 msgid "Align to Y axis"
-msgstr "Align to Y axis"
+msgstr ""
 
 msgid "Add plate"
 msgstr "プレートを追加"
@@ -4361,7 +4292,7 @@ msgid "An object is laid over the plate boundaries."
 msgstr "プレートの境界を超えるオブジェクトがあります"
 
 msgid "A G-code path goes beyond the max print height."
-msgstr "A G-code path goes beyond the max print height."
+msgstr ""
 
 msgid "A G-code path goes beyond the plate boundaries."
 msgstr "G-codeはプレートの境界を超えています。"
@@ -4387,10 +4318,10 @@ msgid "Bed leveling"
 msgstr "ベッドレベリング"
 
 msgid "Vibration compensation"
-msgstr "Vibration compensation"
+msgstr ""
 
 msgid "Motor noise cancellation"
-msgstr "Motor noise cancellation"
+msgstr ""
 
 msgid "Calibration program"
 msgstr "キャリブレーション項目"
@@ -4416,7 +4347,7 @@ msgid "Calibrating"
 msgstr "キャリブレーション中"
 
 msgid "No step selected"
-msgstr "No step selected"
+msgstr ""
 
 msgid "Auto-record Monitoring"
 msgstr "自動録画モニタリング"
@@ -4425,7 +4356,7 @@ msgid "Go Live"
 msgstr "公開"
 
 msgid "Liveview Retry"
-msgstr "Liveview Retry"
+msgstr ""
 
 msgid "Resolution"
 msgstr "分解能"
@@ -4494,7 +4425,7 @@ msgid "No"
 msgstr "いいえ"
 
 msgid "will be closed before creating a new model. Do you want to continue?"
-msgstr "will be closed before creating a new model. Do you want to continue?"
+msgstr ""
 
 msgid "Slice plate"
 msgstr "スライス"
@@ -4644,10 +4575,10 @@ msgid "Import"
 msgstr "インポート"
 
 msgid "Export all objects as one STL"
-msgstr "Export all objects as one STL"
+msgstr ""
 
 msgid "Export all objects as STLs"
-msgstr "Export all objects as STLs"
+msgstr ""
 
 msgid "Export Generic 3MF"
 msgstr "汎用3MF"
@@ -4775,10 +4706,10 @@ msgid "Show object labels in 3D scene"
 msgstr "3Dシーンにラベルを表示"
 
 msgid "Show &Overhang"
-msgstr "Show &Overhang"
+msgstr ""
 
 msgid "Show object overhang highlight in 3D scene"
-msgstr "Show object overhang highlight in 3D scene"
+msgstr ""
 
 msgid "Show Selected Outline (beta)"
 msgstr ""
@@ -4793,19 +4724,19 @@ msgid "Help"
 msgstr "ヘルプ"
 
 msgid "Temperature Calibration"
-msgstr "Temperature Calibration"
+msgstr ""
 
 msgid "Pass 1"
-msgstr "Pass 1"
+msgstr ""
 
 msgid "Flow rate test - Pass 1"
-msgstr "Flow rate test - Pass 1"
+msgstr ""
 
 msgid "Pass 2"
-msgstr "Pass 2"
+msgstr ""
 
 msgid "Flow rate test - Pass 2"
-msgstr "Flow rate test - Pass 2"
+msgstr ""
 
 msgid "YOLO (Recommended)"
 msgstr ""
@@ -4820,34 +4751,34 @@ msgid "Orca YOLO flowrate calibration, 0.005 step"
 msgstr ""
 
 msgid "Flow rate"
-msgstr "Flow rate"
+msgstr ""
 
 msgid "Pressure advance"
-msgstr "Pressure advance"
+msgstr ""
 
 msgid "Retraction test"
-msgstr "Retraction test"
+msgstr ""
 
 msgid "Orca Tolerance Test"
-msgstr "Orca Tolerance Test"
+msgstr ""
 
 msgid "Max flowrate"
-msgstr "Max flowrate"
+msgstr ""
 
 msgid "VFA"
-msgstr "VFA"
+msgstr ""
 
 msgid "More..."
-msgstr "More..."
+msgstr ""
 
 msgid "Tutorial"
-msgstr "Tutorial"
+msgstr ""
 
 msgid "Calibration help"
-msgstr "Calibration help"
+msgstr ""
 
 msgid "More calibrations"
-msgstr "More calibrations"
+msgstr ""
 
 msgid "&Open G-code"
 msgstr "G-codeを開く"
@@ -4862,10 +4793,10 @@ msgid "Reload the plater from disk"
 msgstr "プレートを再読込み"
 
 msgid "Export &Toolpaths as OBJ"
-msgstr "Export &Toolpaths as OBJ"
+msgstr ""
 
 msgid "Export toolpaths as OBJ"
-msgstr "Export toolpaths as OBJ"
+msgstr ""
 
 msgid "Open &Slicer"
 msgstr "Studioを開く"
@@ -4963,53 +4894,48 @@ msgid "Synchronization"
 msgstr "同期"
 
 msgid "The device cannot handle more conversations. Please retry later."
-msgstr "The device cannot handle more conversations. Please retry later."
+msgstr ""
 
 msgid "Player is malfunctioning. Please reinstall the system player."
-msgstr "Player is malfunctioning. Please reinstall the system player."
+msgstr ""
 
 msgid "The player is not loaded, please click \"play\" button to retry."
-msgstr "The player is not loaded; please click the \"play\" button to retry."
+msgstr ""
 
 msgid "Please confirm if the printer is connected."
-msgstr "Please confirm if the printer is connected."
+msgstr ""
 
 msgid ""
 "The printer is currently busy downloading. Please try again after it "
 "finishes."
 msgstr ""
-"The printer is currently busy downloading. Please try again after it "
-"finishes."
 
 msgid "Printer camera is malfunctioning."
-msgstr "Printer camera is malfunctioning."
+msgstr ""
 
 msgid "Problem occurred. Please update the printer firmware and try again."
-msgstr "A problem occurred. Please update the printer firmware and try again."
+msgstr ""
 
 msgid ""
 "LAN Only Liveview is off. Please turn on the liveview on printer screen."
 msgstr ""
-"LAN Only Liveview is off. Please turn on the liveview on printer screen."
 
 msgid "Please enter the IP of printer to connect."
-msgstr "Please enter the IP of the printer to connect."
+msgstr ""
 
 msgid "Initializing..."
 msgstr "初期化中..."
 
 msgid "Connection Failed. Please check the network and try again"
-msgstr "Connection Failed. Please check the network and try again"
+msgstr ""
 
 msgid ""
 "Please check the network and try again, You can restart or update the "
 "printer if the issue persists."
 msgstr ""
-"Please check the network and try again. You can restart or update the "
-"printer if the issue persists."
 
 msgid "The printer has been logged out and cannot connect."
-msgstr "The printer has been logged out and cannot connect."
+msgstr ""
 
 msgid "Video Stopped."
 msgstr ""
@@ -5074,7 +5000,7 @@ msgid "Switch to video files."
 msgstr "ビデオファイルに切替え"
 
 msgid "Switch to 3mf model files."
-msgstr "Switch to 3mf model files."
+msgstr ""
 
 msgid "Delete selected files from printer."
 msgstr "プリンターから選択したファイルを削除"
@@ -5095,7 +5021,7 @@ msgid "Refresh"
 msgstr "再読込"
 
 msgid "Reload file list from printer."
-msgstr "Reload file list from printer."
+msgstr ""
 
 msgid "No printers."
 msgstr "プリンタなし"
@@ -5107,27 +5033,23 @@ msgid "No files"
 msgstr "ファイル無し"
 
 msgid "Load failed"
-msgstr "Load failed"
+msgstr ""
 
 msgid ""
 "Browsing file in SD card is not supported in current firmware. Please update "
 "the printer firmware."
 msgstr ""
-"Browsing file in SD card is not supported in current firmware. Please update "
-"the printer firmware."
 
 msgid ""
 "Please check if the SD card is inserted into the printer.\n"
 "If it still cannot be read, you can try formatting the SD card."
 msgstr ""
-"Please check if the Micro SD card is inserted into the printer.\n"
-"If it still cannot be read, you can try formatting the card."
 
 msgid "LAN Connection Failed (Failed to view sdcard)"
-msgstr "LAN Connection Failed (Failed to view sdcard)"
+msgstr ""
 
 msgid "Browsing file in SD card is not supported in LAN Only Mode."
-msgstr "Browsing file in SD card is not supported in LAN Only Mode."
+msgstr ""
 
 #, c-format, boost-format
 msgid "You are going to delete %u file from printer. Are you sure to continue?"
@@ -5136,23 +5058,23 @@ msgid_plural ""
 msgstr[0] ""
 
 msgid "Delete files"
-msgstr "Delete files"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Do you want to delete the file '%s' from printer?"
-msgstr "Do you want to delete the file '%s' from printer?"
+msgstr ""
 
 msgid "Delete file"
-msgstr "Delete file"
+msgstr ""
 
 msgid "Fetching model information..."
-msgstr "Fetching model information..."
+msgstr ""
 
 msgid "Failed to fetch model information from printer."
-msgstr "Failed to fetch model information from printer."
+msgstr ""
 
 msgid "Failed to parse model information."
-msgstr "Failed to parse model information."
+msgstr ""
 
 msgid ""
 "The .gcode.3mf file contains no G-code data.Please slice it with Orca Slicer "
@@ -5168,8 +5090,6 @@ msgid ""
 "File: %s\n"
 "Title: %s\n"
 msgstr ""
-"File: %s\n"
-"Title: %s\n"
 
 msgid "Download waiting..."
 msgstr "ダウンロード待ち"
@@ -5191,24 +5111,22 @@ msgid ""
 "Reconnecting the printer, the operation cannot be completed immediately, "
 "please try again later."
 msgstr ""
-"Reconnecting the printer, the operation cannot be completed immediately, "
-"please try again later."
 
 msgid "File does not exist."
-msgstr "File does not exist."
+msgstr ""
 
 msgid "File checksum error. Please retry."
-msgstr "File checksum error. Please retry."
+msgstr ""
 
 msgid "Not supported on the current printer version."
-msgstr "Not supported on the current printer version."
+msgstr ""
 
 msgid "Storage unavailable, insert SD card."
-msgstr "Storage unavailable; please insert MicroSD card."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Error code: %d"
-msgstr "Error code: %d"
+msgstr ""
 
 msgid "Speed:"
 msgstr "速度"
@@ -5256,7 +5174,7 @@ msgid "0"
 msgstr "0"
 
 msgid "Layer: N/A"
-msgstr "Layer: N/A"
+msgstr ""
 
 msgid "Clear"
 msgstr "クリア"
@@ -5265,21 +5183,17 @@ msgid ""
 "You have completed printing the mall model, \n"
 "but the synchronization of rating information has failed."
 msgstr ""
-"You have completed printing the mall model, \n"
-"but synchronizing rating information has failed."
 
 msgid "How do you like this printing file?"
-msgstr "How do you like this printing file?"
+msgstr ""
 
 msgid ""
 "(The model has already been rated. Your rating will overwrite the previous "
 "rating.)"
 msgstr ""
-"(The model has already been rated. Your rating will overwrite the previous "
-"rating.)"
 
 msgid "Rate"
-msgstr "Rate"
+msgstr ""
 
 msgid "Camera"
 msgstr "カメラ"
@@ -5297,7 +5211,7 @@ msgid "Control"
 msgstr "コントロール"
 
 msgid "Printer Parts"
-msgstr "Printer Parts"
+msgstr ""
 
 msgid "Print Options"
 msgstr "造型オプション"
@@ -5340,22 +5254,20 @@ msgstr "クラウドにてスライス中"
 
 #, c-format, boost-format
 msgid "In Cloud Slicing Queue, there are %s tasks ahead."
-msgstr "In Cloud Slicing Queue, there are %s tasks ahead of you."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Layer: %s"
-msgstr "Layer: %s"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Layer: %d/%d"
-msgstr "Layer: %d/%d"
+msgstr ""
 
 msgid ""
 "Please heat the nozzle to above 170 degree before loading or unloading "
 "filament."
 msgstr ""
-"Please heat the nozzle to above 170 degree before loading or unloading "
-"filament."
 
 msgid "Still unload"
 msgstr "アンロード"
@@ -5392,108 +5304,95 @@ msgid "Can't start this without SD card."
 msgstr "起動するのにSDカードが必要です。"
 
 msgid "Rate the Print Profile"
-msgstr "Rate the Print Profile"
+msgstr ""
 
 msgid "Comment"
-msgstr "Comment"
+msgstr ""
 
 msgid "Rate this print"
-msgstr "Rate this print"
+msgstr ""
 
 msgid "Add Photo"
-msgstr "Add Photo"
+msgstr ""
 
 msgid "Delete Photo"
-msgstr "Delete Photo"
+msgstr ""
 
 msgid "Submit"
-msgstr "Submit"
+msgstr ""
 
 msgid "Please click on the star first."
-msgstr "Please click on the star first."
+msgstr ""
 
 msgid "InFo"
-msgstr "Info"
+msgstr ""
 
 msgid "Get oss config failed."
-msgstr "Get oss config failed."
+msgstr ""
 
 msgid "Upload Pictures"
-msgstr "Upload Pictures"
+msgstr ""
 
 msgid "Number of images successfully uploaded"
-msgstr "Number of images successfully uploaded"
+msgstr ""
 
 msgid " upload failed"
-msgstr " upload failed"
+msgstr ""
 
 msgid " upload config prase failed\n"
-msgstr " upload config prase failed\n"
+msgstr ""
 
 msgid " No corresponding storage bucket\n"
-msgstr " No corresponding storage bucket\n"
+msgstr ""
 
 msgid " cannot be opened\n"
-msgstr " cannot be opened\n"
+msgstr ""
 
 msgid ""
 "The following issues occurred during the process of uploading images. Do you "
 "want to ignore them?\n"
 "\n"
 msgstr ""
-"The following issues occurred during the process of uploading images. Do you "
-"want to ignore them?\n"
-"\n"
 
 msgid "info"
 msgstr "情報"
 
 msgid "Synchronizing the printing results. Please retry a few seconds later."
-msgstr "Synchronizing the printing results. Please retry a few seconds later."
+msgstr ""
 
 msgid "Upload failed\n"
-msgstr "Upload failed\n"
+msgstr ""
 
 msgid "obtaining instance_id failed\n"
-msgstr "obtaining instance_id failed\n"
+msgstr ""
 
 msgid ""
 "Your comment result cannot be uploaded due to some reasons. As follows:\n"
 "\n"
 "  error code: "
 msgstr ""
-"Your comment result cannot be uploaded due to the following reasons:\n"
-"\n"
-"  error code: "
 
 msgid "error message: "
-msgstr "error message: "
+msgstr ""
 
 msgid ""
 "\n"
 "\n"
 "Would you like to redirect to the webpage for rating?"
 msgstr ""
-"\n"
-"\n"
-"Would you like to redirect to the webpage to give a rating?"
 
 msgid ""
 "Some of your images failed to upload. Would you like to redirect to the "
 "webpage for rating?"
 msgstr ""
-"Some of your images failed to upload. Would you like to redirect to the "
-"webpage for rating?"
 
 msgid "You can select up to 16 images."
-msgstr "You can select up to 16 images."
+msgstr ""
 
 msgid ""
 "At least one successful print record of this print profile is required \n"
 "to give a positive rating(4 or 5stars)."
 msgstr ""
-"At least one successful print record of this print profile is required \n"
-"to give a positive rating (4 or 5 stars)."
 
 msgid "Status"
 msgstr "デバイス状態"
@@ -5543,7 +5442,7 @@ msgid "If you would like to try Orca Slicer Beta, you may click to"
 msgstr ""
 
 msgid "Download Beta Version"
-msgstr "Download Beta Version"
+msgstr ""
 
 msgid "The 3mf file version is newer than the current Orca Slicer version."
 msgstr ""
@@ -5552,13 +5451,13 @@ msgid "Update your Orca Slicer could enable all functionality in the 3mf file."
 msgstr ""
 
 msgid "Current Version: "
-msgstr "Current Version: "
+msgstr ""
 
 msgid "Latest Version: "
-msgstr "Latest Version: "
+msgstr ""
 
 msgid "Not for now"
-msgstr "Not for now"
+msgstr ""
 
 msgid "Server Exception"
 msgstr ""
@@ -5604,7 +5503,7 @@ msgid "Details"
 msgstr "詳細"
 
 msgid "New printer config available."
-msgstr "New printer config available."
+msgstr ""
 
 msgid "Wiki"
 msgstr "Wiki"
@@ -5625,7 +5524,7 @@ msgid "Open Folder."
 msgstr "フォルダを開く"
 
 msgid "Safely remove hardware."
-msgstr "Safely remove hardware."
+msgstr ""
 
 #, c-format, boost-format
 msgid "%1$d Object has custom supports."
@@ -5667,10 +5566,10 @@ msgid "Export successfully."
 msgstr "エクスポートが成功しました。"
 
 msgid "Model file downloaded."
-msgstr "Model file downloaded."
+msgstr ""
 
 msgid "Serious warning:"
-msgstr "Serious warning:"
+msgstr ""
 
 msgid " (Repair)"
 msgstr " (修復)"
@@ -5695,7 +5594,7 @@ msgid "Color painting"
 msgstr "色塗り"
 
 msgid "Cut connectors"
-msgstr "Cut connectors"
+msgstr ""
 
 msgid "Layers"
 msgstr "積層"
@@ -5754,25 +5653,25 @@ msgid "Auto-recovery from step loss"
 msgstr "自動回復"
 
 msgid "Allow Prompt Sound"
-msgstr "Allow Prompt Sound"
+msgstr ""
 
 msgid "Filament Tangle Detect"
-msgstr "Filament Tangle Detection"
+msgstr ""
 
 msgid "Nozzle Clumping Detection"
-msgstr "Nozzle Clumping Detection"
+msgstr ""
 
 msgid "Check if the nozzle is clumping by filament or other foreign objects."
-msgstr "Check if the nozzle is clumping by filament or other foreign objects."
+msgstr ""
 
 msgid "Nozzle Type"
-msgstr "Nozzle Type"
+msgstr "ノズルタイプ"
 
 msgid "Stainless Steel"
-msgstr "Stainless Steel"
+msgstr ""
 
 msgid "Hardened Steel"
-msgstr "Hardened Steel"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%.1f"
@@ -5873,7 +5772,7 @@ msgid "Set filaments to use"
 msgstr "フィラメントを選択"
 
 msgid "Search plate, object and part."
-msgstr "Search plate, object and part."
+msgstr ""
 
 msgid "Pellets"
 msgstr ""
@@ -5897,14 +5796,12 @@ msgid ""
 "Already did a synchronization, do you want to sync only changes or resync "
 "all?"
 msgstr ""
-"Already did a synchronization; do you want to sync only changes or resync "
-"all?"
 
 msgid "Sync"
-msgstr "Sync"
+msgstr ""
 
 msgid "Resync"
-msgstr "Resync"
+msgstr ""
 
 msgid "There are no compatible filaments, and sync is not performed."
 msgstr "適用できるフィラメントがありません、同期を行えません"
@@ -5940,9 +5837,6 @@ msgid ""
 "clogged when printing this filament in a closed enclosure. Please open the "
 "front door and/or remove the upper glass."
 msgstr ""
-"The current heatbed temperature is relatively high. The nozzle may clog when "
-"printing this filament in a closed environment. Please open the front door "
-"and/or remove the upper glass."
 
 msgid ""
 "The nozzle hardness required by the filament is higher than the default "
@@ -5956,8 +5850,6 @@ msgid ""
 "Enabling traditional timelapse photography may cause surface imperfections. "
 "It is recommended to change to smooth mode."
 msgstr ""
-"Enabling traditional timelapse photography may cause surface imperfections. "
-"It is recommended to change to smooth mode."
 
 msgid "Expand sidebar"
 msgstr "サイドバーを展開"
@@ -5995,10 +5887,10 @@ msgstr ""
 "3mfのバージョン%sは%sの%sより新しい為、ソフトウェアを更新してください。"
 
 msgid "Invalid values found in the 3mf:"
-msgstr "Invalid values found in the 3mf:"
+msgstr ""
 
 msgid "Please correct them in the param tabs"
-msgstr "Please correct them in the Param tabs"
+msgstr ""
 
 msgid "The 3mf has following modified G-codes in filament or printer presets:"
 msgstr ""
@@ -6012,7 +5904,7 @@ msgid "Modified G-code"
 msgstr ""
 
 msgid "The 3mf has following customized filament or printer presets:"
-msgstr "The 3mf has following customized filament or printer presets:"
+msgstr ""
 
 msgid ""
 "Please confirm that the G-codes within these presets are safe to prevent any "
@@ -6020,7 +5912,7 @@ msgid ""
 msgstr ""
 
 msgid "Customized Preset"
-msgstr "Customized Preset"
+msgstr ""
 
 msgid "Name of components inside step file is not UTF8 format!"
 msgstr "ファイルのエンコーディング方式はUTF8形式ではありません"
@@ -6029,7 +5921,7 @@ msgid "The name may show garbage characters!"
 msgstr "文字化けがあるようです、ご確認ください"
 
 msgid "Remember my choice."
-msgstr "Remember my choice."
+msgstr ""
 
 #, boost-format
 msgid "Failed loading file \"%1%\". An invalid configuration was found."
@@ -6085,36 +5977,31 @@ msgid "Export STL file:"
 msgstr "STLファイルをエクスポート:"
 
 msgid "Export AMF file:"
-msgstr "Export AMF file:"
+msgstr ""
 
 msgid "Save file as:"
 msgstr "名前を付けて保存"
 
 msgid "Export OBJ file:"
-msgstr "Export OBJ file:"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "The file %s already exists\n"
 "Do you want to replace it?"
 msgstr ""
-"The file %s already exists.\n"
-"Do you want to replace it?"
 
 msgid "Confirm Save As"
-msgstr "Confirm Save As"
+msgstr ""
 
 msgid "Delete object which is a part of cut object"
-msgstr "Delete object which is a part of cut object"
+msgstr ""
 
 msgid ""
 "You try to delete an object which is a part of a cut object.\n"
 "This action will break a cut correspondence.\n"
 "After that model consistency can't be guaranteed."
 msgstr ""
-"You are trying to delete an object which is a part of a cut object.\n"
-"This action will break a cut correspondence.\n"
-"After that, model consistency can't be guaranteed."
 
 msgid "The selected object couldn't be split."
 msgstr "選択したオブジェクトを分割できませんでした。"
@@ -6123,13 +6010,13 @@ msgid "Another export job is running."
 msgstr "エクスポート中です"
 
 msgid "Unable to replace with more than one volume"
-msgstr "Unable to replace with more than one volume"
+msgstr ""
 
 msgid "Error during replace"
 msgstr "交換時のエラー"
 
 msgid "Replace from:"
-msgstr "Replace from:"
+msgstr ""
 
 msgid "Select a new file"
 msgstr "ファイルを選択"
@@ -6141,19 +6028,19 @@ msgid "Please select a file"
 msgstr "ファイルを選択してください"
 
 msgid "Do you want to replace it"
-msgstr "Do you want to replace it?"
+msgstr ""
 
 msgid "Message"
-msgstr "Message"
+msgstr ""
 
 msgid "Reload from:"
-msgstr "Reload from:"
+msgstr ""
 
 msgid "Unable to reload:"
-msgstr "Unable to reload:"
+msgstr ""
 
 msgid "Error during reload"
-msgstr "Error during reload"
+msgstr ""
 
 msgid "There are warnings after slicing models:"
 msgstr "スライスの警告:"
@@ -6214,13 +6101,13 @@ msgid "prepare 3mf file..."
 msgstr "3mfファイルを準備"
 
 msgid "Download failed, unknown file format."
-msgstr "Download failed; unknown file format."
+msgstr ""
 
 msgid "downloading project ..."
 msgstr "プロジェクトをダウンロード中"
 
 msgid "Download failed, File size exception."
-msgstr "Download failed; File size exception."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Project downloaded %d%%"
@@ -6319,13 +6206,13 @@ msgid "Save G-code file as:"
 msgstr "名前を付けて保存"
 
 msgid "Save SLA file as:"
-msgstr "Save SLA file as:"
+msgstr ""
 
 msgid "The provided file name is not valid."
-msgstr "The provided file name is not valid."
+msgstr ""
 
 msgid "The following characters are not allowed by a FAT file system:"
-msgstr "The following characters are not allowed by a FAT file system:"
+msgstr ""
 
 msgid "Save Sliced file as:"
 msgstr "名前を付けて保存:"
@@ -6340,31 +6227,27 @@ msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
 "will be kept. You may fix the meshes and try again."
 msgstr ""
-"Unable to perform boolean operation on model meshes. Only positive parts "
-"will be kept. You may fix the meshes and try again."
 
 #, boost-format
 msgid "Reason: part \"%1%\" is empty."
-msgstr "Reason: part \"%1%\" is empty."
+msgstr ""
 
 #, boost-format
 msgid "Reason: part \"%1%\" does not bound a volume."
-msgstr "Reason: part \"%1%\" does not bound a volume."
+msgstr ""
 
 #, boost-format
 msgid "Reason: part \"%1%\" has self intersection."
-msgstr "Reason: part \"%1%\" has self intersection."
+msgstr ""
 
 #, boost-format
 msgid "Reason: \"%1%\" and another part have no intersection."
-msgstr "Reason: \"%1%\" and another part have no intersection."
+msgstr ""
 
 msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
 "will be exported."
 msgstr ""
-"Unable to perform boolean operation on model meshes. Only positive parts "
-"will be exported."
 
 msgid ""
 "Are you sure you want to store original SVGs with their local paths into the "
@@ -6410,15 +6293,15 @@ msgid "Invalid number"
 msgstr "無効な数字"
 
 msgid "Plate Settings"
-msgstr "Plate Settings"
+msgstr ""
 
 #, boost-format
 msgid "Number of currently selected parts: %1%\n"
-msgstr "Number of currently selected parts: %1%\n"
+msgstr ""
 
 #, boost-format
 msgid "Number of currently selected objects: %1%\n"
-msgstr "Number of currently selected objects: %1%\n"
+msgstr ""
 
 #, boost-format
 msgid "Part name: %1%\n"
@@ -6562,9 +6445,6 @@ msgid ""
 "it is allowed to run multiple instances of same app from the command line. "
 "In such case this settings will allow only one instance."
 msgstr ""
-"On OSX there is always only one instance of app running by default. However "
-"it is allowed to run multiple instances of same app from the command line. "
-"In such case this setting will allow only one instance."
 
 msgid ""
 "If this is enabled, when starting OrcaSlicer and another instance of the "
@@ -6594,14 +6474,12 @@ msgid ""
 msgstr ""
 
 msgid "Zoom to mouse position"
-msgstr "Zoom to mouse position"
+msgstr ""
 
 msgid ""
 "Zoom in towards the mouse pointer's position in the 3D view, rather than the "
 "2D window center."
 msgstr ""
-"Zoom in towards the mouse pointer's position in the 3D view, rather than the "
-"2D window center."
 
 msgid "Use free camera"
 msgstr "フリーカメラを使用"
@@ -6630,17 +6508,17 @@ msgid "If enabled, useful hints are displayed at startup."
 msgstr "有効になる場合、起動時にヒントを表示されます。"
 
 msgid "Flushing volumes: Auto-calculate every time the color changed."
-msgstr "Flushing volumes: Auto-calculate every time the color changed."
+msgstr ""
 
 msgid "If enabled, auto-calculate every time the color changed."
-msgstr "If enabled, auto-calculate every time the color changes."
+msgstr ""
 
 msgid ""
 "Flushing volumes: Auto-calculate every time when the filament is changed."
-msgstr "Flushing volumes: Auto-calculate every time the filament is changed."
+msgstr ""
 
 msgid "If enabled, auto-calculate every time when filament is changed"
-msgstr "If enabled, auto-calculate every time filament is changed"
+msgstr ""
 
 msgid "Remember printer configuration"
 msgstr ""
@@ -6657,8 +6535,6 @@ msgid ""
 "With this option enabled, you can send a task to multiple devices at the "
 "same time and manage multiple devices."
 msgstr ""
-"With this option enabled, you can send a task to multiple devices at the "
-"same time and manage multiple devices."
 
 msgid "Auto arrange plate after cloning"
 msgstr ""
@@ -6676,13 +6552,13 @@ msgid "User Sync"
 msgstr "ユーザー同期"
 
 msgid "Update built-in Presets automatically."
-msgstr "Update built-in presets automatically."
+msgstr ""
 
 msgid "System Sync"
-msgstr "System Sync"
+msgstr ""
 
 msgid "Clear my choice on the unsaved presets."
-msgstr "Clear my choice on the unsaved presets."
+msgstr ""
 
 msgid "Associate files to OrcaSlicer"
 msgstr "ファイルをOrca Slicerに関連付ける"
@@ -6730,16 +6606,16 @@ msgid "Should printer/filament/process settings be loaded when opening a .3mf?"
 msgstr ""
 
 msgid "Maximum recent projects"
-msgstr "Maximum recent projects"
+msgstr ""
 
 msgid "Maximum count of recent projects"
-msgstr "Maximum count of recent projects"
+msgstr ""
 
 msgid "Clear my choice on the unsaved projects."
-msgstr "Clear my choice on the unsaved projects."
+msgstr ""
 
 msgid "No warnings when loading 3MF with modified G-code"
-msgstr "No warnings when loading 3MF with modified G-code"
+msgstr ""
 
 msgid "Auto-Backup"
 msgstr "自動バックアップ"
@@ -6747,14 +6623,12 @@ msgstr "自動バックアップ"
 msgid ""
 "Backup your project periodically for restoring from the occasional crash."
 msgstr ""
-"Backup your project periodically to help with restoring from an occasional "
-"crash."
 
 msgid "every"
-msgstr "every"
+msgstr ""
 
 msgid "The period of backup in seconds."
-msgstr "The period of backup in seconds."
+msgstr ""
 
 msgid "Downloads"
 msgstr "ダウンロード"
@@ -6769,7 +6643,7 @@ msgid "Develop mode"
 msgstr "開発者モード"
 
 msgid "Skip AMS blacklist check"
-msgstr "Skip AMS blacklist check"
+msgstr ""
 
 msgid "Home page and daily tips"
 msgstr "ホームページとヒント"
@@ -6808,16 +6682,16 @@ msgid "Mouse wheel reverses when zooming"
 msgstr "ズーム中にスクロール方向を反転させる"
 
 msgid "Enable SSL(MQTT)"
-msgstr "Enable SSL(MQTT)"
+msgstr ""
 
 msgid "Enable SSL(FTP)"
-msgstr "Enable SSL(FTP)"
+msgstr ""
 
 msgid "Internal developer mode"
-msgstr "Internal developer mode"
+msgstr ""
 
 msgid "Log Level"
-msgstr "Log Level"
+msgstr ""
 
 msgid "fatal"
 msgstr "重大的"
@@ -6877,7 +6751,7 @@ msgid "Click to select filament color"
 msgstr "フィラメントの色を選択"
 
 msgid "Please choose the filament color"
-msgstr "Please choose the filament color"
+msgstr ""
 
 msgid "Add/Remove presets"
 msgstr "プリセットの追加/削除"
@@ -6895,64 +6769,64 @@ msgid "Add/Remove materials"
 msgstr "素材を追加/削除"
 
 msgid "Select/Remove printers(system presets)"
-msgstr "Select/Remove printers(system presets)"
+msgstr ""
 
 msgid "Create printer"
-msgstr "Create printer"
+msgstr ""
 
 msgid "The selected preset is null!"
-msgstr "The selected preset is null!"
+msgstr ""
 
 msgid "End"
-msgstr "End"
+msgstr ""
 
 msgid "Customize"
-msgstr "Customize"
+msgstr ""
 
 msgid "Other layer filament sequence"
-msgstr "Other layer filament sequence"
+msgstr ""
 
 msgid "Please input layer value (>= 2)."
-msgstr "Please input layer value (>= 2)."
+msgstr ""
 
 msgid "Plate name"
-msgstr "Plate name"
+msgstr ""
 
 msgid "Same as Global Print Sequence"
-msgstr "Same as Global Print Sequence"
+msgstr ""
 
 msgid "Print sequence"
 msgstr "造形シーケンス"
 
 msgid "Same as Global"
-msgstr "Same as Global"
+msgstr ""
 
 msgid "Disable"
-msgstr "Disable"
+msgstr ""
 
 msgid "Spiral vase"
 msgstr "スパイラル"
 
 msgid "First layer filament sequence"
-msgstr "First layer filament sequence"
+msgstr ""
 
 msgid "Same as Global Plate Type"
-msgstr "Same as Global Plate Type"
+msgstr ""
 
 msgid "Same as Global Bed Type"
 msgstr "全般設定の「ベッドタイプ」と同様"
 
 msgid "By Layer"
-msgstr "By Layer"
+msgstr ""
 
 msgid "By Object"
-msgstr "By Object"
+msgstr ""
 
 msgid "Accept"
-msgstr "Accept"
+msgstr ""
 
 msgid "Log Out"
-msgstr "Log Out"
+msgstr ""
 
 msgid "Slice all plate to obtain time and filament estimation"
 msgstr "全プレートをスライスし、造形時間を推測します"
@@ -7048,7 +6922,7 @@ msgid "(LAN)"
 msgstr "(LAN)"
 
 msgid "Search"
-msgstr "Search"
+msgstr ""
 
 msgid "My Device"
 msgstr "私のデバイス"
@@ -7075,7 +6949,7 @@ msgid "Bambu Cool Plate"
 msgstr "Bambu 常温プレート"
 
 msgid "PLA Plate"
-msgstr "PLA Plate"
+msgstr ""
 
 msgid "Bambu Engineering Plate"
 msgstr "Bambu エンジニアリングプレート"
@@ -7084,7 +6958,7 @@ msgid "Bambu Smooth PEI Plate"
 msgstr ""
 
 msgid "High temperature Plate"
-msgstr "High temperature Plate"
+msgstr ""
 
 msgid "Bambu Textured PEI Plate"
 msgstr ""
@@ -7093,16 +6967,16 @@ msgid "Send print job to"
 msgstr "造形タスクを送信"
 
 msgid "Flow Dynamics Calibration"
-msgstr "Flow Dynamics Calibration"
+msgstr ""
 
 msgid "Click here if you can't connect to the printer"
-msgstr "Click here if you can't connect to the printer"
+msgstr ""
 
 msgid "send completed"
 msgstr "送信完了"
 
 msgid "Error code"
-msgstr "Error code"
+msgstr ""
 
 msgid "No login account, only printers in LAN mode are displayed"
 msgstr "アカウント無し、ローカルモードのプリンターのみが表示されます"
@@ -7172,8 +7046,6 @@ msgid ""
 "The selected printer (%s) is incompatible with the chosen printer profile in "
 "the slicer (%s)."
 msgstr ""
-"The selected printer (%s) is incompatible with the chosen printer profile in "
-"the slicer (%s)."
 
 msgid "An SD card needs to be inserted to record timelapse."
 msgstr "SDカードが必要です"
@@ -7193,28 +7065,22 @@ msgid ""
 "When enable spiral vase mode, machines with I3 structure will not generate "
 "timelapse videos."
 msgstr ""
-"When spiral vase mode is enabled, machines with I3 structure will not "
-"generate timelapse videos."
 
 msgid ""
 "Timelapse is not supported because Print sequence is set to \"By object\"."
 msgstr ""
-"Timelapse is not supported because Print sequence is set to \"By object\"."
 
 msgid "Errors"
 msgstr "エラー"
 
 msgid "Please check the following:"
-msgstr "Please check the following:"
+msgstr ""
 
 msgid ""
 "The printer type selected when generating G-code is not consistent with the "
 "currently selected printer. It is recommended that you use the same printer "
 "type for slicing."
 msgstr ""
-"The printer type selected when generating G-code is not consistent with the "
-"currently selected printer. It is recommended that you use the same printer "
-"type for slicing."
 
 msgid ""
 "There are some unknown filaments in the AMS mappings. Please check whether "
@@ -7226,57 +7092,48 @@ msgstr ""
 
 #, c-format, boost-format
 msgid "nozzle in preset: %s %s"
-msgstr "nozzle in preset: %s %s"
+msgstr ""
 
 #, c-format, boost-format
 msgid "nozzle memorized: %.2f %s"
-msgstr "nozzle memorized: %.2f %s"
+msgstr ""
 
 msgid ""
 "Your nozzle diameter in sliced file is not consistent with memorized nozzle. "
 "If you changed your nozzle lately, please go to Device > Printer Parts to "
 "change settings."
 msgstr ""
-"Your nozzle diameter in sliced file is not consistent with the saved nozzle. "
-"If you changed your nozzle lately, please go to Device > Printer Parts to "
-"change settings."
 
 #, c-format, boost-format
 msgid ""
 "Printing high temperature material(%s material) with %s may cause nozzle "
 "damage"
 msgstr ""
-"Printing high temperature material(%s material) with %s may cause nozzle "
-"damage"
 
 msgid "Please fix the error above, otherwise printing cannot continue."
-msgstr "Please fix the error above, otherwise printing cannot continue."
+msgstr ""
 
 msgid ""
 "Please click the confirm button if you still want to proceed with printing."
 msgstr ""
-"Please click the confirm button if you still want to proceed with printing."
 
 msgid ""
 "Connecting to the printer. Unable to cancel during the connection process."
 msgstr ""
-"Connecting to the printer. Unable to cancel during the connection process."
 
 msgid ""
 "Caution to use! Flow calibration on Textured PEI Plate may fail due to the "
 "scattered surface."
 msgstr ""
-"Caution! Flow calibration on Textured PEI Plates may fail due to the "
-"scattered surface."
 
 msgid "Automatic flow calibration using Micro Lidar"
-msgstr "Automatic flow calibration using the Micro Lidar"
+msgstr ""
 
 msgid "Modifying the device name"
 msgstr "デバイス名を変更"
 
 msgid "Bind with Pin Code"
-msgstr "Bind with Pin Code"
+msgstr ""
 
 msgid "Bind with Access Code"
 msgstr "アクセスコードと紐付け"
@@ -7288,11 +7145,10 @@ msgid "Cannot send the print task when the upgrade is in progress"
 msgstr "アップデート中では造形タスクを送信できません"
 
 msgid "The selected printer is incompatible with the chosen printer presets."
-msgstr "The selected printer is incompatible with the chosen printer presets."
+msgstr ""
 
 msgid "An SD card needs to be inserted before send to printer SD card."
 msgstr ""
-"A MicroSD card needs to be inserted before sending to the printer SD card."
 
 msgid "The printer is required to be in the same LAN as Orca Slicer."
 msgstr ""
@@ -7305,31 +7161,31 @@ msgid "Slice ok."
 msgstr "スライス完了"
 
 msgid "View all Daily tips"
-msgstr "View all Daily tips"
+msgstr ""
 
 msgid "Failed to create socket"
-msgstr "Failed to create socket"
+msgstr ""
 
 msgid "Failed to connect socket"
-msgstr "Failed to connect socket"
+msgstr ""
 
 msgid "Failed to publish login request"
-msgstr "Failed to publish login request"
+msgstr ""
 
 msgid "Get ticket from device timeout"
-msgstr "Timeout getting ticket from device"
+msgstr ""
 
 msgid "Get ticket from server timeout"
-msgstr "Timeout getting ticket from server"
+msgstr ""
 
 msgid "Failed to post ticket to server"
-msgstr "Failed to post ticket to server"
+msgstr ""
 
 msgid "Failed to parse login report reason"
-msgstr "Failed to parse login report reason"
+msgstr ""
 
 msgid "Receive login report timeout"
-msgstr "Receive login report timeout"
+msgstr ""
 
 msgid "Unknown Failure"
 msgstr "不明な失敗"
@@ -7338,23 +7194,21 @@ msgid ""
 "Please Find the Pin Code in Account page on printer screen,\n"
 " and type in the Pin Code below."
 msgstr ""
-"Please Find the Pin Code in Account page on printer screen,\n"
-" and type in the Pin Code below."
 
 msgid "Can't find Pin Code?"
-msgstr "Can't find Pin Code?"
+msgstr ""
 
 msgid "Pin Code"
-msgstr "Pin Code"
+msgstr ""
 
 msgid "Binding..."
-msgstr "Binding..."
+msgstr ""
 
 msgid "Please confirm on the printer screen"
-msgstr "Please confirm on the printer screen"
+msgstr ""
 
 msgid "Log in failed. Please check the Pin Code."
-msgstr "Log in failed. Please check the Pin Code."
+msgstr ""
 
 msgid "Log in printer"
 msgstr "プリンターを登録"
@@ -7363,13 +7217,13 @@ msgid "Would you like to log in this printer with current account?"
 msgstr "現在のアカウントでプリンターをサインインしますか？"
 
 msgid "Check the reason"
-msgstr "Check the reason"
+msgstr ""
 
 msgid "Read and accept"
-msgstr "Read and accept"
+msgstr ""
 
 msgid "Terms and Conditions"
-msgstr "Terms and Conditions"
+msgstr ""
 
 msgid ""
 "Thank you for purchasing a Bambu Lab device.Before using your Bambu Lab "
@@ -7378,23 +7232,18 @@ msgid ""
 "Use(collectively, the \"Terms\"). If you do not comply with or agree to the "
 "Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services."
 msgstr ""
-"Thank you for purchasing a Bambu Lab device. Before using your Bambu Lab "
-"device, please read the terms and conditions. By clicking to agree to use "
-"your Bambu Lab device, you agree to abide by the Privacy Policy and Terms of "
-"Use (collectively, the \"Terms\"). If you do not comply with or agree to the "
-"Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services."
 
 msgid "and"
-msgstr "and"
+msgstr ""
 
 msgid "Privacy Policy"
-msgstr "Privacy Policy"
+msgstr ""
 
 msgid "We ask for your help to improve everyone's printer"
-msgstr "We ask for your help to improve everyone's printer"
+msgstr ""
 
 msgid "Statement about User Experience Improvement Program"
-msgstr "Statement about User Experience Improvement Program"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -7410,20 +7259,9 @@ msgid ""
 "payment information, or phone numbers. By enabling this service, you agree "
 "to these terms and the statement about Privacy Policy."
 msgstr ""
-"In the 3D Printing community, we learn from each other's successes and "
-"failures to adjust our own slicing parameters and settings. %s follows the "
-"same principle and uses machine learning to improve its performance from the "
-"successes and failures of the vast number of prints by our users. We are "
-"training %s to be smarter by feeding them the real-world data. If you are "
-"willing, this service will access information from your error logs and usage "
-"logs, which may include information described in  Privacy Policy. We will "
-"not collect any Personal Data by which an individual can be identified "
-"directly or indirectly, including without limitation names, addresses, "
-"payment information, or phone numbers. By enabling this service, you agree "
-"to these terms and the statement about Privacy Policy."
 
 msgid "Statement on User Experience Improvement Plan"
-msgstr "Statement on User Experience Improvement Plan"
+msgstr ""
 
 msgid "Log in successful."
 msgstr "登録成功"
@@ -7472,7 +7310,7 @@ msgstr ""
 "ワーを有効にしますか？"
 
 msgid "Still print by object?"
-msgstr "Still print by object?"
+msgstr ""
 
 msgid ""
 "When using support material for the support interface, We recommend the "
@@ -7480,10 +7318,6 @@ msgid ""
 "0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
 "disable independent support layer height"
 msgstr ""
-"When using support material for the support interface, We recommend the "
-"following settings:\n"
-"0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
-"disable independent support layer height"
 
 msgid ""
 "Change these settings automatically? \n"
@@ -7512,17 +7346,15 @@ msgid ""
 "Layer height exceeds the limit in Printer Settings -> Extruder -> Layer "
 "height limits, this may cause printing quality issues."
 msgstr ""
-"Layer height exceeds the limit in Printer Settings -> Extruder -> Layer "
-"height limits, this may cause printing quality issues."
 
 msgid "Adjust to the set range automatically? \n"
-msgstr "Adjust to the set range automatically? \n"
+msgstr ""
 
 msgid "Adjust"
-msgstr "Adjust"
+msgstr ""
 
 msgid "Ignore"
-msgstr "Ignore"
+msgstr ""
 
 msgid ""
 "Experimental feature: Retracting and cutting off the filament at a greater "
@@ -7530,10 +7362,6 @@ msgid ""
 "reduce flush,  it may also elevate the risk of nozzle clogs or other "
 "printing complications."
 msgstr ""
-"Experimental feature: Retracting and cutting off the filament at a greater "
-"distance during filament changes to minimize flush. Although it can notably "
-"reduce flush,  it may also elevate the risk of nozzle clogs or other "
-"printing complications."
 
 msgid ""
 "Experimental feature: Retracting and cutting off the filament at a greater "
@@ -7541,10 +7369,6 @@ msgid ""
 "reduce flush, it may also elevate the risk of nozzle clogs or other printing "
 "complications.Please use with the latest printer firmware."
 msgstr ""
-"Experimental feature: Retracting and cutting off the filament at a greater "
-"distance during filament changes to minimize flush. Although it can notably "
-"reduce flush, it may also elevate the risk of nozzle clogs or other printing "
-"complications. Please use with the latest printer firmware."
 
 msgid ""
 "When recording timelapse without toolhead, it is recommended to add a "
@@ -7687,7 +7511,7 @@ msgid "Acceleration"
 msgstr "加速度"
 
 msgid "Jerk(XY)"
-msgstr "Jerk(XY)"
+msgstr ""
 
 msgid "Raft"
 msgstr "ラフト"
@@ -7720,10 +7544,10 @@ msgid "G-code output"
 msgstr "G-code出力"
 
 msgid "Post-processing Scripts"
-msgstr "Post-processing Scripts"
+msgstr ""
 
 msgid "Notes"
-msgstr "Notes"
+msgstr ""
 
 msgid "Frequent"
 msgstr "よく使う"
@@ -7867,13 +7691,13 @@ msgid "Auxiliary part cooling fan"
 msgstr "パーツ補助冷却ファン"
 
 msgid "Exhaust fan"
-msgstr "Exhaust fan"
+msgstr ""
 
 msgid "During print"
-msgstr "During print"
+msgstr ""
 
 msgid "Complete print"
-msgstr "Complete print"
+msgstr ""
 
 msgid "Filament start G-code"
 msgstr "フィラメント開始G-code"
@@ -7935,7 +7759,7 @@ msgid "Machine end G-code"
 msgstr "プリンター終了G-code"
 
 msgid "Printing by object G-code"
-msgstr "Printing by object G-code"
+msgstr ""
 
 msgid "Before layer change G-code"
 msgstr "積層変更前のG-code"
@@ -7944,7 +7768,7 @@ msgid "Layer change G-code"
 msgstr "積層変更時のG-code"
 
 msgid "Time lapse G-code"
-msgstr "Time lapse G-code"
+msgstr ""
 
 msgid "Change filament G-code"
 msgstr "フィラメント変更G-code"
@@ -8017,12 +7841,9 @@ msgid ""
 "\n"
 "Shall I disable it in order to enable Firmware Retraction?"
 msgstr ""
-"The Wipe option is not available when using the Firmware Retraction mode.\n"
-"\n"
-"Disable it in order to enable Firmware Retraction?"
 
 msgid "Firmware Retraction"
-msgstr "Firmware Retraction"
+msgstr ""
 
 msgid "Detached"
 msgstr "分離的"
@@ -8032,8 +7853,6 @@ msgid ""
 "%d Filament Preset and %d Process Preset is attached to this printer. Those "
 "presets would be deleted if the printer is deleted."
 msgstr ""
-"%d Filament Preset and %d Process Preset is attached to this printer. Those "
-"presets would be deleted if the printer is deleted."
 
 msgid "Presets inherited by other presets cannot be deleted!"
 msgstr ""
@@ -8056,9 +7875,6 @@ msgid ""
 "If the preset corresponds to a filament currently in use on your printer, "
 "please reset the filament information for that slot."
 msgstr ""
-"Are you sure to delete the selected preset? \n"
-"If the preset corresponds to a filament currently in use on your printer, "
-"please reset the filament information for that slot."
 
 #, boost-format
 msgid "Are you sure to %1% the selected preset?"
@@ -8155,14 +7971,12 @@ msgstr ""
 
 #, boost-format
 msgid "You have changed some settings of preset \"%1%\"."
-msgstr "You have changed some settings of preset \"%1%\"."
+msgstr ""
 
 msgid ""
 "\n"
 "You can save or discard the preset values you have modified."
 msgstr ""
-"\n"
-"You can save or discard the preset values you have modified."
 
 msgid ""
 "\n"
@@ -8171,7 +7985,7 @@ msgid ""
 msgstr ""
 
 msgid "You have previously modified your settings."
-msgstr "You have previously modified your settings."
+msgstr ""
 
 msgid ""
 "\n"
@@ -8192,7 +8006,7 @@ msgid "Show all presets (including incompatible)"
 msgstr "全てのプリセットを表示"
 
 msgid "Select presets to compare"
-msgstr "Select presets to compare"
+msgstr ""
 
 msgid ""
 "You can only transfer to current active profile because it has been modified."
@@ -8292,58 +8106,54 @@ msgid "The configuration is up to date."
 msgstr "構成データが最新です"
 
 msgid "Obj file Import color"
-msgstr "Obj file Import color"
+msgstr ""
 
 msgid "Specify number of colors:"
-msgstr "Specify number of colors:"
+msgstr ""
 
 #, c-format, boost-format
 msgid "The color count should be in range [%d, %d]."
-msgstr "The color count should be in range [%d, %d]."
+msgstr ""
 
 msgid "Recommended "
-msgstr "Recommended "
+msgstr ""
 
 msgid "Current filament colors:"
-msgstr "Current filament colors:"
+msgstr ""
 
 msgid "Quick set:"
-msgstr "Quick set:"
+msgstr ""
 
 msgid "Color match"
-msgstr "Color match"
+msgstr ""
 
 msgid "Approximate color matching."
-msgstr "Approximate color matching."
+msgstr ""
 
 msgid "Append"
-msgstr "Append"
+msgstr ""
 
 msgid "Add consumable extruder after existing extruders."
-msgstr "Add consumable extruder after existing extruders."
+msgstr ""
 
 msgid "Reset mapped extruders."
-msgstr "Reset mapped extruders."
+msgstr ""
 
 msgid "Cluster colors"
-msgstr "Cluster colors"
+msgstr ""
 
 msgid "Map Filament"
-msgstr "Map Filament"
+msgstr ""
 
 msgid ""
 "Note:The color has been selected, you can choose OK \n"
 " to continue or manually adjust it."
 msgstr ""
-"Note:The color has been selected, you can choose OK \n"
-" to continue or manually adjust it."
 
 msgid ""
 "Waring:The count of newly added and \n"
 " current extruders exceeds 16."
 msgstr ""
-"Warning: The count of newly added and \n"
-" current extruders exceeds 16."
 
 msgid "Ramming customization"
 msgstr "ラミングのカスタマイズ"
@@ -8388,7 +8198,7 @@ msgid "Auto-Calc"
 msgstr "自動計算"
 
 msgid "Re-calculate"
-msgstr "Re-calculate"
+msgstr ""
 
 msgid "Flushing volumes for filament change"
 msgstr "フィラメントを入替える為のフラッシュ量"
@@ -8454,10 +8264,10 @@ msgid ""
 msgstr ""
 
 msgid "Bambu Network plug-in not detected."
-msgstr "Bambu Network plug-in not detected."
+msgstr ""
 
 msgid "Click here to download it."
-msgstr "Click here to download it."
+msgstr ""
 
 msgid "Login"
 msgstr "サインイン"
@@ -8475,7 +8285,7 @@ msgid "Objects list"
 msgstr "オブジェクト一覧"
 
 msgid "Import geometry data from STL/STEP/3MF/OBJ/AMF files"
-msgstr "Import geometry data from STL/STEP/3MF/OBJ/AMF files"
+msgstr ""
 
 msgid "⌘+Shift+G"
 msgstr "⌘+Shift+G"
@@ -8490,7 +8300,7 @@ msgid "Show/Hide 3Dconnexion devices settings dialog"
 msgstr "3Dconnexion設定を表示/非表示"
 
 msgid "Switch table page"
-msgstr "Switch table page"
+msgstr ""
 
 msgid "Show keyboard shortcuts list"
 msgstr "ショートカット一覧を表示"
@@ -8709,7 +8519,7 @@ msgid "Horizontal slider - Move active thumb Right"
 msgstr "水平スライダー (右)"
 
 msgid "On/Off one layer mode of the vertical slider"
-msgstr "On/Off one layer mode of the vertical slider"
+msgstr ""
 
 msgid "On/Off G-code window"
 msgstr ""
@@ -8750,49 +8560,49 @@ msgid "New version of Orca Slicer"
 msgstr "新バージョン"
 
 msgid "Skip this Version"
-msgstr "Skip this Version"
+msgstr ""
 
 msgid "Done"
-msgstr "Done"
+msgstr ""
 
 msgid "resume"
-msgstr "resume"
+msgstr ""
 
 msgid "Resume Printing"
-msgstr "Resume Printing"
+msgstr ""
 
 msgid "Resume Printing(defects acceptable)"
-msgstr "Resume Printing (defects acceptable)"
+msgstr ""
 
 msgid "Resume Printing(problem solved)"
-msgstr "Resume Printing (problem solved)"
+msgstr ""
 
 msgid "Stop Printing"
-msgstr "Stop Printing"
+msgstr ""
 
 msgid "Check Assistant"
-msgstr "Check Assistant"
+msgstr ""
 
 msgid "Filament Extruded, Continue"
-msgstr "Filament Extruded, Continue"
+msgstr ""
 
 msgid "Not Extruded Yet, Retry"
-msgstr "Not Extruded Yet, Retry"
+msgstr ""
 
 msgid "Finished, Continue"
-msgstr "Finished, Continue"
+msgstr ""
 
 msgid "Load Filament"
 msgstr "ロード"
 
 msgid "Filament Loaded, Resume"
-msgstr "Filament Loaded, Resume"
+msgstr ""
 
 msgid "View Liveview"
-msgstr "View Liveview"
+msgstr ""
 
 msgid "Confirm and Update Nozzle"
-msgstr "Confirm and Update Nozzle"
+msgstr ""
 
 msgid "Connect the printer using IP and access code"
 msgstr ""
@@ -8851,14 +8661,12 @@ msgid "Connecting to printer... The dialog will close later"
 msgstr ""
 
 msgid "Connection failed, please double check IP and Access Code"
-msgstr "Connection failed, please double check IP and Access Code"
+msgstr ""
 
 msgid ""
 "Connection failed! If your IP and Access Code is correct, \n"
 "please move to step 3 for troubleshooting network issues"
 msgstr ""
-"Connection failed! If your IP and Access Code is correct, \n"
-"please move to step 3 for troubleshooting network issues"
 
 msgid "Model:"
 msgstr "モデル"
@@ -9114,7 +8922,7 @@ msgid "allocation failed"
 msgstr "メモリ割り当て失敗"
 
 msgid "file open failed"
-msgstr "file open failed"
+msgstr ""
 
 msgid "file create failed"
 msgstr "ファイルの作成に失敗しました"
@@ -9126,13 +8934,13 @@ msgid "file read failed"
 msgstr "ファイルの読み込みに失敗しました"
 
 msgid "file close failed"
-msgstr "file close failed"
+msgstr ""
 
 msgid "file seek failed"
-msgstr "file seek failed"
+msgstr ""
 
 msgid "file stat failed"
-msgstr "file stat failed"
+msgstr ""
 
 msgid "invalid parameter"
 msgstr "無効なパラメータ"
@@ -9241,7 +9049,7 @@ msgstr ""
 "い。"
 
 msgid "Variable layer height is not supported with Organic supports."
-msgstr "Variable layer height is not supported with Organic supports."
+msgstr ""
 
 msgid ""
 "Different nozzle diameters and different filament diameters may not work "
@@ -9253,8 +9061,6 @@ msgid ""
 "The Wipe Tower is currently only supported with the relative extruder "
 "addressing (use_relative_e_distances=1)."
 msgstr ""
-"The Wipe Tower is currently only supported with the relative extruder "
-"addressing (use_relative_e_distances=1)."
 
 msgid ""
 "Ooze prevention is only supported with the wipe tower when "
@@ -9527,13 +9333,11 @@ msgstr ""
 "下記形式を参照してください https://username:password@your-octopi-address/"
 
 msgid "Device UI"
-msgstr "Device UI"
+msgstr ""
 
 msgid ""
 "Specify the URL of your device user interface if it's not same as print_host"
 msgstr ""
-"Specify the URL of your device user interface if it's not the same as "
-"print_host"
 
 msgid "API Key / Password"
 msgstr "APIキー/パスワード"
@@ -9696,16 +9500,16 @@ msgid "Smooth High Temp Plate"
 msgstr ""
 
 msgid "First layer print sequence"
-msgstr "First layer print sequence"
+msgstr ""
 
 msgid "Other layers print sequence"
-msgstr "Other layers print sequence"
+msgstr ""
 
 msgid "The number of other layers print sequence"
-msgstr "The number of other layers print sequence"
+msgstr ""
 
 msgid "Other layers filament sequence"
-msgstr "Other layers filament sequence"
+msgstr ""
 
 msgid "This G-code is inserted at every layer change before lifting z"
 msgstr "積層が変わる直前に実行するG-codeです。"
@@ -9888,7 +9692,7 @@ msgid ""
 msgstr ""
 
 msgid "Top surface flow ratio"
-msgstr "Top surface flow ratio"
+msgstr ""
 
 msgid ""
 "This factor affects the amount of material for top solid infill. You can "
@@ -9940,7 +9744,7 @@ msgid ""
 msgstr ""
 
 msgid "Only one wall on first layer"
-msgstr "Only one wall on first layer"
+msgstr ""
 
 msgid ""
 "Use only one wall on first layer, to give more space to the bottom infill "
@@ -10059,7 +9863,7 @@ msgid ""
 msgstr ""
 
 msgid "mm/s or %"
-msgstr "mm/s or %"
+msgstr "mm/s 或は %"
 
 msgid "External"
 msgstr ""
@@ -10094,8 +9898,6 @@ msgid ""
 "This controls the generation of the brim at outer and/or inner side of "
 "models. Auto means the brim width is analyzed and calculated automatically."
 msgstr ""
-"This controls the generation of the brim at outer and/or inner side of "
-"models. Auto means the brim width is analyzed and calculated automatically."
 
 msgid "Painted"
 msgstr ""
@@ -10218,7 +10020,7 @@ msgid "Default process profile when switch to this machine profile"
 msgstr "デバイスを切替える時のデフォルト プロセス プロファイル"
 
 msgid "Activate air filtration"
-msgstr "Activate air filtration"
+msgstr ""
 
 msgid "Activate for better air filtration. G-code command: M106 P3 S(0-255)"
 msgstr ""
@@ -10450,7 +10252,7 @@ msgid "Line pattern of bottom surface infill, not bridge infill"
 msgstr "底面のインフィル パターンです、ブリッジインフィルが含まれていません。"
 
 msgid "Internal solid infill pattern"
-msgstr "Internal solid infill pattern"
+msgstr ""
 
 msgid ""
 "Line pattern of internal solid infill. if the detect narrow internal solid "
@@ -10469,7 +10271,7 @@ msgstr ""
 "外壁の造形速度です。普段は内壁より遅い速度を指定し、仕上がりが良くなります。"
 
 msgid "Small perimeters"
-msgstr "Small perimeters"
+msgstr ""
 
 msgid ""
 "This separate setting will affect the speed of perimeters having radius <= "
@@ -10484,7 +10286,6 @@ msgstr ""
 msgid ""
 "This sets the threshold for small perimeter length. Default threshold is 0mm"
 msgstr ""
-"This sets the threshold for small perimeter length. Default threshold is 0mm"
 
 msgid "Walls printing order"
 msgstr ""
@@ -10524,7 +10325,7 @@ msgid "Inner/Outer/Inner"
 msgstr ""
 
 msgid "Print infill first"
-msgstr "Print infill first"
+msgstr ""
 
 msgid ""
 "Order of wall/infill. When the tickbox is unchecked the walls are printed "
@@ -10584,10 +10385,10 @@ msgstr ""
 "ブジェクトの間隔を計算します。"
 
 msgid "Nozzle height"
-msgstr "Nozzle height"
+msgstr ""
 
 msgid "The height of nozzle tip."
-msgstr "The height of nozzle tip."
+msgstr ""
 
 msgid "Bed mesh min"
 msgstr ""
@@ -10667,7 +10468,7 @@ msgid ""
 msgstr ""
 
 msgid "Enable pressure advance"
-msgstr "Enable pressure advance"
+msgstr ""
 
 msgid ""
 "Enable pressure advance, auto calibration result will be overwritten once "
@@ -10805,10 +10606,10 @@ msgid "Default filament color"
 msgstr "フィラメントのデフォルト色"
 
 msgid "Filament notes"
-msgstr "Filament notes"
+msgstr ""
 
 msgid "You can put your notes regarding the filament here."
-msgstr "You can put your notes regarding the filament here."
+msgstr ""
 
 msgid "Required nozzle HRC"
 msgstr "ノズルHRC"
@@ -11061,16 +10862,13 @@ msgid ""
 msgstr "サポート素材は、サポート又はサポート接触面の造形によく使われます。"
 
 msgid "Softening temperature"
-msgstr "Softening temperature"
+msgstr ""
 
 msgid ""
 "The material softens at this temperature, so when the bed temperature is "
 "equal to or greater than it, it's highly recommended to open the front door "
 "and/or remove the upper glass to avoid clogging."
 msgstr ""
-"The material softens at this temperature, so when the bed temperature is "
-"equal to or greater than this, it's highly recommended to open the front "
-"door and/or remove the upper glass to avoid clogs."
 
 msgid "Price"
 msgstr "価格"
@@ -11082,10 +10880,10 @@ msgid "money/kg"
 msgstr "USD/kg"
 
 msgid "Vendor"
-msgstr "Vendor"
+msgstr ""
 
 msgid "Vendor of filament. For show only"
-msgstr "Filament Vendor (Only for show)"
+msgstr ""
 
 msgid "(Undefined)"
 msgstr "(未定義)"
@@ -11199,10 +10997,10 @@ msgid ""
 msgstr ""
 
 msgid "0 (no open anchors)"
-msgstr "0 (no open anchors)"
+msgstr ""
 
 msgid "1000 (unlimited)"
-msgstr "1000 (unlimited)"
+msgstr ""
 
 msgid "Maximum length of the infill anchor"
 msgstr "最長インフィルアンカー"
@@ -11248,14 +11046,12 @@ msgid ""
 msgstr ""
 
 msgid "mm/s² or %"
-msgstr "mm/s² or %"
+msgstr "mm/s² 或は %"
 
 msgid ""
 "Acceleration of sparse infill. If the value is expressed as a percentage "
 "(e.g. 100%), it will be calculated based on the default acceleration."
 msgstr ""
-"Acceleration of sparse infill. If the value is expressed as a percentage "
-"(e.g. 100%), it will be calculated based on the default acceleration."
 
 msgid ""
 "Acceleration of internal solid infill. If the value is expressed as a "
@@ -11270,10 +11066,10 @@ msgstr ""
 "1層目の造形加速度です。遅くするとプレートとの接着を向上させることができます"
 
 msgid "Enable accel_to_decel"
-msgstr "Enable accel_to_decel"
+msgstr ""
 
 msgid "Klipper's max_accel_to_decel will be adjusted automatically"
-msgstr "Klipper's max_accel_to_decel will be adjusted automatically"
+msgstr ""
 
 msgid "accel_to_decel"
 msgstr "accel_to_decel"
@@ -11284,10 +11080,10 @@ msgid ""
 msgstr ""
 
 msgid "Jerk of outer walls"
-msgstr "Jerk of outer walls"
+msgstr ""
 
 msgid "Jerk of inner walls"
-msgstr "Jerk of inner walls"
+msgstr ""
 
 msgid "Jerk for top surface"
 msgstr ""
@@ -11389,10 +11185,10 @@ msgstr ""
 "より、表面にザラザラ感が出来上がります。"
 
 msgid "Contour"
-msgstr "Contour"
+msgstr ""
 
 msgid "Contour and hole"
-msgstr "Contour and hole"
+msgstr ""
 
 msgid "All walls"
 msgstr "すべての壁"
@@ -11473,7 +11269,7 @@ msgid ""
 msgstr ""
 
 msgid "Filter out tiny gaps"
-msgstr "Filter out tiny gaps"
+msgstr ""
 
 msgid "Layers and Perimeters"
 msgstr "積層と境界"
@@ -11492,16 +11288,13 @@ msgstr ""
 "す。"
 
 msgid "Precise Z height"
-msgstr "Precise Z height"
+msgstr ""
 
 msgid ""
 "Enable this to get precise z height of object after slicing. It will get the "
 "precise object height by fine-tuning the layer heights of the last few "
 "layers. Note that this is an experimental parameter."
 msgstr ""
-"Enable this to get precise z height of object after slicing. It will get the "
-"precise object height by fine-tuning the layer heights of the last few "
-"layers. Note that this is an experimental parameter."
 
 msgid "Arc fitting"
 msgstr "曲線フィッティング"
@@ -11566,10 +11359,10 @@ msgid "HRC"
 msgstr "HRC"
 
 msgid "Printer structure"
-msgstr "Printer structure"
+msgstr ""
 
 msgid "The physical arrangement and components of a printing device"
-msgstr "The physical arrangement and components of a printing device"
+msgstr ""
 
 msgid "CoreXY"
 msgstr ""
@@ -11584,10 +11377,10 @@ msgid "Delta"
 msgstr ""
 
 msgid "Best object position"
-msgstr "Best object position"
+msgstr ""
 
 msgid "Best auto arranging position in range [0,1] w.r.t. bed shape."
-msgstr "Best auto arranging position in range [0,1] w.r.t. bed shape."
+msgstr ""
 
 msgid ""
 "Enable this option if machine has auxiliary part cooling fan. G-code "
@@ -11633,7 +11426,7 @@ msgid "money/h"
 msgstr ""
 
 msgid "Support control chamber temperature"
-msgstr "Support controlling chamber temperature"
+msgstr ""
 
 msgid ""
 "This option is enabled if machine support controlling chamber temperature\n"
@@ -11641,7 +11434,7 @@ msgid ""
 msgstr ""
 
 msgid "Support air filtration"
-msgstr "Support air filtration"
+msgstr ""
 
 msgid ""
 "Enable this if printer support air filtration\n"
@@ -11685,7 +11478,7 @@ msgstr ""
 "りません。"
 
 msgid "Exclude objects"
-msgstr "Exclude objects"
+msgstr ""
 
 msgid "Enable this option to add EXCLUDE OBJECT command in G-code."
 msgstr ""
@@ -11769,26 +11562,22 @@ msgid "Name of parent profile"
 msgstr ""
 
 msgid "Interface shells"
-msgstr "Interface shells"
+msgstr ""
 
 msgid ""
 "Force the generation of solid shells between adjacent materials/volumes. "
 "Useful for multi-extruder prints with translucent materials or manual "
 "soluble support material"
 msgstr ""
-"Force the generation of solid shells between adjacent materials/volumes. "
-"Useful for multi-extruder prints with translucent materials or manual "
-"soluble support material"
 
 msgid "Maximum width of a segmented region"
-msgstr "Maximum width of a segmented region"
+msgstr ""
 
 msgid "Maximum width of a segmented region. Zero disables this feature."
 msgstr ""
-"Maximum width of a segmented region. A value of 0 disables this feature."
 
 msgid "Interlocking depth of a segmented region"
-msgstr "Interlocking depth of a segmented region"
+msgstr ""
 
 msgid ""
 "Interlocking depth of a segmented region. It will be ignored if "
@@ -11878,7 +11667,7 @@ msgid "All solid layer"
 msgstr "全てのソリッド積層"
 
 msgid "Ironing Pattern"
-msgstr "Ironing Pattern"
+msgstr ""
 
 msgid "The pattern that will be used when ironing"
 msgstr ""
@@ -12358,10 +12147,10 @@ msgid "Type of the printer"
 msgstr ""
 
 msgid "Printer notes"
-msgstr "Printer notes"
+msgstr ""
 
 msgid "You can put your notes regarding the printer here."
-msgstr "You can put your notes regarding the printer here."
+msgstr ""
 
 msgid "Printer variant"
 msgstr "プリンターバリエーション"
@@ -12453,7 +12242,7 @@ msgstr ""
 "ションが無効になります。"
 
 msgid "Long retraction when cut(beta)"
-msgstr "Long retraction when cut (beta)"
+msgstr ""
 
 msgid ""
 "Experimental feature.Retracting and cutting off the filament at a longer "
@@ -12461,20 +12250,14 @@ msgid ""
 "significantly, it may also raise the risk of nozzle clogs or other printing "
 "problems."
 msgstr ""
-"Experimental feature: Retracting and cutting off the filament at a longer "
-"distance during changes to minimize purge.While this reduces flush "
-"significantly, it may also raise the risk of nozzle clogs or other printing "
-"problems."
 
 msgid "Retraction distance when cut"
-msgstr "Retraction distance when cut"
+msgstr ""
 
 msgid ""
 "Experimental feature.Retraction length before cutting off during filament "
 "change"
 msgstr ""
-"Experimental feature. Retraction length before cutting off during filament "
-"change"
 
 msgid "Z-hop height"
 msgstr ""
@@ -12557,7 +12340,7 @@ msgid "Top and Bottom"
 msgstr ""
 
 msgid "Extra length on restart"
-msgstr "Extra length on restart"
+msgstr ""
 
 msgid ""
 "When the retraction is compensated after the travel move, the extruder will "
@@ -12590,7 +12373,7 @@ msgstr ""
 "ションの速度と同じくなります。"
 
 msgid "Use firmware retraction"
-msgstr "Use firmware retraction"
+msgstr ""
 
 msgid ""
 "This experimental setting uses G10 and G11 commands to have the firmware "
@@ -12639,7 +12422,7 @@ msgstr ""
 "成するものです。"
 
 msgid "Seam gap"
-msgstr "Seam gap"
+msgstr ""
 
 msgid ""
 "In order to reduce the visibility of the seam in a closed loop extrusion, "
@@ -12653,20 +12436,17 @@ msgstr ""
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
 msgstr ""
-"Use scarf joint to minimize seam visibility and increase seam strength."
 
 msgid "Conditional scarf joint"
-msgstr "Conditional scarf joint"
+msgstr ""
 
 msgid ""
 "Apply scarf joints only to smooth perimeters where traditional seams do not "
 "conceal the seams at sharp corners effectively."
 msgstr ""
-"Apply scarf joints only to smooth perimeters where traditional seams do not "
-"conceal the seams at sharp corners effectively."
 
 msgid "Conditional angle threshold"
-msgstr "Conditional angle threshold"
+msgstr ""
 
 msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint "
@@ -12709,44 +12489,39 @@ msgid "This factor affects the amount of material for scarf joints."
 msgstr ""
 
 msgid "Scarf start height"
-msgstr "Scarf start height"
+msgstr ""
 
 msgid ""
 "Start height of the scarf.\n"
 "This amount can be specified in millimeters or as a percentage of the "
 "current layer height. The default value for this parameter is 0."
 msgstr ""
-"Start height of the scarf.\n"
-"This amount can be specified in millimeters or as a percentage of the "
-"current layer height. The default value for this parameter is 0."
 
 msgid "Scarf around entire wall"
-msgstr "Scarf around entire wall"
+msgstr ""
 
 msgid "The scarf extends to the entire length of the wall."
-msgstr "The scarf extends to the entire length of the wall."
+msgstr ""
 
 msgid "Scarf length"
-msgstr "Scarf length"
+msgstr ""
 
 msgid ""
 "Length of the scarf. Setting this parameter to zero effectively disables the "
 "scarf."
 msgstr ""
-"Length of the scarf. Setting this parameter to zero effectively disables the "
-"scarf."
 
 msgid "Scarf steps"
-msgstr "Scarf steps"
+msgstr ""
 
 msgid "Minimum number of segments of each scarf."
-msgstr "Minimum number of segments of each scarf."
+msgstr ""
 
 msgid "Scarf joint for inner walls"
-msgstr "Scarf joint for inner walls"
+msgstr ""
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "Use scarf joint for inner walls as well."
+msgstr ""
 
 msgid "Role base wipe speed"
 msgstr ""
@@ -12781,7 +12556,7 @@ msgid ""
 msgstr ""
 
 msgid "Wipe speed"
-msgstr "Wipe speed"
+msgstr ""
 
 msgid ""
 "The wipe speed is determined by the speed setting specified in this "
@@ -12789,10 +12564,6 @@ msgid ""
 "be calculated based on the travel speed setting above.The default value for "
 "this parameter is 80%"
 msgstr ""
-"The wipe speed is determined by the speed setting specified in this "
-"configuration. If the value is expressed as a percentage (e.g. 80%), it will "
-"be calculated based on the travel speed setting above. The default value for "
-"this parameter is 80%."
 
 msgid "Skirt distance"
 msgstr "スカート距離"
@@ -12809,10 +12580,10 @@ msgid ""
 msgstr ""
 
 msgid "Skirt height"
-msgstr "Skirt height"
+msgstr ""
 
 msgid "How many layers of skirt. Usually only one layer"
-msgstr "Number of skirt layers: usually only one"
+msgstr ""
 
 msgid "Single loop draft shield"
 msgstr ""
@@ -12920,17 +12691,15 @@ msgstr ""
 "で、シームはありません。"
 
 msgid "Smooth Spiral"
-msgstr "Smooth Spiral"
+msgstr ""
 
 msgid ""
 "Smooth Spiral smooths out X and Y moves as well, resulting in no visible "
 "seam at all, even in the XY directions on walls that are not vertical"
 msgstr ""
-"Smooth Spiral smooths out X and Y moves as well, resulting in no visible "
-"seam at all, even in the XY directions on walls that are not vertical"
 
 msgid "Max XY Smoothing"
-msgstr "Max XY Smoothing"
+msgstr ""
 
 #, no-c-format, no-boost-format
 msgid ""
@@ -13073,9 +12842,6 @@ msgid ""
 "triangle mesh slicing. The gap closing operation may reduce the final print "
 "resolution, therefore it is advisable to keep the value reasonably low."
 msgstr ""
-"Cracks smaller than 2x gap closing radius are being filled during the "
-"triangle mesh slicing. The gap closing operation may reduce the final print "
-"resolution, therefore it is advisable to keep the value reasonably low."
 
 msgid "Slicing Mode"
 msgstr "スライシングモード"
@@ -13084,14 +12850,12 @@ msgid ""
 "Use \"Even-odd\" for 3DLabPrint airplane models. Use \"Close holes\" to "
 "close all holes in the model."
 msgstr ""
-"Use \"Even-odd\" for 3DLabPrint airplane models. Use \"Close holes\" to "
-"close all holes in the model."
 
 msgid "Regular"
 msgstr "レギュラー"
 
 msgid "Even-odd"
-msgstr "Even-odd"
+msgstr ""
 
 msgid "Close holes"
 msgstr "穴を閉じる"
@@ -13141,10 +12905,10 @@ msgid "XY separation between an object and its support"
 msgstr "オブジェクトとサポートのXY距離です。"
 
 msgid "Support/object first layer gap"
-msgstr "Support/object first layer gap"
+msgstr ""
 
 msgid "XY separation between an object and its support at the first layer."
-msgstr "XY separation between an object and its support at the first layer."
+msgstr ""
 
 msgid "Pattern angle"
 msgstr "パターン角度"
@@ -13167,10 +12931,10 @@ msgid ""
 msgstr "造形しにくい部分だけサポートを生成します、例えば細長いしっぽ、ハリなど"
 
 msgid "Remove small overhangs"
-msgstr "Remove small overhangs"
+msgstr ""
 
 msgid "Remove small overhangs that possibly need no supports."
-msgstr "This removes small overhangs that may need no support."
+msgstr ""
 
 msgid "Top Z distance"
 msgstr "トップ面とのZ間隔"
@@ -13185,7 +12949,7 @@ msgid "The z gap between the bottom support interface and object"
 msgstr "サポート底面とオブジェクトのZ方向間隔"
 
 msgid "Support/raft base"
-msgstr "Support/raft base"
+msgstr ""
 
 msgid ""
 "Filament to print support base and raft. \"Default\" means no specific "
@@ -13195,12 +12959,11 @@ msgstr ""
 "を使用する意味です。"
 
 msgid "Avoid interface filament for base"
-msgstr "Avoid interface filament for base"
+msgstr ""
 
 msgid ""
 "Avoid using support interface filament to print support base if possible."
 msgstr ""
-"Avoid using support interface filament to print support base if possible."
 
 msgid ""
 "Line width of support. If expressed as a %, it will be computed over the "
@@ -13217,7 +12980,7 @@ msgstr ""
 "なっています。"
 
 msgid "Support/raft interface"
-msgstr "Support/raft interface"
+msgstr ""
 
 msgid ""
 "Filament to print support interface. \"Default\" means no specific filament "
@@ -13236,10 +12999,10 @@ msgid "Bottom interface layers"
 msgstr "底部接触面層数"
 
 msgid "Number of bottom interface layers"
-msgstr "Number of bottom interface layers"
+msgstr ""
 
 msgid "Same as top"
-msgstr "Same as top"
+msgstr ""
 
 msgid "Top interface spacing"
 msgstr "トップ接触面間隔"
@@ -13280,7 +13043,7 @@ msgstr ""
 "を使用する場合同心です。"
 
 msgid "Rectilinear Interlaced"
-msgstr "Rectilinear Interlaced"
+msgstr ""
 
 msgid "Base pattern spacing"
 msgstr "基本パターン間隔"
@@ -13311,7 +13074,7 @@ msgid "Default (Grid/Organic)"
 msgstr ""
 
 msgid "Snug"
-msgstr "Snug"
+msgstr ""
 
 msgid "Organic"
 msgstr "オーガニック"
@@ -13333,9 +13096,6 @@ msgid ""
 "support customizing z-gap and save print time.This option will be invalid "
 "when the prime tower is enabled."
 msgstr ""
-"Support layer uses layer height independent with object layer. This is to "
-"support customizing z-gap and save print time.This option will be invalid "
-"when the prime tower is enabled."
 
 msgid "Threshold angle"
 msgstr "閾値角度"
@@ -13812,7 +13572,7 @@ msgstr ""
 "メモリのファームウェアのため"
 
 msgid "Use relative E distances"
-msgstr "Use relative E distances"
+msgstr ""
 
 msgid ""
 "Relative extrusion is recommended when using \"label_objects\" option.Some "
@@ -13840,9 +13600,6 @@ msgid ""
 "thinner, a certain amount of space is allotted to split or join the wall "
 "segments. It's expressed as a percentage over nozzle diameter"
 msgstr ""
-"When transitioning between different numbers of walls as the part becomes "
-"thinner, a certain amount of space is allotted to split or join the wall "
-"segments. It's expressed as a percentage over nozzle diameter"
 
 msgid "Wall transitioning filter margin"
 msgstr "フィルタマージン"
@@ -13856,13 +13613,6 @@ msgid ""
 "variation can lead to under- or overextrusion problems. It's expressed as a "
 "percentage over nozzle diameter"
 msgstr ""
-"Prevent transitioning back and forth between one extra wall and one less. "
-"This margin extends the range of extrusion widths which follow to [Minimum "
-"wall width - margin, 2 * Minimum wall width + margin]. Increasing this "
-"margin reduces the number of transitions, which reduces the number of "
-"extrusion starts/stops and travel time. However, large extrusion width "
-"variation can lead to under- or overextrusion problems. It's expressed as a "
-"percentage over nozzle diameter"
 
 msgid "Wall transitioning threshold angle"
 msgstr "角度閾値"
@@ -13874,11 +13624,6 @@ msgid ""
 "this setting reduces the number and length of these center walls, but may "
 "leave gaps or overextrude"
 msgstr ""
-"When to create transitions between even and odd numbers of walls. A wedge "
-"shape with an angle greater than this setting will not have transitions and "
-"no walls will be printed in the center to fill the remaining space. Reducing "
-"this setting reduces the number and length of these center walls, but may "
-"leave gaps or overextrude"
 
 msgid "Wall distribution count"
 msgstr "壁面分布カウント"
@@ -13930,10 +13675,6 @@ msgid ""
 "thickness of the feature, the wall will become as thick as the feature "
 "itself. It's expressed as a percentage over nozzle diameter"
 msgstr ""
-"Width of the wall that will replace thin features (according to the Minimum "
-"feature size) of the model. If the Minimum wall width is thinner than the "
-"thickness of the feature, the wall will become as thick as the feature "
-"itself. It's expressed as a percentage over nozzle diameter"
 
 msgid "Detect narrow internal solid infill"
 msgstr "薄いソリッド インフィル検出"
@@ -13948,16 +13689,16 @@ msgstr ""
 "す。"
 
 msgid "invalid value "
-msgstr "invalid value "
+msgstr ""
 
 msgid "Invalid value when spiral vase mode is enabled: "
-msgstr "Invalid value when spiral vase mode is enabled: "
+msgstr ""
 
 msgid "too large line width "
-msgstr "too large line width "
+msgstr ""
 
 msgid " not in range "
-msgstr " not in range "
+msgstr ""
 
 msgid "Export 3MF"
 msgstr "3mf をエクスポート"
@@ -13978,7 +13719,7 @@ msgid "Load cached slicing data from directory"
 msgstr "スライスデータを読込み"
 
 msgid "Export STL"
-msgstr "Export STL"
+msgstr ""
 
 msgid "Export the objects as single STL."
 msgstr ""
@@ -14013,10 +13754,10 @@ msgid ""
 msgstr ""
 
 msgid "Load default filaments"
-msgstr "Load default filaments"
+msgstr ""
 
 msgid "Load first filament as default for those not loaded"
-msgstr "Load first filament as default for those not loaded"
+msgstr ""
 
 msgid "Minimum save"
 msgstr ""
@@ -14028,25 +13769,25 @@ msgid "mtcpp"
 msgstr "mtcpp"
 
 msgid "max triangle count per plate for slicing."
-msgstr "max triangle count per plate for slicing"
+msgstr ""
 
 msgid "mstpp"
 msgstr "mstpp"
 
 msgid "max slicing time per plate in seconds."
-msgstr "max slicing time per plate in seconds"
+msgstr ""
 
 msgid "No check"
-msgstr "No check"
+msgstr ""
 
 msgid "Do not run any validity checks, such as G-code path conflicts check."
 msgstr ""
 
 msgid "Normative check"
-msgstr "Normative check"
+msgstr ""
 
 msgid "Check the normative items."
-msgstr "Check the normative items."
+msgstr ""
 
 msgid "Output Model Info"
 msgstr "出力モデル情報"
@@ -14073,10 +13814,10 @@ msgid "Arrange options: 0-disable, 1-enable, others-auto"
 msgstr "レイアウト設定: 0: 無効　1: 有効　その他: 自動"
 
 msgid "Repetions count"
-msgstr "Repetition count"
+msgstr ""
 
 msgid "Repetions count of the whole model"
-msgstr "Repetition count of the whole model"
+msgstr ""
 
 msgid "Ensure on bed"
 msgstr "ベッド上で確認"
@@ -14132,7 +13873,7 @@ msgid "Skip Objects"
 msgstr "オブジェクトスキップ"
 
 msgid "Skip some objects in this print"
-msgstr "Skip some objects in this print"
+msgstr ""
 
 msgid "Clone Objects"
 msgstr ""
@@ -14141,14 +13882,12 @@ msgid "Clone objects in the load list"
 msgstr ""
 
 msgid "load uptodate process/machine settings when using uptodate"
-msgstr "load uptodate process/machine settings when using uptodate"
+msgstr ""
 
 msgid ""
 "load uptodate process/machine settings from the specified file when using "
 "uptodate"
 msgstr ""
-"load up-to-date process/machine settings from the specified file when using "
-"up-to-date"
 
 msgid "load uptodate filament settings when using uptodate"
 msgstr ""
@@ -14577,21 +14316,19 @@ msgid "Checking support necessity"
 msgstr "サポートの必要性を確認"
 
 msgid "floating regions"
-msgstr "floating regions"
+msgstr ""
 
 msgid "floating cantilever"
-msgstr "floating cantilever"
+msgstr ""
 
 msgid "large overhangs"
-msgstr "large overhangs"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "It seems object %s has %s. Please re-orient the object or enable support "
 "generation."
 msgstr ""
-"It seems object %s has %s. Please re-orient the object or enable support "
-"generation."
 
 msgid "Generating support"
 msgstr "サポートを生成"
@@ -14606,8 +14343,6 @@ msgid ""
 "No layers were detected. You might want to repair your STL file(s) or check "
 "their size or thickness and retry.\n"
 msgstr ""
-"No layers were detected. You might want to repair your STL file(s) or check "
-"their size or thickness and retry.\n"
 
 msgid ""
 "An object's XY size compensation will not be used because it is also color-"
@@ -14621,101 +14356,96 @@ msgstr "サポート: 接触点を生成"
 msgid ""
 "Unknown file format. Input file must have .stl, .obj, .amf(.xml) extension."
 msgstr ""
-"Unknown file format: input file must have .stl, .obj, or .amf(.xml) "
-"extension."
 
 msgid "Loading of a model file failed."
-msgstr "Loading of model file failed."
+msgstr ""
 
 msgid "The supplied file couldn't be read because it's empty"
-msgstr "The supplied file couldn't be read because it's empty."
+msgstr ""
 
 msgid "Unknown file format. Input file must have .3mf or .zip.amf extension."
-msgstr "Unknown file format: input file must have .3mf or .zip.amf extension."
+msgstr ""
 
 msgid "load_obj: failed to parse"
-msgstr "load_obj: failed to parse"
+msgstr ""
 
 msgid "load mtl in obj: failed to parse"
-msgstr "load mtl in obj: failed to parse"
+msgstr ""
 
 msgid "The file contains polygons with more than 4 vertices."
-msgstr "The file contains polygons with more than 4 vertices."
+msgstr ""
 
 msgid "The file contains polygons with less than 2 vertices."
-msgstr "The file contains polygons with less than 2 vertices."
+msgstr ""
 
 msgid "The file contains invalid vertex index."
-msgstr "The file contains invalid vertex index."
+msgstr ""
 
 msgid "This OBJ file couldn't be read because it's empty."
-msgstr "This OBJ file couldn't be read because it's empty."
+msgstr ""
 
 msgid "Flow Rate Calibration"
-msgstr "Flow Rate Calibration"
+msgstr ""
 
 msgid "Max Volumetric Speed Calibration"
-msgstr "Max Volumetric Speed Calibration"
+msgstr ""
 
 msgid "Manage Result"
-msgstr "Manage Results"
+msgstr ""
 
 msgid "Manual Calibration"
-msgstr "Manual Calibration"
+msgstr ""
 
 msgid "Result can be read by human eyes."
-msgstr "Results can be easily seen and understood."
+msgstr ""
 
 msgid "Auto-Calibration"
-msgstr "Auto-Calibration"
+msgstr ""
 
 msgid "We would use Lidar to read the calibration result"
-msgstr "We would use Lidar to read the calibration result."
+msgstr ""
 
 msgid "Prev"
-msgstr "Prev"
+msgstr ""
 
 msgid "Recalibration"
-msgstr "Recalibration"
+msgstr ""
 
 msgid "Calibrate"
-msgstr "Calibrate"
+msgstr ""
 
 msgid "Finish"
 msgstr "完了"
 
 msgid "How to use calibration result?"
-msgstr "How can I use calibration results?"
+msgstr ""
 
 msgid ""
 "You could change the Flow Dynamics Calibration Factor in material editing"
 msgstr ""
-"You can change the Flow Dynamics Calibration Factor in material editing"
 
 msgid ""
 "The current firmware version of the printer does not support calibration.\n"
 "Please upgrade the printer firmware."
 msgstr ""
-"The current firmware version of the printer does not support calibration.\n"
-"Please update the printer firmware."
 
 msgid "Calibration not supported"
-msgstr "Calibration not supported"
+msgstr ""
 
 msgid "Error desc"
-msgstr "Error desc"
+msgstr ""
 
 msgid "Extra info"
-msgstr "Extra info"
+msgstr ""
 
 msgid "Flow Dynamics"
-msgstr "Flow Dynamics"
+msgstr ""
 
 msgid "Flow Rate"
-msgstr "Flow Rate"
+msgstr ""
 
 msgid "Max Volumetric Speed"
-msgstr "Max Volumetric Speed"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -14725,45 +14455,38 @@ msgid ""
 "End value: > Start value\n"
 "Value step: >= %.3f)"
 msgstr ""
-"Please input valid values:\n"
-"Start value: >= %.1f\n"
-"End value: <= %.1f\n"
-"End value: > Start value\n"
-"Value step: >= %.3f)"
 
 msgid "The name cannot be empty."
-msgstr "The name cannot be empty."
+msgstr ""
 
 #, c-format, boost-format
 msgid "The selected preset: %s was not found."
 msgstr ""
 
 msgid "The name cannot be the same as the system preset name."
-msgstr "The name cannot be the same as the system preset name."
+msgstr ""
 
 msgid "The name is the same as another existing preset name"
-msgstr "The name is the same as another existing preset name."
+msgstr ""
 
 msgid "create new preset failed."
-msgstr "Creating new preset failed."
+msgstr ""
 
 msgid ""
 "Are you sure to cancel the current calibration and return to the home page?"
 msgstr ""
-"Are you sure you want to cancel the current calibration and return to the "
-"home page?"
 
 msgid "No Printer Connected!"
-msgstr "No Printer Connected!"
+msgstr ""
 
 msgid "Printer is not connected yet."
-msgstr "A printer is not connected yet."
+msgstr ""
 
 msgid "Please select filament to calibrate."
-msgstr "Please select filament to calibrate."
+msgstr ""
 
 msgid "The input value size must be 3."
-msgstr "The input value size must be 3."
+msgstr ""
 
 msgid ""
 "This machine type can only hold 16 history results per nozzle. You can "
@@ -14772,20 +14495,15 @@ msgid ""
 "historical results. \n"
 "Do you still want to continue the calibration?"
 msgstr ""
-"This machine type can only hold 16 historical results per nozzle. You can "
-"delete the existing historical results and then start calibration. Or you "
-"can continue the calibration, but you cannot create new calibration "
-"historical results. \n"
-"Do you still want to continue the calibration?"
 
 msgid "Connecting to printer..."
-msgstr "Connecting to printer..."
+msgstr ""
 
 msgid "The failed test result has been dropped."
-msgstr "The failed test result has been removed."
+msgstr ""
 
 msgid "Flow Dynamics Calibration result has been saved to the printer"
-msgstr "Flow Dynamics Calibration results have been saved to the printer."
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -14793,32 +14511,27 @@ msgid ""
 "Only one of the results with the same name is saved. Are you sure you want "
 "to override the historical result?"
 msgstr ""
-"There is already a previous calibration result with the same name: %s. Only "
-"one result with a name is saved. Are you sure you want to overwrite the "
-"previous result?"
 
 #, c-format, boost-format
 msgid ""
 "This machine type can only hold %d history results per nozzle. This result "
 "will not be saved."
 msgstr ""
-"This machine type can only hold %d historical results per nozzle. This "
-"result will not be saved."
 
 msgid "Internal Error"
-msgstr "Internal Error"
+msgstr ""
 
 msgid "Please select at least one filament for calibration"
-msgstr "Please select at least one filament for calibration"
+msgstr ""
 
 msgid "Flow rate calibration result has been saved to preset"
-msgstr "Flow rate calibration results have been saved to preset."
+msgstr ""
 
 msgid "Max volumetric speed calibration result has been saved to preset"
-msgstr "Max volumetric speed calibration result has been saved to preset"
+msgstr ""
 
 msgid "When do you need Flow Dynamics Calibration"
-msgstr "When do you need Flow Dynamics Calibration?"
+msgstr ""
 
 msgid ""
 "We now have added the auto-calibration for different filaments, which is "
@@ -14830,17 +14543,9 @@ msgid ""
 "3. If the max volumetric speed or print temperature is changed in the "
 "filament setting."
 msgstr ""
-"We now have added auto-calibration for different filaments, which is fully "
-"automated and the result will be saved to the printer for future use. You "
-"only need to do the calibration in the following limited cases:\n"
-"1. If you introduce a new filament of different brands/models or the "
-"filament is damp\n"
-"2. If the nozzle is worn out or replaced with a new one;\n"
-"3. If the max volumetric speed or print temperature is changed in the "
-"filament setting."
 
 msgid "About this calibration"
-msgstr "About this calibration"
+msgstr ""
 
 msgid ""
 "Please find the details of Flow Dynamics Calibration from our wiki.\n"
@@ -14880,7 +14585,7 @@ msgstr ""
 "しており、新しいアップデートで改善を行う予定です。"
 
 msgid "When to use Flow Rate Calibration"
-msgstr "When to use Flow Rate Calibration"
+msgstr ""
 
 msgid ""
 "After using Flow Dynamics Calibration, there might still be some extrusion "
@@ -14893,24 +14598,12 @@ msgid ""
 "4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as "
 "they should be."
 msgstr ""
-"After using Flow Dynamics Calibration, there might still be some extrusion "
-"issues, such as:\n"
-"1. Over-Extrusion: Excess material on your printed object, forming blobs or "
-"zits, or the layers seem thicker than expected and not uniform.\n"
-"2. Under-Extrusion: Very thin layers, weak infill strength, or gaps in the "
-"top layer of the model, even when printing slowly.\n"
-"3. Poor Surface Quality: The surface of your prints seems rough or uneven.\n"
-"4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as "
-"they should be."
 
 msgid ""
 "In addition, Flow Rate Calibration is crucial for foaming materials like LW-"
 "PLA used in RC planes. These materials expand greatly when heated, and "
 "calibration provides a useful reference flow rate."
 msgstr ""
-"In addition, Flow Rate Calibration is crucial for foaming materials like LW-"
-"PLA used in RC planes. These materials expand greatly when heated, and "
-"calibration provides a useful reference flow rate."
 
 msgid ""
 "Flow Rate Calibration measures the ratio of expected to actual extrusion "
@@ -14920,12 +14613,6 @@ msgid ""
 "you still see the listed defects after you have done other calibrations. For "
 "more details, please check out the wiki article."
 msgstr ""
-"Flow Rate Calibration measures the ratio of expected to actual extrusion "
-"volumes. The default setting works well with Bambu Lab printers and official "
-"filaments as they were pre-calibrated and fine-tuned. For a regular "
-"filament, you usually won't need to perform a Flow Rate Calibration unless "
-"you still see the listed defects after you have done other calibrations. For "
-"more details, please check out our wiki article."
 
 msgid ""
 "Auto Flow Rate Calibration utilizes Bambu Lab's Micro-Lidar technology, "
@@ -14945,100 +14632,78 @@ msgid ""
 "can lead to sub-par prints or printer damage. Please make sure to carefully "
 "read and understand the process before doing it."
 msgstr ""
-"Auto Flow Rate Calibration utilizes Bambu Lab's Micro-Lidar technology, "
-"directly measuring the calibration patterns. However, please be advised that "
-"the efficacy and accuracy of this method may be compromised with specific "
-"types of materials. Particularly, filaments that are transparent or semi-"
-"transparent, sparkling-particled, or have a high-reflective finish may not "
-"be suitable for this calibration and can produce less-than-desirable "
-"results.\n"
-"\n"
-"The calibration results may vary between each calibration or filament. We "
-"are still improving the accuracy and compatibility of this calibration "
-"through firmware updates over time.\n"
-"\n"
-"Caution: Flow Rate Calibration is an advanced process, to be attempted only "
-"by those who fully understand its purpose and implications. Incorrect usage "
-"can lead to sub-par prints or printer damage. Please make sure to carefully "
-"read and understand the process before performing it."
 
 msgid "When you need Max Volumetric Speed Calibration"
-msgstr "When you need Max Volumetric Speed Calibration"
+msgstr ""
 
 msgid "Over-extrusion or under extrusion"
-msgstr "Over-extrusion or under extrusion"
+msgstr ""
 
 msgid "Max Volumetric Speed calibration is recommended when you print with:"
-msgstr "Max Volumetric Speed Calibration is recommended when you print with:"
+msgstr ""
 
 msgid "material with significant thermal shrinkage/expansion, such as..."
-msgstr "material with significant thermal shrinkage/expansion, such as..."
+msgstr ""
 
 msgid "materials with inaccurate filament diameter"
-msgstr "materials with inaccurate filament diameter"
+msgstr ""
 
 msgid "We found the best Flow Dynamics Calibration Factor"
-msgstr "We found the best Flow Dynamics Calibration Factor."
+msgstr ""
 
 msgid ""
 "Part of the calibration failed! You may clean the plate and retry. The "
 "failed test result would be dropped."
 msgstr ""
-"Part of the calibration failed! It may help to clean the plate and retry. "
-"The failed test result will be deleted."
 
 msgid ""
 "*We recommend you to add brand, materia, type, and even humidity level in "
 "the Name"
 msgstr ""
-"*We recommend that you add brand, material, type, and even humidity level to "
-"the name"
 
 msgid "Failed"
 msgstr "失敗"
 
 msgid "Please enter the name you want to save to printer."
-msgstr "Please enter the name you want to save to printer."
+msgstr ""
 
 msgid "The name cannot exceed 40 characters."
-msgstr "The name cannot exceed 40 characters."
+msgstr ""
 
 msgid ""
 "Only one of the results with the same name will be saved. Are you sure you "
 "want to override the other results?"
 msgstr ""
-"Only one of the results with the same name will be saved. Are you sure you "
-"want to replace the other results?"
 
 msgid "Please find the best line on your plate"
-msgstr "Please find the best line on your plate."
+msgstr ""
 
 msgid "Please find the corner with perfect degree of extrusion"
-msgstr "Please find the corner with the perfect degree of extrusion"
+msgstr ""
 
 msgid "Input Value"
-msgstr "Input Value"
+msgstr ""
 
 msgid "Save to Filament Preset"
-msgstr "Save to Filament Presets"
+msgstr ""
 
 msgid "Preset"
-msgstr "Preset"
+msgstr ""
 
 msgid "Record Factor"
-msgstr "Record Factor"
+msgstr ""
 
 msgid "We found the best flow ratio for you"
-msgstr "We found the best flow ratio for you."
+msgstr ""
 
 msgid "Flow Ratio"
-msgstr "Flow Ratio"
+msgstr ""
 
 msgid "Please input a valid value (0.0 < flow ratio < 2.0)"
-msgstr "Please input a valid value (0.0 < flow ratio < 2.0)"
+msgstr ""
 
 msgid "Please enter the name of the preset you want to save."
-msgstr "Please enter the name of the preset you want to save."
+msgstr ""
 
 msgid "Calibration1"
 msgstr "Calibration1"
@@ -15047,156 +14712,150 @@ msgid "Calibration2"
 msgstr "Calibration2"
 
 msgid "Please find the best object on your plate"
-msgstr "Please find the best object on your plate."
+msgstr ""
 
 msgid "Fill in the value above the block with smoothest top surface"
-msgstr "Fill in the value from the block with smoothest top surface"
+msgstr ""
 
 msgid "Skip Calibration2"
-msgstr "Skip Calibration 2"
+msgstr ""
 
 #, c-format, boost-format
 msgid "flow ratio : %s "
-msgstr "flow ratio: %s "
+msgstr ""
 
 msgid "Please choose a block with smoothest top surface"
-msgstr "Please choose the block with the smoothest top surface."
+msgstr ""
 
 msgid "Please choose a block with smoothest top surface."
-msgstr "Please choose the block with the smoothest top surface."
+msgstr ""
 
 msgid "Please input a valid value (0 <= Max Volumetric Speed <= 60)"
-msgstr "Please input a valid value (0 <= Max Volumetric Speed <= 60)"
+msgstr ""
 
 msgid "Calibration Type"
-msgstr "Calibration Type"
+msgstr ""
 
 msgid "Complete Calibration"
-msgstr "Complete Calibration"
+msgstr ""
 
 msgid "Fine Calibration based on flow ratio"
-msgstr "Fine Calibration based on flow ratio"
+msgstr ""
 
 msgid "Title"
-msgstr "Title"
+msgstr ""
 
 msgid ""
 "A test model will be printed. Please clear the build plate and place it back "
 "to the hot bed before calibration."
 msgstr ""
-"A test model will be printed. Please clear the build plate and place it back "
-"on the heatbed before calibration."
 
 msgid "Printing Parameters"
-msgstr "Printing Parameters"
+msgstr ""
 
 msgid "Plate Type"
-msgstr "Plate Type"
+msgstr ""
 
 msgid "filament position"
-msgstr "filament position"
+msgstr ""
 
 msgid "External Spool"
-msgstr "External Spool"
+msgstr ""
 
 msgid "Filament For Calibration"
-msgstr "Filament For Calibration"
+msgstr ""
 
 msgid ""
 "Tips for calibration material: \n"
 "- Materials that can share same hot bed temperature\n"
 "- Different filament brand and family(Brand = Bambu, Family = Basic, Matte)"
 msgstr ""
-"Tips for calibration material: \n"
-"- Materials that can share same hot bed temperature\n"
-"- Different filament brand and family (Brand = Bambu, Family = Basic, Matte, "
-"etc.)"
 
 msgid "Pattern"
-msgstr "Pattern"
+msgstr ""
 
 msgid "Method"
-msgstr "Method"
+msgstr ""
 
 #, c-format, boost-format
 msgid "%s is not compatible with %s"
-msgstr "%s is not compatible with %s"
+msgstr ""
 
 msgid "TPU is not supported for Flow Dynamics Auto-Calibration."
-msgstr "TPU is not supported by Flow Dynamics Auto-Calibration."
+msgstr ""
 
 msgid "Connecting to printer"
-msgstr "Connecting to printer"
+msgstr ""
 
 msgid "From k Value"
-msgstr "From k Value"
+msgstr ""
 
 msgid "To k Value"
-msgstr "To k Value"
+msgstr ""
 
 msgid "Step value"
 msgstr ""
 
 msgid "The nozzle diameter has been synchronized from the printer Settings"
-msgstr "The nozzle diameter has been synchronized from the printer settings."
+msgstr ""
 
 msgid "From Volumetric Speed"
-msgstr "From Volumetric Speed"
+msgstr ""
 
 msgid "To Volumetric Speed"
-msgstr "To Volumetric Speed"
+msgstr ""
 
 msgid "Flow Dynamics Calibration Result"
-msgstr "Flow Dynamics Calibration Result"
+msgstr ""
 
 msgid "New"
-msgstr "New"
+msgstr ""
 
 msgid "No History Result"
-msgstr "No History Result"
+msgstr ""
 
 msgid "Success to get history result"
-msgstr "Success to get history result"
+msgstr ""
 
 msgid "Refreshing the historical Flow Dynamics Calibration records"
-msgstr "Refreshing the previous Flow Dynamics Calibration records"
+msgstr ""
 
 msgid "Action"
-msgstr "Action"
+msgstr ""
 
 #, c-format, boost-format
 msgid "This machine type can only hold %d history results per nozzle."
-msgstr "This machine type can only hold %d historical results per nozzle."
+msgstr ""
 
 msgid "Edit Flow Dynamics Calibration"
-msgstr "Edit Flow Dynamics Calibration"
+msgstr ""
 
 msgid "New Flow Dynamic Calibration"
-msgstr "New Flow Dynamic Calibration"
+msgstr ""
 
 msgid "Ok"
-msgstr "Ok"
+msgstr ""
 
 msgid "The filament must be selected."
-msgstr "The filament must be selected."
+msgstr ""
 
 msgid "Network lookup"
-msgstr "Network lookup"
+msgstr ""
 
 msgid "Address"
-msgstr "Address"
+msgstr ""
 
 msgid "Hostname"
-msgstr "Hostname"
+msgstr ""
 
 msgid "Service name"
-msgstr "Service name"
+msgstr ""
 
 msgid "OctoPrint version"
-msgstr "OctoPrint version"
+msgstr ""
 
 msgid "Searching for devices"
-msgstr "Searching for devices"
+msgstr ""
 
 msgid "Finished"
 msgstr "完了"
@@ -15225,13 +14884,13 @@ msgid "Extruder type"
 msgstr "押出機タイプ"
 
 msgid "PA Tower"
-msgstr "PA Tower"
+msgstr ""
 
 msgid "PA Line"
-msgstr "PA Line"
+msgstr ""
 
 msgid "PA Pattern"
-msgstr "PA Pattern"
+msgstr ""
 
 msgid "Start PA: "
 msgstr "開始PA:"
@@ -15240,7 +14899,7 @@ msgid "End PA: "
 msgstr "終了PA: "
 
 msgid "PA step: "
-msgstr "PA step:"
+msgstr ""
 
 msgid "Accelerations: "
 msgstr ""
@@ -15249,7 +14908,7 @@ msgid "Speeds: "
 msgstr ""
 
 msgid "Print numbers"
-msgstr "Print numbers"
+msgstr ""
 
 msgid "Comma-separated list of printing accelerations"
 msgstr ""
@@ -15263,13 +14922,9 @@ msgid ""
 "End PA: > Start PA\n"
 "PA step: >= 0.001)"
 msgstr ""
-"Please input valid values:\n"
-"Start PA: >= 0.0\n"
-"End PA: > Start PA\n"
-"PA step: >= 0.001)"
 
 msgid "Temperature calibration"
-msgstr "Temperature calibration"
+msgstr ""
 
 msgid "PLA"
 msgstr "PLA"
@@ -15293,16 +14948,16 @@ msgid "PET-CF"
 msgstr "PET-CF"
 
 msgid "Filament type"
-msgstr "Filament type"
+msgstr ""
 
 msgid "Start temp: "
-msgstr "Start temp:"
+msgstr ""
 
 msgid "End temp: "
-msgstr "End temp:"
+msgstr ""
 
 msgid "Temp step: "
-msgstr "Temp step:"
+msgstr ""
 
 msgid ""
 "Please input valid values:\n"
@@ -15312,16 +14967,16 @@ msgid ""
 msgstr ""
 
 msgid "Max volumetric speed test"
-msgstr "Max volumetric speed test"
+msgstr ""
 
 msgid "Start volumetric speed: "
-msgstr "Start volumetric speed:"
+msgstr ""
 
 msgid "End volumetric speed: "
-msgstr "End volumetric speed:"
+msgstr ""
 
 msgid "step: "
-msgstr "step:"
+msgstr ""
 
 msgid ""
 "Please input valid values:\n"
@@ -15331,13 +14986,13 @@ msgid ""
 msgstr ""
 
 msgid "VFA test"
-msgstr "VFA test"
+msgstr ""
 
 msgid "Start speed: "
-msgstr "Start speed:"
+msgstr ""
 
 msgid "End speed: "
-msgstr "End speed:"
+msgstr ""
 
 msgid ""
 "Please input valid values:\n"
@@ -15347,10 +15002,10 @@ msgid ""
 msgstr ""
 
 msgid "Start retraction length: "
-msgstr "Start retraction length:"
+msgstr ""
 
 msgid "End retraction length: "
-msgstr "End retraction length: "
+msgstr ""
 
 msgid "mm/mm"
 msgstr "mm/mm"
@@ -15359,10 +15014,10 @@ msgid "Send G-code to printer host"
 msgstr "プリンターサーバーにGコードを送信"
 
 msgid "Upload to Printer Host with the following filename:"
-msgstr "Upload to Printer Host with the following filename:"
+msgstr ""
 
 msgid "Use forward slashes ( / ) as a directory separator if needed."
-msgstr "Use forward slashes ( / ) as a directory separator if needed."
+msgstr ""
 
 msgid "Upload to storage"
 msgstr "ストレージへのアップロード"
@@ -15372,19 +15027,19 @@ msgstr "アップロード後、デバイスタブに切り替える。"
 
 #, c-format, boost-format
 msgid "Upload filename doesn't end with \"%s\". Do you wish to continue?"
-msgstr "Filename to upload doesn't end with \"%s\". Do you want to continue?"
+msgstr ""
 
 msgid "Upload"
 msgstr "アップロード"
 
 msgid "Print host upload queue"
-msgstr "Print host upload queue"
+msgstr ""
 
 msgid "ID"
 msgstr "ID"
 
 msgid "Progress"
-msgstr "Progress"
+msgstr ""
 
 msgid "Host"
 msgstr "ホスト"
@@ -15397,13 +15052,13 @@ msgid "Filename"
 msgstr "ファイル名"
 
 msgid "Cancel selected"
-msgstr "Cancel selected"
+msgstr ""
 
 msgid "Show error message"
-msgstr "Show error message"
+msgstr ""
 
 msgid "Enqueued"
-msgstr "Queued"
+msgstr ""
 
 msgid "Uploading"
 msgstr "アップロード中"
@@ -15432,64 +15087,64 @@ msgid "Smooth Build Plate (Side B)"
 msgstr ""
 
 msgid "Unable to perform boolean operation on selected parts"
-msgstr "Unable to perform boolean operation on selected parts"
+msgstr ""
 
 msgid "Mesh Boolean"
-msgstr "Mesh Boolean"
+msgstr ""
 
 msgid "Union"
-msgstr "Union"
+msgstr ""
 
 msgid "Difference"
-msgstr "Difference"
+msgstr ""
 
 msgid "Intersection"
-msgstr "Intersection"
+msgstr ""
 
 msgid "Source Volume"
-msgstr "Source Volume"
+msgstr ""
 
 msgid "Tool Volume"
-msgstr "Tool Volume"
+msgstr ""
 
 msgid "Subtract from"
-msgstr "Subtract from"
+msgstr ""
 
 msgid "Subtract with"
-msgstr "Subtract with"
+msgstr ""
 
 msgid "selected"
-msgstr "selected"
+msgstr ""
 
 msgid "Part 1"
-msgstr "Part 1"
+msgstr ""
 
 msgid "Part 2"
-msgstr "Part 2"
+msgstr ""
 
 msgid "Delete input"
-msgstr "Delete input"
+msgstr ""
 
 msgid "Network Test"
-msgstr "Network Test"
+msgstr ""
 
 msgid "Start Test Multi-Thread"
-msgstr "Start Test Multi-Thread"
+msgstr ""
 
 msgid "Start Test Single-Thread"
-msgstr "Start Test Single-Thread"
+msgstr ""
 
 msgid "Export Log"
-msgstr "Export Log"
+msgstr ""
 
 msgid "OrcaSlicer Version:"
 msgstr ""
 
 msgid "System Version:"
-msgstr "System Version:"
+msgstr ""
 
 msgid "DNS Server:"
-msgstr "DNS Server:"
+msgstr ""
 
 msgid "Test OrcaSlicer(GitHub)"
 msgstr ""
@@ -15498,16 +15153,16 @@ msgid "Test OrcaSlicer(GitHub):"
 msgstr ""
 
 msgid "Test Bing.com"
-msgstr "Test Bing.com"
+msgstr ""
 
 msgid "Test bing.com:"
-msgstr "Test bing.com:"
+msgstr ""
 
 msgid "Log Info"
-msgstr "Log Info"
+msgstr ""
 
 msgid "Select filament preset"
-msgstr "Select filament preset"
+msgstr ""
 
 msgid "Create Filament"
 msgstr "フィラメントを作成"
@@ -15516,69 +15171,67 @@ msgid "Create Based on Current Filament"
 msgstr "現在のフィラメントを元に作成"
 
 msgid "Copy Current Filament Preset "
-msgstr "Copy Current Filament Preset "
+msgstr ""
 
 msgid "Basic Information"
-msgstr "Basic Information"
+msgstr ""
 
 msgid "Add Filament Preset under this filament"
-msgstr "Add Filament Preset under this filament"
+msgstr ""
 
 msgid "We could create the filament presets for your following printer:"
-msgstr "We could create the filament presets for your following printer:"
+msgstr ""
 
 msgid "Select Vendor"
-msgstr "Select Vendor"
+msgstr ""
 
 msgid "Input Custom Vendor"
-msgstr "Input Custom Vendor"
+msgstr ""
 
 msgid "Can't find vendor I want"
-msgstr "Can't find vendor I want"
+msgstr ""
 
 msgid "Select Type"
-msgstr "Select Type"
+msgstr ""
 
 msgid "Select Filament Preset"
-msgstr "Select Filament Preset"
+msgstr ""
 
 msgid "Serial"
-msgstr "Serial"
+msgstr ""
 
 msgid "e.g. Basic, Matte, Silk, Marble"
-msgstr "e.g. Basic, Matte, Silk, Marble"
+msgstr ""
 
 msgid "Filament Preset"
-msgstr "Filament Preset"
+msgstr ""
 
 msgid "Create"
-msgstr "Create"
+msgstr ""
 
 msgid "Vendor is not selected, please reselect vendor."
-msgstr "Vendor is not selected; please reselect vendor."
+msgstr ""
 
 msgid "Custom vendor is not input, please input custom vendor."
-msgstr "Custom vendor missing; please input custom vendor."
+msgstr ""
 
 msgid ""
 "\"Bambu\" or \"Generic\" cannot be used as a Vendor for custom filaments."
 msgstr ""
 
 msgid "Filament type is not selected, please reselect type."
-msgstr "Filament type is not selected, please reselect type."
+msgstr ""
 
 msgid "Filament serial is not entered, please enter serial."
-msgstr "Filament serial missing; please input serial."
+msgstr ""
 
 msgid ""
 "There may be escape characters in the vendor or serial input of filament. "
 "Please delete and re-enter."
 msgstr ""
-"There may be disallowed characters in the vendor or serial input of the "
-"filament. Please delete and re-enter."
 
 msgid "All inputs in the custom vendor or serial are spaces. Please re-enter."
-msgstr "All inputs in the custom vendor or serial are spaces. Please re-enter."
+msgstr ""
 
 msgid "The vendor cannot be a number. Please re-enter."
 msgstr ""
@@ -15586,7 +15239,6 @@ msgstr ""
 msgid ""
 "You have not selected a printer or preset yet. Please select at least one."
 msgstr ""
-"You have not selected a printer or preset yet. Please select at least one."
 
 #, c-format, boost-format
 msgid ""
@@ -15594,19 +15246,14 @@ msgid ""
 "If you continue creating, the preset created will be displayed with its full "
 "name. Do you want to continue?"
 msgstr ""
-"The Filament name %s you created already exists. \n"
-"If you continue, the preset created will be displayed with its full name. Do "
-"you want to continue?"
 
 msgid "Some existing presets have failed to be created, as follows:\n"
-msgstr "Some existing presets have failed to be created, as follows:\n"
+msgstr ""
 
 msgid ""
 "\n"
 "Do you want to rewrite it?"
 msgstr ""
-"\n"
-"Do you want to rewrite it?"
 
 msgid ""
 "We would rename the presets as \"Vendor Type Serial @printer you "
@@ -15615,7 +15262,7 @@ msgid ""
 msgstr ""
 
 msgid "Create Printer/Nozzle"
-msgstr "Create Printer/Nozzle"
+msgstr ""
 
 msgid "Create Printer"
 msgstr "プリンターを作成"
@@ -15624,103 +15271,99 @@ msgid "Create Nozzle for Existing Printer"
 msgstr "既存のプリンターに別サイズのノズル径を作成"
 
 msgid "Create from Template"
-msgstr "Create from Template"
+msgstr ""
 
 msgid "Create Based on Current Printer"
-msgstr "Create Based on Current Printer"
+msgstr ""
 
 msgid "Import Preset"
-msgstr "Import Preset"
+msgstr ""
 
 msgid "Create Type"
-msgstr "Create Type"
+msgstr ""
 
 msgid "The model was not found, please reselect vendor."
-msgstr "The model was not found; please reselect vendor."
+msgstr ""
 
 msgid "Select Model"
-msgstr "Select Model"
+msgstr ""
 
 msgid "Select Printer"
-msgstr "Select Printer"
+msgstr ""
 
 msgid "Input Custom Model"
-msgstr "Input Custom Model"
+msgstr ""
 
 msgid "Can't find my printer model"
-msgstr "Can't find my printer model"
+msgstr ""
 
 msgid "Rectangle"
-msgstr "Rectangle"
+msgstr ""
 
 msgid "Printable Space"
-msgstr "Printable Space"
+msgstr ""
 
 msgid "Hot Bed STL"
-msgstr "Hot Bed STL"
+msgstr ""
 
 msgid "Load stl"
-msgstr "Load stl"
+msgstr ""
 
 msgid "Hot Bed SVG"
-msgstr "Hot Bed SVG"
+msgstr ""
 
 msgid "Load svg"
-msgstr "Load svg"
+msgstr ""
 
 msgid "Max Print Height"
-msgstr "Max Print Height"
+msgstr ""
 
 #, c-format, boost-format
 msgid "The file exceeds %d MB, please import again."
-msgstr "The file exceeds %d MB, please import again."
+msgstr ""
 
 msgid "Exception in obtaining file size, please import again."
-msgstr "Exception in obtaining file size, please import again."
+msgstr ""
 
 msgid "Preset path was not found, please reselect vendor."
-msgstr "Preset path was not found; please reselect vendor."
+msgstr ""
 
 msgid "The printer model was not found, please reselect."
-msgstr "The printer model was not found, please reselect."
+msgstr ""
 
 msgid "The nozzle diameter was not found, please reselect."
-msgstr "The nozzle diameter was not found; please reselect."
+msgstr ""
 
 msgid "The printer preset was not found, please reselect."
-msgstr "The printer preset was not found; please reselect."
+msgstr ""
 
 msgid "Printer Preset"
-msgstr "Printer Preset"
+msgstr ""
 
 msgid "Filament Preset Template"
-msgstr "Filament Preset Template"
+msgstr ""
 
 msgid "Deselect All"
-msgstr "Deselect All"
+msgstr ""
 
 msgid "Process Preset Template"
-msgstr "Process Preset Template"
+msgstr ""
 
 msgid "Back Page 1"
-msgstr "Back Page 1"
+msgstr ""
 
 msgid ""
 "You have not yet chosen which printer preset to create based on. Please "
 "choose the vendor and model of the printer"
 msgstr ""
-"You have not yet chosen which printer preset to create based on. Please "
-"choose the vendor and model of the printer"
 
 msgid ""
 "You have entered an illegal input in the printable area section on the first "
 "page. Please check before creating it."
 msgstr ""
-"You have entered a disallowed character in the printable area section on the "
-"first page. Please use only numbers."
 
 msgid "The custom printer or model is not entered, please enter it."
-msgstr "The custom printer or model missing; please input."
+msgstr ""
 
 msgid ""
 "The printer preset you created already has a preset with the same name. Do "
@@ -15731,74 +15374,60 @@ msgid ""
 "reserve.\n"
 "\tCancel: Do not create a preset, return to the creation interface."
 msgstr ""
-"The printer preset you created already has a preset with the same name. Do "
-"you want to overwrite it?\n"
-"\tYes: Overwrite the printer preset with the same name, and filament and "
-"process presets with the same preset name will be recreated \n"
-"and filament and process presets without the same preset name will be "
-"reserved.\n"
-"\tCancel: Do not create a preset; return to the creation interface."
 
 msgid "You need to select at least one filament preset."
-msgstr "You need to select at least one filament preset."
+msgstr ""
 
 msgid "You need to select at least one process preset."
-msgstr "You need to select at least one process preset."
+msgstr ""
 
 msgid "Create filament presets failed. As follows:\n"
-msgstr "Create filament presets failed. As follows:\n"
+msgstr ""
 
 msgid "Create process presets failed. As follows:\n"
-msgstr "Create process presets failed. As follows:\n"
+msgstr ""
 
 msgid "Vendor was not found, please reselect."
-msgstr "Vendor was not found; please reselect."
+msgstr ""
 
 msgid "Current vendor has no models, please reselect."
-msgstr "Current vendor has no models, please reselect."
+msgstr ""
 
 msgid ""
 "You have not selected the vendor and model or entered the custom vendor and "
 "model."
 msgstr ""
-"You have not selected the vendor and model or input the custom vendor and "
-"model."
 
 msgid ""
 "There may be escape characters in the custom printer vendor or model. Please "
 "delete and re-enter."
 msgstr ""
-"There may be escape characters in the custom printer vendor or model. Please "
-"delete and re-enter."
 
 msgid ""
 "All inputs in the custom printer vendor or model are spaces. Please re-enter."
 msgstr ""
-"All inputs in the custom printer vendor or model are spaces. Please re-enter."
 
 msgid "Please check bed printable shape and origin input."
-msgstr "Please check bed printable shape and origin input."
+msgstr ""
 
 msgid ""
 "You have not yet selected the printer to replace the nozzle, please choose."
 msgstr ""
-"You have not yet selected the printer to replace the nozzle for; please "
-"choose a printer."
 
 msgid "Create Printer Successful"
-msgstr "Create Printer Successful"
+msgstr ""
 
 msgid "Create Filament Successful"
-msgstr "Filament Created Successfully"
+msgstr ""
 
 msgid "Printer Created"
-msgstr "Printer Created"
+msgstr ""
 
 msgid "Please go to printer settings to edit your presets"
-msgstr "Please go to printer settings to edit your presets"
+msgstr ""
 
 msgid "Filament Created"
-msgstr "Filament Created"
+msgstr ""
 
 msgid ""
 "Please go to filament setting to edit your presets if you need.\n"
@@ -15806,10 +15435,6 @@ msgid ""
 "volumetric speed has a significant impact on printing quality. Please set "
 "them carefully."
 msgstr ""
-"Please go to filament settings to edit your presets if you need to.\n"
-"Please note that nozzle temperature, hot bed temperature, and maximum "
-"volumetric speed each have a significant impact on printing quality. Please "
-"set them carefully."
 
 msgid ""
 "\n"
@@ -15821,7 +15446,7 @@ msgid ""
 msgstr ""
 
 msgid "Printer Setting"
-msgstr "Printer Setting"
+msgstr ""
 
 msgid "Printer config bundle(.orca_printer)"
 msgstr ""
@@ -15830,31 +15455,31 @@ msgid "Filament bundle(.orca_filament)"
 msgstr ""
 
 msgid "Printer presets(.zip)"
-msgstr "Printer presets(.zip)"
+msgstr ""
 
 msgid "Filament presets(.zip)"
-msgstr "Filament presets(.zip)"
+msgstr ""
 
 msgid "Process presets(.zip)"
-msgstr "Process presets(.zip)"
+msgstr ""
 
 msgid "initialize fail"
-msgstr "initialize fail"
+msgstr ""
 
 msgid "add file fail"
-msgstr "add file fail"
+msgstr ""
 
 msgid "add bundle structure file fail"
-msgstr "add bundle structure file fail"
+msgstr ""
 
 msgid "finalize fail"
-msgstr "finalize fail"
+msgstr ""
 
 msgid "open zip written fail"
-msgstr "open zip written fail"
+msgstr ""
 
 msgid "Export successful"
-msgstr "Export successful"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -15863,10 +15488,6 @@ msgid ""
 "If not, a time suffix will be added, and you can modify the name after "
 "creation."
 msgstr ""
-"The '%s' folder already exists in the current directory. Do you want to "
-"clear it and rebuild it?\n"
-"If not, a time suffix will be added, and you can modify the name after "
-"creation."
 
 msgid ""
 "Printer and all the filament&&process presets that belongs to the printer. \n"
@@ -15877,65 +15498,51 @@ msgid ""
 "User's filament preset set. \n"
 "Can be shared with others."
 msgstr ""
-"User's filament preset set. \n"
-"Can be shared with others."
 
 msgid ""
 "Only display printer names with changes to printer, filament, and process "
 "presets."
 msgstr ""
-"Only display printers with changes to printer, filament, and process presets "
-"are displayed."
 
 msgid "Only display the filament names with changes to filament presets."
-msgstr "Only display the filament names with changes to filament presets."
+msgstr ""
 
 msgid ""
 "Only printer names with user printer presets will be displayed, and each "
 "preset you choose will be exported as a zip."
 msgstr ""
-"Only printer names with user printer presets will be displayed, and each "
-"preset you choose will be exported as a zip."
 
 msgid ""
 "Only the filament names with user filament presets will be displayed, \n"
 "and all user filament presets in each filament name you select will be "
 "exported as a zip."
 msgstr ""
-"Only the filament names with user filament presets will be displayed, \n"
-"and all user filament presets in each filament name you select will be "
-"exported as a zip."
 
 msgid ""
 "Only printer names with changed process presets will be displayed, \n"
 "and all user process presets in each printer name you select will be "
 "exported as a zip."
 msgstr ""
-"Only printer names with changed process presets will be displayed, \n"
-"and all user process presets in each printer name you select will be "
-"exported as a zip."
 
 msgid "Please select at least one printer or filament."
-msgstr "Please select at least one printer or filament."
+msgstr ""
 
 msgid "Please select a type you want to export"
-msgstr "Please select a preset type you want to export"
+msgstr ""
 
 msgid "Failed to create temporary folder, please try Export Configs again."
-msgstr "Failed to create temporary folder, please try Export Configs again."
+msgstr ""
 
 msgid "Edit Filament"
 msgstr "フィラメントを編集"
 
 msgid "Filament presets under this filament"
-msgstr "Filament presets under this filament"
+msgstr ""
 
 msgid ""
 "Note: If the only preset under this filament is deleted, the filament will "
 "be deleted after exiting the dialog."
 msgstr ""
-"Note: If the only preset under this filament is deleted, the filament will "
-"be deleted after exiting the dialog."
 
 msgid "Presets inherited by other presets cannot be deleted"
 msgstr ""
@@ -15945,16 +15552,16 @@ msgid_plural "The following preset inherits this preset."
 msgstr[0] ""
 
 msgid "Delete Preset"
-msgstr "Delete Preset"
+msgstr ""
 
 msgid "Are you sure to delete the selected preset?"
-msgstr "Are you sure to delete the selected preset?"
+msgstr ""
 
 msgid "Delete preset"
-msgstr "Delete preset"
+msgstr ""
 
 msgid "+ Add Preset"
-msgstr "+ Add Preset"
+msgstr ""
 
 msgid "Delete Filament"
 msgstr "フィラメントを削除"
@@ -15964,73 +15571,66 @@ msgid ""
 "If you are using this filament on your printer, please reset the filament "
 "information for that slot."
 msgstr ""
-"All the filament presets belong to this filament would be deleted. \n"
-"If you are using this filament on your printer, please reset the filament "
-"information for that slot."
 
 msgid "Delete filament"
 msgstr "フィラメントを削除"
 
 msgid "Add Preset"
-msgstr "Add Preset"
+msgstr ""
 
 msgid "Add preset for new printer"
-msgstr "Add preset for new printer"
+msgstr ""
 
 msgid "Copy preset from filament"
-msgstr "Copy preset from filament"
+msgstr ""
 
 msgid "The filament choice not find filament preset, please reselect it"
-msgstr "The filament choice not find filament preset, please reselect it"
+msgstr ""
 
 msgid "[Delete Required]"
-msgstr "[Delete Required]"
+msgstr ""
 
 msgid "Edit Preset"
 msgstr "プリセットを編集"
 
 msgid "For more information, please check out Wiki"
-msgstr "For more information, please check out our Wiki"
+msgstr ""
 
 msgid "Collapse"
-msgstr "Collapse"
+msgstr ""
 
 msgid "Daily Tips"
 msgstr "今日のヒント"
 
 #, c-format, boost-format
 msgid "nozzle memorized: %.1f %s"
-msgstr "nozzle memorized: %.1f %s"
+msgstr ""
 
 msgid ""
 "Your nozzle diameter in preset is not consistent with memorized nozzle "
 "diameter. Did you change your nozzle lately?"
 msgstr ""
-"Your nozzle diameter in preset is not consistent with the saved nozzle "
-"diameter. Have you changed your nozzle?"
 
 #, c-format, boost-format
 msgid "*Printing %s material with %s may cause nozzle damage"
-msgstr "*Printing %s material with %s may cause nozzle damage"
+msgstr ""
 
 msgid "Need select printer"
 msgstr "プリンターを選ぶ必要があります"
 
 msgid "The start, end or step is not valid value."
-msgstr "The start, end or step is not valid value."
+msgstr ""
 
 msgid ""
 "Unable to calibrate: maybe because the set calibration value range is too "
 "large, or the step is too small"
 msgstr ""
-"Unable to calibrate: maybe because the set calibration value range is too "
-"large, or the step is too small"
 
 msgid "Physical Printer"
-msgstr "Physical Printer"
+msgstr ""
 
 msgid "Print Host upload"
-msgstr "Print Host upload"
+msgstr ""
 
 msgid "Test"
 msgstr "テスト"
@@ -16045,7 +15645,7 @@ msgid "Are you sure to log out?"
 msgstr "本当にログアウトしますか？"
 
 msgid "Refresh Printers"
-msgstr "Refresh Printers"
+msgstr ""
 
 msgid "View print host webui in Device tab"
 msgstr ""
@@ -16057,106 +15657,98 @@ msgid ""
 "HTTPS CA file is optional. It is only needed if you use HTTPS with a self-"
 "signed certificate."
 msgstr ""
-"HTTPS CA file is optional. It is only needed if you use HTTPS with a self-"
-"signed certificate."
 
 msgid "Certificate files (*.crt, *.pem)|*.crt;*.pem|All files|*.*"
-msgstr "Certificate files (*.crt, *.pem)|*.crt;*.pem|All files|*.*"
+msgstr ""
 
 msgid "Open CA certificate file"
-msgstr "Open CA certificate file"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "On this system, %s uses HTTPS certificates from the system Certificate Store "
 "or Keychain."
 msgstr ""
-"On this system, %s uses HTTPS certificates from the system Certificate Store "
-"or Keychain."
 
 msgid ""
 "To use a custom CA file, please import your CA file into Certificate Store / "
 "Keychain."
 msgstr ""
-"To use a custom CA file, please import your CA file into Certificate Store / "
-"Keychain."
 
 msgid "Login/Test"
 msgstr ""
 
 msgid "Connection to printers connected via the print host failed."
-msgstr "Connection to printers connected via the print host failed."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Mismatched type of print host: %s"
-msgstr "Mismatched type of print host: %s"
+msgstr ""
 
 msgid "Connection to AstroBox is working correctly."
-msgstr "Connection to AstroBox is working correctly."
+msgstr ""
 
 msgid "Could not connect to AstroBox"
-msgstr "Could not connect to AstroBox"
+msgstr ""
 
 msgid "Note: AstroBox version 1.1.0 or higher is required."
-msgstr "Note: AstroBox version 1.1.0 or higher is required."
+msgstr ""
 
 msgid "Connection to Duet is working correctly."
-msgstr "Connection to Duet is working correctly."
+msgstr ""
 
 msgid "Could not connect to Duet"
-msgstr "Could not connect to Duet"
+msgstr ""
 
 msgid "Unknown error occurred"
-msgstr "Unknown error occurred"
+msgstr ""
 
 msgid "Wrong password"
-msgstr "Wrong password"
+msgstr ""
 
 msgid "Could not get resources to create a new connection"
-msgstr "Could not get resources to create a new connection"
+msgstr ""
 
 msgid "Upload not enabled on FlashAir card."
-msgstr "Upload not enabled on FlashAir card."
+msgstr ""
 
 msgid "Connection to FlashAir is working correctly and upload is enabled."
-msgstr "Connection to FlashAir is working correctly and upload is enabled."
+msgstr ""
 
 msgid "Could not connect to FlashAir"
-msgstr "Could not connect to FlashAir"
+msgstr ""
 
 msgid ""
 "Note: FlashAir with firmware 2.00.02 or newer and activated upload function "
 "is required."
 msgstr ""
-"Note: FlashAir with firmware 2.00.02 or newer and activated upload function "
-"is required."
 
 msgid "Connection to MKS is working correctly."
-msgstr "Connection to MKS is working correctly."
+msgstr ""
 
 msgid "Could not connect to MKS"
-msgstr "Could not connect to MKS"
+msgstr ""
 
 msgid "Connection to OctoPrint is working correctly."
-msgstr "Connection to OctoPrint is working correctly."
+msgstr ""
 
 msgid "Could not connect to OctoPrint"
-msgstr "Could not connect to OctoPrint"
+msgstr ""
 
 msgid "Note: OctoPrint version 1.1.0 or higher is required."
-msgstr "Note: OctoPrint version 1.1.0 or higher is required."
+msgstr ""
 
 msgid "Connection to Prusa SL1 / SL1S is working correctly."
-msgstr "Connection to Prusa SL1 / SL1S is working correctly."
+msgstr ""
 
 msgid "Could not connect to Prusa SLA"
-msgstr "Could not connect to Prusa SLA"
+msgstr ""
 
 msgid "Connection to PrusaLink is working correctly."
-msgstr "Connection to PrusaLink is working correctly."
+msgstr ""
 
 msgid "Could not connect to PrusaLink"
-msgstr "Could not connect to PrusaLink"
+msgstr ""
 
 msgid "Storages found"
 msgstr "ストレージが見つかりました"
@@ -16190,15 +15782,13 @@ msgid "Could not connect to Repetier"
 msgstr "Repetierに接続できませんでした。"
 
 msgid "Note: Repetier version 0.90.0 or higher is required."
-msgstr "Note: Repetier version 0.90.0 or higher is required."
+msgstr ""
 
 #, boost-format
 msgid ""
 "HTTP status: %1%\n"
 "Message body: \"%2%\""
 msgstr ""
-"HTTP status: %1%\n"
-"Message body: \"%2%\""
 
 #, boost-format
 msgid ""
@@ -16206,9 +15796,6 @@ msgid ""
 "Message body: \"%1%\"\n"
 "Error: \"%2%\""
 msgstr ""
-"Parsing of host response failed.\n"
-"Message body: \"%1%\"\n"
-"Error: \"%2%\""
 
 #, boost-format
 msgid ""
@@ -16216,34 +15803,23 @@ msgid ""
 "Message body: \"%1%\"\n"
 "Error: \"%2%\""
 msgstr ""
-"Enumeration of host printers failed.\n"
-"Message body: \"%1%\"\n"
-"Error: \"%2%\""
 
 msgid ""
 "It has a small layer height. This results in almost negligible layer lines "
 "and high print quality. It is suitable for most printing cases."
 msgstr ""
-"It has a small layer height. This results in almost negligible layer lines "
-"and high print quality. It is suitable for most printing cases."
 
 msgid ""
 "Compared with the default profile of a 0.2 mm nozzle, it has lower speeds "
 "and acceleration, and the sparse infill pattern is Gyroid. This results in "
 "much higher print quality but a much longer print time."
 msgstr ""
-"Compared with the default profile of a 0.2 mm nozzle, it has lower speeds "
-"and acceleration, and the sparse infill pattern is Gyroid. This results in "
-"much higher print quality but a much longer print time."
 
 msgid ""
 "Compared with the default profile of a 0.2 mm nozzle, it has a slightly "
 "bigger layer height. This results in almost negligible layer lines and "
 "slightly shorter print time."
 msgstr ""
-"Compared with the default profile of a 0.2 mm nozzle, it has a slightly "
-"bigger layer height. This results in almost negligible layer lines and "
-"slightly longer print time."
 
 msgid ""
 "Compared with the default profile of a 0.2 mm nozzle, it has a bigger layer "
@@ -16573,9 +16149,6 @@ msgid ""
 "Did you know that you can fix a corrupted 3D model to avoid a lot of slicing "
 "problems on the Windows system?"
 msgstr ""
-"Fix Model\n"
-"Did you know that you can fix a corrupted 3D model to avoid a lot of slicing "
-"problems on the Windows system?"
 
 #: resources/data/hints.ini: [hint:Timelapse]
 msgid ""
@@ -16826,17 +16399,6 @@ msgstr ""
 #~ "「ツリーストラング」と「ツリーハイブリッド」の場合、下記の設定をお勧めしま"
 #~ "す：接触層数を２、トップ面とのZ間隔を0.1mm。"
 
-#~ msgid ""
-#~ "When using support material for the support interface, We recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-#~ msgstr ""
-#~ "When using support material for the support interface, we recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-
 #~ msgid "Branch Diameter with double walls"
 #~ msgstr "二重ウォール枝径"
 
@@ -16848,9 +16410,6 @@ msgstr ""
 #~ "この直径の円の面積よりも大きな面積を持つ枝は、安定性向上のためために二重"
 #~ "ウォールでプリントされます。 二重ウォールにしないときは、この値をゼロに設"
 #~ "定します。"
-
-#~ msgid "This setting specify the count of walls around support"
-#~ msgstr "This setting specify the count of walls around support"
 
 #, c-format, boost-format
 #~ msgid "Support: generate toolpath at layer %d"
@@ -16943,18 +16502,6 @@ msgstr ""
 #~ msgid "Cooling overhang threshold"
 #~ msgstr "オーバーハングの冷却閾値"
 
-#, c-format
-#~ msgid ""
-#~ "Force cooling fan to be specific speed when overhang degree of printed "
-#~ "part exceeds this value. Expressed as percentage which indicates how much "
-#~ "width of the line without support from lower layer. 0% means forcing "
-#~ "cooling for all outer wall no matter how much overhang degree"
-#~ msgstr ""
-#~ "Force cooling fan to be a specific speed when overhang degree of printed "
-#~ "part exceeds this value. This is expressed as a percentage which "
-#~ "indicates how much width of the line without support from lower layer. "
-#~ "0% means forcing cooling for all outer wall no matter the overhang degree."
-
 #~ msgid "Thick bridges"
 #~ msgstr "厚いブリッジ"
 
@@ -16971,18 +16518,8 @@ msgstr ""
 #~ msgid "Scale"
 #~ msgstr "スケール"
 
-#~ msgid "Cool plate"
-#~ msgstr "常温プレート"
-
 #~ msgid "Z-hop when retract"
 #~ msgstr "リトラクト時にZ方向調整"
-
-#~ msgid ""
-#~ "While printing by Object, the extruder may collide skirt.\n"
-#~ "Thus, reset the skirt layer to 1 to avoid that."
-#~ msgstr ""
-#~ "While printing by object, the extruder may collide with a skirt.\n"
-#~ "Thus, reset the skirt layer to 1 to avoid collisions."
 
 #~ msgid "Limited"
 #~ msgstr "限定"
@@ -16993,13 +16530,6 @@ msgstr ""
 #~ msgstr ""
 #~ "この値を少し (例えば 0.9) 小さくし、ブリッジ用に押出し量を減らし、たるみを"
 #~ "防ぎます。"
-
-#~ msgid ""
-#~ "This factor affects the amount of material for top solid infill. You can "
-#~ "decrease it slightly to have smooth surface finish"
-#~ msgstr ""
-#~ "This factor affects the amount of material for top solid infill. You can "
-#~ "decrease it slightly to have a smooth surface finish."
 
 #~ msgid "Speed of bridge and completely overhang wall"
 #~ msgstr "ブリッジを造形する時に速度です。"
@@ -17033,40 +16563,6 @@ msgstr ""
 #~ "Multi Material Unit 2.0）がフィラメントをアンロードする時間。 この時間は、"
 #~ "Gコード時間予測プログラムによって合計プリント予測時間に追加されます。"
 
-#~ msgid ""
-#~ "Higher chamber temperature can help suppress or reduce warping and "
-#~ "potentially lead to higher interlayer bonding strength for high "
-#~ "temperature materials like ABS, ASA, PC, PA and so on.At the same time, "
-#~ "the air filtration of ABS and ASA will get worse.While for PLA, PETG, "
-#~ "TPU, PVA and other low temperature materials,the actual chamber "
-#~ "temperature should not be high to avoid cloggings, so 0 which stands for "
-#~ "turning off is highly recommended"
-#~ msgstr ""
-#~ "Higher chamber temperature can help suppress or reduce warping and "
-#~ "potentially lead to higher interlayer bonding strength for high "
-#~ "temperature materials like ABS, ASA, PC, PA and so on. At the same time, "
-#~ "the air filtration of ABS and ASA will get worse.While for PLA, PETG, "
-#~ "TPU, PVA and other low temperature materials, the actual chamber "
-#~ "temperature should not be high to avoid clogs, so 0 (turned off) is "
-#~ "highly recommended."
-
-#~ msgid ""
-#~ "Different nozzle diameters and different filament diameters is not "
-#~ "allowed when prime tower is enabled."
-#~ msgstr ""
-#~ "Different nozzle diameters and different filament diameters is not "
-#~ "allowed when prime tower is enabled."
-
-#~ msgid ""
-#~ "Ooze prevention is currently not supported with the prime tower enabled."
-#~ msgstr ""
-#~ "Ooze prevention is currently not supported with the prime tower enabled."
-
-#~ msgid ""
-#~ "Interlocking depth of a segmented region. Zero disables this feature."
-#~ msgstr ""
-#~ "Interlocking depth of a segmented region. Zero disables this feature."
-
 #~ msgid "Wipe tower extruder"
 #~ msgstr "ワイプタワーエクストルーダー"
 
@@ -17075,71 +16571,6 @@ msgstr ""
 
 #~ msgid "Please input a valid value (K in 0~0.3, N in 0.6~2.0)"
 #~ msgstr "有効な値を入力してください (K in 0~0.3, N in 0.6~2.0)"
-
-#~ msgid "Printer local connection failed, please try again."
-#~ msgstr "Printer local connection failed; please try again."
-
-#~ msgid ""
-#~ "Please find the details of Flow Dynamics Calibration from our wiki.\n"
-#~ "\n"
-#~ "Usually the calibration is unnecessary. When you start a single color/"
-#~ "material print, with the \"flow dynamics calibration\" option checked in "
-#~ "the print start menu, the printer will follow the old way, calibrate the "
-#~ "filament before the print; When you start a multi color/material print, "
-#~ "the printer will use the default compensation parameter for the filament "
-#~ "during every filament switch which will have a good result in most "
-#~ "cases.\n"
-#~ "\n"
-#~ "Please note there are a few cases that will make the calibration result "
-#~ "not reliable: using a texture plate to do the calibration; the build "
-#~ "plate does not have good adhesion (please wash the build plate or apply "
-#~ "gluestick!) ...You can find more from our wiki.\n"
-#~ "\n"
-#~ "The calibration results have about 10 percent jitter in our test, which "
-#~ "may cause the result not exactly the same in each calibration. We are "
-#~ "still investigating the root cause to do improvements with new updates."
-#~ msgstr ""
-#~ "Please find the details of Flow Dynamics Calibration from our wiki.\n"
-#~ "\n"
-#~ "Usually the calibration is unnecessary. When you start a single color/"
-#~ "material print, with the \"flow dynamics calibration\" option checked in "
-#~ "the print start menu, the printer will calibrate the filament before the "
-#~ "print; When you start a multi color/material print, the printer will use "
-#~ "the default compensation parameter for the filament during every filament "
-#~ "switch which will have a good result in most cases.\n"
-#~ "\n"
-#~ "Please note there are a few cases that may make the calibration result "
-#~ "unreliable: using a texture plate to do the calibration; using a build "
-#~ "plate with poor adhesion. (please wash the build plate or apply "
-#~ "gluestick!) You can find more on our wiki.\n"
-#~ "\n"
-#~ "The calibration results have about 10 percent variation in our test, "
-#~ "which may cause the results to not be identical for each calibration. We "
-#~ "are still investigating the root cause to further improve this "
-#~ "calibration in future updates."
-
-#~ msgid ""
-#~ "Only one of the results with the same name will be saved. Are you sure "
-#~ "you want to overrides the other results?"
-#~ msgstr ""
-#~ "Only one of the results with the same name will be saved. Are you sure "
-#~ "you want to override the other results?"
-
-#, c-format, boost-format
-#~ msgid ""
-#~ "There is already a historical calibration result with the same name: %s. "
-#~ "Only one of the results with the same name is saved. Are you sure you "
-#~ "want to overrides the historical result?"
-#~ msgstr ""
-#~ "There is already a historical calibration result with the same name: %s. "
-#~ "Only one set of results with the same name is saved. Are you sure you "
-#~ "want to override the previous results?"
-
-#~ msgid "Please find the cornor with perfect degree of extrusion"
-#~ msgstr "Please find the corner with the perfect degree of extrusion"
-
-#~ msgid "V"
-#~ msgstr "V"
 
 #~ msgid "Export &Configs"
 #~ msgstr "構成データ"
@@ -17162,27 +16593,8 @@ msgstr ""
 #~ msgid "Unload Filament"
 #~ msgstr "アンロード"
 
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "AMS スロットを選択し、[ロード] または [アンロード] をタップすると、フィラ"
-#~ "メントが自動的にロードまたはアンロードされます。"
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
 #~ msgid "MainBoard"
 #~ msgstr "メインボード"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
 
 #~ msgid "active"
 #~ msgstr "アクティブ"
@@ -17253,18 +16665,8 @@ msgstr ""
 #~ msgstr "ロード失敗 [%d]!"
 
 #, c-format, boost-format
-#~ msgid "No files [%d]"
-#~ msgstr "No files [%d]"
-
-#, c-format, boost-format
 #~ msgid "Load failed [%d]"
 #~ msgstr "ロード失敗 [%d]"
-
-#~ msgid "Failed to fetching model information from printer."
-#~ msgstr "Failed to fetch model information from printer."
-
-#~ msgid "Failed to parse model informations."
-#~ msgstr "Failed to parse model information"
 
 #, boost-format
 #~ msgid ""
@@ -17306,31 +16708,6 @@ msgstr ""
 #~ msgid "Auto Segment"
 #~ msgstr "自動分割"
 
-#~ msgid "Depth ratio"
-#~ msgstr "Depth ratio"
-
-#~ msgid "Prizm"
-#~ msgstr "Prizm"
-
-#~ msgid "connector is out of cut contour"
-#~ msgstr "connector is out of cut contour"
-
-#~ msgid "connectors are out of cut contour"
-#~ msgstr "connectors are out of cut contour"
-
-#~ msgid "connector is out of object"
-#~ msgstr "connector is out of object"
-
-#~ msgid "connectors is out of object"
-#~ msgstr "Connectors must be on object surface."
-
-#~ msgid ""
-#~ "Invalid state. \n"
-#~ "No one part is selected for keep after cut"
-#~ msgstr ""
-#~ "Invalid state. \n"
-#~ "No one part is selected to keep after cut"
-
 #~ msgid "Edit Text"
 #~ msgstr "テキストを編集"
 
@@ -17339,12 +16716,6 @@ msgstr ""
 
 #~ msgid "Exception"
 #~ msgstr "異常"
-
-#~ msgid "Choose SLA archive:"
-#~ msgstr "Choose SLA archive:"
-
-#~ msgid "Import file"
-#~ msgstr "ファイルインポート"
 
 #~ msgid "Import model and profile"
 #~ msgstr "モデルとプロファイルを取り込む"
@@ -17413,17 +16784,11 @@ msgstr ""
 #~ msgid " doesn't work at 100%% density "
 #~ msgstr "100%% の密度では使用できません"
 
-#~ msgid "Ctrl + Shift + Enter"
-#~ msgstr "Ctrl + Shift + Enter"
-
 #~ msgid "Tool-Lay on Face"
 #~ msgstr "ツール 底面選択"
 
 #~ msgid "Export as STL"
 #~ msgstr "STL形式でエクスポート"
-
-#~ msgid "Check cloud service status"
-#~ msgstr "Check cloud service status"
 
 #~ msgid "Please input a valid value (K in 0~0.5)"
 #~ msgstr "有効な値を入力してください (0 ~ 0.5)"
@@ -17443,10 +16808,6 @@ msgstr ""
 
 #~ msgid "Add/Remove printers"
 #~ msgstr "プリンターを追加/削除"
-
-#, c-format, boost-format
-#~ msgid "%s is not supported by AMS."
-#~ msgstr "%s is not supported by the AMS."
 
 #~ msgid "Don't remind me of this version again"
 #~ msgstr "今後このバージョンの通知をしません"
@@ -17491,14 +16852,8 @@ msgstr ""
 #~ "モデル修復\n"
 #~ "破損したモデルでも修復してスライスできます。"
 
-#~ msgid "Embedded"
-#~ msgstr "Embedded"
-
 #~ msgid "Online Models"
 #~ msgstr "オンラインモデル"
-
-#~ msgid "Show online staff-picked models on the home page"
-#~ msgstr "Show online staff-picked models on the home page"
 
 #~ msgid "The minimum printing speed when slow down for cooling"
 #~ msgstr "冷却のために速度を落とした時の最低造形速度。"
@@ -17541,9 +16896,6 @@ msgstr ""
 #~ msgid "Calibration of extrusion"
 #~ msgstr "押出のキャリブレーション"
 
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "新しいフィラメントを押出機に挿入してください"
-
 #, c-format, boost-format
 #~ msgid ""
 #~ "Bed temperature of other layer is lower than bed temperature of initial "
@@ -17569,15 +16921,6 @@ msgstr ""
 
 #~ msgid "Resonance frequency identification"
 #~ msgstr "共振特性測定"
-
-#~ msgid "Immediately score"
-#~ msgstr "Immediately score"
-
-#~ msgid "Please give a score for your favorite Bambu Market model."
-#~ msgstr "Please give a score for your favorite Bambu Market model."
-
-#~ msgid "Score"
-#~ msgstr "Score"
 
 #~ msgid "Bambu High Temperature Plate"
 #~ msgstr "Bambu 高温プレート"

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -2782,10 +2782,10 @@ msgid "License"
 msgstr "라이센스"
 
 msgid "Orca Slicer is licensed under "
-msgstr "Orca Slicer is licensed under "
+msgstr ""
 
 msgid "GNU Affero General Public License, version 3"
-msgstr "GNU Affero General Public License, version 3"
+msgstr ""
 
 msgid "Orca Slicer is based on PrusaSlicer and BambuStudio"
 msgstr "Orca Slicer는 PrusaSlicer와 BambuStudio를 기반으로 합니다"
@@ -3467,16 +3467,13 @@ msgid ""
 "printers at the same time.(It depends on how many devices can undergo "
 "heating at the same time.)"
 msgstr ""
-"printers at the same time. (It depends on how many devices can undergo "
-"heating at the same time.)"
 
 msgid "Wait"
-msgstr "Wait"
+msgstr ""
 
 msgid ""
 "minute each batch.(It depends on how long it takes to complete the heating.)"
 msgstr ""
-"minute each batch. (It depends on how long it takes to complete heating.)"
 
 msgid "Send"
 msgstr "전송"
@@ -13876,10 +13873,10 @@ msgid "XY separation between an object and its support"
 msgstr "객체와 서포트를 분리하는 XY 간격"
 
 msgid "Support/object first layer gap"
-msgstr "Support/object first layer gap"
+msgstr ""
 
 msgid "XY separation between an object and its support at the first layer."
-msgstr "XY separation between an object and its support at the first layer."
+msgstr ""
 
 msgid "Pattern angle"
 msgstr "패턴 각도"
@@ -17767,16 +17764,6 @@ msgstr ""
 #~ "\"강한 나무\" 및 \"혼합 나무\" 모양의 경우 최소 접점 레이어 2, 상단 Z 거"
 #~ "리 0.1 또는 접점에서 서포트 재료를 사용하는 설정을 권장합니다."
 
-#~ msgid ""
-#~ "When using support material for the support interface, We recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-#~ msgstr ""
-#~ "서포트 접점에 서포트 재료를 사용하는 경우 다음 설정을 권장합니다:\n"
-#~ "상단 Z 거리 0, 접점 간격 0, 접점 패턴 동심원 및 독립적 서포트 높이 비활성"
-#~ "화"
-
 #~ msgid "Branch Diameter with double walls"
 #~ msgstr "이중 벽이 있는 가지 직경"
 
@@ -18014,12 +18001,6 @@ msgstr ""
 #~ msgctxt "Verb"
 #~ msgid "Scale"
 #~ msgstr "규모"
-
-#~ msgid "Orca Slicer "
-#~ msgstr "Orca Slicer "
-
-#~ msgid "Cool plate"
-#~ msgstr "쿨 플레이트"
 
 #~ msgid "Lift Z Enforcement"
 #~ msgstr "강제 Z 올리기"
@@ -18449,12 +18430,6 @@ msgstr ""
 #~ msgid "Please find the cornor with perfect degree of extrusion"
 #~ msgstr "완벽한 압출각도를 가진 모서리를 찾아주세요"
 
-#~ msgid "X"
-#~ msgstr "X"
-
-#~ msgid "Y"
-#~ msgstr "Y"
-
 #~ msgid ""
 #~ "Order of wall/infill. When the tickbox is unchecked the walls are printed "
 #~ "first, which works best in most cases.\n"
@@ -18472,9 +18447,6 @@ msgstr ""
 #~ "이 될 수 있습니다. 그러나 충전재는 출력된 벽이 부착된 부분을 약간 밀어내"
 #~ "어 외부 표면 마감이 더 나빠집니다. 또한 충전재가 부품의 외부 표면을 통해 "
 #~ "빛날 수도 있습니다."
-
-#~ msgid "V"
-#~ msgstr "V"
 
 #~ msgid ""
 #~ "Orca Slicer is based on BambuStudio by Bambulab, which is from "
@@ -18518,36 +18490,8 @@ msgstr ""
 #~ msgid "Unload Filament"
 #~ msgstr "필라멘트 언로드"
 
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "AMS 슬롯을 선택한 후 \"넣기\" 또는 \"빼기\" 버튼을 눌러 필라멘트를 자동으"
-#~ "로 넣거나 뺍니다."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
 #~ msgid "MainBoard"
 #~ msgstr "메인보드"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
-
-#~ msgid "- ℃"
-#~ msgstr "- ℃"
-
-#~ msgid "0.5"
-#~ msgstr "0.5"
-
-#~ msgid "0.005"
-#~ msgstr "0.005"
 
 #~ msgid "active"
 #~ msgstr "활성화"
@@ -18633,9 +18577,6 @@ msgstr ""
 
 #~ msgid "Failed to fetching model information from printer."
 #~ msgstr "프린터에서 모델 정보를 가져오지 못했습니다."
-
-#~ msgid "Failed to parse model informations."
-#~ msgstr "모델 정보를 해석하지 못했습니다."
 
 #~ msgid "Connection lost. Please retry."
 #~ msgstr "연결이 끊어졌습니다. 다시 시도해 주세요."
@@ -18752,9 +18693,6 @@ msgstr ""
 #~ "경사진 표면 근처에 꽉찬 내부 채우기를 추가하여 수직 쉘 두께를 보장합니다 "
 #~ "(상단+하단 꽉찬 레이어)"
 
-#~ msgid " "
-#~ msgstr " "
-
 #~ msgid "Text-Rotate"
 #~ msgstr "텍스트 회전"
 
@@ -18792,16 +18730,6 @@ msgstr ""
 
 #~ msgid "wiki"
 #~ msgstr "위키"
-
-#~ msgid ""
-#~ "Relative extrusion is recommended when using \"label_objects\" "
-#~ "option.Some extruders work better with this option unchecked (absolute "
-#~ "extrusion mode). Wipe tower is only compatible with relative mode. It is "
-#~ "always enabled on BambuLab printers. Default is checked"
-#~ msgstr ""
-#~ "상대적 압출은 \"label_objects\" 옵션(기타; 객체 이름표)을 사용할 때 권장됩"
-#~ "니다. 일부 압출기는 이 옵션을 해제하면 더 잘 작동합니다(절대 압출 모드). "
-#~ "닦기 타워는 상대 모드에서만 호환됩니다"
 
 #~ msgid "Movement:"
 #~ msgstr "이동:"
@@ -18868,9 +18796,6 @@ msgstr ""
 
 #~ msgid "Choose SLA archive:"
 #~ msgstr "SLA 압축파일 선택:"
-
-#~ msgid "Import file"
-#~ msgstr "파일 가져오기"
 
 #~ msgid "Import model and profile"
 #~ msgstr "모델과 파일 가져오기"
@@ -18962,9 +18887,6 @@ msgstr ""
 #, c-format, boost-format
 #~ msgid " doesn't work at 100%% density "
 #~ msgstr " 100%% 밀도에서 작동하지 않음 "
-
-#~ msgid "Ctrl + Shift + Enter"
-#~ msgstr "Ctrl + Shift + Enter"
 
 #~ msgid "Tool-Lay on Face"
 #~ msgstr "바닥면 선택 도구"
@@ -19063,15 +18985,6 @@ msgstr ""
 #~ "3D 화면 작업\n"
 #~ "3D 화면에서 마우스와 터치패널로 보기 및 객체/부품 선택을 제어하는 방법을 "
 #~ "알고 있습니까?"
-
-#~ msgid ""
-#~ "Fix Model\n"
-#~ "Did you know that you can fix a corrupted 3D model to avoid a lot of "
-#~ "slicing problems?"
-#~ msgstr ""
-#~ "모델 수리\n"
-#~ "많은 슬라이싱 문제를 피하기 위해 손상된 3D 모델을 수리할 수 있다는 것을 알"
-#~ "고 있습니까?"
 
 #~ msgid ""
 #~ "When need to print with the printer door opened\n"
@@ -19173,9 +19086,6 @@ msgstr ""
 #~ msgid "Calibration of extrusion"
 #~ msgstr "압출 교정"
 
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "새 필라멘트를 압출기에 밀어 넣으세요"
-
 #, c-format, boost-format
 #~ msgid ""
 #~ "Bed temperature of other layer is lower than bed temperature of initial "
@@ -19246,11 +19156,6 @@ msgstr ""
 #~ "지지대 루프는 내부 다리를 공중에서 압출하는 것을 방지하고, 특히 드문 채우"
 #~ "기 밀도가 낮을 때 상단 표면 품질을 향상시킬 수 있습니다. 이 값은 지지대 루"
 #~ "프의 두께를 결정하며 0은 이 기능을 사용하지 않음을 의미합니다"
-
-#, c-format, boost-format
-#~ msgid ""
-#~ "Klipper's max_accel_to_decel will be adjusted to this % of acceleration"
-#~ msgstr "Klipper의 max_accel_to_decel이 이 가속도 % o로 조정됩니다"
 
 #~ msgid ""
 #~ "Style and shape of the support. For normal support, projecting the "

--- a/localization/i18n/lt/OrcaSlicer_lt.po
+++ b/localization/i18n/lt/OrcaSlicer_lt.po
@@ -8875,9 +8875,6 @@ msgid ""
 "objects, it just orientates the selected ones.Otherwise, it will orientates "
 "all objects in the current disk."
 msgstr ""
-"Auto orientates selected objects or all objects.If there are selected "
-"objects, it just orientates the selected ones.Otherwise, it will orientates "
-"all objects in the current disk."
 
 msgid "Shift+Tab"
 msgstr "Shift+Tab"
@@ -9383,8 +9380,6 @@ msgid ""
 "Failed to generate G-code for invalid custom G-code.\n"
 "\n"
 msgstr ""
-"Failed to generate G-code for invalid custom G-code.\n"
-"\n"
 
 msgid "Please check the custom G-code or use the default custom G-code."
 msgstr ""
@@ -18456,9 +18451,6 @@ msgstr ""
 #~ msgctxt "Verb"
 #~ msgid "Scale"
 #~ msgstr "Mastelis"
-
-#~ msgid "Orca Slicer "
-#~ msgstr "Orca Slicer "
 
 #, c-format, boost-format
 #~ msgid "Connect failed [%d]!"

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -1342,8 +1342,6 @@ msgid ""
 "Select 2 points or circles on objects and \n"
 " specify distance between them."
 msgstr ""
-"Select 2 points or circles on objects and \n"
-" specify distance between them."
 
 msgid "Face"
 msgstr "Face"
@@ -1358,53 +1356,51 @@ msgid ""
 "Feature 1 has been reset, \n"
 "feature 2 has been feature 1"
 msgstr ""
-"Feature 1 has been reset, \n"
-"feature 2 has been feature 1"
 
 msgid "Warning:please select Plane's feature."
-msgstr "Warning: please select Plane's feature."
+msgstr ""
 
 msgid "Warning:please select Point's or Circle's feature."
-msgstr "Warning: please select Point's or Circle's feature."
+msgstr ""
 
 msgid "Warning:please select two different mesh."
-msgstr "Warning: please select two different meshes."
+msgstr ""
 
 msgid "Copy to clipboard"
 msgstr "Kopieer naar klembord"
 
 msgid "Perpendicular distance"
-msgstr "Perpendicular distance"
+msgstr ""
 
 msgid "Distance"
-msgstr "Distance"
+msgstr ""
 
 msgid "Direct distance"
-msgstr "Direct distance"
+msgstr ""
 
 msgid "Distance XYZ"
-msgstr "Distance XYZ"
+msgstr ""
 
 msgid "Parallel"
-msgstr "Parallel"
+msgstr ""
 
 msgid "Center coincidence"
-msgstr "Center coincidence"
+msgstr ""
 
 msgid "Featue 1"
 msgstr "Feature 1"
 
 msgid "Reverse rotation"
-msgstr "Reverse rotation"
+msgstr ""
 
 msgid "Rotate around center:"
-msgstr "Rotate around center:"
+msgstr ""
 
 msgid "Parallel distance:"
 msgstr ""
 
 msgid "Flip by Face 2"
-msgstr "Flip by Face 2"
+msgstr ""
 
 msgid "Ctrl+"
 msgstr "Ctrl+"
@@ -1574,7 +1570,7 @@ msgid "new or open project file is not allowed during the slicing process!"
 msgstr "nieuw of geopend projectbestand is niet toegestaan tijdens het slicen!"
 
 msgid "Open Project"
-msgstr "Open project"
+msgstr ""
 
 msgid ""
 "The version of Orca Slicer is too low and needs to be updated to the latest "
@@ -1584,7 +1580,7 @@ msgstr ""
 "nieuwste versie voordat deze normaal kan worden gebruikt"
 
 msgid "Privacy Policy Update"
-msgstr "Privacy Policy Update"
+msgstr ""
 
 msgid ""
 "The number of user presets cached in the cloud has exceeded the upper limit, "
@@ -2157,11 +2153,6 @@ msgid ""
 "To manipulate with solid parts or negative volumes you have to invalidate "
 "cut information first."
 msgstr ""
-"This action will break a cut correspondence.\n"
-"After that, model consistency can't be guaranteed .\n"
-"\n"
-"To manipulate with solid parts or negative volumes you have to invalidate "
-"cut information first."
 
 msgid "Delete all connectors"
 msgstr "Verwijder alle vberbindingen"
@@ -2178,7 +2169,7 @@ msgid "Assembly"
 msgstr "Montage"
 
 msgid "Cut Connectors information"
-msgstr "Cut Connectors information"
+msgstr ""
 
 msgid "Object manipulation"
 msgstr "Objectmanipulatie"
@@ -2278,10 +2269,10 @@ msgid "to"
 msgstr "naar"
 
 msgid "Remove height range"
-msgstr "Remove height range"
+msgstr ""
 
 msgid "Add height range"
-msgstr "Add height range"
+msgstr ""
 
 msgid "Invalid numeric."
 msgstr "Onjuist getal."
@@ -2313,13 +2304,13 @@ msgid "Mouse ear"
 msgstr ""
 
 msgid "Outer brim only"
-msgstr "Outer brim only"
+msgstr ""
 
 msgid "Inner brim only"
-msgstr "Inner brim only"
+msgstr ""
 
 msgid "Outer and inner brim"
-msgstr "Outer and inner brim"
+msgstr ""
 
 msgid "No-brim"
 msgstr "Geen extra rand (brim)"
@@ -2370,13 +2361,13 @@ msgid "Custom"
 msgstr "Aangepast"
 
 msgid "Pause:"
-msgstr "Pause:"
+msgstr ""
 
 msgid "Custom Template:"
-msgstr "Custom Template:"
+msgstr ""
 
 msgid "Custom G-code:"
-msgstr "Custom G-code:"
+msgstr ""
 
 msgid "Custom G-code"
 msgstr "Aangepaste G-code"
@@ -2394,40 +2385,40 @@ msgid "Add Pause"
 msgstr "Pauze toevoegen"
 
 msgid "Insert a pause command at the beginning of this layer."
-msgstr "Insert a pause command at the beginning of this layer."
+msgstr ""
 
 msgid "Add Custom G-code"
 msgstr "Aangepaste G-code toevoegen"
 
 msgid "Insert custom G-code at the beginning of this layer."
-msgstr "Insert custom G-code at the beginning of this layer."
+msgstr ""
 
 msgid "Add Custom Template"
-msgstr "Aangepaste sjabloon toevoegen"
+msgstr ""
 
 msgid "Insert template custom G-code at the beginning of this layer."
-msgstr "Insert template custom G-code at the beginning of this layer."
+msgstr ""
 
 msgid "Filament "
 msgstr "Filament "
 
 msgid "Change filament at the beginning of this layer."
-msgstr "Change filament at the beginning of this layer."
+msgstr ""
 
 msgid "Delete Pause"
 msgstr "Pauze verwijderen"
 
 msgid "Delete Custom Template"
-msgstr "Delete Custom Template"
+msgstr ""
 
 msgid "Edit Custom G-code"
-msgstr "Edit Custom G-code"
+msgstr ""
 
 msgid "Delete Custom G-code"
-msgstr "Delete Custom G-code"
+msgstr ""
 
 msgid "Delete Filament Change"
-msgstr "Delete Filament Change"
+msgstr ""
 
 msgid "No printer"
 msgstr "Geen printer"
@@ -2439,25 +2430,25 @@ msgid "Failed to connect to the server"
 msgstr "Verbinding maken met de server is mislukt"
 
 msgid "Check the status of current system services"
-msgstr "Check the status of current system services"
+msgstr ""
 
 msgid "code"
-msgstr "code"
+msgstr ""
 
 msgid "Failed to connect to cloud service"
-msgstr "Failed to connect to cloud service"
+msgstr ""
 
 msgid "Please click on the hyperlink above to view the cloud service status"
-msgstr "Please click on the hyperlink above to view the cloud service status"
+msgstr ""
 
 msgid "Failed to connect to the printer"
 msgstr "Verbinding maken met de printer is mislukt"
 
 msgid "Connection to printer failed"
-msgstr "Connection to printer failed"
+msgstr ""
 
 msgid "Please check the network connection of the printer and Orca."
-msgstr "Please check the network connection of the printer and Orca."
+msgstr ""
 
 msgid "Connecting..."
 msgstr "Verbinden..."
@@ -2475,13 +2466,13 @@ msgid "AMS"
 msgstr "AMS"
 
 msgid "Auto Refill"
-msgstr "Auto Refill"
+msgstr ""
 
 msgid "AMS not connected"
 msgstr "AMS niet aangesloten"
 
 msgid "Load"
-msgstr "Load"
+msgstr ""
 
 msgid "Unload"
 msgstr "Lossen"
@@ -2540,7 +2531,7 @@ msgid "Check filament location"
 msgstr "Controleer de positie van het filament"
 
 msgid "Grab new filament"
-msgstr "Grab new filament"
+msgstr ""
 
 msgid ""
 "Choose an AMS slot then press \"Load\" or \"Unload\" button to automatically "
@@ -2630,10 +2621,10 @@ msgid "Filling"
 msgstr "Vullen"
 
 msgid "Bed filling canceled."
-msgstr "Bed filling canceled."
+msgstr ""
 
 msgid "Bed filling done."
-msgstr "Bed filling done."
+msgstr ""
 
 msgid "Searching for optimal orientation"
 msgstr "Zoeken naar optimale oriëntatie"
@@ -2657,52 +2648,44 @@ msgid "Abnormal print file data. Please slice again."
 msgstr "Abnormal print file data: please slice again."
 
 msgid "Task canceled."
-msgstr "Task canceled."
+msgstr ""
 
 msgid "Upload task timed out. Please check the network status and try again."
-msgstr "Upload task timed out. Please check the network status and try again."
+msgstr ""
 
 msgid "Cloud service connection failed. Please try again."
 msgstr "Verbinding met cloudservice is mislukt. Probeer het nog eens."
 
 msgid "Print file not found. please slice again."
-msgstr "Print file not found; please slice again."
+msgstr ""
 
 msgid ""
 "The print file exceeds the maximum allowable size (1GB). Please simplify the "
 "model and slice again."
 msgstr ""
-"The print file exceeds the maximum allowable size (1GB). Please simplify the "
-"model and slice again."
 
 msgid "Failed to send the print job. Please try again."
 msgstr "Het verzenden van de printopdracht is mislukt. Probeer het opnieuw."
 
 msgid "Failed to upload file to ftp. Please try again."
-msgstr "Failed to upload file to ftp. Please try again."
+msgstr ""
 
 msgid ""
 "Check the current status of the bambu server by clicking on the link above."
 msgstr ""
-"Check the current status of the Bambu Lab server by clicking on the link "
-"above."
 
 msgid ""
 "The size of the print file is too large. Please adjust the file size and try "
 "again."
 msgstr ""
-"The size of the print file is too large. Please adjust the file size and try "
-"again."
 
 msgid "Print file not found, Please slice it again and send it for printing."
-msgstr "Print file not found; please slice it again and send it for printing."
+msgstr ""
 
 msgid ""
 "Failed to upload print file to FTP. Please check the network status and try "
 "again."
 msgstr ""
-"Failed to upload print file via FTP. Please check the network status and try "
-"again."
 
 msgid "Sending print job over LAN"
 msgstr "Printopdracht verzenden via LAN"
@@ -2752,33 +2735,29 @@ msgstr ""
 "wordt gestuurd."
 
 msgid "Importing SLA archive"
-msgstr "Importing SLA archive"
+msgstr ""
 
 msgid ""
 "The SLA archive doesn't contain any presets. Please activate some SLA "
 "printer preset first before importing that SLA archive."
 msgstr ""
-"The SLA archive doesn't contain any presets. Please activate some SLA "
-"printer presets first before importing that SLA archive."
 
 msgid "Importing canceled."
-msgstr "Importing canceled."
+msgstr ""
 
 msgid "Importing done."
-msgstr "Importing done."
+msgstr ""
 
 msgid ""
 "The imported SLA archive did not contain any presets. The current SLA "
 "presets were used as fallback."
 msgstr ""
-"The imported SLA archive did not contain any presets. The current SLA "
-"presets were used as fallback."
 
 msgid "You cannot load SLA project with a multi-part object on the bed"
-msgstr "You cannot load an SLA project with a multi-part object on the bed"
+msgstr ""
 
 msgid "Please check your object list before preset changing."
-msgstr "Please check your object list before preset changing."
+msgstr ""
 
 msgid "Attention!"
 msgstr "Let op!"
@@ -2901,13 +2880,13 @@ msgstr ""
 "ondersteund."
 
 msgid "Setting Virtual slot information while printing is not supported"
-msgstr "Setting Virtual slot information while printing is not supported"
+msgstr ""
 
 msgid "Are you sure you want to clear the filament information?"
-msgstr "Are you sure you want to clear the filament information?"
+msgstr ""
 
 msgid "You need to select the material type and color first."
-msgstr "You need to select the material type and color first."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Please input a valid value (K in %.1f~%.1f)"
@@ -2918,13 +2897,13 @@ msgid "Please input a valid value (K in %.1f~%.1f, N in %.1f~%.1f)"
 msgstr ""
 
 msgid "Other Color"
-msgstr "Other Color"
+msgstr ""
 
 msgid "Custom Color"
-msgstr "Custom Color"
+msgstr ""
 
 msgid "Dynamic flow calibration"
-msgstr "Dynamic flow calibration"
+msgstr "Dynamische flow kalibratie"
 
 msgid ""
 "The nozzle temp and max volumetric speed will affect the calibration "
@@ -3031,10 +3010,6 @@ msgid ""
 "desiccant pack is changed. it take hours to absorb the moisture, low "
 "temperatures also slow down the process."
 msgstr ""
-"Please change the desiccant when it is too wet. The indicator may not "
-"represent accurately in following cases: when the lid is open or the "
-"desiccant pack is changed. It takes a few hours to absorb the moisture, and "
-"low temperatures also slow down the process."
 
 msgid ""
 "Config which AMS slot should be used for a filament used in the print job"
@@ -3079,7 +3054,6 @@ msgstr "De printer ondersteunt automatisch bijvullen momenteel niet."
 msgid ""
 "AMS filament backup is not enabled, please enable it in the AMS settings."
 msgstr ""
-"AMS filament backup is not enabled; please enable it in the AMS settings."
 
 msgid ""
 "If there are two identical filaments in AMS, AMS filament backup will be "
@@ -3087,10 +3061,6 @@ msgid ""
 "(Currently supporting automatic supply of consumables with the same brand, "
 "material type, and color)"
 msgstr ""
-"If there are two identical filaments in an AMS, AMS filament backup will be "
-"enabled. \n"
-"(This currently supports automatic supply of consumables with the same "
-"brand, material type, and color)"
 
 msgid "DRY"
 msgstr "DRY"
@@ -3159,7 +3129,7 @@ msgstr ""
 "wordt de resterende capaciteit automatisch bijgewerkt."
 
 msgid "AMS filament backup"
-msgstr "AMS filament backup"
+msgstr ""
 
 msgid ""
 "AMS will continue to another spool with the same properties of filament "
@@ -3169,14 +3139,12 @@ msgstr ""
 "eigenschappen wanneer het huidige filament op is."
 
 msgid "Air Printing Detection"
-msgstr "Air Printing Detection"
+msgstr ""
 
 msgid ""
 "Detects clogging and filament grinding, halting printing immediately to "
 "conserve time and filament."
 msgstr ""
-"Detects clogging and filament grinding, halting printing immediately to "
-"conserve time and filament."
 
 msgid "File"
 msgstr "Bestand"
@@ -3247,19 +3215,19 @@ msgid "Overflow"
 msgstr "Overloop"
 
 msgid "Underflow"
-msgstr "Underflow"
+msgstr "Onderflow"
 
 msgid "Floating reserved operand"
 msgstr "Zwevende gereserveerde operand"
 
 msgid "Stack overflow"
-msgstr "Stack overflow"
+msgstr ""
 
 msgid "Running post-processing scripts"
 msgstr "Het uitvoeren van post-processing scripts"
 
 msgid "Successfully executed post-processing script"
-msgstr "Successfully executed post-processing script"
+msgstr ""
 
 msgid "Unknown error occurred during exporting G-code."
 msgstr "Onbekende fout opgetreden tijdens exporteren van de G-code."
@@ -3337,10 +3305,10 @@ msgid "Device"
 msgstr "Apparaat"
 
 msgid "Task Sending"
-msgstr "Task Sending"
+msgstr ""
 
 msgid "Task Sent"
-msgstr "Task Sent"
+msgstr ""
 
 msgid "Edit multiple printers"
 msgstr ""
@@ -3372,16 +3340,16 @@ msgid "Edit Printers"
 msgstr ""
 
 msgid "Device Name"
-msgstr "Device Name"
+msgstr ""
 
 msgid "Task Name"
-msgstr "Task Name"
+msgstr ""
 
 msgid "Device Status"
-msgstr "Device Status"
+msgstr ""
 
 msgid "Actions"
-msgstr "Actions"
+msgstr ""
 
 msgid ""
 "Please select the devices you would like to manage here (up to 6 devices)"
@@ -3400,7 +3368,7 @@ msgid "Upgrading"
 msgstr ""
 
 msgid "Incompatible"
-msgstr "Incompatible"
+msgstr ""
 
 msgid "syncing"
 msgstr ""
@@ -3448,28 +3416,28 @@ msgid "Resume"
 msgstr "Hervatten"
 
 msgid "Stop"
-msgstr "Stop"
+msgstr ""
 
 msgid "Task Status"
-msgstr "Task Status"
+msgstr ""
 
 msgid "Sent Time"
-msgstr "Sent Time"
+msgstr ""
 
 msgid "There are no tasks to be sent!"
-msgstr "There are no tasks to be sent!"
+msgstr ""
 
 msgid "No historical tasks!"
-msgstr "No historical tasks!"
+msgstr ""
 
 msgid "Loading..."
 msgstr "Laden..."
 
 msgid "No AMS"
-msgstr "No AMS"
+msgstr ""
 
 msgid "Send to Multi-device"
-msgstr "Send to Multi-device"
+msgstr ""
 
 msgid "Preparing print job"
 msgstr "Print opdracht voorbereiden"
@@ -3484,22 +3452,22 @@ msgid "The number of printers in use simultaneously cannot be equal to 0."
 msgstr ""
 
 msgid "Use External Spool"
-msgstr "Use External Spool"
+msgstr ""
 
 msgid "Use AMS"
-msgstr "Use AMS"
+msgstr ""
 
 msgid "Select Printers"
-msgstr "Select Printers"
+msgstr ""
 
 msgid "Ams Status"
-msgstr "AMS Status"
+msgstr ""
 
 msgid "Printing Options"
-msgstr "Printing Options"
+msgstr ""
 
 msgid "Bed Leveling"
-msgstr "Bed leveling"
+msgstr ""
 
 msgid "Timelapse"
 msgstr "Timelapse"
@@ -3508,7 +3476,7 @@ msgid "Flow Dynamic Calibration"
 msgstr ""
 
 msgid "Send Options"
-msgstr "Send Options"
+msgstr ""
 
 msgid "Send to"
 msgstr ""
@@ -3517,16 +3485,13 @@ msgid ""
 "printers at the same time.(It depends on how many devices can undergo "
 "heating at the same time.)"
 msgstr ""
-"printers at the same time. (It depends on how many devices can undergo "
-"heating at the same time.)"
 
 msgid "Wait"
-msgstr "Wait"
+msgstr ""
 
 msgid ""
 "minute each batch.(It depends on how long it takes to complete the heating.)"
 msgstr ""
-"minute each batch. (It depends on how long it takes to complete heating.)"
 
 msgid "Send"
 msgstr "Versturen"
@@ -3550,7 +3515,7 @@ msgid "The name is not allowed to end with space character."
 msgstr "Het is niet toegestaan om een naam met een spatie te laten eindigen."
 
 msgid "The name length exceeds the limit."
-msgstr "The name length exceeds the limit."
+msgstr ""
 
 msgid "Origin"
 msgstr "Begin"
@@ -3636,8 +3601,6 @@ msgid ""
 "The recommended minimum temperature cannot be higher than the recommended "
 "maximum temperature.\n"
 msgstr ""
-"The recommended minimum temperature cannot be higher than the recommended "
-"maximum temperature.\n"
 
 msgid "Please check.\n"
 msgstr "Controleer het.\n"
@@ -3787,8 +3750,6 @@ msgid ""
 "Spiral mode only works when wall loops is 1, support is disabled, top shell "
 "layers is 0, sparse infill density is 0 and timelapse type is traditional."
 msgstr ""
-"Spiral mode only works when wall loops is 1, support is disabled, top shell "
-"layers is 0, sparse infill density is 0 and timelapse type is traditional."
 
 msgid " But machines with I3 structure will not generate timelapse videos."
 msgstr " Maar machines met een I3-structuur genereren geen timelapsevideo's."
@@ -3809,7 +3770,7 @@ msgid "Heatbed preheating"
 msgstr "Printbed opwarmen"
 
 msgid "Sweeping XY mech mode"
-msgstr "Sweeping XY mech mode"
+msgstr ""
 
 msgid "Changing filament"
 msgstr "Filament wordt gewisseld"
@@ -3937,27 +3898,18 @@ msgid ""
 "45℃.In order to avoid extruder clogging,low temperature filament(PLA/PETG/"
 "TPU) is not allowed to be loaded."
 msgstr ""
-"The current chamber temperature or the target chamber temperature exceeds "
-"45℃. In order to avoid extruder clogging, low temperature filament (PLA/PETG/"
-"TPU) is not allowed to be loaded."
 
 msgid ""
 "Low temperature filament(PLA/PETG/TPU) is loaded in the extruder.In order to "
 "avoid extruder clogging,it is not allowed to set the chamber temperature "
 "above 45℃."
 msgstr ""
-"Low temperature filament (PLA/PETG/TPU) is loaded in the extruder. In order "
-"to avoid extruder clogging, it is not allowed to set the chamber temperature "
-"above 45℃."
 
 msgid ""
 "When you set the chamber temperature below 40℃, the chamber temperature "
 "control will not be activated. And the target chamber temperature will "
 "automatically be set to 0℃."
 msgstr ""
-"When you set the chamber temperature below 40℃, the chamber temperature "
-"control will not be activated, and the target chamber temperature will "
-"automatically be set to 0℃."
 
 msgid "Failed to start print job"
 msgstr "Het starten van de printopdracht is mislukt"
@@ -4050,7 +4002,7 @@ msgid "Specific for %1%"
 msgstr ""
 
 msgid "Presets"
-msgstr "Presets"
+msgstr ""
 
 msgid "Print settings"
 msgstr "Print instellingen"
@@ -4080,7 +4032,7 @@ msgstr "Parametervalidatie"
 
 #, c-format, boost-format
 msgid "Value %s is out of range. The valid range is from %d to %d."
-msgstr "Value %s is out of range. The valid range is from %d to %d."
+msgstr ""
 
 msgid "Value is out of range."
 msgstr "Waarde is buiten het bereik."
@@ -4167,7 +4119,7 @@ msgid "Generating geometry index data"
 msgstr "Geometrie-indexgegevens genereren"
 
 msgid "Statistics of All Plates"
-msgstr "Statistics of All Plates"
+msgstr ""
 
 msgid "Display"
 msgstr "Tonen"
@@ -4188,7 +4140,7 @@ msgid "Total time"
 msgstr "Totale tijd"
 
 msgid "Total cost"
-msgstr "Total cost"
+msgstr ""
 
 msgid "up to"
 msgstr "tot"
@@ -4281,10 +4233,10 @@ msgid "Normal mode"
 msgstr "Normale modus"
 
 msgid "Total Filament"
-msgstr "Total Filament"
+msgstr ""
 
 msgid "Model Filament"
-msgstr "Model Filament"
+msgstr ""
 
 msgid "Prepare time"
 msgstr "Voorbereidingstijd"
@@ -4356,7 +4308,7 @@ msgid "Tool Move"
 msgstr "Beweeg tool"
 
 msgid "Tool Rotate"
-msgstr "Tool Rotate"
+msgstr ""
 
 msgid "Move Object"
 msgstr "Beweeg object"
@@ -4380,7 +4332,7 @@ msgid "Spacing"
 msgstr "Uitlijning"
 
 msgid "0 means auto spacing."
-msgstr "0 means auto spacing."
+msgstr ""
 
 msgid "Auto rotate for arrangement"
 msgstr "Automatisch roteren voor rankschikking"
@@ -4483,7 +4435,7 @@ msgid "Micro lidar calibration"
 msgstr "Micro Lidar Kalibratie"
 
 msgid "Bed leveling"
-msgstr "Bed leveling"
+msgstr ""
 
 msgid "Vibration compensation"
 msgstr "Trillingscompensatie"
@@ -4595,7 +4547,7 @@ msgid "No"
 msgstr "Nee"
 
 msgid "will be closed before creating a new model. Do you want to continue?"
-msgstr "will be closed before creating a new model. Do you want to continue?"
+msgstr ""
 
 msgid "Slice plate"
 msgstr "Slice printbed"
@@ -4876,10 +4828,10 @@ msgid "Show object labels in 3D scene"
 msgstr "Toon objectlabels in 3D-scène"
 
 msgid "Show &Overhang"
-msgstr "Show &Overhang"
+msgstr ""
 
 msgid "Show object overhang highlight in 3D scene"
-msgstr "Show object overhang highlight in 3D scene"
+msgstr ""
 
 msgid "Show Selected Outline (beta)"
 msgstr ""
@@ -4891,7 +4843,7 @@ msgid "Preferences"
 msgstr "Voorkeuren"
 
 msgid "Help"
-msgstr "Help"
+msgstr "Hulp"
 
 msgid "Temperature Calibration"
 msgstr "Temperatuurkalibratie"
@@ -4930,7 +4882,7 @@ msgid "Retraction test"
 msgstr "Retractietest"
 
 msgid "Orca Tolerance Test"
-msgstr "Orca Tolerance Test"
+msgstr ""
 
 msgid "Max flowrate"
 msgstr "Max flowrate"
@@ -4988,7 +4940,7 @@ msgid "&View"
 msgstr "&Bekijken"
 
 msgid "&Help"
-msgstr "&Help"
+msgstr "&Hulp"
 
 #, c-format, boost-format
 msgid "A file exists with the same name: %s, do you want to overwrite it?"
@@ -5020,7 +4972,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Export result"
-msgstr "Export resultaat"
+msgstr "Exporteer resultaat"
 
 msgid "Select profile to load:"
 msgstr "Selecteer het te laden profiel:"
@@ -5098,7 +5050,6 @@ msgstr ""
 msgid ""
 "LAN Only Liveview is off. Please turn on the liveview on printer screen."
 msgstr ""
-"LAN Only Liveview is off. Please turn on the liveview on printer screen."
 
 msgid "Please enter the IP of printer to connect."
 msgstr "Voer het IP-adres in van de printer waarmee u verbinding wilt maken."
@@ -5185,7 +5136,7 @@ msgid "Switch to video files."
 msgstr "Schakel over naar videobestanden."
 
 msgid "Switch to 3mf model files."
-msgstr "Switch to 3mf model files."
+msgstr ""
 
 msgid "Delete selected files from printer."
 msgstr "Verwijder geselecteerde bestanden van de printer."
@@ -5206,7 +5157,7 @@ msgid "Refresh"
 msgstr "Vernieuwen"
 
 msgid "Reload file list from printer."
-msgstr "Reload file list from printer."
+msgstr ""
 
 msgid "No printers."
 msgstr "Geen printers."
@@ -5218,14 +5169,12 @@ msgid "No files"
 msgstr "Geen bestanden"
 
 msgid "Load failed"
-msgstr "Load failed"
+msgstr ""
 
 msgid ""
 "Browsing file in SD card is not supported in current firmware. Please update "
 "the printer firmware."
 msgstr ""
-"Browsing file in SD card is not supported in current firmware. Please update "
-"the printer firmware."
 
 msgid ""
 "Please check if the SD card is inserted into the printer.\n"
@@ -5236,10 +5185,10 @@ msgstr ""
 "formatteren."
 
 msgid "LAN Connection Failed (Failed to view sdcard)"
-msgstr "LAN Connection Failed (Failed to view sdcard)"
+msgstr ""
 
 msgid "Browsing file in SD card is not supported in LAN Only Mode."
-msgstr "Browsing file in SD card is not supported in LAN Only Mode."
+msgstr ""
 
 #, c-format, boost-format
 msgid "You are going to delete %u file from printer. Are you sure to continue?"
@@ -5249,17 +5198,17 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Delete files"
-msgstr "Delete files"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Do you want to delete the file '%s' from printer?"
-msgstr "Do you want to delete the file '%s' from printer?"
+msgstr ""
 
 msgid "Delete file"
-msgstr "Delete file"
+msgstr ""
 
 msgid "Fetching model information..."
-msgstr "Fetching model information..."
+msgstr ""
 
 msgid "Failed to fetch model information from printer."
 msgstr "Mislukt bij het ophalen van modelgegevens van de printer."
@@ -5281,8 +5230,6 @@ msgid ""
 "File: %s\n"
 "Title: %s\n"
 msgstr ""
-"File: %s\n"
-"Title: %s\n"
 
 msgid "Download waiting..."
 msgstr "Download wacht..."
@@ -5304,8 +5251,6 @@ msgid ""
 "Reconnecting the printer, the operation cannot be completed immediately, "
 "please try again later."
 msgstr ""
-"Reconnecting the printer, the operation cannot be completed immediately, "
-"please try again later."
 
 msgid "File does not exist."
 msgstr "Bestand bestaat niet."
@@ -5369,7 +5314,7 @@ msgid "0"
 msgstr "0"
 
 msgid "Layer: N/A"
-msgstr "Layer: N/A"
+msgstr ""
 
 msgid "Clear"
 msgstr "Wissen"
@@ -5378,8 +5323,6 @@ msgid ""
 "You have completed printing the mall model, \n"
 "but the synchronization of rating information has failed."
 msgstr ""
-"You have completed printing the mall model, \n"
-"but synchronizing rating information has failed."
 
 msgid "How do you like this printing file?"
 msgstr "Wat vind je van dit afdrukbestand?"
@@ -5410,7 +5353,7 @@ msgid "Control"
 msgstr "Besturing"
 
 msgid "Printer Parts"
-msgstr "Printer Parts"
+msgstr ""
 
 msgid "Print Options"
 msgstr "Print Opties"
@@ -5449,19 +5392,19 @@ msgid "Downloading..."
 msgstr "Downloaden..."
 
 msgid "Cloud Slicing..."
-msgstr "Cloud Slicing..."
+msgstr ""
 
 #, c-format, boost-format
 msgid "In Cloud Slicing Queue, there are %s tasks ahead."
-msgstr "In Cloud Slicing Queue, there are %s tasks ahead of you."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Layer: %s"
-msgstr "Layer: %s"
+msgstr ""
 
 #, c-format, boost-format
 msgid "Layer: %d/%d"
-msgstr "Layer: %d/%d"
+msgstr ""
 
 msgid ""
 "Please heat the nozzle to above 170 degree before loading or unloading "
@@ -5499,7 +5442,7 @@ msgid "Sport"
 msgstr "Sport"
 
 msgid "Ludicrous"
-msgstr "Ludicrous"
+msgstr ""
 
 msgid "Can't start this without SD card."
 msgstr "Kan niet starten zonder microSD-kaart."
@@ -5532,7 +5475,7 @@ msgid "Get oss config failed."
 msgstr "Het ophalen van de oss-configuratie is mislukt."
 
 msgid "Upload Pictures"
-msgstr "Upload Pictures"
+msgstr ""
 
 msgid "Number of images successfully uploaded"
 msgstr "Aantal afbeeldingen succesvol geüpload"
@@ -5547,7 +5490,7 @@ msgid " No corresponding storage bucket\n"
 msgstr " Geen bijbehorende opslag bucket\n"
 
 msgid " cannot be opened\n"
-msgstr " cannot be opened\n"
+msgstr ""
 
 msgid ""
 "The following issues occurred during the process of uploading images. Do you "
@@ -5577,9 +5520,6 @@ msgid ""
 "\n"
 "  error code: "
 msgstr ""
-"Your comment result cannot be uploaded due to the following reasons:\n"
-"\n"
-"  error code: "
 
 msgid "error message: "
 msgstr "foutmelding: "
@@ -5589,9 +5529,6 @@ msgid ""
 "\n"
 "Would you like to redirect to the webpage for rating?"
 msgstr ""
-"\n"
-"\n"
-"Would you like to redirect to the webpage to give a rating?"
 
 msgid ""
 "Some of your images failed to upload. Would you like to redirect to the "
@@ -5673,7 +5610,7 @@ msgid "Latest Version: "
 msgstr "Laatste versie: "
 
 msgid "Not for now"
-msgstr "Not for now"
+msgstr ""
 
 msgid "Server Exception"
 msgstr ""
@@ -5740,7 +5677,7 @@ msgid "Open Folder."
 msgstr "Open bestandsmap."
 
 msgid "Safely remove hardware."
-msgstr "Safely remove hardware."
+msgstr ""
 
 #, c-format, boost-format
 msgid "%1$d Object has custom supports."
@@ -5820,7 +5757,7 @@ msgid "Color painting"
 msgstr "Kleur aanbrengen"
 
 msgid "Cut connectors"
-msgstr "Cut connectors"
+msgstr ""
 
 msgid "Layers"
 msgstr "Lagen"
@@ -5887,7 +5824,7 @@ msgid "Allow Prompt Sound"
 msgstr "Promptgeluid toestaan"
 
 msgid "Filament Tangle Detect"
-msgstr "Filament Tangle Detection"
+msgstr ""
 
 msgid "Nozzle Clumping Detection"
 msgstr "Detectie van klontvorming in mondstuk"
@@ -6030,8 +5967,6 @@ msgid ""
 "Already did a synchronization, do you want to sync only changes or resync "
 "all?"
 msgstr ""
-"Already did a synchronization; do you want to sync only changes or resync "
-"all?"
 
 msgid "Sync"
 msgstr "Sync"
@@ -6136,10 +6071,10 @@ msgstr ""
 "software te upgraden."
 
 msgid "Invalid values found in the 3mf:"
-msgstr "Invalid values found in the 3mf:"
+msgstr ""
 
 msgid "Please correct them in the param tabs"
-msgstr "Please correct them in the Param tabs"
+msgstr ""
 
 msgid "The 3mf has following modified G-codes in filament or printer presets:"
 msgstr ""
@@ -6178,7 +6113,7 @@ msgstr ""
 "verschijnen!"
 
 msgid "Remember my choice."
-msgstr "Remember my choice."
+msgstr ""
 
 #, boost-format
 msgid "Failed loading file \"%1%\". An invalid configuration was found."
@@ -6253,23 +6188,18 @@ msgid ""
 "The file %s already exists\n"
 "Do you want to replace it?"
 msgstr ""
-"The file %s already exists.\n"
-"Do you want to replace it?"
 
 msgid "Confirm Save As"
 msgstr "Opslaan als bevestigen"
 
 msgid "Delete object which is a part of cut object"
-msgstr "Delete object which is a part of cut object"
+msgstr ""
 
 msgid ""
 "You try to delete an object which is a part of a cut object.\n"
 "This action will break a cut correspondence.\n"
 "After that model consistency can't be guaranteed."
 msgstr ""
-"You are trying to delete an object which is a part of a cut object.\n"
-"This action will break a cut correspondence.\n"
-"After that, model consistency can't be guaranteed."
 
 msgid "The selected object couldn't be split."
 msgstr "Het geselecteerde object kan niet opgesplitst worden."
@@ -6373,13 +6303,13 @@ msgid "prepare 3mf file..."
 msgstr "voorbereiden van 3mf bestand..."
 
 msgid "Download failed, unknown file format."
-msgstr "Download failed; unknown file format."
+msgstr ""
 
 msgid "downloading project ..."
 msgstr "project downloaden..."
 
 msgid "Download failed, File size exception."
-msgstr "Download failed; File size exception."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Project downloaded %d%%"
@@ -6503,31 +6433,27 @@ msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
 "will be kept. You may fix the meshes and try again."
 msgstr ""
-"Unable to perform boolean operation on model meshes. Only positive parts "
-"will be kept. You may fix the meshes and try again."
 
 #, boost-format
 msgid "Reason: part \"%1%\" is empty."
-msgstr "Reason: part \"%1%\" is empty."
+msgstr ""
 
 #, boost-format
 msgid "Reason: part \"%1%\" does not bound a volume."
-msgstr "Reason: part \"%1%\" does not bound a volume."
+msgstr ""
 
 #, boost-format
 msgid "Reason: part \"%1%\" has self intersection."
-msgstr "Reason: part \"%1%\" has self intersection."
+msgstr ""
 
 #, boost-format
 msgid "Reason: \"%1%\" and another part have no intersection."
-msgstr "Reason: \"%1%\" and another part have no intersection."
+msgstr ""
 
 msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
 "will be exported."
 msgstr ""
-"Unable to perform boolean operation on model meshes. Only positive parts "
-"will be exported."
 
 msgid ""
 "Are you sure you want to store original SVGs with their local paths into the "
@@ -6569,11 +6495,11 @@ msgid "Invalid number"
 msgstr "Ongeldig nummer"
 
 msgid "Plate Settings"
-msgstr "Plate Settings"
+msgstr ""
 
 #, boost-format
 msgid "Number of currently selected parts: %1%\n"
-msgstr "Number of currently selected parts: %1%\n"
+msgstr ""
 
 #, boost-format
 msgid "Number of currently selected objects: %1%\n"
@@ -6840,8 +6766,6 @@ msgid ""
 "With this option enabled, you can send a task to multiple devices at the "
 "same time and manage multiple devices."
 msgstr ""
-"With this option enabled, you can send a task to multiple devices at the "
-"same time and manage multiple devices."
 
 msgid "Auto arrange plate after cloning"
 msgstr "Plaat automatisch rangschikken na het klonen"
@@ -6948,7 +6872,7 @@ msgid "The period of backup in seconds."
 msgstr "De periode van de back-up in seconden."
 
 msgid "Downloads"
-msgstr "Downloads"
+msgstr ""
 
 msgid "Dark Mode"
 msgstr "Donkere modus"
@@ -6999,16 +6923,16 @@ msgid "Mouse wheel reverses when zooming"
 msgstr "Omgekeerde scrollrichting tijdens het zoomen"
 
 msgid "Enable SSL(MQTT)"
-msgstr "Enable SSL(MQTT)"
+msgstr ""
 
 msgid "Enable SSL(FTP)"
-msgstr "Enable SSL(FTP)"
+msgstr ""
 
 msgid "Internal developer mode"
-msgstr "Internal developer mode"
+msgstr ""
 
 msgid "Log Level"
-msgstr "Log level"
+msgstr ""
 
 msgid "fatal"
 msgstr "fataal"
@@ -7068,7 +6992,7 @@ msgid "Click to select filament color"
 msgstr "Klik om de filament kleur te kiezen"
 
 msgid "Please choose the filament color"
-msgstr "Please choose the filament color"
+msgstr ""
 
 msgid "Add/Remove presets"
 msgstr "Voorinstellingen toevoegen/verwijderen"
@@ -7095,7 +7019,7 @@ msgid "The selected preset is null!"
 msgstr "De geselecteerde preset is nul!"
 
 msgid "End"
-msgstr "End"
+msgstr ""
 
 msgid "Customize"
 msgstr "Aanpassen"
@@ -7110,7 +7034,7 @@ msgid "Plate name"
 msgstr "Plaat naam"
 
 msgid "Same as Global Print Sequence"
-msgstr "Same as Global Print Sequence"
+msgstr ""
 
 msgid "Print sequence"
 msgstr "Afdrukvolgorde"
@@ -7128,7 +7052,7 @@ msgid "First layer filament sequence"
 msgstr "Eerste laag filamentvolgorde"
 
 msgid "Same as Global Plate Type"
-msgstr "Same as Global Plate Type"
+msgstr ""
 
 msgid "Same as Global Bed Type"
 msgstr "Hetzelfde als Global Bed Type"
@@ -7301,7 +7225,7 @@ msgid "send completed"
 msgstr "versturen gelukt"
 
 msgid "Error code"
-msgstr "Error code"
+msgstr ""
 
 msgid "No login account, only printers in LAN mode are displayed"
 msgstr "Geen login-account, alleen printers in LAN-modus worden weergegeven"
@@ -7388,8 +7312,6 @@ msgid ""
 "The selected printer (%s) is incompatible with the chosen printer profile in "
 "the slicer (%s)."
 msgstr ""
-"The selected printer (%s) is incompatible with the chosen printer profile in "
-"the slicer (%s)."
 
 msgid "An SD card needs to be inserted to record timelapse."
 msgstr ""
@@ -7413,8 +7335,6 @@ msgid ""
 "When enable spiral vase mode, machines with I3 structure will not generate "
 "timelapse videos."
 msgstr ""
-"When spiral vase mode is enabled, machines with I3 structure will not "
-"generate timelapse videos."
 
 msgid ""
 "Timelapse is not supported because Print sequence is set to \"By object\"."
@@ -7433,9 +7353,6 @@ msgid ""
 "currently selected printer. It is recommended that you use the same printer "
 "type for slicing."
 msgstr ""
-"The printer type selected when generating G-code is not consistent with the "
-"currently selected printer. It is recommended that you use the same printer "
-"type for slicing."
 
 msgid ""
 "There are some unknown filaments in the AMS mappings. Please check whether "
@@ -7472,12 +7389,11 @@ msgstr ""
 "schade aan het mondstuk veroorzaken"
 
 msgid "Please fix the error above, otherwise printing cannot continue."
-msgstr "Please fix the error above, otherwise printing cannot continue."
+msgstr ""
 
 msgid ""
 "Please click the confirm button if you still want to proceed with printing."
 msgstr ""
-"Please click the confirm button if you still want to proceed with printing."
 
 msgid ""
 "Connecting to the printer. Unable to cancel during the connection process."
@@ -7492,7 +7408,7 @@ msgstr ""
 "mislukken vanwege het verstrooide oppervlak."
 
 msgid "Automatic flow calibration using Micro Lidar"
-msgstr "Automatic flow calibration using the Micro Lidar"
+msgstr ""
 
 msgid "Modifying the device name"
 msgstr "De naam van het apparaat wijzigen"
@@ -7516,7 +7432,6 @@ msgstr ""
 
 msgid "An SD card needs to be inserted before send to printer SD card."
 msgstr ""
-"A MicroSD card needs to be inserted before sending to the printer SD card."
 
 msgid "The printer is required to be in the same LAN as Orca Slicer."
 msgstr "De printer moet zich in hetzelfde LAN bevinden als Orca Slicer."
@@ -7573,7 +7488,7 @@ msgid "Pin Code"
 msgstr "Pincode"
 
 msgid "Binding..."
-msgstr "Binding..."
+msgstr ""
 
 msgid "Please confirm on the printer screen"
 msgstr "Bevestig dit op het printerscherm"
@@ -7603,11 +7518,6 @@ msgid ""
 "Use(collectively, the \"Terms\"). If you do not comply with or agree to the "
 "Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services."
 msgstr ""
-"Thank you for purchasing a Bambu Lab device. Before using your Bambu Lab "
-"device, please read the terms and conditions. By clicking to agree to use "
-"your Bambu Lab device, you agree to abide by the Privacy Policy and Terms of "
-"Use (collectively, the \"Terms\"). If you do not comply with or agree to the "
-"Bambu Lab Privacy Policy, please do not use Bambu Lab equipment and services."
 
 msgid "and"
 msgstr "en"
@@ -7616,10 +7526,10 @@ msgid "Privacy Policy"
 msgstr "Privacybeleid"
 
 msgid "We ask for your help to improve everyone's printer"
-msgstr "We ask for your help to improve everyone's printer"
+msgstr ""
 
 msgid "Statement about User Experience Improvement Program"
-msgstr "Statement about User Experience Improvement Program"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
@@ -7635,20 +7545,9 @@ msgid ""
 "payment information, or phone numbers. By enabling this service, you agree "
 "to these terms and the statement about Privacy Policy."
 msgstr ""
-"In the 3D Printing community, we learn from each other's successes and "
-"failures to adjust our own slicing parameters and settings. %s follows the "
-"same principle and uses machine learning to improve its performance from the "
-"successes and failures of the vast number of prints by our users. We are "
-"training %s to be smarter by feeding them the real-world data. If you are "
-"willing, this service will access information from your error logs and usage "
-"logs, which may include information described in  Privacy Policy. We will "
-"not collect any Personal Data by which an individual can be identified "
-"directly or indirectly, including without limitation names, addresses, "
-"payment information, or phone numbers. By enabling this service, you agree "
-"to these terms and the statement about Privacy Policy."
 
 msgid "Statement on User Experience Improvement Plan"
-msgstr "Statement on User Experience Improvement Plan"
+msgstr ""
 
 msgid "Log in successful."
 msgstr "Inloggen gelukt."
@@ -7711,10 +7610,6 @@ msgid ""
 "0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
 "disable independent support layer height"
 msgstr ""
-"When using support material for the support interface, We recommend the "
-"following settings:\n"
-"0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
-"disable independent support layer height"
 
 msgid ""
 "Change these settings automatically? \n"
@@ -8427,14 +8322,12 @@ msgstr ""
 
 #, boost-format
 msgid "You have changed some settings of preset \"%1%\"."
-msgstr "You have changed some settings of preset \"%1%\"."
+msgstr ""
 
 msgid ""
 "\n"
 "You can save or discard the preset values you have modified."
 msgstr ""
-"\n"
-"You can save or discard the preset values you have modified."
 
 msgid ""
 "\n"
@@ -8443,7 +8336,7 @@ msgid ""
 msgstr ""
 
 msgid "You have previously modified your settings."
-msgstr "You have previously modified your settings."
+msgstr ""
 
 msgid ""
 "\n"
@@ -8464,7 +8357,7 @@ msgid "Show all presets (including incompatible)"
 msgstr "Toon alle presets (inclusief incompatibele)"
 
 msgid "Select presets to compare"
-msgstr "Select presets to compare"
+msgstr ""
 
 msgid ""
 "You can only transfer to current active profile because it has been modified."
@@ -8557,67 +8450,63 @@ msgstr ""
 "Studio."
 
 msgid "Configuration updates"
-msgstr "Configuratie updates"
+msgstr ""
 
 msgid "No updates available."
-msgstr "Geen updates beschikbaar."
+msgstr ""
 
 msgid "The configuration is up to date."
-msgstr "De configuratie is up to date."
+msgstr ""
 
 msgid "Obj file Import color"
-msgstr "Obj file Import color"
+msgstr ""
 
 msgid "Specify number of colors:"
-msgstr "Specify number of colors:"
+msgstr ""
 
 #, c-format, boost-format
 msgid "The color count should be in range [%d, %d]."
-msgstr "The color count should be in range [%d, %d]."
+msgstr ""
 
 msgid "Recommended "
-msgstr "Recommended "
+msgstr ""
 
 msgid "Current filament colors:"
-msgstr "Current filament colors:"
+msgstr ""
 
 msgid "Quick set:"
-msgstr "Quick set:"
+msgstr ""
 
 msgid "Color match"
-msgstr "Color match"
+msgstr ""
 
 msgid "Approximate color matching."
-msgstr "Approximate color matching."
+msgstr ""
 
 msgid "Append"
-msgstr "Append"
+msgstr ""
 
 msgid "Add consumable extruder after existing extruders."
-msgstr "Add consumable extruder after existing extruders."
+msgstr ""
 
 msgid "Reset mapped extruders."
-msgstr "Reset mapped extruders."
+msgstr ""
 
 msgid "Cluster colors"
-msgstr "Cluster colors"
+msgstr ""
 
 msgid "Map Filament"
-msgstr "Map Filament"
+msgstr ""
 
 msgid ""
 "Note:The color has been selected, you can choose OK \n"
 " to continue or manually adjust it."
 msgstr ""
-"Note:The color has been selected, you can choose OK \n"
-" to continue or manually adjust it."
 
 msgid ""
 "Waring:The count of newly added and \n"
 " current extruders exceeds 16."
 msgstr ""
-"Warning: The count of newly added and \n"
-" current extruders exceeds 16."
 
 msgid "Ramming customization"
 msgstr "Ramming aanpassen"
@@ -8751,7 +8640,7 @@ msgid "Objects list"
 msgstr "Object lijst"
 
 msgid "Import geometry data from STL/STEP/3MF/OBJ/AMF files"
-msgstr "Import geometry data from STL/STEP/3MF/OBJ/AMF files"
+msgstr ""
 
 msgid "⌘+Shift+G"
 msgstr "⌘+Shift+G"
@@ -8777,16 +8666,16 @@ msgid "Global shortcuts"
 msgstr "Globale snelkoppelingen"
 
 msgid "Rotate View"
-msgstr "Rotate View"
+msgstr ""
 
 msgid "Pan View"
-msgstr "Pan View"
+msgstr ""
 
 msgid "Mouse wheel"
 msgstr "Muiswiel"
 
 msgid "Zoom View"
-msgstr "Zoom View"
+msgstr ""
 
 msgid "Shift+A"
 msgstr "Shift+A"
@@ -9038,43 +8927,43 @@ msgid "Skip this Version"
 msgstr "Deze versie overslaan"
 
 msgid "Done"
-msgstr "Done"
+msgstr ""
 
 msgid "resume"
-msgstr "resume"
+msgstr ""
 
 msgid "Resume Printing"
-msgstr "Resume Printing"
+msgstr ""
 
 msgid "Resume Printing(defects acceptable)"
-msgstr "Resume Printing (defects acceptable)"
+msgstr ""
 
 msgid "Resume Printing(problem solved)"
-msgstr "Resume Printing (problem solved)"
+msgstr ""
 
 msgid "Stop Printing"
-msgstr "Stop Printing"
+msgstr ""
 
 msgid "Check Assistant"
-msgstr "Check Assistant"
+msgstr ""
 
 msgid "Filament Extruded, Continue"
-msgstr "Filament Extruded, Continue"
+msgstr ""
 
 msgid "Not Extruded Yet, Retry"
-msgstr "Not Extruded Yet, Retry"
+msgstr ""
 
 msgid "Finished, Continue"
-msgstr "Finished, Continue"
+msgstr ""
 
 msgid "Load Filament"
 msgstr "Filament laden"
 
 msgid "Filament Loaded, Resume"
-msgstr "Filament Loaded, Resume"
+msgstr ""
 
 msgid "View Liveview"
-msgstr "View Liveview"
+msgstr ""
 
 msgid "Confirm and Update Nozzle"
 msgstr "Bevestig en update het mondstuk"
@@ -10025,13 +9914,13 @@ msgid "First layer print sequence"
 msgstr "Afdrukvolgorde van de eerste laag"
 
 msgid "Other layers print sequence"
-msgstr "Other layers print sequence"
+msgstr ""
 
 msgid "The number of other layers print sequence"
-msgstr "The number of other layers print sequence"
+msgstr ""
 
 msgid "Other layers filament sequence"
-msgstr "Other layers filament sequence"
+msgstr ""
 
 msgid "This G-code is inserted at every layer change before lifting z"
 msgstr ""
@@ -10274,7 +10163,7 @@ msgid ""
 msgstr ""
 
 msgid "Only one wall on first layer"
-msgstr "Only one wall on first layer"
+msgstr ""
 
 msgid ""
 "Use only one wall on first layer, to give more space to the bottom infill "
@@ -10428,8 +10317,6 @@ msgid ""
 "This controls the generation of the brim at outer and/or inner side of "
 "models. Auto means the brim width is analyzed and calculated automatically."
 msgstr ""
-"This controls the generation of the brim at outer and/or inner side of "
-"models. Auto means the brim width is analyzed and calculated automatically."
 
 msgid "Painted"
 msgstr ""
@@ -10559,7 +10446,7 @@ msgid "Default process profile when switch to this machine profile"
 msgstr "Standaard procesprofiel bij het overschakelen naar dit machineprofiel"
 
 msgid "Activate air filtration"
-msgstr "Activate air filtration"
+msgstr ""
 
 msgid "Activate for better air filtration. G-code command: M106 P3 S(0-255)"
 msgstr ""
@@ -11170,10 +11057,10 @@ msgid "Default filament color"
 msgstr "Standaard filamentkleur"
 
 msgid "Filament notes"
-msgstr "Filament notes"
+msgstr ""
 
 msgid "You can put your notes regarding the filament here."
-msgstr "You can put your notes regarding the filament here."
+msgstr ""
 
 msgid "Required nozzle HRC"
 msgstr "Vereiste mondstuk HRC"
@@ -11429,9 +11316,6 @@ msgid ""
 "equal to or greater than it, it's highly recommended to open the front door "
 "and/or remove the upper glass to avoid clogging."
 msgstr ""
-"The material softens at this temperature, so when the bed temperature is "
-"equal to or greater than this, it's highly recommended to open the front "
-"door and/or remove the upper glass to avoid clogs."
 
 msgid "Price"
 msgstr "Prijs"
@@ -11562,10 +11446,10 @@ msgid ""
 msgstr ""
 
 msgid "0 (no open anchors)"
-msgstr "0 (no open anchors)"
+msgstr ""
 
 msgid "1000 (unlimited)"
-msgstr "1000 (unlimited)"
+msgstr ""
 
 msgid "Maximum length of the infill anchor"
 msgstr "Maximale lengte van de vullingsbevestiging"
@@ -11612,7 +11496,7 @@ msgid ""
 msgstr ""
 
 msgid "mm/s² or %"
-msgstr "mm/s² or %"
+msgstr "mm/s² of %"
 
 msgid ""
 "Acceleration of sparse infill. If the value is expressed as a percentage "
@@ -11762,10 +11646,10 @@ msgstr ""
 "regelt de \"fuzzy\" positie."
 
 msgid "Contour"
-msgstr "Contour"
+msgstr ""
 
 msgid "Contour and hole"
-msgstr "Contour and hole"
+msgstr ""
 
 msgid "All walls"
 msgstr "Alle wanden"
@@ -11869,16 +11753,13 @@ msgstr ""
 "een onregelmatige lijndikte en moeten daarom langzamer worden afgedrukt."
 
 msgid "Precise Z height"
-msgstr "Precise Z height"
+msgstr ""
 
 msgid ""
 "Enable this to get precise z height of object after slicing. It will get the "
 "precise object height by fine-tuning the layer heights of the last few "
 "layers. Note that this is an experimental parameter."
 msgstr ""
-"Enable this to get precise z height of object after slicing. It will get the "
-"precise object height by fine-tuning the layer heights of the last few "
-"layers. Note that this is an experimental parameter."
 
 msgid "Arc fitting"
 msgstr "Boog montage"
@@ -12154,24 +12035,19 @@ msgid "Name of parent profile"
 msgstr ""
 
 msgid "Interface shells"
-msgstr "Interface shells"
+msgstr ""
 
 msgid ""
 "Force the generation of solid shells between adjacent materials/volumes. "
 "Useful for multi-extruder prints with translucent materials or manual "
 "soluble support material"
 msgstr ""
-"Force the generation of solid shells between adjacent materials/volumes. "
-"Useful for multi-extruder prints with translucent materials or manual "
-"soluble support material"
 
 msgid "Maximum width of a segmented region"
 msgstr "Maximale breedte van een gesegmenteerd gebied"
 
 msgid "Maximum width of a segmented region. Zero disables this feature."
 msgstr ""
-"Maximum width of a segmented region. A value of 0 disables this feature."
-
 msgid "Interlocking depth of a segmented region"
 msgstr "Insluitdiepte van een gesegmenteerde regio"
 
@@ -12251,7 +12127,7 @@ msgid "All solid layer"
 msgstr "Alle vaste lagen"
 
 msgid "Ironing Pattern"
-msgstr "Ironing Pattern"
+msgstr ""
 
 msgid "The pattern that will be used when ironing"
 msgstr ""
@@ -12639,7 +12515,7 @@ msgstr ""
 "worden. Als het negatief is, is de laadafstand dus korter."
 
 msgid "Start end points"
-msgstr "Start end points"
+msgstr ""
 
 msgid "The start and end points which is from cutter area to garbage can."
 msgstr ""
@@ -12752,10 +12628,10 @@ msgid "Type of the printer"
 msgstr ""
 
 msgid "Printer notes"
-msgstr "Printer notes"
+msgstr ""
 
 msgid "You can put your notes regarding the printer here."
-msgstr "You can put your notes regarding the printer here."
+msgstr ""
 
 msgid "Printer variant"
 msgstr "Printervariant"
@@ -12855,7 +12731,7 @@ msgstr ""
 "terugtrekken (retraction) uit te schakelen."
 
 msgid "Long retraction when cut(beta)"
-msgstr "Long retraction when cut (beta)"
+msgstr ""
 
 msgid ""
 "Experimental feature.Retracting and cutting off the filament at a longer "
@@ -12869,14 +12745,12 @@ msgstr ""
 "ook het risico op verstoppingen in het mondstuk of andere printproblemen."
 
 msgid "Retraction distance when cut"
-msgstr "Retraction distance when cut"
+msgstr ""
 
 msgid ""
 "Experimental feature.Retraction length before cutting off during filament "
 "change"
 msgstr ""
-"Experimental feature. Retraction length before cutting off during filament "
-"change"
 
 msgid "Z-hop height"
 msgstr ""
@@ -13060,20 +12934,17 @@ msgstr ""
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
 msgstr ""
-"Use scarf joint to minimize seam visibility and increase seam strength."
 
 msgid "Conditional scarf joint"
-msgstr "Conditional scarf joint"
+msgstr ""
 
 msgid ""
 "Apply scarf joints only to smooth perimeters where traditional seams do not "
 "conceal the seams at sharp corners effectively."
 msgstr ""
-"Apply scarf joints only to smooth perimeters where traditional seams do not "
-"conceal the seams at sharp corners effectively."
 
 msgid "Conditional angle threshold"
-msgstr "Conditional angle threshold"
+msgstr ""
 
 msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint "
@@ -13116,44 +12987,39 @@ msgid "This factor affects the amount of material for scarf joints."
 msgstr ""
 
 msgid "Scarf start height"
-msgstr "Scarf start height"
+msgstr ""
 
 msgid ""
 "Start height of the scarf.\n"
 "This amount can be specified in millimeters or as a percentage of the "
 "current layer height. The default value for this parameter is 0."
 msgstr ""
-"Start height of the scarf.\n"
-"This amount can be specified in millimeters or as a percentage of the "
-"current layer height. The default value for this parameter is 0."
 
 msgid "Scarf around entire wall"
-msgstr "Scarf around entire wall"
+msgstr ""
 
 msgid "The scarf extends to the entire length of the wall."
-msgstr "The scarf extends to the entire length of the wall."
+msgstr ""
 
 msgid "Scarf length"
-msgstr "Scarf length"
+msgstr ""
 
 msgid ""
 "Length of the scarf. Setting this parameter to zero effectively disables the "
 "scarf."
 msgstr ""
-"Length of the scarf. Setting this parameter to zero effectively disables the "
-"scarf."
 
 msgid "Scarf steps"
-msgstr "Scarf steps"
+msgstr ""
 
 msgid "Minimum number of segments of each scarf."
-msgstr "Minimum number of segments of each scarf."
+msgstr ""
 
 msgid "Scarf joint for inner walls"
-msgstr "Scarf joint for inner walls"
+msgstr ""
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "Use scarf joint for inner walls as well."
+msgstr ""
 
 msgid "Role base wipe speed"
 msgstr ""
@@ -13216,10 +13082,10 @@ msgid ""
 msgstr ""
 
 msgid "Skirt height"
-msgstr "Skirt height"
+msgstr ""
 
 msgid "How many layers of skirt. Usually only one layer"
-msgstr "Number of skirt layers: usually only one"
+msgstr ""
 
 msgid "Single loop draft shield"
 msgstr ""
@@ -13334,17 +13200,15 @@ msgstr ""
 "met solide onderlagen. Het uiteindelijke gegenereerde model heeft geen naad."
 
 msgid "Smooth Spiral"
-msgstr "Smooth Spiral"
+msgstr ""
 
 msgid ""
 "Smooth Spiral smooths out X and Y moves as well, resulting in no visible "
 "seam at all, even in the XY directions on walls that are not vertical"
 msgstr ""
-"Smooth Spiral smooths out X and Y moves as well, resulting in no visible "
-"seam at all, even in the XY directions on walls that are not vertical"
 
 msgid "Max XY Smoothing"
-msgstr "Max XY Smoothing"
+msgstr ""
 
 #, no-c-format, no-boost-format
 msgid ""
@@ -13564,10 +13428,10 @@ msgid "XY separation between an object and its support"
 msgstr "Dit regelt de XY-afstand tussen een object en zijn support."
 
 msgid "Support/object first layer gap"
-msgstr "Support/object first layer gap"
+msgstr ""
 
 msgid "XY separation between an object and its support at the first layer."
-msgstr "XY separation between an object and its support at the first layer."
+msgstr ""
 
 msgid "Pattern angle"
 msgstr "Patroon hoek"
@@ -13715,7 +13579,7 @@ msgstr ""
 "standaardpatroon voor oplosbare support interfaces Concentrisch is."
 
 msgid "Rectilinear Interlaced"
-msgstr "Rectilinear Interlaced"
+msgstr ""
 
 msgid "Base pattern spacing"
 msgstr "Basis patroon afstand"
@@ -13770,9 +13634,6 @@ msgid ""
 "support customizing z-gap and save print time.This option will be invalid "
 "when the prime tower is enabled."
 msgstr ""
-"Support layer uses layer height independent with object layer. This is to "
-"support customizing z-gap and save print time.This option will be invalid "
-"when the prime tower is enabled."
 
 msgid "Threshold angle"
 msgstr "Drempel hoek"
@@ -14418,16 +14279,16 @@ msgstr ""
 "rechtlijnige patroon gebruikt."
 
 msgid "invalid value "
-msgstr "invalid value "
+msgstr ""
 
 msgid "Invalid value when spiral vase mode is enabled: "
-msgstr "Invalid value when spiral vase mode is enabled: "
+msgstr ""
 
 msgid "too large line width "
-msgstr "too large line width "
+msgstr ""
 
 msgid " not in range "
-msgstr " not in range "
+msgstr ""
 
 msgid "Export 3MF"
 msgstr "Exporteer 3mf"
@@ -14498,13 +14359,13 @@ msgid "mtcpp"
 msgstr "mtcpp"
 
 msgid "max triangle count per plate for slicing."
-msgstr "max triangle count per plate for slicing"
+msgstr ""
 
 msgid "mstpp"
 msgstr "mstpp"
 
 msgid "max slicing time per plate in seconds."
-msgstr "max slicing time per plate in seconds"
+msgstr ""
 
 msgid "No check"
 msgstr "Geen controle"
@@ -14513,10 +14374,10 @@ msgid "Do not run any validity checks, such as G-code path conflicts check."
 msgstr ""
 
 msgid "Normative check"
-msgstr "Normative check"
+msgstr ""
 
 msgid "Check the normative items."
-msgstr "Check the normative items."
+msgstr ""
 
 msgid "Output Model Info"
 msgstr "Model informatie weergeven"
@@ -14599,10 +14460,10 @@ msgid "Load filament settings from the specified file list"
 msgstr "Filament instellingen laden vanuit een bestandslijst"
 
 msgid "Skip Objects"
-msgstr "Skip Objects"
+msgstr ""
 
 msgid "Skip some objects in this print"
-msgstr "Skip some objects in this print"
+msgstr ""
 
 msgid "Clone Objects"
 msgstr ""
@@ -14669,8 +14530,7 @@ msgid ""
 "Sets debug logging level. 0:fatal, 1:error, 2:warning, 3:info, 4:debug, "
 "5:trace\n"
 msgstr ""
-"Sets debug logging level. 0:fataal, 1:error, 2:waarschuwing, 3:info, "
-"4:debug, 5:trace\n"
+""
 
 msgid "Enable timelapse for print"
 msgstr ""
@@ -15015,27 +14875,25 @@ msgid "Generating infill toolpath"
 msgstr "Infill toolpath genereren"
 
 msgid "Detect overhangs for auto-lift"
-msgstr "Detect overhangs for auto-lift"
+msgstr ""
 
 msgid "Checking support necessity"
 msgstr "Controleren of support is noodzakelijk"
 
 msgid "floating regions"
-msgstr "floating regions"
+msgstr ""
 
 msgid "floating cantilever"
-msgstr "floating cantilever"
+msgstr ""
 
 msgid "large overhangs"
-msgstr "large overhangs"
+msgstr ""
 
 #, c-format, boost-format
 msgid ""
 "It seems object %s has %s. Please re-orient the object or enable support "
 "generation."
 msgstr ""
-"It seems object %s has %s. Please re-orient the object or enable support "
-"generation."
 
 msgid "Generating support"
 msgstr "Support genereren"
@@ -15044,14 +14902,12 @@ msgid "Optimizing toolpath"
 msgstr "Optimaliseren van het pad"
 
 msgid "Slicing mesh"
-msgstr "Slicing mesh"
+msgstr ""
 
 msgid ""
 "No layers were detected. You might want to repair your STL file(s) or check "
 "their size or thickness and retry.\n"
 msgstr ""
-"No layers were detected. You might want to repair your STL file(s) or check "
-"their size or thickness and retry.\n"
 
 msgid ""
 "An object's XY size compensation will not be used because it is also color-"
@@ -15065,35 +14921,33 @@ msgstr "Support: contactpunten genereren"
 msgid ""
 "Unknown file format. Input file must have .stl, .obj, .amf(.xml) extension."
 msgstr ""
-"Unknown file format: input file must have .stl, .obj, or .amf(.xml) "
-"extension."
 
 msgid "Loading of a model file failed."
-msgstr "Loading of model file failed."
+msgstr ""
 
 msgid "The supplied file couldn't be read because it's empty"
-msgstr "The supplied file couldn't be read because it's empty."
+msgstr ""
 
 msgid "Unknown file format. Input file must have .3mf or .zip.amf extension."
-msgstr "Unknown file format: input file must have .3mf or .zip.amf extension."
+msgstr ""
 
 msgid "load_obj: failed to parse"
-msgstr "load_obj: failed to parse"
+msgstr ""
 
 msgid "load mtl in obj: failed to parse"
-msgstr "load mtl in obj: failed to parse"
+msgstr ""
 
 msgid "The file contains polygons with more than 4 vertices."
-msgstr "The file contains polygons with more than 4 vertices."
+msgstr ""
 
 msgid "The file contains polygons with less than 2 vertices."
-msgstr "The file contains polygons with less than 2 vertices."
+msgstr ""
 
 msgid "The file contains invalid vertex index."
-msgstr "The file contains invalid vertex index."
+msgstr ""
 
 msgid "This OBJ file couldn't be read because it's empty."
-msgstr "This OBJ file couldn't be read because it's empty."
+msgstr ""
 
 msgid "Flow Rate Calibration"
 msgstr "Flow Rate kalibratie"
@@ -15111,7 +14965,7 @@ msgid "Result can be read by human eyes."
 msgstr "Het resultaat kan door mensenogen worden gelezen."
 
 msgid "Auto-Calibration"
-msgstr "Auto-Calibration"
+msgstr ""
 
 msgid "We would use Lidar to read the calibration result"
 msgstr "We zouden Lidar gebruiken om het kalibratieresultaat af te lezen"
@@ -15196,8 +15050,6 @@ msgstr "nieuwe voorinstelling maken mislukt."
 msgid ""
 "Are you sure to cancel the current calibration and return to the home page?"
 msgstr ""
-"Are you sure you want to cancel the current calibration and return to the "
-"home page?"
 
 msgid "No Printer Connected!"
 msgstr "Geen printer aangesloten!"
@@ -15327,15 +15179,6 @@ msgid ""
 "4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as "
 "they should be."
 msgstr ""
-"After using Flow Dynamics Calibration, there might still be some extrusion "
-"issues, such as:\n"
-"1. Over-Extrusion: Excess material on your printed object, forming blobs or "
-"zits, or the layers seem thicker than expected and not uniform.\n"
-"2. Under-Extrusion: Very thin layers, weak infill strength, or gaps in the "
-"top layer of the model, even when printing slowly.\n"
-"3. Poor Surface Quality: The surface of your prints seems rough or uneven.\n"
-"4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as "
-"they should be."
 
 msgid ""
 "In addition, Flow Rate Calibration is crucial for foaming materials like LW-"
@@ -15380,22 +15223,6 @@ msgid ""
 "can lead to sub-par prints or printer damage. Please make sure to carefully "
 "read and understand the process before doing it."
 msgstr ""
-"Auto Flow Rate Calibration utilizes Bambu Lab's Micro-Lidar technology, "
-"directly measuring the calibration patterns. However, please be advised that "
-"the efficacy and accuracy of this method may be compromised with specific "
-"types of materials. Particularly, filaments that are transparent or semi-"
-"transparent, sparkling-particled, or have a high-reflective finish may not "
-"be suitable for this calibration and can produce less-than-desirable "
-"results.\n"
-"\n"
-"The calibration results may vary between each calibration or filament. We "
-"are still improving the accuracy and compatibility of this calibration "
-"through firmware updates over time.\n"
-"\n"
-"Caution: Flow Rate Calibration is an advanced process, to be attempted only "
-"by those who fully understand its purpose and implications. Incorrect usage "
-"can lead to sub-par prints or printer damage. Please make sure to carefully "
-"read and understand the process before performing it."
 
 msgid "When you need Max Volumetric Speed Calibration"
 msgstr "Wanneer u maximale volumetrische snelheidskalibratie nodig hebt"
@@ -15529,7 +15356,7 @@ msgid "Printing Parameters"
 msgstr "Afdrukparameters"
 
 msgid "Plate Type"
-msgstr "Plate Type"
+msgstr ""
 
 msgid "filament position"
 msgstr "filament positie"
@@ -15589,7 +15416,7 @@ msgid "Flow Dynamics Calibration Result"
 msgstr "Kalibratieresultaat van Flow Dynamics"
 
 msgid "New"
-msgstr "New"
+msgstr ""
 
 msgid "No History Result"
 msgstr "Geen geschiedenisresultaat"
@@ -15612,19 +15439,19 @@ msgid "Edit Flow Dynamics Calibration"
 msgstr "Flow Dynamics-kalibratie bewerken"
 
 msgid "New Flow Dynamic Calibration"
-msgstr "New Flow Dynamic Calibration"
+msgstr ""
 
 msgid "Ok"
 msgstr "Ok"
 
 msgid "The filament must be selected."
-msgstr "The filament must be selected."
+msgstr ""
 
 msgid "Network lookup"
 msgstr "Netwerk opzoeken"
 
 msgid "Address"
-msgstr "Address"
+msgstr ""
 
 msgid "Hostname"
 msgstr "Hostnaam"
@@ -16376,7 +16203,7 @@ msgid "Please select a type you want to export"
 msgstr "Selecteer het type preset dat je wilt exporteren"
 
 msgid "Failed to create temporary folder, please try Export Configs again."
-msgstr "Failed to create temporary folder, please try Export Configs again."
+msgstr ""
 
 msgid "Edit Filament"
 msgstr "Bewerk filament"
@@ -16551,16 +16378,16 @@ msgid "Mismatched type of print host: %s"
 msgstr "Verkeerd type afdrukhost: %s"
 
 msgid "Connection to AstroBox is working correctly."
-msgstr "Connection to AstroBox is working correctly."
+msgstr ""
 
 msgid "Could not connect to AstroBox"
 msgstr "Kan geen verbinding maken met AstroBox"
 
 msgid "Note: AstroBox version 1.1.0 or higher is required."
-msgstr "Note: AstroBox version 1.1.0 or higher is required."
+msgstr ""
 
 msgid "Connection to Duet is working correctly."
-msgstr "Connection to Duet is working correctly."
+msgstr ""
 
 msgid "Could not connect to Duet"
 msgstr "Kan geen verbinding maken met Duet"
@@ -16578,7 +16405,7 @@ msgid "Upload not enabled on FlashAir card."
 msgstr "Uploaden niet ingeschakeld op FlashAir-kaart."
 
 msgid "Connection to FlashAir is working correctly and upload is enabled."
-msgstr "Connection to FlashAir is working correctly and upload is enabled."
+msgstr ""
 
 msgid "Could not connect to FlashAir"
 msgstr "Kan geen verbinding maken met FlashAir"
@@ -16591,28 +16418,28 @@ msgstr ""
 "uploadfunctie is vereist."
 
 msgid "Connection to MKS is working correctly."
-msgstr "Connection to MKS is working correctly."
+msgstr ""
 
 msgid "Could not connect to MKS"
 msgstr "Kan geen verbinding maken met MKS"
 
 msgid "Connection to OctoPrint is working correctly."
-msgstr "Connection to OctoPrint is working correctly."
+msgstr ""
 
 msgid "Could not connect to OctoPrint"
 msgstr "Kan geen verbinding maken met OctoPrint"
 
 msgid "Note: OctoPrint version 1.1.0 or higher is required."
-msgstr "Note: OctoPrint version 1.1.0 or higher is required."
+msgstr ""
 
 msgid "Connection to Prusa SL1 / SL1S is working correctly."
-msgstr "Connection to Prusa SL1 / SL1S is working correctly."
+msgstr ""
 
 msgid "Could not connect to Prusa SLA"
 msgstr "Kan geen verbinding maken met Prusa SLA"
 
 msgid "Connection to PrusaLink is working correctly."
-msgstr "Connection to PrusaLink is working correctly."
+msgstr ""
 
 msgid "Could not connect to PrusaLink"
 msgstr "Kan geen verbinding maken met PrusaLink"
@@ -16648,7 +16475,7 @@ msgid "Could not connect to Repetier"
 msgstr "Kan geen verbinding maken met Repetier"
 
 msgid "Note: Repetier version 0.90.0 or higher is required."
-msgstr "Note: Repetier version 0.90.0 or higher is required."
+msgstr ""
 
 #, boost-format
 msgid ""
@@ -17350,17 +17177,6 @@ msgstr ""
 #~ "instellingen aan: ten minste 2 interfacelagen, ten minste 0,1 mm op z "
 #~ "afstand of gebruik support materiaal op de interface."
 
-#~ msgid ""
-#~ "When using support material for the support interface, We recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-#~ msgstr ""
-#~ "When using support material for the support interface, we recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-
 #~ msgid "This setting specify the count of walls around support"
 #~ msgstr "Deze instelling specificeert het aantal muren rond de ondersteuning"
 
@@ -17391,9 +17207,6 @@ msgstr ""
 #, c-format, boost-format
 #~ msgid "Support: propagate branches at layer %d"
 #~ msgstr "Support: verspreid takken op laag %d"
-
-#~ msgid "Current Cabin humidity"
-#~ msgstr "Current Cabin humidity"
 
 #~ msgid "Stopped."
 #~ msgstr "Gestopt."
@@ -17499,21 +17312,11 @@ msgstr ""
 #~ msgid "Scale"
 #~ msgstr "Schalen"
 
-#~ msgid "Cool plate"
-#~ msgstr "Koudeplaat"
-
 #~ msgid "Z-hop when retract"
 #~ msgstr "Z-hop tijdens terugtrekken (retraction)"
 
 #~ msgid "Reverse on odd"
 #~ msgstr "Overhang omkering"
-
-#~ msgid ""
-#~ "While printing by Object, the extruder may collide skirt.\n"
-#~ "Thus, reset the skirt layer to 1 to avoid that."
-#~ msgstr ""
-#~ "While printing by object, the extruder may collide with a skirt.\n"
-#~ "Thus, reset the skirt layer to 1 to avoid collisions."
 
 #~ msgid "Limited"
 #~ msgstr "Gelimiteerd"
@@ -17589,23 +17392,6 @@ msgstr ""
 #~ "wordt toegevoegd aan de totale printtijd in de tijdsschatting."
 
 #~ msgid ""
-#~ "Higher chamber temperature can help suppress or reduce warping and "
-#~ "potentially lead to higher interlayer bonding strength for high "
-#~ "temperature materials like ABS, ASA, PC, PA and so on.At the same time, "
-#~ "the air filtration of ABS and ASA will get worse.While for PLA, PETG, "
-#~ "TPU, PVA and other low temperature materials,the actual chamber "
-#~ "temperature should not be high to avoid cloggings, so 0 which stands for "
-#~ "turning off is highly recommended"
-#~ msgstr ""
-#~ "Higher chamber temperature can help suppress or reduce warping and "
-#~ "potentially lead to higher interlayer bonding strength for high "
-#~ "temperature materials like ABS, ASA, PC, PA and so on. At the same time, "
-#~ "the air filtration of ABS and ASA will get worse.While for PLA, PETG, "
-#~ "TPU, PVA and other low temperature materials, the actual chamber "
-#~ "temperature should not be high to avoid clogs, so 0 (turned off) is "
-#~ "highly recommended."
-
-#~ msgid ""
 #~ "Different nozzle diameters and different filament diameters is not "
 #~ "allowed when prime tower is enabled."
 #~ msgstr ""
@@ -17628,9 +17414,6 @@ msgstr ""
 
 #~ msgid "Please input a valid value (K in 0~0.3, N in 0.6~2.0)"
 #~ msgstr "Voer een geldige waarde in (K in 0~0,3, N in 0,6~2,0)"
-
-#~ msgid "Printer local connection failed, please try again."
-#~ msgstr "Printer local connection failed; please try again."
 
 #~ msgid ""
 #~ "Please find the details of Flow Dynamics Calibration from our wiki.\n"
@@ -17693,12 +17476,6 @@ msgstr ""
 #~ msgid "Please find the cornor with perfect degree of extrusion"
 #~ msgstr "Zoek de hoek met de perfecte extrusiegraad"
 
-#~ msgid "V"
-#~ msgstr "V"
-
-#~ msgid "Export &Configs"
-#~ msgstr "Export &Configs"
-
 #~ msgid "Infill direction"
 #~ msgstr "Vulling (infill) richting"
 
@@ -17720,33 +17497,14 @@ msgstr ""
 #~ msgid "Unload Filament"
 #~ msgstr "Lossen"
 
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "Kies een AMS sleuf en druk op de \"Laden\" of \"Verwijderen\" knop om het "
-#~ "filament automatisch te laden of te verwijderen."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
 #~ msgid "MainBoard"
 #~ msgstr "Moederbord"
 
 #~ msgid "TH"
 #~ msgstr "th"
 
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
-
 #~ msgid "active"
 #~ msgstr "Actief"
-
-#~ msgid "Jump to layer"
-#~ msgstr "Jump to layer"
 
 #~ msgid "Cabin humidity"
 #~ msgstr "Vochtigheid in de cabine"
@@ -17817,20 +17575,6 @@ msgstr ""
 #, c-format, boost-format
 #~ msgid "Load failed [%d]!"
 #~ msgstr "Laden mislukt [%d]!"
-
-#, c-format, boost-format
-#~ msgid "No files [%d]"
-#~ msgstr "No files [%d]"
-
-#, c-format, boost-format
-#~ msgid "Load failed [%d]"
-#~ msgstr "Load failed [%d]"
-
-#~ msgid "Failed to fetching model informations from printer."
-#~ msgstr "Failed to fetch model information from printer."
-
-#~ msgid "Failed to parse model informations."
-#~ msgstr "Failed to parse model information"
 
 #, boost-format
 #~ msgid ""
@@ -17908,30 +17652,6 @@ msgstr ""
 #~ msgid "Exception"
 #~ msgstr "Uitzondering"
 
-#~ msgid "Choose SLA archive:"
-#~ msgstr "Choose SLA archive:"
-
-#~ msgid "Import file"
-#~ msgstr "Import file"
-
-#~ msgid "Import model and profile"
-#~ msgstr "Import model and profile"
-
-#~ msgid "Import profile only"
-#~ msgstr "Import profile only"
-
-#~ msgid "Import model only"
-#~ msgstr "Import model only"
-
-#~ msgid "Accurate"
-#~ msgstr "Accurate"
-
-#~ msgid "Balanced"
-#~ msgstr "Balanced"
-
-#~ msgid "Quick"
-#~ msgstr "Quick"
-
 #~ msgid ""
 #~ "Discribe how long the nozzle will move along the last path when retracting"
 #~ msgstr ""
@@ -17949,9 +17669,6 @@ msgstr ""
 #~ "functie Simplify mesh? Klik met de rechtermuisknop op het model en "
 #~ "selecteer Model vereenvoudigen. Lees meer in de documentatie."
 
-#~ msgid "Filling bed "
-#~ msgstr "Filling bed"
-
 #, boost-format
 #~ msgid "%1% infill pattern doesn't support 100%% density."
 #~ msgstr "%1% het gekozen vulling patroon ondersteund geen 100%% dichtheid."
@@ -17966,10 +17683,6 @@ msgstr ""
 #~ "Nee - Zet de dichtheid automatisch terug naar de standaard niet 100% "
 #~ "waarde"
 
-#~ msgid "Please heat the nozzle to above 170 degree before loading filament."
-#~ msgstr ""
-#~ "Verwarm de nozzle tot meer dan 170 graden voordat je het filament laadt."
-
 #, c-format
 #~ msgid "Density of internal sparse infill, 100% means solid throughout"
 #~ msgstr ""
@@ -17983,21 +17696,11 @@ msgstr ""
 #~ msgstr ""
 #~ "Deze instelling specificeert het aantal wanden rond de tree support."
 
-#, c-format, boost-format
-#~ msgid " doesn't work at 100%% density "
-#~ msgstr " doesn't work at 100%% density "
-
-#~ msgid "Ctrl + Shift + Enter"
-#~ msgstr "Ctrl + Shift + Enter"
-
 #~ msgid "Tool-Lay on Face"
 #~ msgstr "Hulpmiddel op zijde plaatsen"
 
 #~ msgid "Export as STL"
 #~ msgstr "Exporteer als STL-bestand"
-
-#~ msgid "Check cloud service status"
-#~ msgstr "Check cloud service status"
 
 #~ msgid "Please input a valid value (K in 0~0.5)"
 #~ msgstr "Voer een geldige waarde in (K in 0 ~ 0,5)"
@@ -18018,10 +17721,6 @@ msgstr ""
 
 #~ msgid "Add/Remove printers"
 #~ msgstr "Printers toevoegen/verwijderen"
-
-#, c-format, boost-format
-#~ msgid "%s is not supported by AMS."
-#~ msgstr "%s is not supported by the AMS."
 
 #~ msgid "Don't remind me of this version again"
 #~ msgstr "Herinner me niet meer aan deze versie."
@@ -18062,30 +17761,11 @@ msgstr ""
 #~ "en het aanraakscherm in de 3D-scène kunt bedienen?"
 
 #~ msgid ""
-#~ "Fix Model\n"
-#~ "Did you know that you can fix a corrupted 3D model to avoid a lot of "
-#~ "slicing problems?"
-#~ msgstr ""
-#~ "Model repareren\n"
-#~ "Wist u dat u een beschadigd 3D-model kunt repareren om veel snijproblemen "
-#~ "te voorkomen?"
-
-# Source and destination string both English but don't match!
-#~ msgid "Embeded"
-#~ msgstr "Embedded"
-
-#~ msgid ""
 #~ "OrcaSlicer configuration file may be corrupted and is not abled to be "
 #~ "parsed.Please delete the file and try again."
 #~ msgstr ""
 #~ "OrcaSlicer configuratiebestand is mogelijks corrupt, en kan niet verwerkt "
 #~ "worden.Verwijder het configuratiebestand en probeer het opnieuw."
-
-#~ msgid "Online Models"
-#~ msgstr "Online Models"
-
-#~ msgid "Show online staff-picked models on the home page"
-#~ msgstr "Show online staff-picked models on the home page"
 
 #~ msgid "The minimum printing speed when slow down for cooling"
 #~ msgstr "De minimale printsnelheid indien er afgeremd wordt om af te koelen"
@@ -18130,14 +17810,8 @@ msgstr ""
 #~ msgid "The model has too many empty layers."
 #~ msgstr "Het model heeft te veel lege lagen."
 
-#~ msgid "Cali"
-#~ msgstr "Cali"
-
 #~ msgid "Calibration of extrusion"
 #~ msgstr "Kalibratie van de extrusie"
-
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "Push new filament into the extruder"
 
 #, c-format, boost-format
 #~ msgid ""
@@ -18162,20 +17836,8 @@ msgstr ""
 #~ "Houd de printer open tijdens het printproces om te zorgen voor "
 #~ "luchtcirculatie, of om de temperatuur van het warmwaterbed te verlagen."
 
-#~ msgid "Total Time Estimation"
-#~ msgstr "Total Time Estimation"
-
 #~ msgid "Resonance frequency identification"
 #~ msgstr "Identificatie van de resonantiefrequentie"
-
-#~ msgid "Immediately score"
-#~ msgstr "Immediately score"
-
-#~ msgid "Please give a score for your favorite Bambu Market model."
-#~ msgstr "Please give a score for your favorite Bambu Market model."
-
-#~ msgid "Score"
-#~ msgstr "Score"
 
 #~ msgid "Bambu High Temperature Plate"
 #~ msgstr "Bambu High Temperature (hoge temperatuur) Plate"

--- a/localization/i18n/pl/OrcaSlicer_pl.po
+++ b/localization/i18n/pl/OrcaSlicer_pl.po
@@ -2551,9 +2551,7 @@ msgid "Pull back current filament"
 msgstr "Wycofuje obecny filament"
 
 msgid "Push new filament into extruder"
-msgstr ""
-"Załaduj nowy\n"
-"filament do extrudera"
+msgstr "Załaduj nowy filament do extrudera"
 
 msgid "Purge old filament"
 msgstr "Oczyść dyszę"
@@ -4294,7 +4292,7 @@ msgid "travel"
 msgstr "przemieszczenie"
 
 msgid "Extruder"
-msgstr "Extruder"
+msgstr ""
 
 msgid "Filament change times"
 msgstr "Liczba zmian filamentu"
@@ -7318,22 +7316,22 @@ msgid "Busy"
 msgstr "Zajęty"
 
 msgid "Bambu Cool Plate"
-msgstr "Bambu Cool Plate"
+msgstr ""
 
 msgid "PLA Plate"
 msgstr "Płyta PLA"
 
 msgid "Bambu Engineering Plate"
-msgstr "Bambu Engineering Plate"
+msgstr ""
 
 msgid "Bambu Smooth PEI Plate"
-msgstr "Bambu Smooth PEI Plate"
+msgstr ""
 
 msgid "High temperature Plate"
 msgstr "Płyta wysokotemperaturowa"
 
 msgid "Bambu Textured PEI Plate"
-msgstr "Bambu Textured PEI Plate"
+msgstr ""
 
 msgid "Send print job to"
 msgstr "Wyślij zadanie druku do"
@@ -16569,7 +16567,7 @@ msgid "flow ratio : %s "
 msgstr "współczynnik przepływu: %s "
 
 msgid "Please choose a block with smoothest top surface"
-msgstr "Please choose a block with smoothest top surface"
+msgstr "Wybierz blok z najgładszą górną powierzchnią"
 
 msgid "Please choose a block with smoothest top surface."
 msgstr "Wybierz blok z najgładszą górną powierzchnią."
@@ -18537,17 +18535,6 @@ msgstr ""
 #~ "ustawienia: co najmniej 2 warstwy łączące, co najmniej 0,1 mm odległości "
 #~ "od góry lub używanie materiałów podporowych na łączeniach."
 
-#~ msgid ""
-#~ "When using support material for the support interface, We recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-#~ msgstr ""
-#~ "Przy użyciu materiału podporowego do warstw łączących podpory zalecamy "
-#~ "następujące ustawienia:\n"
-#~ "0 odległość osu Z od góry, 0 odstęp warstwy łączącej, wzór koncentryczny "
-#~ "i wyłączenie niezależnej wysokości warstwy podpory"
-
 #~ msgid "Branch Diameter with double walls"
 #~ msgstr "Średnica gałęzi z podwójnymi ścianami"
 
@@ -18802,12 +18789,6 @@ msgstr ""
 #~ msgctxt "Verb"
 #~ msgid "Scale"
 #~ msgstr "Skala"
-
-#~ msgid "Orca Slicer "
-#~ msgstr "Orca Slicer "
-
-#~ msgid "Cool plate"
-#~ msgstr "Cool plate / PLA Plate"
 
 #~ msgid "Lift Z Enforcement"
 #~ msgstr "Wymuszenie podniesienia osi Z"
@@ -19253,12 +19234,6 @@ msgstr ""
 #~ "jeden z wyników o tej samej nazwie zostanie zapisany. Czy na pewno chcesz "
 #~ "zastąpić ten wynik?"
 
-#~ msgid "X"
-#~ msgstr "X"
-
-#~ msgid "Y"
-#~ msgstr "Y"
-
 #~ msgid ""
 #~ "Associate OrcaSlicer with prusaslicer:// links so that Orca can open "
 #~ "PrusaSlicer links from Printable.com"
@@ -19286,9 +19261,6 @@ msgstr ""
 #~ "gdzie są do nich przymocowane. Skutkuje to gorszym wykończeniem "
 #~ "zewnętrznej powierzchni. Może to również spowodować prześwitywanie "
 #~ "wypełnienia przez zewnętrzne powierzchnie części."
-
-#~ msgid "V"
-#~ msgstr "V"
 
 #~ msgid "Maximum print speed when purging"
 #~ msgstr "Maksymalna prędkość druku podczas czyszczenia"
@@ -19417,23 +19389,8 @@ msgstr ""
 #~ msgid "MainBoard"
 #~ msgstr "MainBoard (Płyta główna)"
 
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
 #~ msgid "HMS"
 #~ msgstr "Stan drukarki (HMS)"
-
-#~ msgid "- ℃"
-#~ msgstr "- ℃"
-
-#~ msgid "0.5"
-#~ msgstr "0.5"
-
-#~ msgid "0.005"
-#~ msgstr "0.005"
 
 #~ msgid "active"
 #~ msgstr "aktywny"
@@ -19526,9 +19483,6 @@ msgstr ""
 
 #~ msgid "Failed to fetching model information from printer."
 #~ msgstr "Nie udało się pobrać informacji o modelach z drukarki."
-
-#~ msgid "Failed to parse model informations."
-#~ msgstr "Nie udało się sparsować informacji o modelach."
 
 #~ msgid "Connection lost. Please retry."
 #~ msgstr "Utracono połączenie. Proszę spróbować ponownie."
@@ -20167,9 +20121,6 @@ msgstr ""
 #~ msgid "Choose SLA archive:"
 #~ msgstr "Wybierz archiwum SLA:"
 
-#~ msgid "Import file"
-#~ msgstr "Importuj plik"
-
 #~ msgid "Import model and profile"
 #~ msgstr "Importuj model i profil"
 
@@ -20499,9 +20450,6 @@ msgstr ""
 #~ "Wybrany plik 3MF zawiera model pomalowany do Multi Material przy pomocy "
 #~ "nowszej wersji OrcaSlicer i nie jest kompatybilny."
 
-#~ msgid " "
-#~ msgstr " "
-
 #~ msgid ""
 #~ "Number of mm the overhang need to be for the reversal to be considered "
 #~ "useful. Can be a (%) of the perimeter width.\n"
@@ -20733,15 +20681,6 @@ msgstr ""
 #~ "przesunięciu urządzenia poza obszar drukowalny i zużyciu sprzętu."
 
 #~ msgid ""
-#~ "The current chamber temperature or the target chamber temperature exceeds "
-#~ "45℃. In order to avoid extruder clogging, low-temperature filament (PLA/"
-#~ "PETG/TPU) is not allowed to be loaded."
-#~ msgstr ""
-#~ "Aktualna temperatura komory lub docelowa temperatura komory przekracza "
-#~ "45℃. Aby uniknąć zatkania ekstruzora, niedopuszczalne jest ładowanie "
-#~ "filamentu o niskiej temperaturze (PLA/PETG/TPU)."
-
-#~ msgid ""
 #~ "Low-temperature filament (PLA/PETG/TPU) is loaded in the extruder. In "
 #~ "order to avoid extruder clogging, it is not allowed to set the chamber "
 #~ "temperature above 45℃."
@@ -20781,13 +20720,6 @@ msgstr ""
 
 #~ msgid "Connect Printer (LAN)"
 #~ msgstr "Podłącz drukarkę (LAN)"
-
-#~ msgid ""
-#~ "Please heat the nozzle to above 170 degrees before loading or unloading "
-#~ "filament."
-#~ msgstr ""
-#~ "Przed załadowaniem lub rozładowaniem filamentu podgrzej dyszę do "
-#~ "temperatury powyżej 170 stopni."
 
 #~ msgid ""
 #~ "Cannot read filament info: the filament is loaded to the tool head, "
@@ -20848,12 +20780,6 @@ msgstr ""
 #~ "Plik 3MF jest generowany przez starą wersję Orca Slicer, wczytuj tylko "
 #~ "dane geometrii."
 
-#~ msgid ""
-#~ "The 3mf has the following modified G-codes in filament or printer presets:"
-#~ msgstr ""
-#~ "Plik 3MF ma następujące zmodyfikowane kody G w profilach filamentu lub "
-#~ "drukarki:"
-
 #~ msgid "The 3mf has the following customized filament or printer presets:"
 #~ msgstr "Plik 3MF ma następujące dostosowane profile filamentu lub drukarki:"
 
@@ -20869,34 +20795,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Zmiana języka aplikacji przy jednoczesnym istniejących zmodyfikowanych "
 #~ "ustawieniach"
-
-#~ msgid ""
-#~ "In the 3D Printing community, we learn from each other's successes and "
-#~ "failures to adjust our own slicing parameters and settings. %s follows "
-#~ "the same principle and uses machine learning to improve its performance "
-#~ "from the successes and failures of the vast number of prints by our "
-#~ "users. We are training %s to be smarter by feeding them the real-world "
-#~ "data. If you are willing, this service will access information from your "
-#~ "error logs and usage logs, which may include information described in "
-#~ "Privacy Policy. We will not collect any Personal Data by which an "
-#~ "individual can be identified directly or indirectly, including without "
-#~ "limitation names, addresses, payment information, or phone numbers. By "
-#~ "enabling this service, you agree to these terms and the statement about "
-#~ "Privacy Policy."
-#~ msgstr ""
-#~ "W społeczności druku 3D uczymy się od siebie nawzajem, korzystając z "
-#~ "sukcesów i porażek, aby dostosować nasze parametry i ustawienia cięcia. "
-#~ "%s stosuje tę samą zasadę i wykorzystuje uczenie maszynowe do poprawy "
-#~ "swojej wydajności na podstawie sukcesów i porażek ogromnej liczby "
-#~ "wydruków naszych użytkowników. Szkolimy %s, aby było mądrzejsze, "
-#~ "dostarczając mu danych z rzeczywistego świata. Jeśli wyrażasz zgodę, ta "
-#~ "usługa uzyska dostęp do informacji z Twoich logów błędów i dzienników "
-#~ "użycia, które mogą zawierać informacje opisane w Polityce Prywatności. "
-#~ "Nie będziemy zbierać żadnych danych osobowych, dzięki którym można by "
-#~ "bezpośrednio lub pośrednio zidentyfikować osobę, w tym między innymi "
-#~ "nanawisk, adresów, informacji o płatnościach czy numerów telefonów. "
-#~ "Włączając tę usługę, zgadzasz się na te warunki i oświadczenie o Polityce "
-#~ "Prywatności."
 
 #~ msgid ""
 #~ "Change these settings automatically? \n"
@@ -20940,13 +20838,6 @@ msgstr ""
 #~ "Może być to %% szerokości obryski.\n"
 #~ "Wartość 0 umożliwia odwrócenie na każdej nieparzystej warstwie, "
 #~ "niezależnie od wszystkiego."
-
-#~ msgid ""
-#~ "Smooth Spiral smooths out X and Y moves as well resulting in no visible "
-#~ "seam at all, even in the XY directions on walls that are not vertical"
-#~ msgstr ""
-#~ "Smooth Spiral wygładza również ruchy w osiach X i Y, co skutkuje brakiem "
-#~ "widocznych szwów, nawet w kierunkach XY na ścianach, które nie są pionowe"
 
 #, c-format, boost-format
 #~ msgid ""
@@ -21054,9 +20945,6 @@ msgstr ""
 #~ msgid " doesn't work at 100%% density "
 #~ msgstr " nie działa przy 100% gęstości "
 
-#~ msgid "Ctrl + Shift + Enter"
-#~ msgstr "Ctrl + Shift + Enter"
-
 #~ msgid "Tool-Lay on Face"
 #~ msgstr "Narzędzie - Połóż na Powierzchni"
 
@@ -21159,15 +21047,6 @@ msgstr ""
 #~ "Czy wiesz, jak kontrolować widok i wybór obiektów/części za pomocą myszy "
 #~ "i panelu dotykowego w scenie 3D?"
 
-#~ msgid ""
-#~ "Fix Model\n"
-#~ "Did you know that you can fix a corrupted 3D model to avoid a lot of "
-#~ "slicing problems?"
-#~ msgstr ""
-#~ "Napraw model\n"
-#~ "Czy wiesz, że możesz naprawić uszkodzony model 3D, aby uniknąć wielu "
-#~ "problemów z krojeniem?"
-
 #~ msgid "Embedded"
 #~ msgstr "Osadzone"
 
@@ -21262,9 +21141,6 @@ msgstr ""
 #~ msgid "Calibration of extrusion"
 #~ msgstr "Kalibracja ekstruzji"
 
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "Wsuń nowy filament do ekstrudera"
-
 #, c-format, boost-format
 #~ msgid ""
 #~ "Bed temperature of other layer is lower than bed temperature of initial "
@@ -21338,13 +21214,6 @@ msgstr ""
 #~ "powietrza i poprawić jakość górnej powierzchni, szczególnie gdy gęstość "
 #~ "wypełnienia jest niska. Ta wartość określa grubość pętli podpory. 0 "
 #~ "oznacza wyłączenie tej funkcji"
-
-#, fuzzy, c-format, boost-format
-#~ msgid ""
-#~ "Klipper's max_accel_to_decel will be adjusted to this % of acceleration"
-#~ msgstr ""
-#~ "Maksymalne przyspieszenie Klippera max_accel_to_decel zostanie "
-#~ "dostosowane do tego % przyspieszenia"
 
 #~ msgid ""
 #~ "Style and shape of the support. For normal support, projecting the "

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -300,7 +300,7 @@ msgid "Square"
 msgstr "Kvadrat"
 
 msgid "Hexagon"
-msgstr "Hexagon"
+msgstr ""
 
 msgid "Keep orientation"
 msgstr "Behåll orienteringen"
@@ -908,7 +908,7 @@ msgstr "Vänster"
 
 msgctxt "Alignment"
 msgid "Center"
-msgstr "Center"
+msgstr ""
 
 msgctxt "Alignment"
 msgid "Right"
@@ -1243,46 +1243,46 @@ msgid "No feature"
 msgstr ""
 
 msgid "Vertex"
-msgstr "Vertex"
+msgstr ""
 
 msgid "Edge"
-msgstr "Edge"
+msgstr ""
 
 msgid "Plane"
-msgstr "Plane"
+msgstr ""
 
 msgid "Point on edge"
-msgstr "Point on edge"
+msgstr ""
 
 msgid "Point on circle"
-msgstr "Point on circle"
+msgstr ""
 
 msgid "Point on plane"
-msgstr "Point on plane"
+msgstr ""
 
 msgid "Center of edge"
-msgstr "Center of edge"
+msgstr ""
 
 msgid "Center of circle"
-msgstr "Center of circle"
+msgstr ""
 
 msgid "Select feature"
-msgstr "Select feature"
+msgstr ""
 
 msgid "Select point"
-msgstr "Select point"
+msgstr ""
 
 msgid "Delete"
 msgstr "Radera"
 
 msgid "Restart selection"
-msgstr "Restart selection"
+msgstr ""
 
 msgid "Esc"
 msgstr "Esc"
 
 msgid "Cancel a feature until exit"
-msgstr "Cancel a feature until exit"
+msgstr ""
 
 msgid "Measure"
 msgstr "Measure"
@@ -1290,17 +1290,16 @@ msgstr "Measure"
 msgid ""
 "Please confirm explosion ratio = 1,and please select at least one object"
 msgstr ""
-"Please confirm explosion ratio = 1, and please select at least one object"
 
 msgid "Please select at least one object."
-msgstr "Please select at least one object."
+msgstr ""
 
 msgid "Edit to scale"
-msgstr "Edit to scale"
+msgstr ""
 
 msgctxt "Verb"
 msgid "Scale all"
-msgstr "Scale all"
+msgstr ""
 
 msgid "None"
 msgstr "Ingen"
@@ -1312,24 +1311,20 @@ msgid "Length"
 msgstr "Längd"
 
 msgid "Selection"
-msgstr "Selection"
+msgstr ""
 
 msgid " (Moving)"
-msgstr " (Moving)"
+msgstr ""
 
 msgid ""
 "Select 2 faces on objects and \n"
 " make objects assemble together."
 msgstr ""
-"Select 2 faces on objects and \n"
-" make objects assemble together."
 
 msgid ""
 "Select 2 points or circles on objects and \n"
 " specify distance between them."
 msgstr ""
-"Select 2 points or circles on objects and \n"
-" specify distance between them."
 
 msgid "Face"
 msgstr "Face"
@@ -1344,53 +1339,51 @@ msgid ""
 "Feature 1 has been reset, \n"
 "feature 2 has been feature 1"
 msgstr ""
-"Feature 1 has been reset, \n"
-"feature 2 has been feature 1"
 
 msgid "Warning:please select Plane's feature."
-msgstr "Warning: please select Plane's feature."
+msgstr ""
 
 msgid "Warning:please select Point's or Circle's feature."
-msgstr "Warning: please select Point's or Circle's feature."
+msgstr ""
 
 msgid "Warning:please select two different mesh."
-msgstr "Warning: please select two different meshes."
+msgstr ""
 
 msgid "Copy to clipboard"
 msgstr "Kopiera till urklipp"
 
 msgid "Perpendicular distance"
-msgstr "Perpendicular distance"
+msgstr ""
 
 msgid "Distance"
-msgstr "Distance"
+msgstr ""
 
 msgid "Direct distance"
-msgstr "Direct distance"
+msgstr ""
 
 msgid "Distance XYZ"
-msgstr "Distance XYZ"
+msgstr ""
 
 msgid "Parallel"
-msgstr "Parallel"
+msgstr ""
 
 msgid "Center coincidence"
-msgstr "Center coincidence"
+msgstr ""
 
 msgid "Featue 1"
 msgstr "Feature 1"
 
 msgid "Reverse rotation"
-msgstr "Reverse rotation"
+msgstr ""
 
 msgid "Rotate around center:"
-msgstr "Rotate around center:"
+msgstr ""
 
 msgid "Parallel distance:"
 msgstr ""
 
 msgid "Flip by Face 2"
-msgstr "Flip by Face 2"
+msgstr ""
 
 msgid "Ctrl+"
 msgstr "Ctrl +"
@@ -1732,7 +1725,7 @@ msgid "Cube"
 msgstr "Kub"
 
 msgid "Cylinder"
-msgstr "Cylinder"
+msgstr ""
 
 msgid "Cone"
 msgstr "Kon"
@@ -1997,7 +1990,7 @@ msgid "Simplify Model"
 msgstr "Förenkla modellen"
 
 msgid "Center"
-msgstr "Center"
+msgstr ""
 
 msgid "Drop"
 msgstr ""
@@ -2438,13 +2431,13 @@ msgid "AMS"
 msgstr "AMS"
 
 msgid "Auto Refill"
-msgstr "Auto Refill"
+msgstr ""
 
 msgid "AMS not connected"
 msgstr "AMS ej ansluten"
 
 msgid "Load"
-msgstr "Load"
+msgstr ""
 
 msgid "Unload"
 msgstr "Mata ut"
@@ -2773,7 +2766,7 @@ msgid "Orca Slicer is licensed under "
 msgstr "Orca Slicer är licensierad under "
 
 msgid "GNU Affero General Public License, version 3"
-msgstr "GNU Affero General Public License, version 3"
+msgstr ""
 
 msgid "Orca Slicer is based on PrusaSlicer and BambuStudio"
 msgstr ""
@@ -2986,10 +2979,6 @@ msgid ""
 "desiccant pack is changed. it take hours to absorb the moisture, low "
 "temperatures also slow down the process."
 msgstr ""
-"Please change the desiccant when it is too wet. The indicator may not "
-"represent accurately in following cases: when the lid is open or the "
-"desiccant pack is changed. It takes a few hours to absorb the moisture, and "
-"low temperatures also slow down the process."
 
 msgid ""
 "Config which AMS slot should be used for a filament used in the print job"
@@ -3034,7 +3023,6 @@ msgstr "Printern stöder för närvarande inte automatisk påfyllning."
 msgid ""
 "AMS filament backup is not enabled, please enable it in the AMS settings."
 msgstr ""
-"AMS filament backup is not enabled; please enable it in the AMS settings."
 
 msgid ""
 "If there are two identical filaments in AMS, AMS filament backup will be "
@@ -3042,10 +3030,6 @@ msgid ""
 "(Currently supporting automatic supply of consumables with the same brand, "
 "material type, and color)"
 msgstr ""
-"If there are two identical filaments in an AMS, AMS filament backup will be "
-"enabled. \n"
-"(This currently supports automatic supply of consumables with the same "
-"brand, material type, and color)"
 
 msgid "DRY"
 msgstr "DRY"
@@ -3113,7 +3097,7 @@ msgstr ""
 "återstående kapaciteten automatiskt."
 
 msgid "AMS filament backup"
-msgstr "AMS filament backup"
+msgstr ""
 
 msgid ""
 "AMS will continue to another spool with the same properties of filament "
@@ -3123,14 +3107,12 @@ msgstr ""
 "när det aktuella filamentet tar slut."
 
 msgid "Air Printing Detection"
-msgstr "Air Printing Detection"
+msgstr ""
 
 msgid ""
 "Detects clogging and filament grinding, halting printing immediately to "
 "conserve time and filament."
 msgstr ""
-"Detects clogging and filament grinding, halting printing immediately to "
-"conserve time and filament."
 
 msgid "File"
 msgstr "Fil"
@@ -3211,7 +3193,7 @@ msgid "Running post-processing scripts"
 msgstr "Kör efterbearbetnings skript"
 
 msgid "Successfully executed post-processing script"
-msgstr "Successfully executed post-processing script"
+msgstr ""
 
 msgid "Unknown error occurred during exporting G-code."
 msgstr ""
@@ -3278,10 +3260,10 @@ msgid "Device"
 msgstr "Enhet"
 
 msgid "Task Sending"
-msgstr "Task Sending"
+msgstr ""
 
 msgid "Task Sent"
-msgstr "Task Sent"
+msgstr ""
 
 msgid "Edit multiple printers"
 msgstr ""
@@ -3313,16 +3295,16 @@ msgid "Edit Printers"
 msgstr ""
 
 msgid "Device Name"
-msgstr "Device Name"
+msgstr ""
 
 msgid "Task Name"
-msgstr "Task Name"
+msgstr ""
 
 msgid "Device Status"
-msgstr "Device Status"
+msgstr ""
 
 msgid "Actions"
-msgstr "Actions"
+msgstr ""
 
 msgid ""
 "Please select the devices you would like to manage here (up to 6 devices)"
@@ -3392,25 +3374,25 @@ msgid "Stop"
 msgstr "Stopp"
 
 msgid "Task Status"
-msgstr "Task Status"
+msgstr ""
 
 msgid "Sent Time"
-msgstr "Sent Time"
+msgstr ""
 
 msgid "There are no tasks to be sent!"
-msgstr "There are no tasks to be sent!"
+msgstr ""
 
 msgid "No historical tasks!"
-msgstr "No historical tasks!"
+msgstr ""
 
 msgid "Loading..."
 msgstr "Laddar..."
 
 msgid "No AMS"
-msgstr "No AMS"
+msgstr ""
 
 msgid "Send to Multi-device"
-msgstr "Send to Multi-device"
+msgstr ""
 
 msgid "Preparing print job"
 msgstr "Förbereder utskriftsjobb"
@@ -3425,19 +3407,19 @@ msgid "The number of printers in use simultaneously cannot be equal to 0."
 msgstr ""
 
 msgid "Use External Spool"
-msgstr "Use External Spool"
+msgstr ""
 
 msgid "Use AMS"
-msgstr "Use AMS"
+msgstr ""
 
 msgid "Select Printers"
-msgstr "Select Printers"
+msgstr ""
 
 msgid "Ams Status"
-msgstr "AMS Status"
+msgstr ""
 
 msgid "Printing Options"
-msgstr "Printing Options"
+msgstr ""
 
 msgid "Bed Leveling"
 msgstr "Justering av Byggplattan"
@@ -3449,7 +3431,7 @@ msgid "Flow Dynamic Calibration"
 msgstr ""
 
 msgid "Send Options"
-msgstr "Send Options"
+msgstr ""
 
 msgid "Send to"
 msgstr ""
@@ -3458,16 +3440,13 @@ msgid ""
 "printers at the same time.(It depends on how many devices can undergo "
 "heating at the same time.)"
 msgstr ""
-"printers at the same time. (It depends on how many devices can undergo "
-"heating at the same time.)"
 
 msgid "Wait"
-msgstr "Wait"
+msgstr ""
 
 msgid ""
 "minute each batch.(It depends on how long it takes to complete the heating.)"
 msgstr ""
-"minute each batch. (It depends on how long it takes to complete heating.)"
 
 msgid "Send"
 msgstr "Skicka"
@@ -3574,8 +3553,6 @@ msgid ""
 "The recommended minimum temperature cannot be higher than the recommended "
 "maximum temperature.\n"
 msgstr ""
-"The recommended minimum temperature cannot be higher than the recommended "
-"maximum temperature.\n"
 
 msgid "Please check.\n"
 msgstr "Kontrollera.\n"
@@ -3610,9 +3587,6 @@ msgid ""
 "temperature,it may result in material softening and clogging.The maximum "
 "safe temperature for the material is %d"
 msgstr ""
-"Current chamber temperature is higher than the material's safe temperature; "
-"this may result in material softening and nozzle clogs.The maximum safe "
-"temperature for the material is %d"
 
 msgid ""
 "Too small layer height.\n"
@@ -3870,27 +3844,18 @@ msgid ""
 "45℃.In order to avoid extruder clogging,low temperature filament(PLA/PETG/"
 "TPU) is not allowed to be loaded."
 msgstr ""
-"The current chamber temperature or the target chamber temperature exceeds "
-"45℃. In order to avoid extruder clogging, low temperature filament (PLA/PETG/"
-"TPU) is not allowed to be loaded."
 
 msgid ""
 "Low temperature filament(PLA/PETG/TPU) is loaded in the extruder.In order to "
 "avoid extruder clogging,it is not allowed to set the chamber temperature "
 "above 45℃."
 msgstr ""
-"Low temperature filament (PLA/PETG/TPU) is loaded in the extruder. In order "
-"to avoid extruder clogging, it is not allowed to set the chamber temperature "
-"above 45℃."
 
 msgid ""
 "When you set the chamber temperature below 40℃, the chamber temperature "
 "control will not be activated. And the target chamber temperature will "
 "automatically be set to 0℃."
 msgstr ""
-"When you set the chamber temperature below 40℃, the chamber temperature "
-"control will not be activated, and the target chamber temperature will "
-"automatically be set to 0℃."
 
 msgid "Failed to start printing job"
 msgstr "Det gick inte att starta utskriftsjobbet"
@@ -4013,7 +3978,7 @@ msgstr "Parameter validering"
 
 #, c-format, boost-format
 msgid "Value %s is out of range. The valid range is from %d to %d."
-msgstr "Value %s is out of range. The valid range is from %d to %d."
+msgstr ""
 
 msgid "Value is out of range."
 msgstr "Värdet är utanför intervallet."
@@ -4108,7 +4073,7 @@ msgid "Flushed"
 msgstr "Rensad"
 
 msgid "Tower"
-msgstr "Tower"
+msgstr "Torn"
 
 msgid "Total"
 msgstr "Totalt"
@@ -4120,7 +4085,7 @@ msgid "Total time"
 msgstr "Total tid"
 
 msgid "Total cost"
-msgstr "Total cost"
+msgstr ""
 
 msgid "up to"
 msgstr "upp till"
@@ -4213,10 +4178,10 @@ msgid "Normal mode"
 msgstr "Normalt läge"
 
 msgid "Total Filament"
-msgstr "Total Filament"
+msgstr ""
 
 msgid "Model Filament"
-msgstr "Model Filament"
+msgstr ""
 
 msgid "Prepare time"
 msgstr "Förbered tid"
@@ -4312,7 +4277,7 @@ msgid "Spacing"
 msgstr "Mellanrum"
 
 msgid "0 means auto spacing."
-msgstr "0 means auto spacing."
+msgstr ""
 
 msgid "Auto rotate for arrangement"
 msgstr "Auto rotera  för arrangemang"
@@ -4855,13 +4820,13 @@ msgid "Flow rate"
 msgstr "Flödeshastighet"
 
 msgid "Pressure advance"
-msgstr "Pressure advance"
+msgstr ""
 
 msgid "Retraction test"
-msgstr "Retraction test"
+msgstr ""
 
 msgid "Orca Tolerance Test"
-msgstr "Orca Tolerance Test"
+msgstr ""
 
 msgid "Max flowrate"
 msgstr "Max flödes hastighet"
@@ -4951,7 +4916,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "Export result"
-msgstr "Export resultat"
+msgstr "Exportera resultat"
 
 msgid "Select profile to load:"
 msgstr "Välj den profil som ska laddas:"
@@ -5027,7 +4992,6 @@ msgstr ""
 msgid ""
 "LAN Only Liveview is off. Please turn on the liveview on printer screen."
 msgstr ""
-"LAN Only Liveview is off. Please turn on the liveview on printer screen."
 
 msgid "Please enter the IP of printer to connect."
 msgstr "Ange printerns IP för att ansluta."
@@ -5135,7 +5099,7 @@ msgid "Refresh"
 msgstr "Uppdatera"
 
 msgid "Reload file list from printer."
-msgstr "Reload file list from printer."
+msgstr ""
 
 msgid "No printers."
 msgstr "Ingen printer."
@@ -5147,14 +5111,12 @@ msgid "No files"
 msgstr "Inga filer"
 
 msgid "Load failed"
-msgstr "Load failed"
+msgstr ""
 
 msgid ""
 "Browsing file in SD card is not supported in current firmware. Please update "
 "the printer firmware."
 msgstr ""
-"Browsing file in SD card is not supported in current firmware. Please update "
-"the printer firmware."
 
 msgid ""
 "Please check if the SD card is inserted into the printer.\n"
@@ -5164,10 +5126,10 @@ msgstr ""
 "Om det fortfarande inte går att läsa kan du försöka formatera SD kortet."
 
 msgid "LAN Connection Failed (Failed to view sdcard)"
-msgstr "LAN Connection Failed (Failed to view sdcard)"
+msgstr ""
 
 msgid "Browsing file in SD card is not supported in LAN Only Mode."
-msgstr "Browsing file in SD card is not supported in LAN Only Mode."
+msgstr ""
 
 #, c-format, boost-format
 msgid "You are going to delete %u file from printer. Are you sure to continue?"
@@ -5209,8 +5171,6 @@ msgid ""
 "File: %s\n"
 "Title: %s\n"
 msgstr ""
-"File: %s\n"
-"Title: %s\n"
 
 msgid "Download waiting..."
 msgstr "Nedladdning väntar..."
@@ -5232,8 +5192,6 @@ msgid ""
 "Reconnecting the printer, the operation cannot be completed immediately, "
 "please try again later."
 msgstr ""
-"Reconnecting the printer, the operation cannot be completed immediately, "
-"please try again later."
 
 msgid "File does not exist."
 msgstr "Filen finns inte."
@@ -5306,8 +5264,6 @@ msgid ""
 "You have completed printing the mall model, \n"
 "but the synchronization of rating information has failed."
 msgstr ""
-"You have completed printing the mall model, \n"
-"but synchronizing rating information has failed."
 
 msgid "How do you like this printing file?"
 msgstr "Vad tycker du om den här utskriftsfilen?"
@@ -5338,7 +5294,7 @@ msgid "Control"
 msgstr "Kontroll"
 
 msgid "Printer Parts"
-msgstr "Printer Parts"
+msgstr ""
 
 msgid "Print Options"
 msgstr "Utskriftsalternativ"
@@ -5459,7 +5415,7 @@ msgid "Get oss config failed."
 msgstr "Hämta konfigurationen för oss misslyckades."
 
 msgid "Upload Pictures"
-msgstr "Upload Pictures"
+msgstr ""
 
 msgid "Number of images successfully uploaded"
 msgstr "Antal bilder som laddats upp framgångsrikt"
@@ -5474,7 +5430,7 @@ msgid " No corresponding storage bucket\n"
 msgstr " Ingen motsvarande lagrings plats\n"
 
 msgid " cannot be opened\n"
-msgstr " cannot be opened\n"
+msgstr ""
 
 msgid ""
 "The following issues occurred during the process of uploading images. Do you "
@@ -5502,9 +5458,6 @@ msgid ""
 "\n"
 "  error code: "
 msgstr ""
-"Your comment result cannot be uploaded due to the following reasons:\n"
-"\n"
-"  error code: "
 
 msgid "error message: "
 msgstr "felmeddelande: "
@@ -5514,9 +5467,6 @@ msgid ""
 "\n"
 "Would you like to redirect to the webpage for rating?"
 msgstr ""
-"\n"
-"\n"
-"Would you like to redirect to the webpage to give a rating?"
 
 msgid ""
 "Some of your images failed to upload. Would you like to redirect to the "
@@ -5598,7 +5548,7 @@ msgid "Latest Version: "
 msgstr "Senaste versionen: "
 
 msgid "Not for now"
-msgstr "Not for now"
+msgstr ""
 
 msgid "Server Exception"
 msgstr ""
@@ -5802,16 +5752,16 @@ msgid "Allow Prompt Sound"
 msgstr "Tillåt Prompt Ljud"
 
 msgid "Filament Tangle Detect"
-msgstr "Filament Tangle Detection"
+msgstr ""
 
 msgid "Nozzle Clumping Detection"
-msgstr "Nozzle Clumping Detection"
+msgstr ""
 
 msgid "Check if the nozzle is clumping by filament or other foreign objects."
-msgstr "Check if the nozzle is clumping by filament or other foreign objects."
+msgstr ""
 
 msgid "Nozzle Type"
-msgstr "Nozzle Type"
+msgstr "Nozzel Typ"
 
 msgid "Stainless Steel"
 msgstr "Rostfritt stål"
@@ -6273,13 +6223,13 @@ msgid "prepare 3mf file..."
 msgstr "förbereder 3mf-filen..."
 
 msgid "Download failed, unknown file format."
-msgstr "Download failed; unknown file format."
+msgstr ""
 
 msgid "downloading project ..."
 msgstr "laddar ner projekt ..."
 
 msgid "Download failed, File size exception."
-msgstr "Download failed; File size exception."
+msgstr ""
 
 #, c-format, boost-format
 msgid "Project downloaded %d%%"
@@ -6399,24 +6349,22 @@ msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
 "will be kept. You may fix the meshes and try again."
 msgstr ""
-"Unable to perform boolean operation on model meshes. Only positive parts "
-"will be kept. You may fix the meshes and try again."
 
 #, boost-format
 msgid "Reason: part \"%1%\" is empty."
-msgstr "Reason: part \"%1%\" is empty."
+msgstr ""
 
 #, boost-format
 msgid "Reason: part \"%1%\" does not bound a volume."
-msgstr "Reason: part \"%1%\" does not bound a volume."
+msgstr ""
 
 #, boost-format
 msgid "Reason: part \"%1%\" has self intersection."
-msgstr "Reason: part \"%1%\" has self intersection."
+msgstr ""
 
 #, boost-format
 msgid "Reason: \"%1%\" and another part have no intersection."
-msgstr "Reason: \"%1%\" and another part have no intersection."
+msgstr ""
 
 msgid ""
 "Unable to perform boolean operation on model meshes. Only positive parts "
@@ -6709,8 +6657,6 @@ msgid ""
 "With this option enabled, you can send a task to multiple devices at the "
 "same time and manage multiple devices."
 msgstr ""
-"With this option enabled, you can send a task to multiple devices at the "
-"same time and manage multiple devices."
 
 msgid "Auto arrange plate after cloning"
 msgstr ""
@@ -6793,7 +6739,7 @@ msgid "Clear my choice on the unsaved projects."
 msgstr "Rensa mitt val för de osparade projekten."
 
 msgid "No warnings when loading 3MF with modified G-code"
-msgstr "No warnings when loading 3MF with modified G-code"
+msgstr ""
 
 msgid "Auto-Backup"
 msgstr "Auto Säkerhetskopiera"
@@ -6958,16 +6904,16 @@ msgid "The selected preset is null!"
 msgstr "Den valda förinställningen är noll!"
 
 msgid "End"
-msgstr "End"
+msgstr ""
 
 msgid "Customize"
 msgstr "Anpassa"
 
 msgid "Other layer filament sequence"
-msgstr "Other layer filament sequence"
+msgstr ""
 
 msgid "Please input layer value (>= 2)."
-msgstr "Please input layer value (>= 2)."
+msgstr ""
 
 msgid "Plate name"
 msgstr "Plattans namn"
@@ -6979,10 +6925,10 @@ msgid "Print sequence"
 msgstr "Utskrifts sekvens"
 
 msgid "Same as Global"
-msgstr "Same as Global"
+msgstr ""
 
 msgid "Disable"
-msgstr "Disable"
+msgstr ""
 
 msgid "Spiral vase"
 msgstr "Spiral vas"
@@ -7129,13 +7075,13 @@ msgid "Busy"
 msgstr "Upptagen"
 
 msgid "Bambu Cool Plate"
-msgstr "Bambu Cool Plate"
+msgstr ""
 
 msgid "PLA Plate"
 msgstr "PLA platta"
 
 msgid "Bambu Engineering Plate"
-msgstr "Bambu Engineering Plate"
+msgstr ""
 
 msgid "Bambu Smooth PEI Plate"
 msgstr ""
@@ -7245,8 +7191,6 @@ msgid ""
 "The selected printer (%s) is incompatible with the chosen printer profile in "
 "the slicer (%s)."
 msgstr ""
-"The selected printer (%s) is incompatible with the chosen printer profile in "
-"the slicer (%s)."
 
 msgid "An SD card needs to be inserted to record timelapse."
 msgstr "Ett Micro SD-kort måste sättas i för att spela in en timelapse."
@@ -7268,8 +7212,6 @@ msgid ""
 "When enable spiral vase mode, machines with I3 structure will not generate "
 "timelapse videos."
 msgstr ""
-"When spiral vase mode is enabled, machines with I3 structure will not "
-"generate timelapse videos."
 
 msgid ""
 "Timelapse is not supported because Print sequence is set to \"By object\"."
@@ -7314,20 +7256,15 @@ msgid ""
 "If you changed your nozzle lately, please go to Device > Printer Parts to "
 "change settings."
 msgstr ""
-"Your nozzle diameter in sliced file is not consistent with the saved nozzle. "
-"If you changed your nozzle lately, please go to Device > Printer Parts to "
-"change settings."
 
 #, c-format, boost-format
 msgid ""
 "Printing high temperature material(%s material) with %s may cause nozzle "
 "damage"
 msgstr ""
-"Printing high temperature material(%s material) with %s may cause nozzle "
-"damage"
 
 msgid "Please fix the error above, otherwise printing cannot continue."
-msgstr "Please fix the error above, otherwise printing cannot continue."
+msgstr ""
 
 msgid ""
 "Please click the confirm button if you still want to proceed with printing."
@@ -7348,13 +7285,13 @@ msgstr ""
 "grund av ytan."
 
 msgid "Automatic flow calibration using Micro Lidar"
-msgstr "Automatic flow calibration using the Micro Lidar"
+msgstr ""
 
 msgid "Modifying the device name"
 msgstr "Ändra enhetens namn"
 
 msgid "Bind with Pin Code"
-msgstr "Bind with Pin Code"
+msgstr ""
 
 msgid "Bind with Access Code"
 msgstr ""
@@ -7415,23 +7352,21 @@ msgid ""
 "Please Find the Pin Code in Account page on printer screen,\n"
 " and type in the Pin Code below."
 msgstr ""
-"Please Find the Pin Code in Account page on printer screen,\n"
-" and type in the Pin Code below."
 
 msgid "Can't find Pin Code?"
-msgstr "Can't find Pin Code?"
+msgstr ""
 
 msgid "Pin Code"
-msgstr "Pin Code"
+msgstr ""
 
 msgid "Binding..."
-msgstr "Binding..."
+msgstr ""
 
 msgid "Please confirm on the printer screen"
-msgstr "Please confirm on the printer screen"
+msgstr ""
 
 msgid "Log in failed. Please check the Pin Code."
-msgstr "Log in failed. Please check the Pin Code."
+msgstr ""
 
 msgid "Log in printer"
 msgstr "Logga in skrivare"
@@ -7562,10 +7497,6 @@ msgid ""
 "0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
 "disable independent support layer height"
 msgstr ""
-"When using support material for the support interface, We recommend the "
-"following settings:\n"
-"0 top z distance, 0 interface spacing, interlaced rectilinear pattern and "
-"disable independent support layer height"
 
 msgid ""
 "Change these settings automatically? \n"
@@ -7802,7 +7733,7 @@ msgid "Post-processing Scripts"
 msgstr "Skript för efterbehandling"
 
 msgid "Notes"
-msgstr "Notes"
+msgstr ""
 
 msgid "Frequent"
 msgstr "Återkommande"
@@ -7869,7 +7800,7 @@ msgid ""
 msgstr ""
 
 msgid "Cool Plate"
-msgstr ""
+msgstr "Kall platta"
 
 msgid ""
 "Bed temperature when the Cool Plate is installed. A value of 0 means the "
@@ -8257,14 +8188,12 @@ msgstr ""
 
 #, boost-format
 msgid "You have changed some settings of preset \"%1%\"."
-msgstr "You have changed some settings of preset \"%1%\"."
+msgstr ""
 
 msgid ""
 "\n"
 "You can save or discard the preset values you have modified."
 msgstr ""
-"\n"
-"You can save or discard the preset values you have modified."
 
 msgid ""
 "\n"
@@ -8273,7 +8202,7 @@ msgid ""
 msgstr ""
 
 msgid "You have previously modified your settings."
-msgstr "You have previously modified your settings."
+msgstr ""
 
 msgid ""
 "\n"
@@ -8394,58 +8323,54 @@ msgid "The configuration is up to date."
 msgstr "Konfigurationen är aktuell."
 
 msgid "Obj file Import color"
-msgstr "Obj file Import color"
+msgstr ""
 
 msgid "Specify number of colors:"
-msgstr "Specify number of colors:"
+msgstr ""
 
 #, c-format, boost-format
 msgid "The color count should be in range [%d, %d]."
-msgstr "The color count should be in range [%d, %d]."
+msgstr ""
 
 msgid "Recommended "
-msgstr "Recommended "
+msgstr ""
 
 msgid "Current filament colors:"
-msgstr "Current filament colors:"
+msgstr ""
 
 msgid "Quick set:"
-msgstr "Quick set:"
+msgstr ""
 
 msgid "Color match"
-msgstr "Color match"
+msgstr ""
 
 msgid "Approximate color matching."
-msgstr "Approximate color matching."
+msgstr ""
 
 msgid "Append"
-msgstr "Append"
+msgstr ""
 
 msgid "Add consumable extruder after existing extruders."
-msgstr "Add consumable extruder after existing extruders."
+msgstr ""
 
 msgid "Reset mapped extruders."
-msgstr "Reset mapped extruders."
+msgstr ""
 
 msgid "Cluster colors"
-msgstr "Cluster colors"
+msgstr ""
 
 msgid "Map Filament"
-msgstr "Map Filament"
+msgstr ""
 
 msgid ""
 "Note:The color has been selected, you can choose OK \n"
 " to continue or manually adjust it."
 msgstr ""
-"Note:The color has been selected, you can choose OK \n"
-" to continue or manually adjust it."
 
 msgid ""
 "Waring:The count of newly added and \n"
 " current extruders exceeds 16."
 msgstr ""
-"Warning: The count of newly added and \n"
-" current extruders exceeds 16."
 
 msgid "Ramming customization"
 msgstr ""
@@ -8851,40 +8776,40 @@ msgid "Done"
 msgstr "Klar"
 
 msgid "resume"
-msgstr "resume"
+msgstr ""
 
 msgid "Resume Printing"
-msgstr "Resume Printing"
+msgstr ""
 
 msgid "Resume Printing(defects acceptable)"
-msgstr "Resume Printing (defects acceptable)"
+msgstr ""
 
 msgid "Resume Printing(problem solved)"
-msgstr "Resume Printing (problem solved)"
+msgstr ""
 
 msgid "Stop Printing"
-msgstr "Stop Printing"
+msgstr ""
 
 msgid "Check Assistant"
-msgstr "Check Assistant"
+msgstr ""
 
 msgid "Filament Extruded, Continue"
-msgstr "Filament Extruded, Continue"
+msgstr ""
 
 msgid "Not Extruded Yet, Retry"
-msgstr "Not Extruded Yet, Retry"
+msgstr ""
 
 msgid "Finished, Continue"
-msgstr "Finished, Continue"
+msgstr ""
 
 msgid "Load Filament"
 msgstr "Ladda Filament"
 
 msgid "Filament Loaded, Resume"
-msgstr "Filament Loaded, Resume"
+msgstr ""
 
 msgid "View Liveview"
-msgstr "View Liveview"
+msgstr ""
 
 msgid "Confirm and Update Nozzle"
 msgstr "Bekräfta och uppdatera nozzeln"
@@ -9035,7 +8960,7 @@ msgid "Loading repaired objects"
 msgstr "Laddar de reparerade objekten"
 
 msgid "Exporting 3mf file failed"
-msgstr "Export av 3mf filen misslyckades"
+msgstr "Exporterar av 3mf filen misslyckades"
 
 msgid "Import 3mf file failed"
 msgstr "Importen av 3mf filen misslyckades"
@@ -9792,13 +9717,13 @@ msgid "First layer print sequence"
 msgstr "Första lagrets utskrifts ordning"
 
 msgid "Other layers print sequence"
-msgstr "Other layers print sequence"
+msgstr ""
 
 msgid "The number of other layers print sequence"
-msgstr "The number of other layers print sequence"
+msgstr ""
 
 msgid "Other layers filament sequence"
-msgstr "Other layers filament sequence"
+msgstr ""
 
 msgid "This G-code is inserted at every layer change before lifting z"
 msgstr "Denna G-kod används för varje lager innan Z axis lyfts"
@@ -10314,7 +10239,7 @@ msgid "Default process profile when switch to this machine profile"
 msgstr "Standard process profil vid byte till denna maskinens profil"
 
 msgid "Activate air filtration"
-msgstr "Activate air filtration"
+msgstr ""
 
 msgid "Activate for better air filtration. G-code command: M106 P3 S(0-255)"
 msgstr ""
@@ -10918,10 +10843,10 @@ msgid "Default filament color"
 msgstr "Standard filament färg"
 
 msgid "Filament notes"
-msgstr "Filament notes"
+msgstr ""
 
 msgid "You can put your notes regarding the filament here."
-msgstr "You can put your notes regarding the filament here."
+msgstr ""
 
 msgid "Required nozzle HRC"
 msgstr "HRC nozzle krävs"
@@ -11164,9 +11089,6 @@ msgid ""
 "equal to or greater than it, it's highly recommended to open the front door "
 "and/or remove the upper glass to avoid clogging."
 msgstr ""
-"The material softens at this temperature, so when the bed temperature is "
-"equal to or greater than this, it's highly recommended to open the front "
-"door and/or remove the upper glass to avoid clogs."
 
 msgid "Price"
 msgstr "Pris"
@@ -11346,7 +11268,7 @@ msgid ""
 msgstr ""
 
 msgid "mm/s² or %"
-msgstr "mm/s² or %"
+msgstr "mm/s² eller %"
 
 msgid ""
 "Acceleration of sparse infill. If the value is expressed as a percentage "
@@ -11599,16 +11521,13 @@ msgstr ""
 "linjebredd och bör skrivas ut långsammare"
 
 msgid "Precise Z height"
-msgstr "Precise Z height"
+msgstr ""
 
 msgid ""
 "Enable this to get precise z height of object after slicing. It will get the "
 "precise object height by fine-tuning the layer heights of the last few "
 "layers. Note that this is an experimental parameter."
 msgstr ""
-"Enable this to get precise z height of object after slicing. It will get the "
-"precise object height by fine-tuning the layer heights of the last few "
-"layers. Note that this is an experimental parameter."
 
 msgid "Arc fitting"
 msgstr "Arc passning"
@@ -11875,23 +11794,19 @@ msgid "Name of parent profile"
 msgstr ""
 
 msgid "Interface shells"
-msgstr "Interface shells"
+msgstr ""
 
 msgid ""
 "Force the generation of solid shells between adjacent materials/volumes. "
 "Useful for multi-extruder prints with translucent materials or manual "
 "soluble support material"
 msgstr ""
-"Force the generation of solid shells between adjacent materials/volumes. "
-"Useful for multi-extruder prints with translucent materials or manual "
-"soluble support material"
 
 msgid "Maximum width of a segmented region"
 msgstr "Maximal bredd för en segmenterad region"
 
 msgid "Maximum width of a segmented region. Zero disables this feature."
 msgstr ""
-"Maximum width of a segmented region. A value of 0 disables this feature."
 
 msgid "Interlocking depth of a segmented region"
 msgstr "Sammanhängande djup i en segmenterad region"
@@ -12451,10 +12366,10 @@ msgid "Type of the printer"
 msgstr ""
 
 msgid "Printer notes"
-msgstr "Printer notes"
+msgstr ""
 
 msgid "You can put your notes regarding the printer here."
-msgstr "You can put your notes regarding the printer here."
+msgstr ""
 
 msgid "Printer variant"
 msgstr ""
@@ -12468,7 +12383,7 @@ msgstr ""
 "lösliga gränssnitt"
 
 msgid "Raft expansion"
-msgstr "Raft expansion"
+msgstr ""
 
 msgid "Expand all raft layers in XY plane"
 msgstr "Öka alla raft lager i XY planet"
@@ -12549,7 +12464,7 @@ msgstr ""
 "långa förflyttningar. Sätt på 0 för att inaktivera retraktion"
 
 msgid "Long retraction when cut(beta)"
-msgstr "Long retraction when cut (beta)"
+msgstr ""
 
 msgid ""
 "Experimental feature.Retracting and cutting off the filament at a longer "
@@ -12557,20 +12472,14 @@ msgid ""
 "significantly, it may also raise the risk of nozzle clogs or other printing "
 "problems."
 msgstr ""
-"Experimental feature: Retracting and cutting off the filament at a longer "
-"distance during changes to minimize purge.While this reduces flush "
-"significantly, it may also raise the risk of nozzle clogs or other printing "
-"problems."
 
 msgid "Retraction distance when cut"
-msgstr "Retraction distance when cut"
+msgstr ""
 
 msgid ""
 "Experimental feature.Retraction length before cutting off during filament "
 "change"
 msgstr ""
-"Experimental feature. Retraction length before cutting off during filament "
-"change"
 
 msgid "Z-hop height"
 msgstr ""
@@ -12747,20 +12656,17 @@ msgstr ""
 
 msgid "Use scarf joint to minimize seam visibility and increase seam strength."
 msgstr ""
-"Use scarf joint to minimize seam visibility and increase seam strength."
 
 msgid "Conditional scarf joint"
-msgstr "Conditional scarf joint"
+msgstr ""
 
 msgid ""
 "Apply scarf joints only to smooth perimeters where traditional seams do not "
 "conceal the seams at sharp corners effectively."
 msgstr ""
-"Apply scarf joints only to smooth perimeters where traditional seams do not "
-"conceal the seams at sharp corners effectively."
 
 msgid "Conditional angle threshold"
-msgstr "Conditional angle threshold"
+msgstr ""
 
 msgid ""
 "This option sets the threshold angle for applying a conditional scarf joint "
@@ -12803,44 +12709,39 @@ msgid "This factor affects the amount of material for scarf joints."
 msgstr ""
 
 msgid "Scarf start height"
-msgstr "Scarf start height"
+msgstr ""
 
 msgid ""
 "Start height of the scarf.\n"
 "This amount can be specified in millimeters or as a percentage of the "
 "current layer height. The default value for this parameter is 0."
 msgstr ""
-"Start height of the scarf.\n"
-"This amount can be specified in millimeters or as a percentage of the "
-"current layer height. The default value for this parameter is 0."
 
 msgid "Scarf around entire wall"
-msgstr "Scarf around entire wall"
+msgstr ""
 
 msgid "The scarf extends to the entire length of the wall."
-msgstr "The scarf extends to the entire length of the wall."
+msgstr ""
 
 msgid "Scarf length"
-msgstr "Scarf length"
+msgstr ""
 
 msgid ""
 "Length of the scarf. Setting this parameter to zero effectively disables the "
 "scarf."
 msgstr ""
-"Length of the scarf. Setting this parameter to zero effectively disables the "
-"scarf."
 
 msgid "Scarf steps"
-msgstr "Scarf steps"
+msgstr ""
 
 msgid "Minimum number of segments of each scarf."
-msgstr "Minimum number of segments of each scarf."
+msgstr ""
 
 msgid "Scarf joint for inner walls"
-msgstr "Scarf joint for inner walls"
+msgstr ""
 
 msgid "Use scarf joint for inner walls as well."
-msgstr "Use scarf joint for inner walls as well."
+msgstr ""
 
 msgid "Role base wipe speed"
 msgstr ""
@@ -13017,17 +12918,15 @@ msgstr ""
 "solida bottenlager. Den slutgiltligt genererade modellen har ingen söm"
 
 msgid "Smooth Spiral"
-msgstr "Smooth Spiral"
+msgstr ""
 
 msgid ""
 "Smooth Spiral smooths out X and Y moves as well, resulting in no visible "
 "seam at all, even in the XY directions on walls that are not vertical"
 msgstr ""
-"Smooth Spiral smooths out X and Y moves as well, resulting in no visible "
-"seam at all, even in the XY directions on walls that are not vertical"
 
 msgid "Max XY Smoothing"
-msgstr "Max XY Smoothing"
+msgstr ""
 
 #, no-c-format, no-boost-format
 msgid ""
@@ -13231,10 +13130,10 @@ msgid "XY separation between an object and its support"
 msgstr "XY avstånd mellan objektet och support"
 
 msgid "Support/object first layer gap"
-msgstr "Support/object first layer gap"
+msgstr ""
 
 msgid "XY separation between an object and its support at the first layer."
-msgstr "XY separation between an object and its support at the first layer."
+msgstr ""
 
 msgid "Pattern angle"
 msgstr "Mönster vinkel"
@@ -14716,7 +14615,7 @@ msgid "load_obj: failed to parse"
 msgstr "load_obj: misslyckades med att analysera"
 
 msgid "load mtl in obj: failed to parse"
-msgstr "load mtl in obj: failed to parse"
+msgstr ""
 
 msgid "The file contains polygons with more than 4 vertices."
 msgstr "Filen innehåller polygoner med fler än 4 hörn."
@@ -14852,11 +14751,6 @@ msgid ""
 "historical results. \n"
 "Do you still want to continue the calibration?"
 msgstr ""
-"This machine type can only hold 16 historical results per nozzle. You can "
-"delete the existing historical results and then start calibration. Or you "
-"can continue the calibration, but you cannot create new calibration "
-"historical results. \n"
-"Do you still want to continue the calibration?"
 
 msgid "Connecting to printer..."
 msgstr "Ansluter till skrivaren..."
@@ -14882,8 +14776,6 @@ msgid ""
 "This machine type can only hold %d history results per nozzle. This result "
 "will not be saved."
 msgstr ""
-"This machine type can only hold %d historical results per nozzle. This "
-"result will not be saved."
 
 msgid "Internal Error"
 msgstr "Internt fel"
@@ -14959,15 +14851,6 @@ msgid ""
 "4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as "
 "they should be."
 msgstr ""
-"After using Flow Dynamics Calibration, there might still be some extrusion "
-"issues, such as:\n"
-"1. Over-Extrusion: Excess material on your printed object, forming blobs or "
-"zits, or the layers seem thicker than expected and not uniform.\n"
-"2. Under-Extrusion: Very thin layers, weak infill strength, or gaps in the "
-"top layer of the model, even when printing slowly.\n"
-"3. Poor Surface Quality: The surface of your prints seems rough or uneven.\n"
-"4. Weak Structural Integrity: Prints break easily or don't seem as sturdy as "
-"they should be."
 
 msgid ""
 "In addition, Flow Rate Calibration is crucial for foaming materials like LW-"
@@ -15012,22 +14895,6 @@ msgid ""
 "can lead to sub-par prints or printer damage. Please make sure to carefully "
 "read and understand the process before doing it."
 msgstr ""
-"Auto Flow Rate Calibration utilizes Bambu Lab's Micro-Lidar technology, "
-"directly measuring the calibration patterns. However, please be advised that "
-"the efficacy and accuracy of this method may be compromised with specific "
-"types of materials. Particularly, filaments that are transparent or semi-"
-"transparent, sparkling-particled, or have a high-reflective finish may not "
-"be suitable for this calibration and can produce less-than-desirable "
-"results.\n"
-"\n"
-"The calibration results may vary between each calibration or filament. We "
-"are still improving the accuracy and compatibility of this calibration "
-"through firmware updates over time.\n"
-"\n"
-"Caution: Flow Rate Calibration is an advanced process, to be attempted only "
-"by those who fully understand its purpose and implications. Incorrect usage "
-"can lead to sub-par prints or printer damage. Please make sure to carefully "
-"read and understand the process before performing it."
 
 msgid "When you need Max Volumetric Speed Calibration"
 msgstr "När du behöver kalibrering av maximal volymhastighet"
@@ -15218,7 +15085,7 @@ msgid "Flow Dynamics Calibration Result"
 msgstr "Resultat för kalibrering av flödesdynamik"
 
 msgid "New"
-msgstr "New"
+msgstr ""
 
 msgid "No History Result"
 msgstr "Inget historikresultat"
@@ -15234,25 +15101,25 @@ msgstr "Åtgärd"
 
 #, c-format, boost-format
 msgid "This machine type can only hold %d history results per nozzle."
-msgstr "This machine type can only hold %d historical results per nozzle."
+msgstr ""
 
 msgid "Edit Flow Dynamics Calibration"
 msgstr "Redigera kalibrering av flödesdynamik"
 
 msgid "New Flow Dynamic Calibration"
-msgstr "New Flow Dynamic Calibration"
+msgstr ""
 
 msgid "Ok"
 msgstr "Ok"
 
 msgid "The filament must be selected."
-msgstr "The filament must be selected."
+msgstr ""
 
 msgid "Network lookup"
 msgstr "Nätverks sökning"
 
 msgid "Address"
-msgstr "Address"
+msgstr ""
 
 msgid "Hostname"
 msgstr "Värdnamn"
@@ -15993,7 +15860,7 @@ msgid "Please select a type you want to export"
 msgstr "Välj en inställningstyp som du vill exportera"
 
 msgid "Failed to create temporary folder, please try Export Configs again."
-msgstr "Failed to create temporary folder, please try Export Configs again."
+msgstr ""
 
 msgid "Edit Filament"
 msgstr "Redigera filament"
@@ -16166,16 +16033,16 @@ msgid "Mismatched type of print host: %s"
 msgstr "Felaktig typ av utskriftsvärd: %s"
 
 msgid "Connection to AstroBox is working correctly."
-msgstr "Connection to AstroBox is working correctly."
+msgstr ""
 
 msgid "Could not connect to AstroBox"
 msgstr "Kunde inte ansluta till AstroBox"
 
 msgid "Note: AstroBox version 1.1.0 or higher is required."
-msgstr "Note: AstroBox version 1.1.0 or higher is required."
+msgstr ""
 
 msgid "Connection to Duet is working correctly."
-msgstr "Connection to Duet is working correctly."
+msgstr ""
 
 msgid "Could not connect to Duet"
 msgstr "Kunde inte ansluta till Duet"
@@ -16193,7 +16060,7 @@ msgid "Upload not enabled on FlashAir card."
 msgstr "Uppladdning inte aktiverad på FlashAir kort."
 
 msgid "Connection to FlashAir is working correctly and upload is enabled."
-msgstr "Connection to FlashAir is working correctly and upload is enabled."
+msgstr ""
 
 msgid "Could not connect to FlashAir"
 msgstr "Kunde inte ansluta till FlashAir"
@@ -16206,28 +16073,28 @@ msgstr ""
 "uppladdningsfunktion krävs."
 
 msgid "Connection to MKS is working correctly."
-msgstr "Connection to MKS is working correctly."
+msgstr ""
 
 msgid "Could not connect to MKS"
 msgstr "Kunde inte ansluta till MKS"
 
 msgid "Connection to OctoPrint is working correctly."
-msgstr "Connection to OctoPrint is working correctly."
+msgstr ""
 
 msgid "Could not connect to OctoPrint"
 msgstr "Kunde inte ansluta till OctoPrint"
 
 msgid "Note: OctoPrint version 1.1.0 or higher is required."
-msgstr "Note: OctoPrint version 1.1.0 or higher is required."
+msgstr ""
 
 msgid "Connection to Prusa SL1 / SL1S is working correctly."
-msgstr "Connection to Prusa SL1 / SL1S is working correctly."
+msgstr ""
 
 msgid "Could not connect to Prusa SLA"
 msgstr "Kunde inte ansluta till Prusa SLA"
 
 msgid "Connection to PrusaLink is working correctly."
-msgstr "Connection to PrusaLink is working correctly."
+msgstr ""
 
 msgid "Could not connect to PrusaLink"
 msgstr "Kunde inte ansluta till PrusaLink"
@@ -16257,13 +16124,13 @@ msgid "Could not connect to Prusa Connect"
 msgstr ""
 
 msgid "Connection to Repetier is working correctly."
-msgstr "Connection to Repetier is working correctly."
+msgstr ""
 
 msgid "Could not connect to Repetier"
 msgstr "Kunde inte ansluta till Repetier"
 
 msgid "Note: Repetier version 0.90.0 or higher is required."
-msgstr "Note: Repetier version 0.90.0 or higher is required."
+msgstr ""
 
 #, boost-format
 msgid ""
@@ -16540,7 +16407,7 @@ msgid "Brim Ears"
 msgstr ""
 
 msgid "Please select single object."
-msgstr "Please select single object."
+msgstr ""
 
 #: resources/data/hints.ini: [hint:Precise wall]
 msgid ""
@@ -16945,9 +16812,6 @@ msgstr ""
 #~ msgid "Support: propagate branches at layer %d"
 #~ msgstr "Support: föröka grenar vid lager %d"
 
-#~ msgid "Current Cabin humidity"
-#~ msgstr "Current Cabin humidity"
-
 #~ msgid "Stopped."
 #~ msgstr "Avbruten."
 
@@ -17038,9 +16902,6 @@ msgstr ""
 #~ msgid "Scale"
 #~ msgstr "Skala"
 
-#~ msgid "Cool plate"
-#~ msgstr "Kall platta"
-
 #~ msgid "Z-hop when retract"
 #~ msgstr "Z-hopp vid retraktion"
 
@@ -17077,23 +16938,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Ladda ur gammalt filament vid byte av filament, endast för statistiska "
 #~ "ändamål"
-
-#~ msgid ""
-#~ "Higher chamber temperature can help suppress or reduce warping and "
-#~ "potentially lead to higher interlayer bonding strength for high "
-#~ "temperature materials like ABS, ASA, PC, PA and so on.At the same time, "
-#~ "the air filtration of ABS and ASA will get worse.While for PLA, PETG, "
-#~ "TPU, PVA and other low temperature materials,the actual chamber "
-#~ "temperature should not be high to avoid cloggings, so 0 which stands for "
-#~ "turning off is highly recommended"
-#~ msgstr ""
-#~ "Higher chamber temperature can help suppress or reduce warping and "
-#~ "potentially lead to higher interlayer bonding strength for high "
-#~ "temperature materials like ABS, ASA, PC, PA and so on. At the same time, "
-#~ "the air filtration of ABS and ASA will get worse.While for PLA, PETG, "
-#~ "TPU, PVA and other low temperature materials, the actual chamber "
-#~ "temperature should not be high to avoid clogs, so 0 (turned off) is "
-#~ "highly recommended."
 
 #~ msgid ""
 #~ "Different nozzle diameters and different filament diameters is not "
@@ -17183,9 +17027,6 @@ msgstr ""
 #~ msgid "Please find the cornor with perfect degree of extrusion"
 #~ msgstr "Hitta hörnet med den perfekta graden av extrudering"
 
-#~ msgid "V"
-#~ msgstr "V"
-
 #~ msgid "Export &Configs"
 #~ msgstr "Exportera konfiguration"
 
@@ -17210,27 +17051,11 @@ msgstr ""
 #~ msgid "Unload Filament"
 #~ msgstr "Mata ut"
 
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "Välj ett AMS fack tryck sedan \"Ladda eller \"Mata ur\" knappen för att "
-#~ "automatiskt mata eller mata ut filament."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
 #~ msgid "MainBoard"
 #~ msgstr "Moderkort"
 
-#~ msgid "TH"
-#~ msgstr "TH"
-
 #~ msgid "XCam"
 #~ msgstr "X Kamera"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
 
 #~ msgid "active"
 #~ msgstr "aktiv"
@@ -17318,9 +17143,6 @@ msgstr ""
 #~ msgid "Failed to fetching model information from printer."
 #~ msgstr "Det gick inte att hämta modell information från skrivaren."
 
-#~ msgid "Failed to parse model informations."
-#~ msgstr "Det gick inte att analysera modellinformation"
-
 #, boost-format
 #~ msgid ""
 #~ "You have changed some settings of preset \"%1%\". \n"
@@ -17399,9 +17221,6 @@ msgstr ""
 #~ msgid "Choose SLA archive:"
 #~ msgstr "Välj SLA arkiv:"
 
-#~ msgid "Import file"
-#~ msgstr "Importera fil"
-
 #~ msgid "Import model and profile"
 #~ msgstr "Importera modell och profil"
 
@@ -17454,9 +17273,6 @@ msgstr ""
 #~ "Nej - Återställ automatiskt densiteten till standardvärdet som inte är "
 #~ "100 %."
 
-#~ msgid "Please heat the nozzle to above 170 degree before loading filament."
-#~ msgstr "Värm nozzeln till över 170 grader innan du laddar filamentet."
-
 #, c-format
 #~ msgid "Density of internal sparse infill, 100% means solid throughout"
 #~ msgstr ""
@@ -17471,9 +17287,6 @@ msgstr ""
 #, c-format, boost-format
 #~ msgid " doesn't work at 100%% density "
 #~ msgstr " fungerar inte vid 100%% densitet "
-
-#~ msgid "Ctrl + Shift + Enter"
-#~ msgstr "Ctrl + Shift + Enter"
 
 #~ msgid "Tool-Lay on Face"
 #~ msgstr "Ytplacerings verktyg"
@@ -17542,15 +17355,6 @@ msgstr ""
 #~ "Vet du hur du kontrollerar vy och objekt/delval med mus och pekskärm i 3D-"
 #~ "scenen?"
 
-#~ msgid ""
-#~ "Fix Model\n"
-#~ "Did you know that you can fix a corrupted 3D model to avoid a lot of "
-#~ "slicing problems?"
-#~ msgstr ""
-#~ "Fix Modell\n"
-#~ "Visste du att du kan fixa en skadad 3D-modell för att undvika många "
-#~ "berednings problem?"
-
 #~ msgid "Embedded"
 #~ msgstr "Inbäddad"
 
@@ -17605,9 +17409,6 @@ msgstr ""
 #~ msgid "Calibration of extrusion"
 #~ msgstr "Kalibrering av extrudering"
 
-#~ msgid "Push new filament into the extruder"
-#~ msgstr "Mata nytt filament till extruder"
-
 #, c-format, boost-format
 #~ msgid ""
 #~ "Bed temperature of other layer is lower than bed temperature of initial "
@@ -17646,9 +17447,6 @@ msgstr ""
 
 #~ msgid "Score"
 #~ msgstr "Resultat"
-
-#~ msgid "Bambu High Temperature Plate"
-#~ msgstr "Bambu High Temperature Plate"
 
 #~ msgid "Can't connect to the printer"
 #~ msgstr "Kan inte ansluta till skrivaren"

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -3252,10 +3252,10 @@ msgid "Underflow"
 msgstr "Düşük Akış"
 
 msgid "Floating reserved operand"
-msgstr "Floating reserved operand"
+msgstr ""
 
 msgid "Stack overflow"
-msgstr "Stack overflow"
+msgstr ""
 
 msgid "Running post-processing scripts"
 msgstr "İşlem sonrası komut dosyalarını çalıştırma"
@@ -7269,22 +7269,22 @@ msgid "Busy"
 msgstr "Meşgul"
 
 msgid "Bambu Cool Plate"
-msgstr "Bambu Cool Plate"
+msgstr ""
 
 msgid "PLA Plate"
 msgstr "PLA Plaka"
 
 msgid "Bambu Engineering Plate"
-msgstr "Bambu Engineering Plate"
+msgstr ""
 
 msgid "Bambu Smooth PEI Plate"
-msgstr "Bambu Smooth PEI Plate"
+msgstr ""
 
 msgid "High temperature Plate"
-msgstr "High Temperature Plate"
+msgstr ""
 
 msgid "Bambu Textured PEI Plate"
-msgstr "Bambu Textured PEI Plate"
+msgstr ""
 
 msgid "Send print job to"
 msgstr "Yazdırma işini şuraya gönder"
@@ -8022,7 +8022,7 @@ msgstr ""
 "SuperTack üzerine yazdırmayı desteklemediği anlamına gelir"
 
 msgid "Cool Plate"
-msgstr ""
+msgstr "Soğuk plaka"
 
 msgid ""
 "Bed temperature when the Cool Plate is installed. A value of 0 means the "
@@ -8190,7 +8190,7 @@ msgid "Layer change G-code"
 msgstr "Katman Değişimi G-kod"
 
 msgid "Time lapse G-code"
-msgstr "Time Lapse G-code"
+msgstr ""
 
 msgid "Change filament G-code"
 msgstr "Filament Değişimi G-kod"
@@ -18368,17 +18368,6 @@ msgstr ""
 #~ "en az 2 arayüz katmanı, en az 0,1 mm üst z mesafesi veya arayüzde destek "
 #~ "malzemeleri kullanılması."
 
-#~ msgid ""
-#~ "When using support material for the support interface, We recommend the "
-#~ "following settings:\n"
-#~ "0 top z distance, 0 interface spacing, concentric pattern and disable "
-#~ "independent support layer height"
-#~ msgstr ""
-#~ "Destek arayüzü için destek materyali kullanırken aşağıdaki ayarları "
-#~ "öneriyoruz:\n"
-#~ "0 üst z mesafesi, 0 arayüz aralığı, eş merkezli desen ve bağımsız destek "
-#~ "katmanı yüksekliğini devre dışı bırakma"
-
 #~ msgid "Branch Diameter with double walls"
 #~ msgstr "Çift duvarlı dal çapı"
 
@@ -18637,9 +18626,6 @@ msgstr ""
 
 #~ msgid "Orca Slicer "
 #~ msgstr "Orca Dilimleyici "
-
-#~ msgid "Cool plate"
-#~ msgstr "Soğuk plaka"
 
 #~ msgid "Lift Z Enforcement"
 #~ msgstr "Z Kaldırma Uygulaması"
@@ -19157,12 +19143,6 @@ msgstr ""
 #~ msgid "Please find the cornor with perfect degree of extrusion"
 #~ msgstr "Lütfen mükemmel ekstrüzyon derecesine sahip köşeyi bulun"
 
-#~ msgid "X"
-#~ msgstr "X"
-
-#~ msgid "Y"
-#~ msgstr "Y"
-
 #~ msgid ""
 #~ "Associate OrcaSlicer with prusaslicer:// links so that Orca can open "
 #~ "PrusaSlicer links from Printable.com"
@@ -19188,9 +19168,6 @@ msgstr ""
 #~ "duvarları tutturulduğu yerden hafifçe dışarı doğru itecek ve bu da daha "
 #~ "kötü bir dış yüzey kalitesine neden olacaktır. Ayrıca dolgunun parçanın "
 #~ "dış yüzeylerinden parlamasına da neden olabilir."
-
-#~ msgid "V"
-#~ msgstr "V"
 
 #~ msgid ""
 #~ "Orca Slicer is based on BambuStudio by Bambulab, which is from "
@@ -19291,36 +19268,8 @@ msgstr ""
 #~ msgid "Unload Filament"
 #~ msgstr "Filamenti Çıkarın"
 
-#~ msgid ""
-#~ "Choose an AMS slot then press \"Load\" or \"Unload\" button to "
-#~ "automatically load or unload filiament."
-#~ msgstr ""
-#~ "Filamenti otomatik olarak yüklemek veya çıkarmak için bir AMS yuvası "
-#~ "seçin ve ardından \"Yükle\" veya \"Boşalt\" düğmesine basın."
-
-#~ msgid "MC"
-#~ msgstr "MC"
-
 #~ msgid "MainBoard"
 #~ msgstr "Anakart"
-
-#~ msgid "TH"
-#~ msgstr "TH"
-
-#~ msgid "XCam"
-#~ msgstr "XCam"
-
-#~ msgid "HMS"
-#~ msgstr "HMS"
-
-#~ msgid "- ℃"
-#~ msgstr "- °C"
-
-#~ msgid "0.5"
-#~ msgstr "0.5"
-
-#~ msgid "0.005"
-#~ msgstr "0.005"
 
 #~ msgid "New Flow Dynamics Calibration"
 #~ msgstr "Yeni Akış Dinamiği Kalibrasyonu"
@@ -19439,9 +19388,6 @@ msgstr ""
 
 #~ msgid "Failed to fetching model informations from printer."
 #~ msgstr "Model bilgileri yazıcıdan alınamadı."
-
-#~ msgid "Failed to parse model informations."
-#~ msgstr "Model bilgileri ayrıştırılamadı."
 
 #~ msgid "Connection lost. Please retry."
 #~ msgstr "Bağlantı koptu. Lütfen tekrar deneyiniz."
@@ -19583,9 +19529,6 @@ msgstr ""
 #~ "Çok eğimli yüzeyler için bu seçenek çok ince bir üst katman "
 #~ "oluşturacağından ve devre dışı bırakılması gerektiğinden uygun değildir."
 
-#~ msgid " "
-#~ msgstr " "
-
 #~ msgid "Text-Rotate"
 #~ msgstr "Metin Döndürme"
 
@@ -19632,18 +19575,6 @@ msgstr ""
 
 #~ msgid "wiki"
 #~ msgstr "wiki"
-
-#~ msgid ""
-#~ "Relative extrusion is recommended when using \"label_objects\" "
-#~ "option.Some extruders work better with this option unchecked (absolute "
-#~ "extrusion mode). Wipe tower is only compatible with relative mode. It is "
-#~ "always enabled on BambuLab printers. Default is checked"
-#~ msgstr ""
-#~ "\"label_objects\" seçeneği kullanılırken göreceli ekstrüzyon önerilir. "
-#~ "Bazı ekstruderler bu seçeneğin işareti kaldırıldığında (mutlak ekstrüzyon "
-#~ "modu) daha iyi çalışır. Temizleme kulesi yalnızca göreceli modla "
-#~ "uyumludur. BambuLab yazıcılarında her zaman etkindir. Varsayılan olarak "
-#~ "işaretlendi"
 
 #~ msgid "Movement:"
 #~ msgstr "Hareket:"
@@ -19711,9 +19642,6 @@ msgstr ""
 
 #~ msgid "Choose SLA archive:"
 #~ msgstr "SLA arşivini seçin:"
-
-#~ msgid "Import file"
-#~ msgstr "Dosyayı içe aktar"
 
 #~ msgid "Import model and profile"
 #~ msgstr "Modeli ve profili içe aktar"
@@ -19912,15 +19840,6 @@ msgstr ""
 #~ "3D sahnede fare ve dokunmatik panel ile görünümü ve nesne/parça seçimini "
 #~ "nasıl kontrol edeceğinizi biliyor muydunuz?"
 
-#~ msgid ""
-#~ "Fix Model\n"
-#~ "Did you know that you can fix a corrupted 3D model to avoid a lot of "
-#~ "slicing problems?"
-#~ msgstr ""
-#~ "Modeli Düzelt\n"
-#~ "Pek çok dilimleme sorununu önlemek için bozuk bir 3D modeli "
-#~ "düzeltebileceğinizi biliyor muydunuz?"
-
 #~ msgid "Embedded"
 #~ msgstr "Gömülü"
 
@@ -20027,11 +19946,6 @@ msgstr ""
 #~ "Yüksek sıcaklık plakası takıldığında yatak sıcaklığı. 0 değeri, "
 #~ "filamentin Yüksek Sıcaklık Plakasına yazdırmayı desteklemediği anlamına "
 #~ "gelir"
-
-#~ msgid ""
-#~ "Klipper's max_accel_to_decel will be adjusted to this % of acceleration"
-#~ msgstr ""
-#~ "Klipper max_accel_to_decel değeri bu hızlanma % değerine ayarlanacaktır"
 
 #~ msgid "Maximum acceleration for travel (M204 T)"
 #~ msgstr "Hareket için maksimum hızlanma (M204 T)"

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -16931,9 +16931,6 @@ msgstr ""
 #~ msgid "Orca Slicer "
 #~ msgstr "逆戟鲸切片"
 
-#~ msgid "Cool plate"
-#~ msgstr "低温打印热床"
-
 #~ msgid "Lift Z Enforcement"
 #~ msgstr "强化抬Z策略"
 
@@ -17206,9 +17203,6 @@ msgstr ""
 #~ msgid "Wipe tower extruder"
 #~ msgstr "擦拭塔挤出机"
 
-#~ msgid "V"
-#~ msgstr "V"
-
 #~ msgid "Export &Configs"
 #~ msgstr "导出预设"
 
@@ -17430,9 +17424,6 @@ msgstr ""
 #~ "Add solid infill near sloping surfaces to guarantee the vertical shell "
 #~ "thickness (top+bottom solid layers)"
 #~ msgstr "在斜面表面附近添加实心填充，以保证垂直外壳厚度（顶部+底部实心层）"
-
-#~ msgid " "
-#~ msgstr " "
 
 #~ msgid "Text-Rotate"
 #~ msgstr "旋转文字"

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -6827,7 +6827,7 @@ msgid "The selected preset is null!"
 msgstr "選擇的預設為空！"
 
 msgid "End"
-msgstr "End"
+msgstr ""
 
 msgid "Customize"
 msgstr "自訂"


### PR DESCRIPTION
# Description
I found many duplicate strings (translation identical to source) on the translation files.
This makes no difference for the end-user, but makes the work harder for the translator, since the translation tools show these strings as already translated.
Most of the duplicate strings were inherited from BambuStudio.