### PR TITLE
Fix -j to export CMAKE_BUILD_PARALLEL_LEVEL.

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -49,7 +49,7 @@ while getopts ":1j:bcdghirsu" opt; do
         export CMAKE_BUILD_PARALLEL_LEVEL=1
         ;;
     j )
-        CMAKE_BUILD_PARALLEL_LEVEL=$OPTARG
+        export CMAKE_BUILD_PARALLEL_LEVEL=$OPTARG
         ;;
     b )
         BUILD_DEBUG="1"


### PR DESCRIPTION
# Description

The existing support to use a specified number of cores for compilation was setting the variable `CMAKE_BUILD_PARALLEL_LEVEL` but not exporting it, so CMake was not being affected. In a 16 core SMT 32 GiB RAM system this meant the default concurrency was used and RAM was very soon exhausted while compiling.

The `-1` option did work (as it was exporting the value).

# Screenshots/Recordings/Graphs

## Tests

Tested that `./BuildLinux.sh -dsi -j 8` now can build OrcaSlicer in my machine without running out of RAM.
