### PR TITLE
Fix: Bed icons not vertically centered on circular shaped plates

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -635,10 +635,8 @@ void PartPlate::calc_vertex_for_icons(int index, PickingModel &model)
     float gap_top  = PARTPLATE_ICON_GAP_TOP  * factor;
     p += Vec2d(gap_left,-1 * (index * (size + gap_y) + gap_top));
 
-    if (m_plater && m_plater->get_build_volume_type() == BuildVolume_Type::Circle){
-        int bed_icon_count = 6;
-        p[1] -= std::max(0.0, (bed_ext.size()(1) - bed_icon_count * size - (bed_icon_count) * gap_y) / 2);
-    }
+    if (m_plater && m_plater->get_build_volume_type() == BuildVolume_Type::Circle)
+        p[1] -= std::max(0.0, (bed_ext.size()(1) - (size + gap_y) * 6 /* bed_icon_count */) / 2);
 
     poly.contour.append({ scale_(p(0))       , scale_(p(1) - size) });
     poly.contour.append({ scale_(p(0) + size), scale_(p(1) - size) });

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -635,8 +635,10 @@ void PartPlate::calc_vertex_for_icons(int index, PickingModel &model)
     float gap_top  = PARTPLATE_ICON_GAP_TOP  * factor;
     p += Vec2d(gap_left,-1 * (index * (size + gap_y) + gap_top));
 
-    if (m_plater && m_plater->get_build_volume_type() == BuildVolume_Type::Circle)
-        p[1] -= std::max(0.0, (bed_ext.size()(1) - 5 * size - 4 * gap_y - gap_top) / 2);
+    if (m_plater && m_plater->get_build_volume_type() == BuildVolume_Type::Circle){
+        int bed_icon_count = 6;
+        p[1] -= std::max(0.0, (bed_ext.size()(1) - bed_icon_count * size - (bed_icon_count) * gap_y) / 2);
+    }
 
     poly.contour.append({ scale_(p(0))       , scale_(p(1) - size) });
     poly.contour.append({ scale_(p(0) + size), scale_(p(1) - size) });
@@ -2684,6 +2686,8 @@ bool PartPlate::set_shape(const Pointfs& shape, const Pointfs& exclude_areas, Ve
         calc_vertex_for_icons(3, m_lock_icon);
         calc_vertex_for_icons(4, m_plate_settings_icon);
         calc_vertex_for_icons(5, m_move_front_icon);
+        // ORCA also change bed_icon_count number in calc_vertex_for_icons() after adding or removing icons for circular shaped beds that uses vertical alingment for icons
+
 		//calc_vertex_for_number(0, (m_plate_index < 9), m_plate_idx_icon);
 		calc_vertex_for_number(0, false, m_plate_idx_icon);
 		if (m_plater) {


### PR DESCRIPTION
After adding "Move to front" icon, vertical alignment of icons broken on circular shaped plates

• Removed gap_top from calculation to get perfect center
• Added a reminder near calc_vertex_for_icons that recommends change icon number for future changes

Before-After
![Screenshot-20250412175151](https://github.com/user-attachments/assets/5a2d8219-2e36-4a50-a0ab-18e6378bc6ee)
