### PR TITLE
FIX: prevent dead loop of conflict checker

### DIFF
--- a/src/libslic3r/GCode/ConflictChecker.cpp
+++ b/src/libslic3r/GCode/ConflictChecker.cpp
@@ -119,7 +119,9 @@ float LinesBucketQueue::getCurrBottomZ()
     }
 
     for (LinesBucket *bp : lowests) {
+        float prevZ = bp->curBottomZ();
         bp->raise();
+        if (bp->curBottomZ() == prevZ) continue;
         if (bp->valid()) { line_bucket_ptr_queue.push(bp); }
     }
     return layerBottomZ;


### PR DESCRIPTION
cherry picked from commit bambulab/BambuStudio@b952006e4db49f00054cc2ac539074222c890d08
Thanks BambuLab!

Fix #9094
![image](https://github.com/user-attachments/assets/67fc5dfb-ad60-4dbf-a0b4-4b5b875819da)