### PR TITLE
Fix: Rotation gizmo axis line colors not matches with axis colors

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoRotate.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoRotate.cpp
@@ -174,7 +174,9 @@ void GLGizmoRotate::on_render()
             render_angle_arc(m_highlight_color, hover_radius_changed);
         }
 
-        render_grabber_connection(color, radius_changed);
+        // ORCA dont use axis color on line because they are not on same direction with axis
+        const ColorRGBA line_color = (m_hover_id != -1) ? m_drag_color : ColorRGBA(.6f, .6f ,.6f, 1.f);
+        render_grabber_connection(line_color, radius_changed); 
         shader->stop_using();
     }
 


### PR DESCRIPTION
Fixes https://github.com/SoftFever/OrcaSlicer/issues/3357

BEFORE
• Line colors and directions not matches with Axis and that makes confusion
![Screenshot-20250420204505](https://github.com/user-attachments/assets/1541f79f-dfd8-42f6-87f8-137ccf3a4623)

AFTER
• No color, no confusion
![Screenshot-20250420211939](https://github.com/user-attachments/assets/fbde3879-e668-4a1e-9429-7bc6d798d5aa)

• Didn't used proper colors on lines because that makes more confusing. Grabber and line color will not match if lines has correct color