### PR TITLE
Trigger build workflow when flatpak changes are made

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -13,6 +13,7 @@ on:
      - 'localization/**'
      - 'resources/**'
      - ".github/workflows/build_*.yml"
+     - 'flatpak/**'
 
   pull_request:
     branches:
@@ -27,6 +28,7 @@ on:
      - 'BuildLinux.sh'
      - 'build_release_vs2022.bat'
      - 'build_release_macos.sh'
+     - 'flatpak/**'
 
   workflow_dispatch: # allows for manual dispatch
     inputs:


### PR DESCRIPTION
This should cause the build workflow to run when any changes are made under the flatpak folder. One example of this being needed is the PR #8964 not causing the build workflow to be triggered. 