### PR TITLE
Adds resonance avoidance feature from qidi slicer to orca slicer 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 <h1> <p "font-size:200px;"><img align="left" src="https://github.com/SoftFever/OrcaSlicer/blob/main/resources/images/OrcaSlicer.ico" width="100"> Orca Slicer</p> </h1>
 
+This Fork has been modified to have the option to use resonance avoidance based on the changes made by qidi for qidi slicer. Adding a precompiled option if you don't wish to build it yourself and trust me. Otherwise I reccomend building it yourself. 
+
 [![Build all](https://github.com/SoftFever/OrcaSlicer/actions/workflows/build_all.yml/badge.svg?branch=main)](https://github.com/SoftFever/OrcaSlicer/actions/workflows/build_all.yml)
 <br>Orca Slicer is an open source slicer for FDM printers. 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <h1> <p "font-size:200px;"><img align="left" src="https://github.com/SoftFever/OrcaSlicer/blob/main/resources/images/OrcaSlicer.ico" width="100"> Orca Slicer</p> </h1>
 
-This Fork has been modified to have the option to use resonance avoidance based on the changes made by qidi for qidi slicer. Adding a precompiled option if you don't wish to build it yourself and trust me. Otherwise I reccomend building it yourself. 
+This Fork has been modified to have the option to use resonance avoidance based on the changes made by qidi for qidi slicer. 
 
 [![Build all](https://github.com/SoftFever/OrcaSlicer/actions/workflows/build_all.yml/badge.svg?branch=main)](https://github.com/SoftFever/OrcaSlicer/actions/workflows/build_all.yml)
 <br>Orca Slicer is an open source slicer for FDM printers. 

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -165,6 +165,7 @@ public:
     GCode() :
     	m_origin(Vec2d::Zero()),
         m_enable_loop_clipping(true),
+        m_resonance_avoidance(true),
         m_enable_cooling_markers(false),
         m_enable_extrusion_role_markers(false),
         m_last_processor_extrusion_role(erNone),
@@ -506,6 +507,8 @@ private:
     AvoidCrossingPerimeters             m_avoid_crossing_perimeters;
     RetractWhenCrossingPerimeters       m_retract_when_crossing_perimeters;
     bool                                m_enable_loop_clipping;
+    //resonance avoidance
+    bool                                m_resonance_avoidance; 
     // If enabled, the G-code generator will put following comments at the ends
     // of the G-code lines: _EXTRUDE_SET_SPEED, _WIPE, _OVERHANG_FAN_START, _OVERHANG_FAN_END
     // Those comments are received and consumed (removed from the G-code) by the CoolingBuffer.pm Perl module.

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -835,7 +835,10 @@ static std::vector<std::string> s_Preset_print_options {
      "hole_to_polyhole", "hole_to_polyhole_threshold", "hole_to_polyhole_twisted", "mmu_segmented_region_max_width", "mmu_segmented_region_interlocking_depth",
      "small_area_infill_flow_compensation", "small_area_infill_flow_compensation_model",
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold",
-     "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width","calib_flowrate_topinfill_special_order"
+     "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width","calib_flowrate_topinfill_special_order",
+     //resonance avoidance
+    "resonance_avoidance", "min_resonance_avoidance_speed", "max_resonance_avoidance_speed"
+
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -836,7 +836,7 @@ static std::vector<std::string> s_Preset_print_options {
      "small_area_infill_flow_compensation", "small_area_infill_flow_compensation_model",
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold",
      "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width","calib_flowrate_topinfill_special_order",
-     //resonance avoidance
+     //resonance avoidance ported from qidi slicer
     "resonance_avoidance", "min_resonance_avoidance_speed", "max_resonance_avoidance_speed"
 
 };

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1317,6 +1317,31 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(1));
 
+     // Y27
+    def          = this->add("resonance_avoidance", coBool);
+    def->label   = L("Resonance avoidance");
+    def->tooltip = L("By reducing the speed of the outer wall to avoid the resonance zone of the printer, ringing on the surface of the "
+                     "model are avoided.\n"
+                     "Please turn this option off when testing ringing.");
+    def->mode    = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(true));
+
+    def           = this->add("min_resonance_avoidance_speed", coFloat);
+    def->label    = L("Min");
+    def->tooltip  = L("Minimum speed of resonance avoidance.");
+    def->sidetext = L("mm/s");
+    def->min      = 0;
+    def->mode     = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(70));
+
+    def           = this->add("max_resonance_avoidance_speed", coFloat);
+    def->label    = L("Max");
+    def->tooltip  = L("Maximum speed of resonance avoidance.");
+    def->sidetext = L("mm/s");
+    def->min      = 0;
+    def->mode     = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(120));
+
     def = this->add("compatible_printers", coStrings);
     def->label = L("Compatible machine");
     def->mode = comAdvanced;

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1317,7 +1317,7 @@ void PrintConfigDef::init_fff_params()
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(1));
 
-     // Y27
+     // resonance avoidance ported over from qidi slicer
     def          = this->add("resonance_avoidance", coBool);
     def->label   = L("Resonance avoidance");
     def->tooltip = L("By reducing the speed of the outer wall to avoid the resonance zone of the printer, ringing on the surface of the "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1042,7 +1042,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                scarf_joint_flow_ratio))
     ((ConfigOptionPercent,              scarf_overhang_threshold))
 
-        //resonance avoidance
+        //resonance avoidance ported from qidi slicer
     ((ConfigOptionBool,                resonance_avoidance))
     ((ConfigOptionFloat,               min_resonance_avoidance_speed))
     ((ConfigOptionFloat,               max_resonance_avoidance_speed))

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1042,6 +1042,11 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                scarf_joint_flow_ratio))
     ((ConfigOptionPercent,              scarf_overhang_threshold))
 
+        //resonance avoidance
+    ((ConfigOptionBool,                resonance_avoidance))
+    ((ConfigOptionFloat,               min_resonance_avoidance_speed))
+    ((ConfigOptionFloat,               max_resonance_avoidance_speed))
+
 
 )
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2158,9 +2158,23 @@ void TabPrint::build()
         optgroup->append_single_option_line("support_interface_speed");
         optgroup = page->new_optgroup(L("Overhang speed"), L"param_overhang_speed", 15);
         optgroup->append_single_option_line("enable_overhang_speed", "slow-down-for-overhang");
+        optgroup->append_separator();
+
+        optgroup = page->new_optgroup(L("Resonance Avoidance"));
+        optgroup->append_single_option_line("resonance_avoidance");
+
+        // Resonance‑avoidance speed inputs
+        {
+        Line resonance_line = {L("Resonance Avoidance Speed"), L("")};
+        resonance_line.append_option(optgroup->get_option("min_resonance_avoidance_speed"));
+        resonance_line.append_option(optgroup->get_option("max_resonance_avoidance_speed"));
+        optgroup->append_line(resonance_line);
+        }
         // Orca: DEPRECATED
         // optgroup->append_single_option_line("overhang_speed_classic", "slow-down-for-overhang");
+        optgroup = page->new_optgroup(L("Slow down for curled perimeters"));
         optgroup->append_single_option_line("slowdown_for_curled_perimeters");
+        optgroup = page->new_optgroup(L("Overhang Speeds"));
         Line line = { L("Overhang speed"), L("This is the speed for various overhang degrees. Overhang degrees are expressed as a percentage of line width. 0 speed means no slowing down for the overhang degree range and wall speed is used") };
         line.label_path = "slow-down-for-overhang";
         line.append_option(optgroup->get_option("overhang_1_4_speed"));

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2159,7 +2159,7 @@ void TabPrint::build()
         optgroup = page->new_optgroup(L("Overhang speed"), L"param_overhang_speed", 15);
         optgroup->append_single_option_line("enable_overhang_speed", "slow-down-for-overhang");
         optgroup->append_separator();
-
+//resonance avoidance ported over from qidi slicer
         optgroup = page->new_optgroup(L("Resonance Avoidance"));
         optgroup->append_single_option_line("resonance_avoidance");
 


### PR DESCRIPTION
# Description


> Please provide a summary of the changes made in this PR. Include details such as:
  > *[ What issue does this PR address or fix?](https://github.com/SoftFever/OrcaSlicer/issues/7120)
  > *Introduces 
  > * Are there any breaking changes or dependencies that need to be considered? Not that I am aware of


# Screenshots/Recordings/Graphs


> ![image](https://github.com/user-attachments/assets/436b5d70-4881-40ff-8864-f9a27ff0cc99)
> Please attach images that can help explain the changes.
-->

## Tests


> Verified that it avoid the set speed zones when slicing prints. 
-->
