### PR TITLE
Fix brim ear paint memory leaking & multi-selection with shift+left click

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
@@ -265,16 +265,12 @@ void GLGizmoBrimEars::data_changed(bool is_serializing)
 
 bool GLGizmoBrimEars::on_mouse(const wxMouseEvent& mouse_event)
 {
-    if (use_grabbers(mouse_event)) {
-        return true;
-    }
-
     // wxCoord == int --> wx/types.h
     Vec2i32 mouse_coord(mouse_event.GetX(), mouse_event.GetY());
     Vec2d   mouse_pos = mouse_coord.cast<double>();
 
     if (mouse_event.Moving()) {
-        return gizmo_event(SLAGizmoEventType::Moving, mouse_pos, mouse_event.ShiftDown(), mouse_event.AltDown(), false);
+        gizmo_event(SLAGizmoEventType::Moving, mouse_pos, mouse_event.ShiftDown(), mouse_event.AltDown(), false);
     }
     
     // when control is down we allow scene pan and rotation even when clicking
@@ -317,15 +313,15 @@ bool GLGizmoBrimEars::on_mouse(const wxMouseEvent& mouse_event)
             return false;
         }
     } else if (mouse_event.LeftUp()) {
-        if (!m_parent.is_mouse_dragging()) {
+        if (gizmo_event(SLAGizmoEventType::LeftUp, mouse_pos, mouse_event.ShiftDown(), mouse_event.AltDown(), control_down)
+            && !m_parent.is_mouse_dragging()) {
             // in case SLA/FDM gizmo is selected, we just pass the LeftUp
             // event and stop processing - neither object moving or selecting
             // is suppressed in that case
-            gizmo_event(SLAGizmoEventType::LeftUp, mouse_pos, mouse_event.ShiftDown(), mouse_event.AltDown(), control_down);
             return true;
         }
     }
-    return false;
+    return use_grabbers(mouse_event);
 }
 
 // Following function is called from GLCanvas3D to inform the gizmo about a mouse/keyboard event.

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
@@ -100,7 +100,7 @@ void GLGizmoBrimEars::on_render()
 void GLGizmoBrimEars::render_points(const Selection &selection)
 {
     auto editing_cache = m_editing_cache;
-    if (render_hover_point != nullptr) { editing_cache.push_back(*render_hover_point); }
+    if (render_hover_point) { editing_cache.push_back(*render_hover_point); }
 
     size_t cache_size = editing_cache.size();
 
@@ -344,10 +344,9 @@ bool GLGizmoBrimEars::gizmo_event(SLAGizmoEventType action, const Vec2d &mouse_p
         Transform3d             inverse_trsf = volume->get_instance_transformation().get_matrix_no_offset().inverse();
         std::pair<Vec3f, Vec3f> pos_and_normal;
         if (unproject_on_mesh2(mouse_position, pos_and_normal)) {
-            render_hover_point = new CacheEntry(BrimPoint(pos_and_normal.first, m_new_point_head_diameter / 2.f), false, (inverse_trsf * m_world_normal).cast<float>(), true);
+            render_hover_point = CacheEntry(BrimPoint(pos_and_normal.first, m_new_point_head_diameter / 2.f), false, (inverse_trsf * m_world_normal).cast<float>(), true);
         } else {
-            delete render_hover_point;
-            render_hover_point = nullptr;
+            render_hover_point.reset();
         }
     } else if (action == SLAGizmoEventType::LeftDown && (shift_down || alt_down || control_down)) {
         // left down with shift - show the selection rectangle:

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.hpp
@@ -108,7 +108,7 @@ private:
     const Vec3d m_world_normal = {0, 0, 1};
     std::map<GLVolume*, std::shared_ptr<PickRaycaster>>   m_mesh_raycaster_map;
     GLVolume* m_last_hit_volume;
-    CacheEntry* render_hover_point = nullptr;
+    std::optional<CacheEntry> render_hover_point;
 
     bool m_link_text_hover = false;
     

--- a/src/slic3r/GUI/ImGuiWrapper.cpp
+++ b/src/slic3r/GUI/ImGuiWrapper.cpp
@@ -768,6 +768,7 @@ bool ImGuiWrapper::bbl_slider_float(const std::string& label, float* v, float v_
     bool ret = ImGui::BBLSliderFloat(str_label.c_str(), v, v_min, v_max, format, power);
 
     m_last_slider_status.hovered = ImGui::IsItemHovered();
+    m_last_slider_status.edited = ImGui::IsItemEdited();
     m_last_slider_status.clicked = ImGui::IsItemClicked();
     m_last_slider_status.deactivated_after_edit = ImGui::IsItemDeactivatedAfterEdit();
 


### PR DESCRIPTION
- You are now able to select multiple brim ears in brim paint tool with shift+left mouse click.
- Fix the brim size preview when dragging the brim size slider. Now the size of selected brim will update while dragging the slider.
- Fix a memory leaking when moving cursor on the model


![9167_brim_paint](https://github.com/user-attachments/assets/34772403-db55-44c7-adda-7c795a3b7799)

