### PR TITLE
Set Crosshatch as default infill pattern instead of grid

### DIFF
--- a/resources/profiles/Anycubic/process/0.08mm HighDetail @Anycubic Kobra 3 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.08mm HighDetail @Anycubic Kobra 3 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "450",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.10mm Detail @Anycubic Kobra 3 0.2 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.10mm Detail @Anycubic Kobra 3 0.2 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.22",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "150",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.12mm Detail @Anycubic Kobra 3 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.12mm Detail @Anycubic Kobra 3 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "430",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.15mm Optimal @Anycubic Kobra.json
+++ b/resources/profiles/Anycubic/process/0.15mm Optimal @Anycubic Kobra.json
@@ -29,7 +29,7 @@
 	"line_width": "0.4",
 	"infill_direction": "45",
 	"sparse_infill_density": "15%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_acceleration": "1000",
 	"travel_acceleration": "0",
 	"inner_wall_acceleration": "0",

--- a/resources/profiles/Anycubic/process/0.16mm Optimal @Anycubic Kobra 2 Pro 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.16mm Optimal @Anycubic Kobra 2 Pro 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "300",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.16mm Optimal @Anycubic Kobra 3 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.16mm Optimal @Anycubic Kobra 3 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "300",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra 2 Max 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra 2 Max 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "200",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "150",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra 2 Plus 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra 2 Plus 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "200",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra 2 Pro 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra 2 Pro 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "200",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra 3 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra 3 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "300",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra.json
+++ b/resources/profiles/Anycubic/process/0.20mm Standard @Anycubic Kobra.json
@@ -29,7 +29,7 @@
 	"line_width": "0.4",
 	"infill_direction": "45",
 	"sparse_infill_density": "15%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_acceleration": "1000",
 	"travel_acceleration": "0",
 	"inner_wall_acceleration": "0",

--- a/resources/profiles/Anycubic/process/0.24mm Draft @Anycubic Kobra 3 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.24mm Draft @Anycubic Kobra 3 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "200",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.28mm Draft @Anycubic Kobra 2 Pro 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.28mm Draft @Anycubic Kobra 2 Pro 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "120",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.28mm SuperDraft @Anycubic Kobra 3 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.28mm SuperDraft @Anycubic Kobra 3 0.4 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "200",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.30mm Draft @Anycubic Kobra.json
+++ b/resources/profiles/Anycubic/process/0.30mm Draft @Anycubic Kobra.json
@@ -29,7 +29,7 @@
 	"line_width": "0.4",
 	"infill_direction": "45",
 	"sparse_infill_density": "15%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_acceleration": "1000",
 	"travel_acceleration": "0",
 	"inner_wall_acceleration": "0",

--- a/resources/profiles/Anycubic/process/0.30mm Standard @Anycubic Kobra 3 0.6 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.30mm Standard @Anycubic Kobra 3 0.6 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.62",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "100",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Anycubic/process/0.40mm Standard @Anycubic Kobra 3 0.8 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.40mm Standard @Anycubic Kobra 3 0.8 nozzle.json
@@ -192,7 +192,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.82",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "100",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Artillery/process/0.20mm Standard @Artillery X3Plus 0.4 nozzle.json
+++ b/resources/profiles/Artillery/process/0.20mm Standard @Artillery X3Plus 0.4 nozzle.json
@@ -186,7 +186,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "150",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Artillery/process/0.20mm Standard @Artillery X3Pro 0.4 nozzle.json
+++ b/resources/profiles/Artillery/process/0.20mm Standard @Artillery X3Pro 0.4 nozzle.json
@@ -186,7 +186,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "150",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Artillery/process/0.20mm Standard @Artillery X4Plus 0.4 nozzle.json
+++ b/resources/profiles/Artillery/process/0.20mm Standard @Artillery X4Plus 0.4 nozzle.json
@@ -186,7 +186,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "200",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/Artillery/process/0.20mm Standard @Artillery X4Pro 0.4 nozzle.json
+++ b/resources/profiles/Artillery/process/0.20mm Standard @Artillery X4Pro 0.4 nozzle.json
@@ -186,7 +186,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "200",
     "spiral_mode": "0",
     "spiral_mode_max_xy_smoothing": "200%",

--- a/resources/profiles/BBL/process/fdm_process_common.json
+++ b/resources/profiles/BBL/process/fdm_process_common.json
@@ -18,7 +18,7 @@
     "line_width": "0.45",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_line_width": "0.42",
     "initial_layer_print_height": "0.2",
     "initial_layer_speed": "20",

--- a/resources/profiles/Blocks/process/fdm_process_blocks_common.json
+++ b/resources/profiles/Blocks/process/fdm_process_blocks_common.json
@@ -31,7 +31,7 @@
     "line_width": "0.42",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_acceleration": "3000",
     "initial_layer_line_width": "0.42",
     "initial_layer_print_height": "0.2",

--- a/resources/profiles/Blocks/process/fdm_process_common 0.6 nozzle.json
+++ b/resources/profiles/Blocks/process/fdm_process_common 0.6 nozzle.json
@@ -25,7 +25,7 @@
     "line_width": "0.62",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_line_width": "0.62",
     "initial_layer_print_height": "0.2",
     "infill_combination": "0",

--- a/resources/profiles/Blocks/process/fdm_process_common 0.8 nozzle.json
+++ b/resources/profiles/Blocks/process/fdm_process_common 0.8 nozzle.json
@@ -30,7 +30,7 @@
     "bridge_no_support": "0",
     "elefant_foot_compensation": "0.1",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "infill_combination": "0",
     "infill_wall_overlap": "15%",
     "interface_shells": "0",

--- a/resources/profiles/Blocks/process/fdm_process_common 1.0 nozzle.json
+++ b/resources/profiles/Blocks/process/fdm_process_common 1.0 nozzle.json
@@ -23,7 +23,7 @@
     "bridge_no_support": "0",
     "elefant_foot_compensation": "0.1",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "infill_combination": "0",
     "infill_wall_overlap": "15%",
     "interface_shells": "0",

--- a/resources/profiles/Blocks/process/fdm_process_common 1.2 nozzle.json
+++ b/resources/profiles/Blocks/process/fdm_process_common 1.2 nozzle.json
@@ -23,7 +23,7 @@
     "bridge_no_support": "0",
     "elefant_foot_compensation": "0.1",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "infill_combination": "0",
     "infill_wall_overlap": "15%",
     "interface_shells": "0",

--- a/resources/profiles/Blocks/process/fdm_process_common.json
+++ b/resources/profiles/Blocks/process/fdm_process_common.json
@@ -19,7 +19,7 @@
     "line_width": "0.45",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_line_width": "0.42",
     "initial_layer_print_height": "0.2",
     "initial_layer_speed": "20",

--- a/resources/profiles/Co Print/process/fdm_process_common.json
+++ b/resources/profiles/Co Print/process/fdm_process_common.json
@@ -19,7 +19,7 @@
     "line_width": "0.42",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_line_width": "0.5",
     "layer_height": "0.2",
     "initial_layer_print_height": "0.2",

--- a/resources/profiles/Co Print/process/fdm_process_coprint_common.json
+++ b/resources/profiles/Co Print/process/fdm_process_coprint_common.json
@@ -28,7 +28,7 @@
     "line_width": "0.42",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_line_width": "0.5",
     "initial_layer_print_height": "0.2",
     "initial_layer_speed": "60",

--- a/resources/profiles/Comgrow/process/0.20mm Optimal @Comgrow T300 0.4 - official.json
+++ b/resources/profiles/Comgrow/process/0.20mm Optimal @Comgrow T300 0.4 - official.json
@@ -30,7 +30,7 @@
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "10%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_line_width": "0.5",
 	"initial_layer_print_height": "0.3",
 	"infill_combination": "0",

--- a/resources/profiles/Elegoo/process/ECC/fdm_process_ecc_common.json
+++ b/resources/profiles/Elegoo/process/ECC/fdm_process_ecc_common.json
@@ -19,7 +19,7 @@
     "line_width": "0.45",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_line_width": "0.42",
     "initial_layer_print_height": "0.2",
     "initial_layer_speed": "20",

--- a/resources/profiles/Eryone/process/0.20mm Standard @Thinker X400.json
+++ b/resources/profiles/Eryone/process/0.20mm Standard @Thinker X400.json
@@ -150,7 +150,7 @@
     "sparse_infill_density": "15%",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "250",
     "spiral_mode": "0",
     "staggered_inner_seams": "0",

--- a/resources/profiles/Flashforge/process/0.20mm Standard @Flashforge G3U 0.4 Nozzle.json
+++ b/resources/profiles/Flashforge/process/0.20mm Standard @Flashforge G3U 0.4 Nozzle.json
@@ -150,7 +150,7 @@
   "sparse_infill_density": "15%",
   "sparse_infill_filament": "1",
   "sparse_infill_line_width": "0.45",
-  "sparse_infill_pattern": "grid",
+  "sparse_infill_pattern": "crosshatch",
   "sparse_infill_speed": "270",
   "spiral_mode": "0",
   "staggered_inner_seams": "0",

--- a/resources/profiles/Flashforge/process/fdm_process_common.json
+++ b/resources/profiles/Flashforge/process/fdm_process_common.json
@@ -17,7 +17,7 @@
   "line_width": "0.45",
   "infill_direction": "45",
   "sparse_infill_density": "15%",
-  "sparse_infill_pattern": "grid",
+  "sparse_infill_pattern": "crosshatch",
   "initial_layer_line_width": "0.42",
   "initial_layer_print_height": "0.2",
   "initial_layer_speed": "20",

--- a/resources/profiles/FlyingBear/process/S1/fdm_process_common_S1.json
+++ b/resources/profiles/FlyingBear/process/S1/fdm_process_common_S1.json
@@ -131,7 +131,7 @@
 	"sparse_infill_density": "15%",
 	"sparse_infill_filament": "1",
 	"sparse_infill_line_width": "0.45",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 
 	"spiral_mode": "0",
 	"staggered_inner_seams": "0",

--- a/resources/profiles/FlyingBear/process/fdm_process_common.json
+++ b/resources/profiles/FlyingBear/process/fdm_process_common.json
@@ -131,7 +131,7 @@
 	"sparse_infill_density": "15%",
 	"sparse_infill_filament": "1",
 	"sparse_infill_line_width": "0.45",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 
 	"spiral_mode": "0",
 	"staggered_inner_seams": "0",

--- a/resources/profiles/Geeetech/process/fdm_process_common.json
+++ b/resources/profiles/Geeetech/process/fdm_process_common.json
@@ -17,7 +17,7 @@
     "line_width": "0.45",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_line_width": "0.42",
     "initial_layer_print_height": "0.2",
     "initial_layer_speed": "20",

--- a/resources/profiles/Geeetech/process/fdm_process_geeetech_common.json
+++ b/resources/profiles/Geeetech/process/fdm_process_geeetech_common.json
@@ -26,7 +26,7 @@
     "line_width": "0.4",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_acceleration": "500",
     "travel_acceleration": "700",
     "inner_wall_acceleration": "500",

--- a/resources/profiles/Ginger Additive/process/0.60mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/0.60mm Standard.json
@@ -55,7 +55,7 @@
   "skirt_loops": "3",
   "sparse_infill_density": "0%",
   "sparse_infill_line_width": "1.26",
-  "sparse_infill_pattern": "grid",
+  "sparse_infill_pattern": "crosshatch",
   "sparse_infill_speed": "200",
   "spiral_mode_max_xy_smoothing": "1e+07",
   "spiral_mode_smooth": "1",

--- a/resources/profiles/Ginger Additive/process/1.50mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/1.50mm Standard.json
@@ -45,7 +45,7 @@
   "skirt_distance": "10",
   "sparse_infill_density": "10%",
   "sparse_infill_line_width": "3.2",
-  "sparse_infill_pattern": "grid",
+  "sparse_infill_pattern": "crosshatch",
   "sparse_infill_speed": "120",
   "spiral_mode_max_xy_smoothing": "1e+07",
   "spiral_mode_smooth": "1",

--- a/resources/profiles/Ginger Additive/process/1.80mm Vasemode.json
+++ b/resources/profiles/Ginger Additive/process/1.80mm Vasemode.json
@@ -49,7 +49,7 @@
   "skirt_distance": "10",
   "sparse_infill_density": "0%",
   "sparse_infill_line_width": "4.2",
-  "sparse_infill_pattern": "grid",
+  "sparse_infill_pattern": "crosshatch",
   "sparse_infill_speed": "120",
   "spiral_mode": "1",
   "spiral_mode_max_xy_smoothing": "1e+07",

--- a/resources/profiles/Ginger Additive/process/2.50mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/2.50mm Standard.json
@@ -50,7 +50,7 @@
   "skirt_distance": "10",
   "sparse_infill_density": "10%",
   "sparse_infill_line_width": "5.5",
-  "sparse_infill_pattern": "grid",
+  "sparse_infill_pattern": "crosshatch",
   "sparse_infill_speed": "120",
   "spiral_mode_max_xy_smoothing": "1e+07",
   "spiral_mode_smooth": "1",

--- a/resources/profiles/Ginger Additive/process/4.00mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/4.00mm Standard.json
@@ -49,7 +49,7 @@
   "skirt_distance": "10",
   "sparse_infill_density": "10%",
   "sparse_infill_line_width": "9.5",
-  "sparse_infill_pattern": "grid",
+  "sparse_infill_pattern": "crosshatch",
   "sparse_infill_speed": "120",
   "spiral_mode_max_xy_smoothing": "1e+07",
   "spiral_mode_smooth": "1",

--- a/resources/profiles/InfiMech/process/HSN/fdm_process_common_HSN.json
+++ b/resources/profiles/InfiMech/process/HSN/fdm_process_common_HSN.json
@@ -130,7 +130,7 @@
 	"sparse_infill_density": "15%",
 	"sparse_infill_filament": "1",
 	"sparse_infill_line_width": "0.45",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 
 	"spiral_mode": "0",
 	"staggered_inner_seams": "0",

--- a/resources/profiles/InfiMech/process/fdm_process_common.json
+++ b/resources/profiles/InfiMech/process/fdm_process_common.json
@@ -130,7 +130,7 @@
 	"sparse_infill_density": "15%",
 	"sparse_infill_filament": "1",
 	"sparse_infill_line_width": "0.45",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 
 	"spiral_mode": "0",
 	"staggered_inner_seams": "0",

--- a/resources/profiles/Kingroon/process/0.20mm Standard @Kingroon KP3S V1.json
+++ b/resources/profiles/Kingroon/process/0.20mm Standard @Kingroon KP3S V1.json
@@ -30,7 +30,7 @@
   "slow_down_layers": "2",
   "slowdown_for_curled_perimeters": "1",
   "sparse_infill_acceleration": "6000",
-  "sparse_infill_pattern": "grid",
+  "sparse_infill_pattern": "crosshatch",
   "sparse_infill_speed": "300",
   "support_type": "normal(manual)",
   "thick_bridges": "1",

--- a/resources/profiles/Prusa/process/process_common_mk4s.json
+++ b/resources/profiles/Prusa/process/process_common_mk4s.json
@@ -53,7 +53,7 @@
     "sparse_infill_acceleration": "4000",
     "sparse_infill_filament": "1",
     "sparse_infill_line_width": "0.45",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "sparse_infill_speed": "200",
     "support_angle": "0",
     "support_base_pattern": "rectilinear",

--- a/resources/profiles/Qidi/process/0.12mm Fine @Qidi X3.json
+++ b/resources/profiles/Qidi/process/0.12mm Fine @Qidi X3.json
@@ -25,7 +25,7 @@
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "15%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_line_width": "0.5",
 	"initial_layer_print_height": "0.2",
 	"infill_combination": "0",

--- a/resources/profiles/Qidi/process/0.16mm Optimal @Qidi X3.json
+++ b/resources/profiles/Qidi/process/0.16mm Optimal @Qidi X3.json
@@ -23,7 +23,7 @@
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "15%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_line_width": "0.5",
 	"infill_combination": "0",
 	"sparse_infill_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.24mm Draft @Qidi X3.json
+++ b/resources/profiles/Qidi/process/0.24mm Draft @Qidi X3.json
@@ -21,7 +21,7 @@
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "15%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_line_width": "0.5",
 	"infill_combination": "0",
 	"sparse_infill_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi XPlus4.json
@@ -25,7 +25,7 @@
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "15%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_line_width": "0.5",
 	"initial_layer_print_height": "0.25",
 	"infill_combination": "0",

--- a/resources/profiles/Qidi/process/0.28mm Extra Draft @Qidi X3.json
+++ b/resources/profiles/Qidi/process/0.28mm Extra Draft @Qidi X3.json
@@ -21,7 +21,7 @@
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "15%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_line_width": "0.5",
 	"infill_combination": "0",
 	"sparse_infill_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XPlus4.json
@@ -25,7 +25,7 @@
 	"line_width": "0.42",
 	"infill_direction": "45",
 	"sparse_infill_density": "15%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_line_width": "0.5",
 	"initial_layer_print_height": "0.3",
 	"infill_combination": "0",

--- a/resources/profiles/Qidi/process/fdm_process_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_common.json
@@ -18,7 +18,7 @@
     "line_width": "0.45",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_line_width": "0.42",
     "initial_layer_print_height": "0.2",
     "initial_layer_speed": "20",

--- a/resources/profiles/Qidi/process/fdm_process_qidi_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_qidi_common.json
@@ -27,7 +27,7 @@
     "line_width": "0.4",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "initial_layer_acceleration": "500",
     "travel_acceleration": "700",
     "inner_wall_acceleration": "500",

--- a/resources/profiles/Qidi/process/fdm_process_qidi_x3_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_qidi_x3_common.json
@@ -30,7 +30,7 @@
     "line_width": "0.42",
     "infill_direction": "45",
     "sparse_infill_density": "15%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "internal_bridge_support_thickness": "0.8",
     "initial_layer_acceleration": "500",
     "initial_layer_line_width": "0.5",

--- a/resources/profiles/Sovol/process/0.18mm Optimal @Sovol SV07Plus.json
+++ b/resources/profiles/Sovol/process/0.18mm Optimal @Sovol SV07Plus.json
@@ -31,7 +31,7 @@
 	"line_width": "0.44",
 	"infill_direction": "45",
 	"sparse_infill_density": "15%",
-	"sparse_infill_pattern": "grid",
+	"sparse_infill_pattern": "crosshatch",
 	"initial_layer_acceleration": "0",
 	"travel_acceleration": "0",
 	"inner_wall_acceleration": "0",

--- a/resources/profiles/Volumic/process/fdm_process_volumic_common.json
+++ b/resources/profiles/Volumic/process/fdm_process_volumic_common.json
@@ -48,7 +48,7 @@
     "wall_infill_order": "inner wall/outer wall/infill",
     "infill_direction": "45",
     "sparse_infill_density": "25%",
-    "sparse_infill_pattern": "grid",
+    "sparse_infill_pattern": "crosshatch",
     "infill_combination": "0",
 	"infill_anchor":"20%",
     "infill_wall_overlap": "20%",


### PR DESCRIPTION
# Description

Grid is inefficient, grid is bad, gris is evil 😆
Making this change to be in line with the change made for 1.9 if I remember well...
