### PR TITLE
FIX: enable circle fitting of tree support with larger threshold

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -733,8 +733,6 @@ void PrintObject::simplify_extrusion_path()
     }
 
     if (this->set_started(posSimplifySupportPath)) {
-        //BBS: disable circle simplification for support as it causes separation of support walls
-        #if 0
         m_print->set_status(75, L("Optimizing toolpath"));
         BOOST_LOG_TRIVIAL(debug) << "Simplify extrusion path of support in parallel - start";
         tbb::parallel_for(
@@ -748,7 +746,6 @@ void PrintObject::simplify_extrusion_path()
         );
         m_print->throw_if_canceled();
         BOOST_LOG_TRIVIAL(debug) << "Simplify extrusion path of support in parallel - end";
-        #endif
         this->set_done(posSimplifySupportPath);
     }
 }

--- a/src/libslic3r/libslic3r.h
+++ b/src/libslic3r/libslic3r.h
@@ -75,7 +75,7 @@ static constexpr double RESOLUTION = 0.0125;
 static constexpr double SPARSE_INFILL_RESOLUTION = 0.04;
 #define                 SCALED_SPARSE_INFILL_RESOLUTION (SPARSE_INFILL_RESOLUTION / SCALING_FACTOR)
 
-static constexpr double SUPPORT_RESOLUTION = 0.1;
+static constexpr double SUPPORT_RESOLUTION = 0.0375;
 #define                 SCALED_SUPPORT_RESOLUTION (SUPPORT_RESOLUTION / SCALING_FACTOR)
 // Maximum perimeter length for the loop to apply the small perimeter speed. 
 #define                 SMALL_PERIMETER_LENGTH(LENGTH)  (((LENGTH) / SCALING_FACTOR) * 2 * PI)


### PR DESCRIPTION
jira: STUDIO-8588
Change-Id: Ia566fa14f7f786ff905fc3484885634811a6d686 (cherry picked from commit bambulab/BambuStudio@82c72b19bdaa5d1dd3b7e62faa87a8e9b471ac0a)

Fix #9035

Thanks BambuLab!

Now the file size is reduced a lot when arc fitting is enabled:
![image](https://github.com/user-attachments/assets/c12a48dc-efbc-4d3d-ba62-001ffa257a06)
