### PR TITLE
Increase skirt_loops max value to 1000000

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4337,7 +4337,7 @@ void PrintConfigDef::init_fff_params()
     def->full_label = L("Skirt loops");
     def->tooltip = L("Number of loops for the skirt. Zero means disabling skirt");
     def->min = 0;
-    def->max = 10;
+    def->max = 1000000;
     def->mode = comSimple;
     def->set_default_value(new ConfigOptionInt(1));
 


### PR DESCRIPTION
Increased the maximum allowed value for skirt_loops from 10 to 1000000.