### PR TITLE
Added TPU, ABS, and PETG Profiles for Co Print ChromaSet-2

### DIFF
--- a/resources/profiles/Co Print.json
+++ b/resources/profiles/Co Print.json
@@ -1,6 +1,6 @@
 {
   "name": "Co Print",
-  "version": "02.03.00.02",
+  "version": "02.02.00.04",
   "force_update": "0",
   "description": "CoPrint configurations",
   "machine_model_list": [
@@ -36,6 +36,18 @@
     {
       "name": "CoPrint Generic PLA",
       "sub_path": "filament/CoPrint Generic PLA.json"
+    },
+    {
+      "name": "CoPrint Generic ABS",
+      "sub_path": "filament/CoPrint Generic ABS.json"
+    },
+    {
+      "name": "CoPrint Generic PETG",
+      "sub_path": "filament/CoPrint Generic PETG.json"
+    },
+	{
+      "name": "CoPrint Generic TPU",
+      "sub_path": "filament/CoPrint Generic TPU.json"
     }
 	],
   "machine_list": [

--- a/resources/profiles/Co Print.json
+++ b/resources/profiles/Co Print.json
@@ -1,6 +1,6 @@
 {
   "name": "Co Print",
-  "version": "02.02.00.02",
+  "version": "02.03.00.02",
   "force_update": "0",
   "description": "CoPrint configurations",
   "machine_model_list": [

--- a/resources/profiles/Co Print.json
+++ b/resources/profiles/Co Print.json
@@ -1,6 +1,6 @@
 {
   "name": "Co Print",
-  "version": "02.02.00.04",
+  "version": "02.02.00.02",
   "force_update": "0",
   "description": "CoPrint configurations",
   "machine_model_list": [

--- a/resources/profiles/Co Print/filament/CoPrint Generic ABS.json
+++ b/resources/profiles/Co Print/filament/CoPrint Generic ABS.json
@@ -1,0 +1,82 @@
+{
+	
+	
+	"type": "filament",
+	"filament_id": "GFL99",
+	"setting_id": "GFSA04",
+	"from": "system",
+	"instantiation": "true",
+    "inherits": "CoPrint Generic PLA",
+    "name": "CoPrint Generic ABS",
+	"close_fan_the_first_x_layers": [
+        "3"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "60"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_density": [
+        "1.04"
+    ],
+    "filament_flow_ratio": [
+        "0.94"
+    ],
+    "filament_max_volumetric_speed": [
+        "16"
+    ],
+    "filament_settings_id": [
+        "CoPrint Generic PLA- ABS"
+    ],
+    "filament_type": [
+        "ABS"
+    ],
+    "from": "User",
+    "full_fan_speed_layer": [
+        "5"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "100"
+    ],
+    "nozzle_temperature": [
+        "280"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "260"
+    ],
+    "nozzle_temperature_range_high": [
+        "280"
+    ],
+    "nozzle_temperature_range_low": [
+        "240"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "pressure_advance": [
+        "0.02"
+    ],
+    "slow_down_layer_time": [
+        "12"
+    ],
+    "slow_down_min_speed": [
+        "20"
+    ],
+    "temperature_vitrification": [
+        "100"
+    ],
+	"compatible_printers": [
+		"Co Print ChromaSet 0.4 nozzle",
+		"Co Print ChromaSet 0.4 nozzle - Ender-3 V3",
+		"Co Print ChromaSet 0.4 nozzle - Ender-3 V3 Plus",
+		"Co Print ChromaSet 0.4 nozzle fast"
+	]
+	
+}

--- a/resources/profiles/Co Print/filament/CoPrint Generic ABS.json
+++ b/resources/profiles/Co Print/filament/CoPrint Generic ABS.json
@@ -1,15 +1,15 @@
 {
 	
 	
-	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSA04",
-	"from": "system",
-	"instantiation": "true",
+    "type": "filament",
+    "filament_id": "GFL99",
+    "setting_id": "GFSA04",
+    "from": "system",
+    "instantiation": "true",
     "inherits": "CoPrint Generic PLA",
     "name": "CoPrint Generic ABS",
-	"close_fan_the_first_x_layers": [
-        "3"
+    "close_fan_the_first_x_layers": [
+    "3"
     ],
     "fan_cooling_layer_time": [
         "30"
@@ -29,13 +29,9 @@
     "filament_max_volumetric_speed": [
         "16"
     ],
-    "filament_settings_id": [
-        "CoPrint Generic PLA- ABS"
-    ],
     "filament_type": [
         "ABS"
     ],
-    "from": "User",
     "full_fan_speed_layer": [
         "5"
     ],

--- a/resources/profiles/Co Print/filament/CoPrint Generic PETG.json
+++ b/resources/profiles/Co Print/filament/CoPrint Generic PETG.json
@@ -1,0 +1,50 @@
+{
+	"type": "filament",
+	"filament_id": "GFL99",
+	"setting_id": "GFSA04",
+	"from": "system",
+	"instantiation": "true",
+    "inherits": "CoPrint Generic PLA",
+    "name": "CoPrint Generic PETG",
+	"fan_max_speed": [
+        "90"
+    ],
+    "fan_min_speed": [
+        "60"
+    ],
+    "filament_deretraction_speed": [
+        "50"
+    ],
+    "filament_retraction_length": [
+        "1.2"
+    ],
+    "filament_retraction_speed": [
+        "50"
+    ],
+    "filament_settings_id": [
+        "CoPrint Generic PLA - PETG"
+    ],
+    "filament_type": [
+        "PETG"
+    ],
+    "from": "User",
+    "hot_plate_temp": [
+        "70"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "70"
+    ],
+    "nozzle_temperature": [
+        "240"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "240"
+    ],
+	"compatible_printers": [
+		"Co Print ChromaSet 0.4 nozzle",
+		"Co Print ChromaSet 0.4 nozzle - Ender-3 V3",
+		"Co Print ChromaSet 0.4 nozzle - Ender-3 V3 Plus",
+		"Co Print ChromaSet 0.4 nozzle fast"
+	]
+
+}

--- a/resources/profiles/Co Print/filament/CoPrint Generic PETG.json
+++ b/resources/profiles/Co Print/filament/CoPrint Generic PETG.json
@@ -1,13 +1,13 @@
 {
-	"type": "filament",
-	"filament_id": "GFL99",
-	"setting_id": "GFSA04",
-	"from": "system",
-	"instantiation": "true",
+    "type": "filament",
+    "filament_id": "GFL99",
+    "setting_id": "GFSA04",
+    "from": "system",
+    "instantiation": "true",
     "inherits": "CoPrint Generic PLA",
     "name": "CoPrint Generic PETG",
-	"fan_max_speed": [
-        "90"
+    "fan_max_speed": [
+    "90"
     ],
     "fan_min_speed": [
         "60"
@@ -21,13 +21,9 @@
     "filament_retraction_speed": [
         "50"
     ],
-    "filament_settings_id": [
-        "CoPrint Generic PLA - PETG"
-    ],
     "filament_type": [
         "PETG"
     ],
-    "from": "User",
     "hot_plate_temp": [
         "70"
     ],

--- a/resources/profiles/Co Print/filament/CoPrint Generic TPU.json
+++ b/resources/profiles/Co Print/filament/CoPrint Generic TPU.json
@@ -1,0 +1,52 @@
+{
+	"type": "filament",
+	"filament_id": "GFL99",
+	"setting_id": "GFSA04",
+	"from": "system",
+	"instantiation": "true",
+    "inherits": "CoPrint Generic PLA",
+    "name": "CoPrint Generic TPU",
+	"fan_max_speed": [
+        "80"
+    ],
+    "fan_min_speed": [
+        "80"
+    ],
+    "filament_deretraction_speed": [
+        "20"
+    ],
+    "filament_flow_ratio": [
+        "0.97"
+    ],
+    "filament_retract_when_changing_layer": [
+        "0"
+    ],
+    "filament_retraction_length": [
+        "1.8"
+    ],
+    "filament_retraction_speed": [
+        "20"
+    ],
+    "filament_type": [
+        "TPU"
+    ],
+    "hot_plate_temp": [
+        "50"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "50"
+    ],
+
+    "nozzle_temperature": [
+        "230"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "230"
+    ],
+	"compatible_printers": [
+		"Co Print ChromaSet 0.4 nozzle",
+		"Co Print ChromaSet 0.4 nozzle - Ender-3 V3",
+		"Co Print ChromaSet 0.4 nozzle - Ender-3 V3 Plus",
+		"Co Print ChromaSet 0.4 nozzle fast"
+	]
+}


### PR DESCRIPTION
Description:
This PR adds new print profiles for TPU, ABS, and PETG to the Co Print ChromaSet profile.

Changes Made:

Added TPU, ABS, and PETG material settings to the resources/profiles/Co Print.json file.
Optimized filament paths and parameters to align with Co Print ChromaSet.
Adjusted settings to maintain compatibility with the existing PLA profile.
These updates will enhance the printing experience for Co Print ChromaSet users by providing optimized profiles for a wider range of materials.