### PR TITLE
Improve gcode preview flow rate scale

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -1146,6 +1146,7 @@ void GCodeProcessor::reset()
     m_forced_width = 0.0f;
     m_forced_height = 0.0f;
     m_mm3_per_mm = 0.0f;
+    m_travel_dist = 0.0f;
     m_fan_speed = 0.0f;
     m_z_offset = 0.0f;
 
@@ -2644,7 +2645,8 @@ void GCodeProcessor::process_G1(const GCodeReader::GCodeLine& line, const std::o
 
     EMoveType type = move_type(delta_pos);
     if (type == EMoveType::Extrude) {
-        float delta_xyz = std::sqrt(sqr(delta_pos[X]) + sqr(delta_pos[Y]) + sqr(delta_pos[Z]));
+        const float delta_xyz = std::sqrt(sqr(delta_pos[X]) + sqr(delta_pos[Y]) + sqr(delta_pos[Z]));
+        m_travel_dist = delta_xyz;
         float volume_extruded_filament = area_filament_cross_section * delta_pos[E];
         float area_toolpath_cross_section = volume_extruded_filament / delta_xyz;
 
@@ -3121,7 +3123,8 @@ void  GCodeProcessor::process_G2_G3(const GCodeReader::GCodeLine& line)
     EMoveType type = move_type(delta_pos[E]);
 
 
-    float delta_xyz = std::sqrt(sqr(arc_length) + sqr(delta_pos[Z]));
+    const float delta_xyz = std::sqrt(sqr(arc_length) + sqr(delta_pos[Z]));
+    m_travel_dist         = delta_xyz;
     if (type == EMoveType::Extrude) {
         float volume_extruded_filament = area_filament_cross_section * delta_pos[E];
         float area_toolpath_cross_section = volume_extruded_filament / delta_xyz;
@@ -4778,6 +4781,7 @@ void GCodeProcessor::store_move_vertex(EMoveType type, EMovePathType path_type)
         m_width,
         m_height,
         m_mm3_per_mm,
+        m_travel_dist,
         m_fan_speed,
         m_extruder_temps[m_extruder_id],
         static_cast<float>(m_result.moves.size()),

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -162,6 +162,7 @@ class Print;
             float width{ 0.0f }; // mm
             float height{ 0.0f }; // mm
             float mm3_per_mm{ 0.0f };
+            float travel_dist{ 0.0f }; // mm
             float fan_speed{ 0.0f }; // percentage
             float temperature{ 0.0f }; // Celsius degrees
             float time{ 0.0f }; // s
@@ -704,6 +705,7 @@ class Print;
         float m_forced_width; // mm
         float m_forced_height; // mm
         float m_mm3_per_mm;
+        float m_travel_dist; // mm
         float m_fan_speed; // percentage
         float m_z_offset; // mm
         ExtrusionRole m_extrusion_role;

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -412,6 +412,7 @@ void GCodeViewer::SequentialView::Marker::render(int canvas_width, int canvas_he
         //     break;
         // }
         case EViewType::VolumetricRate: {
+            if (m_curr_move.type != EMoveType::Extrude) break;
             ImGui::SameLine(startx2);
             sprintf(buf, "%s%.2f", flow.c_str(), m_curr_move.volumetric_rate());
             ImGui::PushItemWidth(item_size);

--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -1143,8 +1143,12 @@ void GCodeViewer::refresh(const GCodeProcessorResult& gcode_result, const std::v
             m_extrusions.ranges.width.update_from(round_to_bin(curr.width));
             m_extrusions.ranges.fan_speed.update_from(curr.fan_speed);
             m_extrusions.ranges.temperature.update_from(curr.temperature);
-            if (curr.extrusion_role != erCustom || is_visible(erCustom))
-                m_extrusions.ranges.volumetric_rate.update_from(round_to_bin(curr.volumetric_rate()));
+            if (curr.delta_extruder > 0.005 && curr.travel_dist > 0.01) {
+                // Ignore very tiny extrusions from flow rate calculation, because
+                // it could give very imprecise result due to rounding in gcode generation
+                if (curr.extrusion_role != erCustom || is_visible(erCustom))
+                    m_extrusions.ranges.volumetric_rate.update_from(round_to_bin(curr.volumetric_rate()));
+            }
 
             if (curr.layer_duration > 0.f) {
                 m_extrusions.ranges.layer_duration.update_from(curr.layer_duration);


### PR DESCRIPTION
Fix #9313

This PR filter out very tiny extrusions from the flow rate scale calculation. Due to the [gcode decimal point percision issue](https://github.com/SoftFever/OrcaSlicer/issues/9190#issuecomment-2777957355), such small extrusions gives flow rate far off, which causes confusion to user.

Note, even with this fix, there will still be some extrusions with flow rate higher than the `filament_max_volumetric_speed` option, which is normal, again, because of the rounding in generating gcodes. Thus we always suggest to set `filament_max_volumetric_speed` slightly lower than the machine's limit: https://github.com/SoftFever/OrcaSlicer/wiki/Calibration#max-volumetric-speed

![image](https://github.com/user-attachments/assets/390dbe2b-a56c-420b-a31e-a747b9407aaf)
