### PR TITLE
Fixed an issue where the Max Volumetric Speed doesn't consider the Filament Flow Ratio

### DIFF
--- a/src/libslic3r/Extruder.hpp
+++ b/src/libslic3r/Extruder.hpp
@@ -34,7 +34,9 @@ public:
     double unretract();
     double E() const { return m_share_extruder ? m_share_E : m_E; }
     void   reset_E() { m_E = 0.; m_share_E = 0.; }
+    // e_per_mm is extrusion_per_mm = geometric volume * (filament flow ratio / cross-sectional area)  [Doesn't account for print_flow_ratio, or modifiers like bridge flow ratio etc.]
     double e_per_mm(double mm3_per_mm) const { return mm3_per_mm * m_e_per_mm3; }
+    // e_per_mm3 is extrusion_per_mm3 = filament flow ratio / cross-sectional area    [Doesn't account for print_flow_ratio, or modifiers like bridge flow ratio etc.]
     double e_per_mm3() const { return m_e_per_mm3; }
     // Used filament volume in mm^3.
     double extruded_volume() const;

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5271,9 +5271,10 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
     }
 
     // calculate effective extrusion length per distance unit (e_per_mm)
-    auto _mm3_per_mm = path.mm3_per_mm * this->config().print_flow_ratio 
+    double filament_flow_ratio = m_config.option<ConfigOptionFloats>("filament_flow_ratio")->get_at(0);
     // We set _mm3_per_mm to effectove flow = Geometric volume * print flow ratio * filament flow ratio * role-based-flow-ratios
-    _m3_per_mm *= m_config.filament_flow_ratio;
+    auto _mm3_per_mm = path.mm3_per_mm * this->config().print_flow_ratio;
+    _mm3_per_mm *= filament_flow_ratio;
     if (path.role() == erTopSolidInfill)
         _mm3_per_mm *= m_config.top_solid_infill_flow_ratio;
     else if (path.role() == erBottomSurface)
@@ -5284,8 +5285,8 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
         _mm3_per_mm *= m_config.scarf_joint_flow_ratio;
     // Effective extrusion length per distance unit = (filament_flow_ratio/cross_section) * mm3_per_mm / print flow ratio
     // m_writer.extruder()->e_per_mm3() below is (filament flow ratio / cross-sectional area)
-    double e_per_mm = m_writer.extruder()->e_per_mm3() * min_mm3_per_mm
-    e_per_mm /= m_config.filament_flow_ratio;
+    double e_per_mm = m_writer.extruder()->e_per_mm3() * _mm3_per_mm;
+    e_per_mm /= filament_flow_ratio;
 
 
 


### PR DESCRIPTION
Update: Due to lots of noise and confusion from people having similar issues but not quite related, here is a distilled version of what's the PR And what it fixes:

### Below is the key idea:

If filament_flow_ratio is strictly bringing an underfeeding extruder up to the “true geometry volume,” then in physical terms, you are not actually overextruding – you’re merely achieving what the slicer’s geometry said you should. In that scenario:
	1.	Geometry says: 0.12 mm³/mm
	2.	Your extruder hardware was previously underfeeding by 10%. Without a 1.10 filament ratio, it would only deliver ~0.108 mm³/mm physically.
	3.	By setting filament_flow_ratio = 1.10, you correct the hardware so that physically 1.0 mm of extruder steps now yields 0.12 mm³/mm for real.
	4.	Result: The nozzle truly extrudes 0.12 mm³/mm, matching the geometry. No extra flow is happening beyond that.

Because you’re not pushing extra plastic above the geometry volume, ignoring filament ratio in the speed cap will not cause an overshoot. You’re effectively printing at the geometry’s volume anyway. So from a purely volumetric standpoint, the slicer’s existing approach won’t produce a big mismatch or overshoot your hotend’s limit.

⸻

### Why We Still Prefer to Account for filament_flow_ratio

The slicer cannot know whether “filament_flow_ratio = 1.10” is purely correcting an underfeeding extruder or intentionally overextruding. Numerically, both cases look identical: the extruder is told “1.10× steps.”
	•	If it’s real calibration, physically you’re just hitting geometry’s baseline flow.
	•	If it’s a real desire for 10% more plastic, physically you’re pushing geometry × 1.10.

Hence, the safest approach is to treat filament ratio as possibly changing the real final flow. If it truly is just calibration, the difference from 1.0 is presumably quite small and the impact on speed capping is negligible. But if it’s actually overextrusion, ignoring it in the speed cap can let you exceed your intended volumetric speed limit.

⸻

### Bottom Line

* Case: “True calibration”
    - Your filament ratio >1.0 is purely offsetting a hardware shortfall. Physically, you match the geometry volume. Speed capping will not overshoot.
* Case: “Real overextrusion”
   - The filament ratio genuinely pushes above geometry volume. If the slicer ignores it in capping, you can exceed your max flow limit.

Because the slicer can’t distinguish these scenarios, factoring filament_flow_ratio into the speed cap is more robust. If your filament ratio is really just small calibration, you won’t see much slowdown anyway; if it’s actual overextrusion, you avoid overshooting the limit.


The only downside to this is:
If someone is printing to fix underfeeding, they will see a very slight change in speed time, this, to me is totally fine given that we get better, more precise flow rates vs before, given the way almost all users use filament_flow_ratio, especially when they set >1 from calib tests.


Secondary:
**Fixes Flow calibration tests also** since users set filament flow ratio, all >1 calibration test pad values, when used in printing will use wrong speedcap, since calibration treat the ratio as intentional over extrusion, but when the user uses the same value as filament_flow_ratio, they'd see a different flow profile due to speedcap working differently between the calibration test and printing. This PR would automatically make both inline with each other. This also fixes issues where users would set a filament flow ratio and then do a yolo test to calibrate to values outside standard yolo range. Prior to fix, mixing flow and print ratios would result in different extrusions in test (which uses both ratios) vs in actual printing when they've set just filament flow ratio.