### PR TITLE
Junction Deviation Machine Limit 

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3139,7 +3139,14 @@ void GCode::print_machine_envelope(GCodeOutputStream &file, Print &print)
             print.config().machine_max_jerk_y.values.front() * factor,
             print.config().machine_max_jerk_z.values.front() * factor,
             print.config().machine_max_jerk_e.values.front() * factor);
-    }
+
+        // New Marlin uses M205 J[mm] for junction deviation (only apply if it is > 0)
+
+        if (flavor == gcfMarlinFirmware && config().machine_max_junction_deviation.values.front() > 0) {
+            file.write_format("M205 J%.4lf ; set Junction Deviation, mm\n",
+                              print.config().machine_max_junction_deviation.values.front());
+        }
+    }       
 }
 
 // BBS

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -1038,6 +1038,10 @@ void GCodeProcessor::apply_config(const DynamicPrintConfig& config)
         if (machine_max_jerk_e != nullptr)
             m_time_processor.machine_limits.machine_max_jerk_e.values = machine_max_jerk_e->values;
 
+          const ConfigOptionFloats* machine_max_junction_deviation = config.option<ConfigOptionFloats>("machine_max_junction_deviation");
+        if (machine_max_junction_deviation != nullptr)
+              m_time_processor.machine_limits.machine_max_junction_deviation.values = machine_max_junction_deviation->values;
+
         const ConfigOptionFloats* machine_max_acceleration_extruding = config.option<ConfigOptionFloats>("machine_max_acceleration_extruding");
         if (machine_max_acceleration_extruding != nullptr)
             m_time_processor.machine_limits.machine_max_acceleration_extruding.values = machine_max_acceleration_extruding->values;
@@ -3805,6 +3809,7 @@ void GCodeProcessor::process_M205(const GCodeReader::GCodeLine& line)
 
             if (line.has_value('T', value))
                 set_option_value(m_time_processor.machine_limits.machine_min_travel_rate, i, value);
+
         }
     }
 }

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -136,6 +136,7 @@ public:
     double          m_last_jerk;
     double          m_max_jerk_z;
     double          m_max_jerk_e;
+    double          m_max_junction_deviation;
 
     unsigned int  m_travel_acceleration;
     unsigned int  m_travel_jerk;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -875,6 +875,7 @@ static std::vector<std::string> s_Preset_machine_limits_options {
     "machine_max_speed_x", "machine_max_speed_y", "machine_max_speed_z", "machine_max_speed_e",
     "machine_min_extruding_rate", "machine_min_travel_rate",
     "machine_max_jerk_x", "machine_max_jerk_y", "machine_max_jerk_z", "machine_max_jerk_e",
+    "machine_max_junction_deviation",
 };
 
 static std::vector<std::string> s_Preset_printer_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3436,6 +3436,15 @@ void PrintConfigDef::init_fff_params()
             def->set_default_value(new ConfigOptionFloats(axis.max_jerk));
         }
     }
+    // M205 J... [mm] machine junction deviation limits 
+    def = this->add("machine_max_junction_deviation", coFloats);
+    def->full_label = L("Maximum Junction Deviation");
+    def->category = L("Machine limits");
+    def->tooltip = L("Maximum junction deviation (M205 J, only apply if  JD > 0 for Marlin Firmware)");
+    def->sidetext = L("mm");
+    def->min = 0;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloats{0. ,0. });
 
     // M205 S... [mm/sec]
     def = this->add("machine_min_extruding_rate", coFloats);

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1070,6 +1070,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloats,               machine_max_jerk_y))
     ((ConfigOptionFloats,               machine_max_jerk_z))
     ((ConfigOptionFloats,               machine_max_jerk_e))
+    // M205 J... [mm]
+    ((ConfigOptionFloats,               machine_max_junction_deviation))
     // M205 T... [mm/sec]
     ((ConfigOptionFloats,               machine_min_travel_rate))
     // M205 S... [mm/sec]

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4118,6 +4118,9 @@ PageShp TabPrinter::build_kinematics_page()
             append_option_line(optgroup, "machine_max_jerk_" + axis);
         }
 
+        // machine max junction deviation
+      // optgroup = page->new_optgroup(L("Junction Deviation"));
+         append_option_line(optgroup, "machine_max_junction_deviation");
     //optgroup = page->new_optgroup(L("Minimum feedrates"));
     //    append_option_line(optgroup, "machine_min_extruding_rate");
     //    append_option_line(optgroup, "machine_min_travel_rate");


### PR DESCRIPTION
Added Junction Deviation Menu for Marlin Firmware

This update introduces a new Junction Deviation (JD) menu, allowing users to configure the maximum JD value for printers using Marlin firmware. JD is now the preferred motion control parameter, as the traditional jerk setting is considered obsolete in recent Marlin versions.

The JD value will only be applied if:

- The firmware is Marlin.
- The JD value is set to a number greater than zero.

Make sure the "Emit Limits to G-code" option is enabled for the JD setting to be included in the generated G-code.

![image](https://github.com/user-attachments/assets/1b466822-25dd-4a97-bf8d-ec8377305df5)
![image](https://github.com/user-attachments/assets/f84b5e6c-d287-457e-b021-6489cfb7ae6b)
![image](https://github.com/user-attachments/assets/0e7ed4c7-0e5f-4c6e-abaf-068c5400b918)


