### PR TITLE
Modernize wxButtons on Parameters & Physical Printer window

### DIFF
--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -136,9 +136,26 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
 
     m_optgroup->append_single_option_line("host_type");
 
-    auto create_sizer_with_btn = [](wxWindow* parent, ScalableButton** btn, const std::string& icon_name, const wxString& label) {
-        *btn = new ScalableButton(parent, wxID_ANY, icon_name, label, wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT);
-        (*btn)->SetFont(wxGetApp().normal_font());
+    auto create_sizer_with_btn = [](wxWindow* parent, Button** btn, const std::string& icon_name, const wxString& label) {
+        *btn = new Button(parent, label, ""/*icon_name*/, 0, parent->FromDIP(16));
+        (*btn)->SetFont(Label::Body_14);
+        (*btn)->SetMinSize(wxSize(parent->FromDIP(120), parent->FromDIP(26)));
+        (*btn)->SetSize(wxSize(parent->FromDIP(120), parent->FromDIP(26)));
+        (*btn)->SetCornerRadius(parent->FromDIP(4));
+        StateColor clr_bg = StateColor(
+            std::pair(wxColour("#DFDFDF"), (int)StateColor::Disabled),
+            std::pair(wxColour("#DFDFDF"), (int)StateColor::Pressed),
+            std::pair(wxColour("#D4D4D4"), (int)StateColor::Hovered),
+            std::pair(wxColour("#DFDFDF"), (int)StateColor::Normal),
+            std::pair(wxColour("#DFDFDF"), (int)StateColor::Enabled)
+        );
+        (*btn)->SetBackgroundColor(clr_bg);
+        (*btn)->SetBorderColor(clr_bg);
+        (*btn)->SetTextColor(StateColor(
+            std::pair(wxColour("#6B6A6A"), (int)StateColor::Disabled),
+            std::pair(wxColour("#262E30"), (int)StateColor::Hovered),
+            std::pair(wxColour("#262E30"), (int)StateColor::Normal)
+        ));
 
         auto sizer = new wxBoxSizer(wxHORIZONTAL);
         sizer->Add(*btn);
@@ -235,9 +252,8 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
 
     auto print_host_printers = [this, create_sizer_with_btn](wxWindow* parent) {
         //add_scaled_button(parent, &m_printhost_port_browse_btn, "browse", _(L("Refresh Printers")), wxBU_LEFT | wxBU_EXACTFIT);
-        auto sizer = create_sizer_with_btn(parent, &m_printhost_port_browse_btn, "monitor_signal_strong", _(L("Refresh Printers")));
-        ScalableButton* btn = m_printhost_port_browse_btn;
-        btn->SetFont(Slic3r::GUI::wxGetApp().normal_font());
+        auto sizer = create_sizer_with_btn(parent, &m_printhost_port_browse_btn, "monitor_signal_strong", _L("Refresh") + " " + dots);
+        Button* btn = m_printhost_port_browse_btn;
         btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent e) { update_printers(); });
         return sizer;
     };
@@ -712,11 +728,11 @@ void PhysicalPrinterDialog::on_dpi_changed(const wxRect& suggested_rect)
 {
     const int& em = em_unit();
 
-    m_printhost_browse_btn->msw_rescale();
-    m_printhost_test_btn->msw_rescale();
-    m_printhost_logout_btn->msw_rescale();
+    m_printhost_browse_btn->Rescale();
+    m_printhost_test_btn->Rescale();
+    m_printhost_logout_btn->Rescale();
     if (m_printhost_cafile_browse_btn)
-        m_printhost_cafile_browse_btn->msw_rescale();
+        m_printhost_cafile_browse_btn->Rescale();
 
     m_optgroup->msw_rescale();
 

--- a/src/slic3r/GUI/PhysicalPrinterDialog.hpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.hpp
@@ -11,7 +11,7 @@
 
 class wxTextCtrl;
 class wxStaticText;
-class ScalableButton;
+class Button;
 class wxBoxSizer;
 
 namespace Slic3r {
@@ -28,12 +28,12 @@ class PhysicalPrinterDialog : public DPIDialog
     DynamicPrintConfig* m_config            { nullptr };
     ConfigOptionsGroup* m_optgroup          { nullptr };
 
-    ScalableButton*     m_printhost_browse_btn              {nullptr};
-    ScalableButton*     m_printhost_test_btn                {nullptr};
-    ScalableButton*     m_printhost_logout_btn              {nullptr};
-    ScalableButton*     m_printhost_cafile_browse_btn       {nullptr};
-    ScalableButton*     m_printhost_client_cert_browse_btn  {nullptr};
-    ScalableButton*     m_printhost_port_browse_btn         {nullptr};
+    Button*     m_printhost_browse_btn              {nullptr};
+    Button*     m_printhost_test_btn                {nullptr};
+    Button*     m_printhost_logout_btn              {nullptr};
+    Button*     m_printhost_cafile_browse_btn       {nullptr};
+    Button*     m_printhost_client_cert_browse_btn  {nullptr};
+    Button*     m_printhost_port_browse_btn         {nullptr};
 
     RoundedRectangle*   m_input_area                        {nullptr};
     wxStaticText*       m_valid_label                       {nullptr};

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3545,14 +3545,30 @@ void TabFilament::build()
         optgroup->append_single_option_line("filament_stamping_loading_speed");
         optgroup->append_single_option_line("filament_stamping_distance");
         create_line_with_widget(optgroup.get(), "filament_ramming_parameters", "", [this](wxWindow* parent) {
-            auto ramming_dialog_btn = new wxButton(parent, wxID_ANY, _(L("Ramming settings"))+dots, wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
-            wxGetApp().UpdateDarkUI(ramming_dialog_btn);
-            ramming_dialog_btn->SetFont(Slic3r::GUI::wxGetApp().normal_font());
-            ramming_dialog_btn->SetSize(ramming_dialog_btn->GetBestSize());
-            auto sizer = new wxBoxSizer(wxHORIZONTAL);
-            sizer->Add(ramming_dialog_btn);
+            // ORCA modernize button style
+            Button* btn = new Button(parent, _(L("Set")) + " " + dots);
+            btn->SetFont(Label::Body_14);
+            btn->SetSize(wxSize(FromDIP(120), FromDIP(26)));
+            btn->SetCornerRadius(FromDIP(4));
+            StateColor clr_bg = StateColor(
+                std::pair(wxColour("#DFDFDF"), (int)StateColor::Disabled),
+                std::pair(wxColour("#DFDFDF"), (int)StateColor::Pressed),
+                std::pair(wxColour("#D4D4D4"), (int)StateColor::Hovered),
+                std::pair(wxColour("#DFDFDF"), (int)StateColor::Normal),
+                std::pair(wxColour("#DFDFDF"), (int)StateColor::Enabled)
+            );
+            btn->SetBackgroundColor(clr_bg);
+            btn->SetBorderColor(clr_bg);
+            btn->SetTextColor(StateColor(
+                std::pair(wxColour("#6B6A6A"), (int)StateColor::Disabled),
+                std::pair(wxColour("#262E30"), (int)StateColor::Hovered),
+                std::pair(wxColour("#262E30"), (int)StateColor::Normal)
+            ));
 
-            ramming_dialog_btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent& e) {
+            auto sizer = new wxBoxSizer(wxHORIZONTAL);
+            sizer->Add(btn);
+
+            btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent& e) {
                 RammingDialog dlg(this,(m_config->option<ConfigOptionStrings>("filament_ramming_parameters"))->get_at(0));
                 if (dlg.ShowModal() == wxID_OK) {
                     load_key_value("filament_ramming_parameters", dlg.get_parameters());
@@ -5907,10 +5923,27 @@ wxSizer* Tab::compatible_widget_create(wxWindow* parent, PresetDependencies &dep
     deps.checkbox = new wxCheckBox(parent, wxID_ANY, _(L("All")));
     deps.checkbox->SetFont(Slic3r::GUI::wxGetApp().normal_font());
     wxGetApp().UpdateDarkUI(deps.checkbox, false, true);
-    deps.btn = new ScalableButton(parent, wxID_ANY, "printer", from_u8((boost::format(" %s %s") % _utf8(L("Set")) % std::string(dots.ToUTF8())).str()),
-                                  wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT, true);
-    deps.btn->SetFont(Slic3r::GUI::wxGetApp().normal_font());
-    deps.btn->SetSize(deps.btn->GetBestSize());
+
+    // ORCA modernize button style
+    Button* btn = new Button(parent, _(L("Set")) + " " + dots);
+    btn->SetFont(Label::Body_14);
+    btn->SetSize(wxSize(FromDIP(120), FromDIP(26)));
+    btn->SetCornerRadius(FromDIP(4));
+    StateColor clr_bg = StateColor(
+        std::pair(wxColour("#DFDFDF"), (int)StateColor::Disabled),
+        std::pair(wxColour("#DFDFDF"), (int)StateColor::Pressed),
+        std::pair(wxColour("#D4D4D4"), (int)StateColor::Hovered),
+        std::pair(wxColour("#DFDFDF"), (int)StateColor::Normal),
+        std::pair(wxColour("#DFDFDF"), (int)StateColor::Enabled)
+    );
+    btn->SetBackgroundColor(clr_bg);
+    btn->SetBorderColor(clr_bg);
+    btn->SetTextColor(StateColor(
+        std::pair(wxColour("#6B6A6A"), (int)StateColor::Disabled),
+        std::pair(wxColour("#262E30"), (int)StateColor::Hovered),
+        std::pair(wxColour("#262E30"), (int)StateColor::Normal)
+    ));
+    deps.btn = btn;
 
     auto sizer = new wxBoxSizer(wxHORIZONTAL);
     sizer->Add((deps.checkbox), 0, wxALIGN_CENTER_VERTICAL);
@@ -5994,10 +6027,25 @@ wxSizer* Tab::compatible_widget_create(wxWindow* parent, PresetDependencies &dep
 // Return a callback to create a TabPrinter widget to edit bed shape
 wxSizer* TabPrinter::create_bed_shape_widget(wxWindow* parent)
 {
-    ScalableButton* btn = new ScalableButton(parent, wxID_ANY, "printer", " " + _(L("Set")) + " " + dots,
-        wxDefaultSize, wxDefaultPosition, wxBU_LEFT | wxBU_EXACTFIT, true);
-    btn->SetFont(wxGetApp().normal_font());
-    btn->SetSize(btn->GetBestSize());
+     // ORCA modernize button style
+    Button* btn = new Button(parent, _(L("Set")) + " " + dots);
+    btn->SetFont(Label::Body_14);
+    btn->SetSize(wxSize(FromDIP(120), FromDIP(26)));
+    btn->SetCornerRadius(FromDIP(4));
+    StateColor clr_bg = StateColor(
+        std::pair(wxColour("#DFDFDF"), (int)StateColor::Disabled),
+        std::pair(wxColour("#DFDFDF"), (int)StateColor::Pressed),
+        std::pair(wxColour("#D4D4D4"), (int)StateColor::Hovered),
+        std::pair(wxColour("#DFDFDF"), (int)StateColor::Normal),
+        std::pair(wxColour("#DFDFDF"), (int)StateColor::Enabled)
+    );
+    btn->SetBackgroundColor(clr_bg);
+    btn->SetBorderColor(clr_bg);
+    btn->SetTextColor(StateColor(
+        std::pair(wxColour("#6B6A6A"), (int)StateColor::Disabled),
+        std::pair(wxColour("#262E30"), (int)StateColor::Hovered),
+        std::pair(wxColour("#262E30"), (int)StateColor::Normal)
+    ));
 
     auto sizer = new wxBoxSizer(wxHORIZONTAL);
     sizer->Add(btn, 0, wxALIGN_CENTER_VERTICAL);

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -40,7 +40,6 @@
 #include "ParamsPanel.hpp"
 #include "Widgets/RoundedRectangle.hpp"
 #include "Widgets/TextInput.hpp"
-#include "Widgets/CheckBox.hpp"
 
 class TabCtrl;
 

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -40,6 +40,7 @@
 #include "ParamsPanel.hpp"
 #include "Widgets/RoundedRectangle.hpp"
 #include "Widgets/TextInput.hpp"
+#include "Widgets/CheckBox.hpp"
 
 class TabCtrl;
 
@@ -164,7 +165,7 @@ protected:
    	struct PresetDependencies {
 		Preset::Type type	  = Preset::TYPE_INVALID;
 		wxCheckBox 	*checkbox = nullptr;
-		ScalableButton 	*btn  = nullptr;
+		Button 	*btn  = nullptr;
 		std::string  key_list; // "compatible_printers"
 		std::string  key_condition;
 		wxString     dialog_title;

--- a/src/slic3r/GUI/Widgets/StateColor.cpp
+++ b/src/slic3r/GUI/Widgets/StateColor.cpp
@@ -11,6 +11,10 @@ static std::map<wxColour, wxColour> gDarkColors{
     {"#FF6F00", "#D15B00"}, // rgb(255, 111, 0)    Secondary color
     {"#D01B1B", "#BB2A3A"}, // rgb(208, 27, 27)    ???
     {"#262E30", "#EFEFF0"}, // rgb(38, 46, 48)     Button text color | Input Text Color
+    {"#DFDFDF", "#3E3E45"}, // rgb(223, 223, 223)  Button Background color
+    {"#D4D4D4", "#4D4D54"}, // rgb(212, 212, 212)  Button Background color on Hover
+    {"#6B6A6A", "#909090"}, // rgb(107, 107, 106)  Button Dimmed text
+    {"#6B6B6A", "#B3B3B5"}, // rgb(107, 107, 106)  Input box side text
     {"#2C2C2E", "#B3B3B4"}, // rgb(44, 44, 46)     ???
     {"#6B6B6B", "#818183"}, // rgb(107, 107, 107)  Disabled Text
     {"#ACACAC", "#65656A"}, // rgb(172, 172, 172)  Disabled Text on boxes | Dimmed Elements
@@ -28,7 +32,6 @@ static std::map<wxColour, wxColour> gDarkColors{
     {"#DBDBDB", "#4A4A51"}, // rgb(219, 219, 219)  Input/Combo Box Border Color
     {"#EDFAF2", "#283232"}, // rgb(229, 240, 238)  Not Used anymore // Was used for BBS Combo / Dropdown focused background color
     {"#323A3C", "#E5E5E6"}, // rgb(50, 58, 60)     Text color used on search list | 
-    {"#6B6B6A", "#B3B3B5"}, // rgb(107, 107, 106)  Button Dimmed text | Input box side text 
     {"#303A3C", "#E5E5E5"}, // rgb(48, 58, 60)     Object Table > Column header text color | StaticBox Border Color
     {"#FEFFFF", "#242428"}, // rgb(254, 255, 255)  Side Tabbar bg | 
     {"#A6A9AA", "#2D2D29"}, // rgb(166, 169, 170)  Seperator color


### PR DESCRIPTION
i decided to send this PR https://github.com/SoftFever/OrcaSlicer/pull/8184 as small parts since it needs a lot work. i will limit that PR as "style management"

This PR matches style of wxButtons that exist on parameters and printer connection window

### COMMON CHANGES
• Removed icons
• Matched button widths with parameter boxes
• Makes buttons look same on all platforms

### PRINTER CONNECTION WINDOW
• Added a min width to buttons that same with width of input box
• Used "Refresh ..." instead "Refresh Printers" on Obico

Before-After
![Screenshot-20250423191128](https://github.com/user-attachments/assets/65b56d1d-7967-4f9d-851e-74b15be750d6)
![Screenshot-20250423191119](https://github.com/user-attachments/assets/2dc3b47a-33c9-4362-94f7-2880529d2b6f)

Before-After
![Screenshot-20250423191425](https://github.com/user-attachments/assets/03703e23-2692-46aa-abfd-3cce0ccb72b9)
![Screenshot-20250423191443](https://github.com/user-attachments/assets/cd886158-35b3-4deb-8c0c-f2d527a34a83)

### PARAMETER BOXES
• Used "Set ..." for Ramming Parameters button

Before-After
![Screenshot-20250423191647](https://github.com/user-attachments/assets/425945f2-c4b3-4041-958b-07d732abc2d5)
![Screenshot-20250423191626](https://github.com/user-attachments/assets/30c8d04b-2860-41e2-8ecd-7ce6761442bb)

Before-After
![Screenshot-20250423191834](https://github.com/user-attachments/assets/82a6569c-c46f-4f8a-b8b2-0b1453f0292a)
![Screenshot-20250423191808](https://github.com/user-attachments/assets/d8c116d8-431e-4581-8d64-cf5c452dc1f0)

Before-After
![Screenshot-20250423192059](https://github.com/user-attachments/assets/400ac0a3-6481-4bd1-88ce-a03b0576b6a4)
![Screenshot-20250423192052](https://github.com/user-attachments/assets/adf02018-27d6-45eb-a2e6-31a3dbf531a2)
