### PR TITLE
Fix infill anchor missing for FillPlanePath

### DIFF
--- a/src/libslic3r/Fill/FillPlanePath.cpp
+++ b/src/libslic3r/Fill/FillPlanePath.cpp
@@ -119,42 +119,44 @@ void FillPlanePath::_fill_surface_single(
 
     if (polyline.size() >= 2) {
         Polylines polylines = intersection_pl(polyline, expolygon);
-        Polylines chained;
-        if (params.dont_connect() || params.density > 0.5 || polylines.size() <= 1) {
-            // ORCA: special flag for flow rate calibration
-            auto is_flow_calib = params.extrusion_role == erTopSolidInfill &&
-                                 this->print_object_config->has("calib_flowrate_topinfill_special_order") &&
-                                 this->print_object_config->option("calib_flowrate_topinfill_special_order")->getBool() &&
-                                 dynamic_cast<FillArchimedeanChords*>(this);
-            if (is_flow_calib) {
-                // We want the spiral part to be printed inside-out
-                // Find the center spiral line first, by looking for the longest one
-                auto it = std::max_element(polylines.begin(), polylines.end(), [](const Polyline& a, const Polyline& b) { return a.length() < b.length(); });
-                Polyline center_spiral = std::move(*it);
+        if (!polylines.empty()) {
+            Polylines chained;
+            if (params.dont_connect() || params.density > 0.5) {
+                // ORCA: special flag for flow rate calibration
+                auto is_flow_calib = params.extrusion_role == erTopSolidInfill &&
+                                     this->print_object_config->has("calib_flowrate_topinfill_special_order") &&
+                                     this->print_object_config->option("calib_flowrate_topinfill_special_order")->getBool() &&
+                                     dynamic_cast<FillArchimedeanChords*>(this);
+                if (is_flow_calib) {
+                    // We want the spiral part to be printed inside-out
+                    // Find the center spiral line first, by looking for the longest one
+                    auto     it            = std::max_element(polylines.begin(), polylines.end(),
+                                                              [](const Polyline& a, const Polyline& b) { return a.length() < b.length(); });
+                    Polyline center_spiral = std::move(*it);
 
-                // Ensure the spiral is printed from inside to out
-                if (center_spiral.first_point().squaredNorm() > center_spiral.last_point().squaredNorm()) {
-                    center_spiral.reverse();
+                    // Ensure the spiral is printed from inside to out
+                    if (center_spiral.first_point().squaredNorm() > center_spiral.last_point().squaredNorm()) {
+                        center_spiral.reverse();
+                    }
+
+                    // Chain the other polylines
+                    polylines.erase(it);
+                    chained = chain_polylines(std::move(polylines));
+
+                    // Then add the center spiral back
+                    chained.push_back(std::move(center_spiral));
+                } else {
+                    chained = chain_polylines(std::move(polylines));
                 }
-
-                // Chain the other polylines
-                polylines.erase(it);
-                chained = chain_polylines(std::move(polylines));
-
-                // Then add the center spiral back
-                chained.push_back(std::move(center_spiral));
-            } else {
-                chained = chain_polylines(std::move(polylines));
+            } else
+                connect_infill(std::move(polylines), expolygon, chained, this->spacing, params);
+            // paths must be repositioned and rotated back
+            for (Polyline& pl : chained) {
+                pl.translate(shift.x(), shift.y());
+                pl.rotate(direction.first);
             }
+            append(polylines_out, std::move(chained));
         }
-        else
-            connect_infill(std::move(polylines), expolygon, chained, this->spacing, params);
-        // paths must be repositioned and rotated back
-        for (Polyline &pl : chained) {
-            pl.translate(shift.x(), shift.y());
-            pl.rotate(direction.first);
-        }
-        append(polylines_out, std::move(chained));
     }
 }
 


### PR DESCRIPTION
# Description

Fix #9323 

in #9407 thin infill anchor missing issue was not fixed in FillPlanePath since the behavior with flow calibration was not fully understood. Some further investigation shows that top layers have infill > 50% and therefore are not affected by [not checking the number of lines when determining if connecting infill (and creating anchors is allowed)](https://github.com/SoftFever/OrcaSlicer/blob/main/src/libslic3r/Fill/FillPlanePath.cpp#L123).

## Tests

Local Windows build tested with issue example and flow calibration.
With flow calibration the top surface archimedean chord inner spiral is printed at last, starting at the center outwards.