### PR TITLE
Make Custom GCode Editor resizable

### DIFF
--- a/src/slic3r/GUI/EditGCodeDialog.cpp
+++ b/src/slic3r/GUI/EditGCodeDialog.cpp
@@ -86,7 +86,7 @@ EditGCodeDialog::EditGCodeDialog(wxWindow* parent, const std::string& key, const
     wxGetApp().UpdateDarkUI(m_gcode_editor);
 
     grid_sizer->Add(param_sizer,  1, wxEXPAND);
-    grid_sizer->Add(m_add_btn,      0, wxTOP, m_params_list->GetSize().y/2);
+    grid_sizer->Add(m_add_btn,      0, wxALIGN_CENTER_VERTICAL);
     grid_sizer->Add(m_gcode_editor, 2, wxEXPAND);
 
     grid_sizer->AddGrowableRow(0, 1);

--- a/src/slic3r/GUI/EditGCodeDialog.cpp
+++ b/src/slic3r/GUI/EditGCodeDialog.cpp
@@ -71,7 +71,7 @@ EditGCodeDialog::EditGCodeDialog(wxWindow* parent, const std::string& key, const
     m_params_list = new ParamsViewCtrl(this, wxSize(em * 45, em * 70));
     m_params_list->SetFont(wxGetApp().code_font());
     wxGetApp().UpdateDarkUI(m_params_list);
-    param_sizer->Add(m_params_list, 0, wxEXPAND | wxALL, border);
+    param_sizer->Add(m_params_list, 1, wxEXPAND | wxALL, border);
 
     m_add_btn = new ScalableButton(this, wxID_ANY, "add_copies");
     m_add_btn->SetToolTip(_L("Add selected placeholder to G-code"));

--- a/src/slic3r/GUI/EditGCodeDialog.cpp
+++ b/src/slic3r/GUI/EditGCodeDialog.cpp
@@ -68,7 +68,7 @@ EditGCodeDialog::EditGCodeDialog(wxWindow* parent, const std::string& key, const
 
     param_sizer->Add(m_search_bar, 0, wxEXPAND | wxALL, border);
 
-    m_params_list = new ParamsViewCtrl(this, wxSize(em * 45, em * 70));
+    m_params_list = new ParamsViewCtrl(this, wxDefaultSize);
     m_params_list->SetFont(wxGetApp().code_font());
     wxGetApp().UpdateDarkUI(m_params_list);
     param_sizer->Add(m_params_list, 1, wxEXPAND | wxALL, border);
@@ -76,7 +76,7 @@ EditGCodeDialog::EditGCodeDialog(wxWindow* parent, const std::string& key, const
     m_add_btn = new ScalableButton(this, wxID_ANY, "add_copies");
     m_add_btn->SetToolTip(_L("Add selected placeholder to G-code"));
 
-    m_gcode_editor = new wxTextCtrl(this, wxID_ANY, value, wxDefaultPosition, wxSize(em * 75, em * 70), wxTE_MULTILINE
+    m_gcode_editor = new wxTextCtrl(this, wxID_ANY, value, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE
 #ifdef _WIN32
     | wxBORDER_SIMPLE
 #endif
@@ -91,7 +91,7 @@ EditGCodeDialog::EditGCodeDialog(wxWindow* parent, const std::string& key, const
 
     grid_sizer->AddGrowableRow(0, 1);
     grid_sizer->AddGrowableCol(0, 1);
-    grid_sizer->AddGrowableCol(2, 1);
+    grid_sizer->AddGrowableCol(2, 2);
 
     m_param_label = new wxStaticText(this, wxID_ANY, _L("Select placeholder"));
     m_param_label->SetFont(wxGetApp().bold_font());
@@ -115,6 +115,7 @@ EditGCodeDialog::EditGCodeDialog(wxWindow* parent, const std::string& key, const
     topSizer->SetSizeHints(this);
 
     this->Fit();
+    SetSize({100 * em, 70 * em});
     this->Layout();
 
     this->CenterOnScreen();

--- a/src/slic3r/GUI/EditGCodeDialog.cpp
+++ b/src/slic3r/GUI/EditGCodeDialog.cpp
@@ -35,7 +35,7 @@ namespace GUI {
 //------------------------------------------
 
 EditGCodeDialog::EditGCodeDialog(wxWindow* parent, const std::string& key, const std::string& value) :
-    DPIDialog(parent, wxID_ANY, format_wxstr(_L("Edit Custom G-code (%1%)"), key), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE/* | wxRESIZE_BORDER*/)
+    DPIDialog(parent, wxID_ANY, format_wxstr(_L("Edit Custom G-code (%1%)"), key), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
 {
     SetFont(wxGetApp().normal_font());
     SetBackgroundColour(*wxWHITE);

--- a/src/slic3r/GUI/EditGCodeDialog.cpp
+++ b/src/slic3r/GUI/EditGCodeDialog.cpp
@@ -115,7 +115,9 @@ EditGCodeDialog::EditGCodeDialog(wxWindow* parent, const std::string& key, const
     topSizer->SetSizeHints(this);
 
     this->Fit();
-    SetSize({100 * em, 70 * em});
+
+    fit_in_display(*this, {100 * em, 70 * em});
+
     this->Layout();
 
     this->CenterOnScreen();

--- a/src/slic3r/GUI/GUI_Utils.cpp
+++ b/src/slic3r/GUI/GUI_Utils.cpp
@@ -481,5 +481,18 @@ bool generate_image(const std::string &filename, wxImage &image, wxSize img_size
 
 std::deque<wxDialog*> dialogStack;
 
+void fit_in_display(wxTopLevelWindow& window, wxSize desired_size)
+{
+    const auto display_size = wxDisplay(window.GetParent()).GetClientArea();
+    if (desired_size.GetWidth() > display_size.GetWidth()) {
+        desired_size.SetWidth(display_size.GetWidth() * 4 / 5);
+    }
+    if (desired_size.GetHeight() > display_size.GetHeight()) {
+        desired_size.SetHeight(display_size.GetHeight() * 4 / 5);
+    }
+
+    window.SetSize(desired_size);
+}
+
 }
 }

--- a/src/slic3r/GUI/GUI_Utils.cpp
+++ b/src/slic3r/GUI/GUI_Utils.cpp
@@ -18,6 +18,7 @@
 #include <wx/dcclient.h>
 #include <wx/font.h>
 #include <wx/fontutil.h>
+#include <wx/display.h>
 
 #include "libslic3r/Config.hpp"
 

--- a/src/slic3r/GUI/GUI_Utils.hpp
+++ b/src/slic3r/GUI/GUI_Utils.hpp
@@ -494,6 +494,12 @@ bool generate_image(const std::string &filename, wxImage &image, wxSize img_size
 int get_dpi_for_window(const wxWindow *window);
 
 
+/// <summary>
+/// Make sure the given window fits inside current display
+/// </summary>
+void fit_in_display(wxTopLevelWindow& window, wxSize desired_size);
+
+
 }}
 
 #endif


### PR DESCRIPTION
Fix #9385

FYI @Ocraftyone @discip
I also reverts https://github.com/SoftFever/OrcaSlicer/commit/aef74ab0050783bfaf7d67f531dd6877008e843c (https://github.com/SoftFever/OrcaSlicer/pull/3417#issuecomment-1886793312) because I don't think that really matters, given you are not clicking the plus button while changing the selected variable at the same time. And it's not possible to set the button at a fixed position since it's resizeable now. And the resizability brings more benifits than having a perfect fixed plus button.

Now the dialog can be expanded and shrinked, and its initial size should now never exceeds the usable size of your monitor:

![demo](https://github.com/user-attachments/assets/9b3f39ee-df8c-43e4-8a60-904f21409c8d)
