### PR TITLE
Make gcode 3mf file smaller when sending to BBL printers

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12830,7 +12830,7 @@ int Plater::send_gcode(int plate_idx, Export3mfProgressFn proFn)
         return -1;
     }
 
-    SaveStrategy strategy = SaveStrategy::Silence | SaveStrategy::SkipModel | SaveStrategy::WithGcode;
+    SaveStrategy strategy = SaveStrategy::Silence | SaveStrategy::SkipModel | SaveStrategy::WithGcode | SaveStrategy::SkipAuxiliary;
 #if !BBL_RELEASE_TO_PUBLIC
     //only save model in QA environment
     std::string sel = get_app_config()->get("iot_environment");


### PR DESCRIPTION
By remove the auxiliary directory when sending for printing

cherry picked from commit bambulab/BambuStudio@6eb533019eda9c810f3eaf80a81fd7698ebb4578

Thanks BambuLab.