### PR TITLE
Update to mpfr-4.2.2.tar.bz2

### DIFF
--- a/deps/MPFR/MPFR.cmake
+++ b/deps/MPFR/MPFR.cmake
@@ -25,8 +25,8 @@ else ()
     endif ()
 
     ExternalProject_Add(dep_MPFR
-        URL https://www.mpfr.org/mpfr-current/mpfr-4.2.1.tar.bz2
-        URL_HASH SHA256=b9df93635b20e4089c29623b19420c4ac848a1b29df1cfd59f26cab0d2666aa0
+        URL https://www.mpfr.org/mpfr-current/mpfr-4.2.2.tar.bz2
+        URL_HASH SHA256=9ad62c7dc910303cd384ff8f1f4767a655124980bb6d8650fe62c815a231bb7b
         DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/MPFR
         BUILD_IN_SOURCE ON
         CONFIGURE_COMMAND autoreconf -f -i && 


### PR DESCRIPTION
Needed an update, the old link is 404.

# Description

The old version is no longer available for download. 
