### PR TITLE
Fix: Correct color of bed plates without 3D model

### DIFF
--- a/src/slic3r/GUI/3DBed.cpp
+++ b/src/slic3r/GUI/3DBed.cpp
@@ -729,7 +729,9 @@ void Bed3D::render_default(bool bottom, const Transform3d& view_matrix, const Tr
         if (m_model.get_filename().empty() && !bottom) {
             // draw background
             glsafe(::glDepthMask(GL_FALSE));
-            m_triangles.set_color(DEFAULT_MODEL_COLOR);
+            ColorRGBA color = m_is_dark ? DEFAULT_MODEL_COLOR_DARK : DEFAULT_MODEL_COLOR;   // ORCA add dark mode support
+            color = ColorRGBA(color[0] * 0.8f, color[1] * 0.8f,color[2] * 0.8f, color[3]);  // ORCA shift color a darker tone to fix difference between flat / gouraud_light shader
+            m_triangles.set_color(color);
             m_triangles.render();
             glsafe(::glDepthMask(GL_TRUE));
         }


### PR DESCRIPTION
• Matches colors of bed plate with 3D model and bed plate without 3D model
• Adds dark mode support for bed plate without 3D model

I have to shift color to darker tone after matching colors because flat shader caused much brighter color

### COMPARISON
Before
![Screenshot-20250412160119](https://github.com/user-attachments/assets/e29abb1c-f865-4521-8692-92d56902fcc1)

After
![Screenshot-20250412160012](https://github.com/user-attachments/assets/b3f96446-52a2-4f97-ba42-dcca177413ed)

After - Before
![Screenshot-20250412161949](https://github.com/user-attachments/assets/45459b64-c69e-4e23-bf99-8eef03cda777)
