### PR TITLE
Fix the use of "bed type" to "plate type"

### DIFF
--- a/localization/i18n/OrcaSlicer.pot
+++ b/localization/i18n/OrcaSlicer.pot
@@ -14218,7 +14218,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr ""
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr ""
 
 msgid "filament position"

--- a/localization/i18n/ca/OrcaSlicer_ca.po
+++ b/localization/i18n/ca/OrcaSlicer_ca.po
@@ -16708,7 +16708,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Paràmetres d'impressió"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "Tipus de placa"
 
 msgid "filament position"

--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -15462,7 +15462,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Parametry tisku"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "Typ Podložky"
 
 msgid "filament position"

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -16828,7 +16828,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Druckparameter"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "Druckbetttyp"
 
 msgid "filament position"

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -5897,7 +5897,7 @@ msgid "Connection"
 msgstr "Connection"
 
 msgid "Bed type"
-msgstr "Bed type"
+msgstr ""
 
 msgid "Flushing volumes"
 msgstr "Flushing volumes"
@@ -9767,7 +9767,7 @@ msgstr ""
 "the Textured PEI Plate."
 
 msgid "Bed types supported by the printer"
-msgstr "Bed types supported by the printer"
+msgstr ""
 
 msgid "Smooth Cool Plate"
 msgstr ""
@@ -15177,8 +15177,8 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Printing Parameters"
 
-msgid "Plate Type"
-msgstr "Plate Type"
+msgid "Plate type"
+msgstr ""
 
 msgid "filament position"
 msgstr "filament position"

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -16580,8 +16580,8 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Parámetros de Impresión"
 
-msgid "Plate Type"
-msgstr "Tipo de Bandeja"
+msgid "Plate type"
+msgstr "Tipo de bandeja"
 
 msgid "filament position"
 msgstr "Posición de filamento"
@@ -21683,12 +21683,6 @@ msgstr ""
 
 #~ msgid "Plate %d: %s does not support filament %s (%s)."
 #~ msgstr "Placa %d: %s no admite el filamento %s (%s)."
-
-#~ msgid "Plate type"
-#~ msgstr "Plate type"
-
-#~ msgid "Plate types supported by the printer"
-#~ msgstr "Plate types supported by the printer"
 
 #~ msgid "Please Fill Task Report."
 #~ msgstr "Por favor rellene el informe de tareas."

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -16952,7 +16952,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Paramètres d’impression"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "Type de plaque"
 
 msgid "filament position"

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -15343,8 +15343,8 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Nyomtatási paraméterek"
 
-msgid "Plate Type"
-msgstr "Plate Type"
+msgid "Plate type"
+msgstr ""
 
 msgid "filament position"
 msgstr "filamentpozíció"

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -16858,7 +16858,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Parametri di stampa"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "Tipo di piatto"
 
 msgid "filament position"

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -15123,8 +15123,8 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Printing Parameters"
 
-msgid "Plate Type"
-msgstr "Plate Type"
+msgid "Plate type"
+msgstr ""
 
 msgid "filament position"
 msgstr "filament position"

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -15914,7 +15914,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "출력 매개변수"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "플레이트 타입"
 
 msgid "filament position"

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -15546,8 +15546,8 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Afdrukparameters"
 
-msgid "Plate Type"
-msgstr "Plate Type"
+msgid "Plate type"
+msgstr ""
 
 msgid "filament position"
 msgstr "filament positie"

--- a/localization/i18n/pl/OrcaSlicer_pl.po
+++ b/localization/i18n/pl/OrcaSlicer_pl.po
@@ -16613,7 +16613,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Parametry drukowania"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "Typ Płyty"
 
 msgid "filament position"

--- a/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
+++ b/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
@@ -16650,8 +16650,8 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Parâmetros de Impressão"
 
-msgid "Plate Type"
-msgstr "Tipo de Placa"
+msgid "Plate type"
+msgstr "Tipo de placa"
 
 msgid "filament position"
 msgstr "posição do filamento"

--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -16957,7 +16957,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Параметры печати"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "Типа печатной пластины"
 
 msgid "filament position"

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -15174,7 +15174,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Parametrar för utskrift"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "Typ av byggplatta"
 
 msgid "filament position"

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -16443,7 +16443,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Yazdırma Parametreleri"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "Plaka Tipi"
 
 msgid "filament position"

--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -16553,7 +16553,7 @@ msgstr ""
 msgid "Printing Parameters"
 msgstr "Параметри друку"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "Тип Пластини"
 
 msgid "filament position"

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -14996,7 +14996,7 @@ msgstr "将打印一份测试模型。在校准之前，请清理打印平台并
 msgid "Printing Parameters"
 msgstr "打印参数"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "热床类型"
 
 msgid "filament position"

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -15296,7 +15296,7 @@ msgstr "將列印一份測試模型。在校正之前，請清理列印板並將
 msgid "Printing Parameters"
 msgstr "列印參數"
 
-msgid "Plate Type"
+msgid "Plate type"
 msgstr "熱床類型"
 
 msgid "filament position"

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -801,8 +801,8 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionInts{45});
 
     def = this->add("curr_bed_type", coEnum);
-    def->label = L("Bed type");
-    def->tooltip = L("Bed types supported by the printer");
+    def->label = L("Plate type");
+    def->tooltip = L("Plate types supported by the printer.");
     def->mode = comSimple;
     def->enum_keys_map = &s_keys_map_BedType;
     // Orca: make sure the order of the values is the same as the BedType enum 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -801,8 +801,8 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionInts{45});
 
     def = this->add("curr_bed_type", coEnum);
-    def->label = L("Plate type");
-    def->tooltip = L("Plate types supported by the printer.");
+    def->label = L("Build plate type");
+    def->tooltip = L("Build plate types supported by the printer.");
     def->mode = comSimple;
     def->enum_keys_map = &s_keys_map_BedType;
     // Orca: make sure the order of the values is the same as the BedType enum 

--- a/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
@@ -521,7 +521,7 @@ void CalibrationPresetPage::create_selection_panel(wxWindow* parent)
 
     panel_sizer->AddSpacer(PRESET_GAP);
 
-    auto plate_type_combo_text = new Label(parent, _L("Plate Type"));
+    auto plate_type_combo_text = new Label(parent, _L("Plate type"));
     plate_type_combo_text->SetFont(Label::Head_14);
     plate_type_combo_text->Wrap(-1);
     panel_sizer->Add(plate_type_combo_text, 0, wxALL, 0);

--- a/src/slic3r/GUI/ExtrusionCalibration.cpp
+++ b/src/slic3r/GUI/ExtrusionCalibration.cpp
@@ -86,7 +86,7 @@ void ExtrusionCalibration::create()
     select_sizer->Add(m_comboBox_filament, 0, wxEXPAND);
     select_sizer->Add(0, EXTRUSION_CALIBRATION_WIDGET_GAP, 0, 0);
 
-    auto bed_type_sel_text = new wxStaticText(m_step_1_panel, wxID_ANY, _L("Bed Type"), wxDefaultPosition, wxDefaultSize, 0);
+    auto bed_type_sel_text = new wxStaticText(m_step_1_panel, wxID_ANY, _L("Plate type"), wxDefaultPosition, wxDefaultSize, 0);
     select_sizer->Add(bed_type_sel_text, 0, wxALIGN_LEFT);
     select_sizer->AddSpacer(FromDIP(4));
 

--- a/src/slic3r/GUI/PlateSettingsDialog.cpp
+++ b/src/slic3r/GUI/PlateSettingsDialog.cpp
@@ -394,7 +394,7 @@ PlateSettingsDialog::PlateSettingsDialog(wxWindow* parent, const wxString& title
     if (!wxGetApp().preset_bundle->is_bbl_vendor())
       m_bed_type_choice->Disable();
 
-    wxStaticText* m_bed_type_txt = new wxStaticText(this, wxID_ANY, _L("Bed type"));
+    wxStaticText* m_bed_type_txt = new wxStaticText(this, wxID_ANY, _L("Plate type"));
     m_bed_type_txt->SetFont(Label::Body_14);
     top_sizer->Add(m_bed_type_txt, 0, wxALIGN_CENTER_VERTICAL | wxALIGN_LEFT | wxTOP | wxBOTTOM, FromDIP(5));
     top_sizer->Add(m_bed_type_choice, 0, wxALIGN_CENTER_VERTICAL | wxALIGN_RIGHT | wxTOP | wxBOTTOM, FromDIP(5));

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -791,7 +791,7 @@ Sidebar::Sidebar(Plater *parent)
 
         // Bed type selection
         wxBoxSizer* bed_type_sizer = new wxBoxSizer(wxHORIZONTAL);
-        wxStaticText* bed_type_title = new wxStaticText(p->m_panel_printer_content, wxID_ANY, _L("Bed type"));
+        wxStaticText* bed_type_title = new wxStaticText(p->m_panel_printer_content, wxID_ANY, _L("Plate type"));
         //bed_type_title->SetBackgroundColour();
         bed_type_title->Wrap(-1);
         bed_type_title->SetFont(Label::Body_14);


### PR DESCRIPTION
# Description
Some places referred to "bed type" when they meant "plate type".
@SoftFever, this one is separated from #8881 because it changes the meaning of the strings, requiring new translations.