### PR TITLE
Fix the translation of "in" (inches) in fr, de

### DIFF
--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -209,8 +209,9 @@ msgstr "Gizmo-Skalieren"
 msgid "Error: Please close all toolbar menus first"
 msgstr "Fehler: Bitte schließen sie zuerst alle Werkzeugleistenmenüs"
 
+#. inches
 msgid "in"
-msgstr "in"
+msgstr ""
 
 msgid "mm"
 msgstr "mm"

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -212,8 +212,9 @@ msgstr "Gizmo-Redimensionner"
 msgid "Error: Please close all toolbar menus first"
 msgstr "Erreur : Veuillez d'abord fermer tous les menus de la barre d'outils"
 
+#. inches
 msgid "in"
-msgstr "dans"
+msgstr ""
 
 msgid "mm"
 msgstr "mm"


### PR DESCRIPTION
# Description
de and fr translated "in" as "inside", should be "inches".  I removed the wrong translation in french, and marked other translations so that they can be reviewed.