### PR TITLE
Make printer model search more flexible

### DIFF
--- a/resources/web/guide/21/21.js
+++ b/resources/web/guide/21/21.js
@@ -216,14 +216,16 @@ function FilterModelList(keyword) {
 
 	let nTotal = pModel.length;
 	let ModelHtml = {};
+	let kwSplit = keyword.toLowerCase().match(/\S+/g) || [];
 
 	$('#Content').empty();
 	for (let n = 0; n < nTotal; n++) {
 		let OneModel = pModel[n];
 
 		let strVendor = OneModel['vendor'];
-		let ModelName = OneModel['model'];
-		if (ModelName.toLowerCase().indexOf(keyword.toLowerCase()) == -1)
+		let search = (OneModel['model'] + '\0' + strVendor).toLowerCase();
+
+		if (!kwSplit.every(s => search.includes(s)))
 			continue;
 
 		//Add Vendor Html Node

--- a/resources/web/guide/24/24.js
+++ b/resources/web/guide/24/24.js
@@ -216,14 +216,16 @@ function FilterModelList(keyword) {
 
 	let nTotal = pModel.length;
 	let ModelHtml = {};
+	let kwSplit = keyword.toLowerCase().match(/\S+/g) || [];
 
 	$('#Content').empty();
 	for (let n = 0; n < nTotal; n++) {
 		let OneModel = pModel[n];
 
 		let strVendor = OneModel['vendor'];
-		let ModelName = OneModel['model'];
-		if (ModelName.toLowerCase().indexOf(keyword.toLowerCase()) == -1)
+		let search = (OneModel['model'] + '\0' + strVendor).toLowerCase();
+
+		if (!kwSplit.every(s => search.includes(s)))
 			continue;
 
 		//Add Vendor Html Node


### PR DESCRIPTION
# Description

The printer model search can be hard to use, depending on how profiles are named. This makes it a little easier by matching on both the vendor and model name, and tokenizing the query and matching all of the tokens, instead of trying to find the whole query substring in the model name.
<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

https://github.com/user-attachments/assets/861bcf99-eaa7-42b8-9bba-8e03b18a06be


## Tests

I've only tested this on macOS. I don't have the ability to test on other platforms. I've tried to stick to simple and fairly old JavaScript, but I'm not certain that it will work with the Windows or Linux web view.

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
