### PR TITLE
fix case-sensitive mismatches in localization/i18n/list.txt

### DIFF
--- a/localization/i18n/list.txt
+++ b/localization/i18n/list.txt
@@ -47,7 +47,7 @@ src/slic3r/GUI/Jobs/UpgradeNetworkJob.cpp
 src/slic3r/GUI/AboutDialog.cpp
 src/slic3r/GUI/AMSMaterialsSetting.cpp
 src/slic3r/GUI/ExtrusionCalibration.cpp
-src/slic3r/GUI/AMSMappingPopup.cpp
+src/slic3r/GUI/AmsMappingPopup.cpp
 src/slic3r/GUI/AMSSetting.cpp
 src/slic3r/GUI/BBLTopbar.cpp
 src/slic3r/GUI/DownloadProgressDialog.cpp


### PR DESCRIPTION
replace AMSMappingPopup.cpp with AmsMappingPopup.cpp (the case-sensitive filename)

# Description

in localization/i18n/list.txt its called AMSMappingPopup.cpp but the actual filename is AmsMappingPopup.cpp, running `run_gettext.sh --full` will produce an error because of a case-sensitive mismatches. 

I opened issue #9065 before, because I wasn't sure the problem is the list or the filename. But on a second look it's probably the list…
