### PR TITLE
Fix query of gcode's slicer version.

### DIFF
--- a/src/slic3r/GUI/SelectMachine.cpp
+++ b/src/slic3r/GUI/SelectMachine.cpp
@@ -3662,7 +3662,7 @@ bool SelectMachineDialog::is_show_timelapse()
         return false;
     };
 
-    std::string standard_version = "01.04.00.00";
+    std::string standard_version = "2.2.0";
     PartPlate *plate      = m_plater->get_partplate_list().get_curr_plate();
     fs::path   gcode_path = plate->get_tmp_gcode_path();
 
@@ -3680,7 +3680,7 @@ bool SelectMachineDialog::is_show_timelapse()
                 }
                 break;
             }
-            if (line == "BambuStudio")
+            if (line == "OrcaSlicer")
                 is_version = true;
         }
     }


### PR DESCRIPTION
The BambuStudio string this function queries would never be present in OrcaSlicer generated gcode, as it's replaced with the equivalent OrcaSlicer versioning string.  

This update makes it look for the OrcaSlicer string instead, so that it doesn't read through the potentially hundreds of thousands of unrelated gcode lines after line 2.  This fixes the issues seen with responsiveness when opening the print dialog with large models, as the function is repeatedly called.

This fixes issue #3893.
