### PR TITLE
Remove 'www' subdomain from official link to avoid certificate warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Join our Discord community here:<br>
  
  <h3>🚨🚨🚨Important Security Alert🚨🚨🚨</h3> 
 
-The only official platforms for OrcaSlicer are **our GitHub project page**, <a href="https://www.orcaslicer.com/">**orcaslicer.com**</a>, and the <a href="https://discord.gg/P4VE9UY9gJ">**official Discord channel**</a>.
+The only official platforms for OrcaSlicer are **our GitHub project page**, <a href="https://orcaslicer.com/">**orcaslicer.com**</a>, and the <a href="https://discord.gg/P4VE9UY9gJ">**official Discord channel**</a>.
 
 Please be aware that "**orcaslicer.net**", "**orcaslicer.co**" or "**orca-slicer.com**" are NOT an official website for OrcaSlicer and may be potentially malicious. These sites appear to use AI-generated content, lacking genuine context and seems to exist solely to profit from advertisements. Worse, it may redirect download links to harmful sources. For your safety, avoid downloading OrcaSlicer from this site as the links may be compromised. 
 


### PR DESCRIPTION
# Description

'www.orcaslicer.com' creates certificate warnings, and ultimately redirects to 'orcaslicer.com' anyway. Thus, I opened this PR to remove the subdomain.

# Screenshots/Recordings/Graphs

![image](https://github.com/user-attachments/assets/e0775f0a-bb60-4bb9-8781-7f254fc6f24a)

## Tests

I clicked the new link.
