### PR TITLE
Fix crash when switching back to prepare tab after clicking the support paint icon in preview

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6394,7 +6394,7 @@ void Plater::priv::set_current_panel(wxPanel* panel, bool no_slice)
     if (current_panel == view3D) {
         if (old_panel == preview)
             preview->get_canvas3d()->unbind_event_handlers();
-        else if (old_panel == assemble_view)
+        else if (old_panel == assemble_view) {
             assemble_view->get_canvas3d()->unbind_event_handlers();
 
             GLCanvas3D* assemble_canvas = assemble_view->get_canvas3d();
@@ -6408,6 +6408,7 @@ void Plater::priv::set_current_panel(wxPanel* panel, bool no_slice)
                     view3d_selection.add(real_idx, false);
                 }
             }
+        }
 
         view3D->get_canvas3d()->bind_event_handlers();
 


### PR DESCRIPTION
Brackets were missing when merging BBS 1.8 code, which cause crash when switching back to prepare tab after clicking the support paint icon in preview:

1. Paint support on any object
2. Switch to preview tab
3. Switch to object list
4. Click the support painting icon in object list
5. Switch back to prepare tab
6. Crash

![switch_tab_crash](https://github.com/user-attachments/assets/1f5d816a-cb0e-48e5-a2de-27d6f5e70557)


