### PR TITLE
Add filament load time for Creality Hi

### DIFF
--- a/resources/profiles/Creality/machine/Creality Hi 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Hi 0.4 nozzle.json
@@ -131,6 +131,7 @@
         "2"
     ],
     "single_extruder_multi_material": "1",
+    "machine_load_filament_time": "105",
     "machine_pause_gcode": "PAUSE",
     "change_filament_gcode": "G2 Z{z_after_toolchange + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X260 Y180 F30000\nG1 Z{z_after_toolchange} F600",
     "default_filament_profile": [

--- a/resources/profiles/Creality/machine/Creality Hi 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Hi 0.6 nozzle.json
@@ -131,6 +131,7 @@
         "2"
     ],
     "single_extruder_multi_material": "1",
+    "machine_load_filament_time": "105",
     "machine_pause_gcode": "PAUSE",
     "change_filament_gcode": "G2 Z{z_after_toolchange + 0.4} I0.86 J0.86 P1 F10000 ; spiral lift a little from second lift\nG1 X260 Y180 F30000\nG1 Z{z_after_toolchange} F600",
     "default_filament_profile": [


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

Set the `machine_load_filament_time` value in the profiles for the Creality Hi, so that print time estimation is more realistic for multimaterial prints.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

### Estimations from Creality Print

With a 0.4 nozzle, 4h53m

<img width="865" alt="creality-4" src="https://github.com/user-attachments/assets/89bc1153-8d7a-4de8-9913-51347120c1ac" />

With a 0.6 nozzle, 3h17m

<img width="944" alt="creality-6" src="https://github.com/user-attachments/assets/4ebf9a2f-2f2f-4d30-b45b-ce82ec1f4319" />

### Estimations in OrcaSlicer

With a 0.4 nozzle, 4h53m (up from the previous estimate of 1h20m)

<img width="907" alt="orca-after-4" src="https://github.com/user-attachments/assets/46c01603-bb94-489d-9481-3ce37d0b3bee" />

With a 0.6 nozzle, 3h12m (up from the previous estimate of 45m)

<img width="936" alt="orca-after-6" src="https://github.com/user-attachments/assets/e8869421-b262-4090-9df8-0c10fe92a97b" />

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

Since this change only affects print time estimation, I did not conduct any physical testing on the printer. But for reference, the project I was slicing in both slicers was this multicolour fox: [fox.3mf.zip](https://github.com/user-attachments/files/19550775/fox.3mf.zip)

