### PR TITLE
Fix: Prevent move of Advanced toggle when highlighting Global / Objects switch

### DIFF
--- a/src/slic3r/GUI/ParamsPanel.cpp
+++ b/src/slic3r/GUI/ParamsPanel.cpp
@@ -366,13 +366,13 @@ void ParamsPanel::create_layout()
         m_mode_sizer->Add( m_title_label, 0, wxALIGN_CENTER );
         m_mode_sizer->AddStretchSpacer(2);
         m_mode_sizer->Add(m_mode_region, 0, wxALIGN_CENTER);
-        m_mode_sizer->AddStretchSpacer(1);
+        m_mode_sizer->AddSpacer(FromDIP(SidebarProps::ElementSpacing()));
         m_mode_sizer->Add(m_tips_arrow, 0, wxALIGN_CENTER);
         m_mode_sizer->AddStretchSpacer(8);
         m_mode_sizer->Add( m_title_view, 0, wxALIGN_CENTER );
         m_mode_sizer->AddSpacer(FromDIP(SidebarProps::ElementSpacing()));
         m_mode_sizer->Add(m_mode_view, 0, wxALIGN_CENTER);
-        m_mode_sizer->AddStretchSpacer(2);
+        m_mode_sizer->AddSpacer(FromDIP(SidebarProps::ElementSpacing() * 6)); // ORCA using spacer prevents shaky mode_view when tips_arrow highlighting mode_region instead using AddStretchSpacer
         m_mode_sizer->Add(m_setting_btn, 0, wxALIGN_CENTER);
         m_mode_sizer->AddSpacer(FromDIP(SidebarProps::IconSpacing()));
         m_mode_sizer->Add(m_compare_btn, 0, wxALIGN_CENTER);


### PR DESCRIPTION
### HOW TO REPLICATE
• Add a cube model
• Right click to object in canvas > Edit Process Settings

### CHANGES
• Removed AddStretchSpacer() after advanced toggle
• Slightly decreaced distance between tip_arrow and global / objects switch

### COMPARISON
videos starts a bit late but its in loop

BEFORE
![orca-slicer_31BW8imn8k](https://github.com/user-attachments/assets/2bdde16a-7d4f-440a-8da8-921442c86a0d)

AFTER - Only Global / Objects switch moves
![orca-slicer_SM1cAMDypy](https://github.com/user-attachments/assets/ef72af11-c307-4d75-87f1-e64dc57eeb1d)
