### PR TITLE
Fix wrong travel before printing first skirt point

### DIFF
--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -363,7 +363,7 @@ private:
     std::string     extrude_entity(const ExtrusionEntity &entity, std::string description = "", double speed = -1., const ExtrusionEntitiesPtr& region_perimeters = ExtrusionEntitiesPtr());
     // Orca: pass the complete collection of region perimeters to the extrude loop to check whether the wipe before external loop
     // should be executed
-    std::string     extrude_loop(ExtrusionLoop loop, std::string description, double speed = -1., const ExtrusionEntitiesPtr& region_perimeters = ExtrusionEntitiesPtr());
+    std::string     extrude_loop(ExtrusionLoop loop, std::string description, double speed = -1., const ExtrusionEntitiesPtr& region_perimeters = ExtrusionEntitiesPtr(), const Point* start_point = nullptr);
     std::string     extrude_multi_path(ExtrusionMultiPath multipath, std::string description = "", double speed = -1.);
     std::string     extrude_path(ExtrusionPath path, std::string description = "", double speed = -1.);
     


### PR DESCRIPTION
Fix #9109

don't modify `last_pos`, otherwise it could move out of plate/to wrong places and cause issue

Old:
![image](https://github.com/user-attachments/assets/7f4a8df1-98e3-4b1d-9094-41d1f7ac4024)

New:
![image](https://github.com/user-attachments/assets/822a8567-e114-4a77-b357-2436b81df176)