### PR TITLE
Fix typo

### DIFF
--- a/build_release_vs2022.bat
+++ b/build_release_vs2022.bat
@@ -1,4 +1,4 @@
-@REM OcarSlicer build script for Windows
+@REM OrcaSlicer build script for Windows
 @echo off
 set WP=%CD%
 


### PR DESCRIPTION
Typo in remark in batch file. - OcarSlicer should be OrcaSlicer

Possibly the greatest contribution to the next version!