### PR TITLE
Improve brim paint gizmo shortcuts

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
@@ -590,6 +590,9 @@ void GLGizmoBrimEars::begin_radius_change(float initial_value)
 
 void GLGizmoBrimEars::update_cache_radius()
 {
+    if (render_hover_point)
+        render_hover_point->brim_point.head_front_radius = m_new_point_head_diameter / 2.f;
+
     for (auto &cache_entry : m_editing_cache)
         if (cache_entry.selected) {
             cache_entry.brim_point.head_front_radius = m_new_point_head_diameter / 2.f;

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
@@ -57,8 +57,8 @@ bool GLGizmoBrimEars::on_init()
     m_desc["left_click"]               = _L("Add a brim ear");
     m_desc["right_click_caption"]      = _L("Right click");
     m_desc["right_click"]              = _L("Delete a brim ear");
-    m_desc["ctrl_mouse_wheel_caption"] = _L("Ctrl+Mouse wheel");
-    m_desc["ctrl_mouse_wheel"]         = _L("Adjust section view");
+    m_desc["alt_mouse_wheel_caption"]  = _L("Alt + Mouse wheel");
+    m_desc["alt_mouse_wheel"]          = _L("Adjust section view");
 
     return true;
 }
@@ -479,14 +479,14 @@ bool GLGizmoBrimEars::gizmo_event(SLAGizmoEventType action, const Vec2d &mouse_p
     }
 
     // mouse wheel up
-    if (action == SLAGizmoEventType::MouseWheelUp && control_down) {
+    if (action == SLAGizmoEventType::MouseWheelUp && alt_down) {
         double pos = m_c->object_clipper()->get_position();
         pos        = std::min(1., pos + 0.01);
         m_c->object_clipper()->set_position_by_ratio(pos, false, true);
         return true;
     }
 
-    if (action == SLAGizmoEventType::MouseWheelDown && control_down) {
+    if (action == SLAGizmoEventType::MouseWheelDown && alt_down) {
         double pos = m_c->object_clipper()->get_position();
         pos        = std::max(0., pos - 0.01);
         m_c->object_clipper()->set_position_by_ratio(pos, false, true);
@@ -737,7 +737,7 @@ void GLGizmoBrimEars::on_render_input_window(float x, float y, float bottom_limi
 
 void GLGizmoBrimEars::show_tooltip_information(float x, float y)
 {
-    std::array<std::string, 3> info_array  = std::array<std::string, 3>{"left_click", "right_click", "ctrl_mouse_wheel"};
+    std::array<std::string, 3> info_array  = std::array<std::string, 3>{"left_click", "right_click", "alt_mouse_wheel"};
     float                      caption_max = 0.f;
     for (const auto &t : info_array) { caption_max = std::max(caption_max, m_imgui->calc_text_size(m_desc[t + "_caption"]).x); }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.hpp
@@ -144,6 +144,10 @@ private:
     void get_detection_radius_max();
     void update_raycasters();
 
+    void begin_radius_change(float initial_value);
+    void update_cache_radius();
+    void apply_radius_change();
+
 protected:
     void on_set_state() override;
     void on_set_hover_id() override

--- a/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmosManager.cpp
@@ -849,12 +849,14 @@ bool GLGizmosManager::on_key(wxKeyEvent& evt)
                 if (gizmo_event(SLAGizmoEventType::AltUp) || (is_editing && is_rectangle_dragging))
                     processed = true;
             }
-
-            // BBS
-            if (m_current == MmuSegmentation && keyCode > '0' && keyCode <= '9') {
-                // capture number key
-                processed = true;
+            else if (keyCode == WXK_CONTROL) {
+                gizmo_event(SLAGizmoEventType::CtrlUp);
             }
+        }
+        // BBS
+        if (m_current == MmuSegmentation && keyCode > '0' && keyCode <= '9') {
+            // capture number key
+            processed = true;
         }
         if (m_current == Measure || m_current == Assembly) {
             if (keyCode == WXK_CONTROL)


### PR DESCRIPTION
1. Change the section view shortcut to Alt+mouse wheel, makes it consistent with other paint gizmos such as support/seam/color paint
2. Add new ctrl+mouse wheel up/down shortcut to change the size of the brim, similar to other paint gizmos that uses the same shortcut to change brush size