### PR TITLE
Fix endless loop in ReplaceString

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -39,7 +39,10 @@ std::set<std::string> SplitStringAndRemoveDuplicateElement(const std::string &st
 void ReplaceString(std::string &resource_str, const std::string &old_str, const std::string &new_str)
 {
     std::string::size_type pos = 0;
-    while ((pos = resource_str.find(old_str)) != std::string::npos) { resource_str.replace(pos, old_str.length(), new_str); }
+    while ((pos = resource_str.find(old_str, pos)) != std::string::npos) {
+        resource_str.replace(pos, old_str.length(), new_str);
+        pos += new_str.length(); //advance position to continue after replacement
+    }
 }
 }
 


### PR DESCRIPTION
Current code 

```
void ReplaceString(std::string &resource_str, const std::string &old_str, const std::string &new_str)
{
    std::string::size_type pos = 0;
    while ((pos = resource_str.find(old_str)) != std::string::npos) {
          resource_str.replace(pos, old_str.length(), new_str);
    }
}
```

always search and replace from very beginning, thus endless replaces the same string in the case when `new_str `starts from the same sequence as `old_str`, like `some_key` -> `some_key_new`.

This fix advances searching position:

```
    while ((pos = resource_str.find(old_str, pos)) != std::string::npos) {
        resource_str.replace(pos, old_str.length(), new_str);
        pos += new_str.length(); //advance position to continue after replacement
    }
```

Credits to ChatGPT, DeepSeek and Grok. They all found the problem and provided the same fix)))