### PR TITLE
Mark SV06 ACE PLA compatible with 0.2 nozzle

### DIFF
--- a/resources/profiles/Sovol/filament/Sovol SV06 ACE PLA.json
+++ b/resources/profiles/Sovol/filament/Sovol SV06 ACE PLA.json
@@ -12,6 +12,7 @@
         "3"
     ],
 	"compatible_printers": [
+		"Sovol SV06 ACE 0.2 nozzle",
 		"Sovol SV06 ACE 0.4 nozzle",
 		"Sovol SV06 ACE 0.6 nozzle",
 		"Sovol SV06 ACE 0.8 nozzle"


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

When the Sovol SV06 ACE 0.2/0.6/0.8 nozzle configs were split out of the default 0.4 nozzle config, it looks like no PLA filament was configured as compatible with  the 0.2 nozzle machine. There isn't currently a dedicated 0.2 nozzle version of this filament, so I'm just associated the regular Sovol PLA one.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

N/A

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

Verified PLA filament profiles can now be selected for the Sovol SV06 ACE 0.2 nozzle machine.
