### PR TITLE
Fix speed up during overhang slowdown when curled perimeters is enabled.

### DIFF
--- a/src/libslic3r/GCode/ExtrusionProcessor.hpp
+++ b/src/libslic3r/GCode/ExtrusionProcessor.hpp
@@ -442,6 +442,10 @@ public:
             };
             
             float extrusion_speed = std::min(calculate_speed(curr.distance), calculate_speed(next.distance));
+            // ORCA: Clamp resulting speed to lowest of calculated speed based on the overhang values and the current speed
+            // Fixes bug where resulting overhang speed is higher than the current speed due to (for example) volumetric flow limits.
+            extrusion_speed = std::min(extrusion_speed, original_speed);
+            
             if(slowdown_for_curled_edges) {
                 float curled_speed = calculate_speed(artificial_distance_to_curled_lines);
             	extrusion_speed       = std::min(curled_speed, extrusion_speed); // adjust extrusion speed based on what is smallest - the calculated overhang speed or the artificial curled speed


### PR DESCRIPTION
On some edge cases mostly observed when curled perimeter detection is enabled, and the perimeter speeds are limited due to flow rate limits, the resulting overhang speed calculation creates a speed ramp up. This could also happen with the curled perimeter detection being disabled too.

This happens because the calculated overhang speed is not limited by the actual print speed but instead calculated by the speed thresholds in the overhang % boxes. Typically this is not an issue, as the overhang speed should be set to less than the profile print speeds; however when slowing down due to flow rates, this is not the case.

![image](https://github.com/user-attachments/assets/c4e045d9-2296-4356-8226-cd065f11bddf)

This PR addresses this by clamping the resulting speed to the min between the flow rate limited external perimeter speed and calculated slowdown for curled overhang speeds.

![image](https://github.com/user-attachments/assets/6e19aae6-e808-45da-a679-8c0b33987a1d)

Fixes: #7435

