### PR TITLE
Correct repair menu message

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -530,7 +530,7 @@ MeshErrorsInfo ObjectList::get_mesh_errors_info(const int obj_idx, const int vol
         *non_manifold_edges = stats.open_edges;
 
     if (is_windows10() && !sidebar_info)
-        tooltip += "\n" + _L("Right click the icon to fix model object");
+        tooltip += "\n" + _L("Click the icon to repair model object");
 
     return { tooltip, get_warning_icon_name(stats) };
 }


### PR DESCRIPTION
Actually it's left click, not right. Also use word "repair" to make it consistent with other messages.

![image](https://github.com/user-attachments/assets/108886f1-460e-45da-9310-83a8b7895b0f)
