### PR TITLE
Allow right click on empty space while an object selected

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -4493,6 +4493,12 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
                 render();
             }
 
+            //ORCA allow right click on empty space while an object selected
+            if (m_hover_plate_idxs.empty() && m_hover_volume_idxs.empty() && (m_canvas_type == CanvasView3D) && !m_mouse.dragging) {
+                deselect_all();
+                render();
+            }
+
             Vec2d logical_pos = pos.cast<double>();
 #if ENABLE_RETINA_GL
             const float factor = m_retina_helper->get_scale_factor();


### PR DESCRIPTION
### PROBLEM
I use mostly "Add model" from context menu but current code blocks right click if an object selected that forces me to unnecessary left click to deselect objects first 

### SOLUTION
Code changes allows right click on empty space while an object selected
deselects objects then shows context menu

![Screenshot-20250413185428](https://github.com/user-attachments/assets/fbe7155e-e287-4d47-a492-d017cdad030b)

tried pan, multiple selection etc. and it works as expected

### FOUND BUGS
Current code has minor issues for right click but can be blocked. right click on bed icons and toolbar
![Screenshot-20250413185639](https://github.com/user-attachments/assets/37f2cc8d-0f9f-4aca-8a53-2706e03735c7)
![Screenshot-20250413185647](https://github.com/user-attachments/assets/d5c379a4-02af-43ae-8826-9f11c1810fd0)
