### PR TITLE
Fix PCTG calibration temperatures

### DIFF
--- a/src/slic3r/GUI/calib_dlg.cpp
+++ b/src/slic3r/GUI/calib_dlg.cpp
@@ -432,8 +432,8 @@ void Temp_Calibration_Dlg::on_filament_type_changed(wxCommandEvent& event) {
             end = 230;
             break;
 	case tPCTG:
-            start = 240;
-            end = 280;
+            start = 280;
+            end = 240;
             break;
         case tTPU:
             start = 240;


### PR DESCRIPTION
It looks like start and end values are swapped. Start needs to be greater than end. If you try to hit "Ok" for the default values, it results in this error:

```
Please input valid values:
Start temp: <= 350
End temp: >= 170
Start temp > End temp + 5)
```

<img width="415" alt="image" src="https://github.com/user-attachments/assets/8ded3a90-7069-43a0-8be1-badd93ee59b1" />
