### PR TITLE
Do not loade web page until switching to device page

### DIFF
--- a/src/slic3r/GUI/PrinterWebView.cpp
+++ b/src/slic3r/GUI/PrinterWebView.cpp
@@ -77,10 +77,24 @@ void PrinterWebView::load_url(wxString& url, wxString apikey)
         return;
     m_apikey = apikey;
     m_apikey_sent = false;
-    
-    m_browser->LoadURL(url);
+
+    if (this->IsShown()) {
+        m_url_deferred = *wxEmptyString;
+        m_browser->LoadURL(url);
+    } else {
+        m_url_deferred = url;
+    }
     //m_browser->SetFocus();
     UpdateState();
+}
+
+bool PrinterWebView::Show(bool show)
+{
+    if (show && !m_url_deferred.empty()) {
+        m_browser->LoadURL(m_url_deferred);
+        m_url_deferred = *wxEmptyString;
+    }
+    return wxPanel::Show(show);
 }
 
 void PrinterWebView::reload()

--- a/src/slic3r/GUI/PrinterWebView.hpp
+++ b/src/slic3r/GUI/PrinterWebView.hpp
@@ -43,6 +43,9 @@ public:
     void OnLoaded(wxWebViewEvent& evt);
     void reload();
     void update_mode();
+
+    bool Show(bool show = true) override;
+
 private:
     void SendAPIKey();
 
@@ -50,6 +53,8 @@ private:
     long m_zoomFactor;
     wxString m_apikey;
     bool m_apikey_sent;
+
+    wxString m_url_deferred;
 
     // DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
This should make Linux user life a bit easier so Orca don't crash unless switch to device tab manually.
