### PR TITLE
Add 2D honeycomb infill pattern

### DIFF
--- a/resources/images/param_2dhoneycomb.svg
+++ b/resources/images/param_2dhoneycomb.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M2,21.5 h20 M2,2.5 v1.5 l5,3 v6 l-5,3 v5.5 M12,2 v2 l-5,3 v6 l5,3 v6 M12,2 v2 l5,3 v6 l-5,3 v6 M22,2.5 v1.5 l-5,3 v6 l5,3 v5.5" style="fill:none;stroke:#009688;stroke-linecap:round;stroke-linejoin:round"/>
+  <rect x="1.5" y="1.5" width="21" height="21" rx="2" style="fill:none;stroke:#949494;stroke-linecap:round;stroke-linejoin:round"/>
+</svg>

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -68,6 +68,9 @@ struct SurfaceFillParams
     float lattice_angle_1 = 0.f;
     float lattice_angle_2 = 0.f;
 
+    // Params for 2D honeycomb
+    float infill_overhang_angle = 60.f;
+
 	bool operator<(const SurfaceFillParams &rhs) const {
 #define RETURN_COMPARE_NON_EQUAL(KEY) if (this->KEY < rhs.KEY) return true; if (this->KEY > rhs.KEY) return false;
 #define RETURN_COMPARE_NON_EQUAL_TYPED(TYPE, KEY) if (TYPE(this->KEY) < TYPE(rhs.KEY)) return true; if (TYPE(this->KEY) > TYPE(rhs.KEY)) return false;
@@ -96,31 +99,33 @@ struct SurfaceFillParams
 		RETURN_COMPARE_NON_EQUAL(solid_infill_speed);
         RETURN_COMPARE_NON_EQUAL(lattice_angle_1);
 		RETURN_COMPARE_NON_EQUAL(lattice_angle_2);
+		RETURN_COMPARE_NON_EQUAL(infill_overhang_angle);
 
 		return false;
 	}
 
-	bool operator==(const SurfaceFillParams &rhs) const {
-		return  this->extruder 			== rhs.extruder 		&&
-				this->pattern 			== rhs.pattern 			&&
-				this->spacing 			== rhs.spacing 			&&
-				this->overlap 			== rhs.overlap 			&&
-				this->angle   			== rhs.angle   			&&
-				this->rotate_angle   	== rhs.rotate_angle   			&&
-				this->bridge   			== rhs.bridge   		&&
-				this->bridge_angle 		== rhs.bridge_angle		&&
-				this->density   		== rhs.density   		&&
-//				this->dont_adjust   	== rhs.dont_adjust 		&&
-				this->anchor_length  	== rhs.anchor_length    &&
-				this->anchor_length_max == rhs.anchor_length_max &&
-				this->flow 				== rhs.flow 			&&
-				this->extrusion_role	== rhs.extrusion_role	&&
-				this->sparse_infill_speed	== rhs.sparse_infill_speed &&
-				this->top_surface_speed		== rhs.top_surface_speed &&
-				this->solid_infill_speed	== rhs.solid_infill_speed &&
-                this->lattice_angle_1		== rhs.lattice_angle_1 &&
-				this->lattice_angle_2	    == rhs.lattice_angle_2;
-	}
+    bool operator==(const SurfaceFillParams &rhs) const {
+        return  this->extruder              == rhs.extruder             &&
+                this->pattern               == rhs.pattern              &&
+                this->spacing               == rhs.spacing              &&
+                this->overlap               == rhs.overlap              &&
+                this->angle                 == rhs.angle                &&
+                this->rotate_angle          == rhs.rotate_angle         &&
+                this->bridge                == rhs.bridge               &&
+                this->bridge_angle          == rhs.bridge_angle         &&
+                this->density               == rhs.density              &&
+//              this->dont_adjust           == rhs.dont_adjust          &&
+                this->anchor_length         == rhs.anchor_length        &&
+                this->anchor_length_max     == rhs.anchor_length_max    &&
+                this->flow                  == rhs.flow                 &&
+                this->extrusion_role        == rhs.extrusion_role       &&
+                this->sparse_infill_speed   == rhs.sparse_infill_speed  &&
+                this->top_surface_speed     == rhs.top_surface_speed    &&
+                this->solid_infill_speed    == rhs.solid_infill_speed   &&
+                this->lattice_angle_1       == rhs.lattice_angle_1      &&
+                this->lattice_angle_2       == rhs.lattice_angle_2      &&
+                this->infill_overhang_angle == rhs.infill_overhang_angle;
+    }
 };
 
 struct SurfaceFill {
@@ -621,6 +626,7 @@ std::vector<SurfaceFill> group_fills(const Layer &layer)
 		        params.density       = float(region_config.sparse_infill_density);
                 params.lattice_angle_1 = region_config.lattice_angle_1;
                 params.lattice_angle_2 = region_config.lattice_angle_2;
+                params.infill_overhang_angle = region_config.infill_overhang_angle;
 
 		        if (surface.is_solid()) {
 		            params.density = 100.f;
@@ -965,6 +971,7 @@ void Layer::make_fills(FillAdaptive::Octree* adaptive_fill_octree, FillAdaptive:
         params.layer_height      = layerm->layer()->height;
         params.lattice_angle_1   = surface_fill.params.lattice_angle_1; 
         params.lattice_angle_2   = surface_fill.params.lattice_angle_2;
+        params.infill_overhang_angle   = surface_fill.params.infill_overhang_angle;
 
 		// BBS
 		params.flow = surface_fill.params.flow;
@@ -1045,6 +1052,7 @@ Polylines Layer::generate_sparse_infill_polylines_for_anchoring(FillAdaptive::Oc
         case ipLine:
         case ipConcentric:
         case ipHoneycomb:
+        case ip2DHoneycomb:
         case ip3DHoneycomb:
         case ipGyroid:
         case ipHilbertCurve:
@@ -1095,6 +1103,7 @@ Polylines Layer::generate_sparse_infill_polylines_for_anchoring(FillAdaptive::Oc
         params.layer_height      = layerm.layer()->height;
         params.lattice_angle_1   = surface_fill.params.lattice_angle_1; 
         params.lattice_angle_2   = surface_fill.params.lattice_angle_2; 
+        params.infill_overhang_angle   = surface_fill.params.infill_overhang_angle;
 
         for (ExPolygon &expoly : surface_fill.expolygons) {
             // Spacing is modified by the filler to indicate adjustments. Reset it for each expolygon.

--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -39,6 +39,7 @@ Fill* Fill::new_from_type(const InfillPattern type)
     switch (type) {
     case ipConcentric:          return new FillConcentric();
     case ipHoneycomb:           return new FillHoneycomb();
+    case ip2DHoneycomb:         return new Fill2DHoneycomb();
     case ip3DHoneycomb:         return new Fill3DHoneycomb();
     case ipGyroid:              return new FillGyroid();
     case ipRectilinear:         return new FillRectilinear();

--- a/src/libslic3r/Fill/FillBase.hpp
+++ b/src/libslic3r/Fill/FillBase.hpp
@@ -73,6 +73,9 @@ struct FillParams
     coordf_t    lattice_angle_1    { 0.f };
     coordf_t    lattice_angle_2    { 0.f };
 
+    // For 2D Honeycomb
+    float       infill_overhang_angle    { 60 };
+
     // BBS
     Flow            flow;
     ExtrusionRole   extrusion_role{ ExtrusionRole(0) };

--- a/src/libslic3r/Fill/FillRectilinear.hpp
+++ b/src/libslic3r/Fill/FillRectilinear.hpp
@@ -132,6 +132,14 @@ protected:
     float _layer_angle(size_t idx) const override { return 0.f; }
 };
 
+class Fill2DHoneycomb : public FillAlignedRectilinear
+{
+public:
+    Fill* clone() const override { return new Fill2DHoneycomb(*this); }
+    ~Fill2DHoneycomb() override = default;
+    Polylines fill_surface(const Surface *surface, const FillParams &params) override;
+};
+
 
 class FillSupportBase : public FillRectilinear
 {

--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -381,17 +381,18 @@ coordf_t Layer::get_sparse_infill_max_void_area()
         switch (pattern) {
             case ipConcentric:
             case ipRectilinear:
+            case ip2DLattice:
             case ipLine:
             case ipGyroid:
             case ipAlignedRectilinear:
             case ipOctagramSpiral:
             case ipHilbertCurve:
+            case ip2DHoneycomb:
             case ip3DHoneycomb:
             case ipArchimedeanChords:
                 max_void_area = std::max(max_void_area, spacing * spacing);
                 break;
             case ipGrid:
-            case ip2DLattice:
             case ipHoneycomb:
             case ipLightning:
                 max_void_area = std::max(max_void_area, 4.0 * spacing * spacing);

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -785,7 +785,7 @@ static std::vector<std::string> s_Preset_print_options {
     "layer_height", "initial_layer_print_height", "wall_loops", "alternate_extra_wall", "slice_closing_radius", "spiral_mode", "spiral_mode_smooth", "spiral_mode_max_xy_smoothing", "spiral_starting_flow_ratio", "spiral_finishing_flow_ratio", "slicing_mode",
     "top_shell_layers", "top_shell_thickness", "bottom_shell_layers", "bottom_shell_thickness",
     "extra_perimeters_on_overhangs", "ensure_vertical_shell_thickness", "reduce_crossing_wall", "detect_thin_wall", "detect_overhang_wall", "overhang_reverse", "overhang_reverse_threshold","overhang_reverse_internal_only", "wall_direction",
-    "seam_position", "staggered_inner_seams", "wall_sequence", "is_infill_first", "sparse_infill_density", "sparse_infill_pattern", "lattice_angle_1", "lattice_angle_2", "top_surface_pattern", "bottom_surface_pattern",
+    "seam_position", "staggered_inner_seams", "wall_sequence", "is_infill_first", "sparse_infill_density", "sparse_infill_pattern", "lattice_angle_1", "lattice_angle_2", "infill_overhang_angle", "top_surface_pattern", "bottom_surface_pattern",
     "infill_direction", "solid_infill_direction", "rotate_solid_infill_direction",  "counterbore_hole_bridging",
     "minimum_sparse_infill_area", "reduce_infill_retraction","internal_solid_infill_pattern","gap_fill_target",
     "ironing_type", "ironing_pattern", "ironing_flow", "ironing_speed", "ironing_spacing", "ironing_angle", "ironing_inset",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -151,6 +151,7 @@ static t_config_enum_values s_keys_map_InfillPattern {
     { "monotonic",          ipMonotonic },
     { "monotonicline",      ipMonotonicLine },
     { "alignedrectilinear", ipAlignedRectilinear },
+    { "2dhoneycomb",        ip2DHoneycomb },
     { "3dhoneycomb",        ip3DHoneycomb },
     { "hilbertcurve",       ipHilbertCurve },
     { "archimedeanchords",  ipArchimedeanChords },
@@ -2356,6 +2357,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_values.push_back("honeycomb");
     def->enum_values.push_back("adaptivecubic");
     def->enum_values.push_back("alignedrectilinear");
+    def->enum_values.push_back("2dhoneycomb");
     def->enum_values.push_back("3dhoneycomb");
     def->enum_values.push_back("hilbertcurve");
     def->enum_values.push_back("archimedeanchords");
@@ -2376,6 +2378,7 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("Honeycomb"));
     def->enum_labels.push_back(L("Adaptive Cubic"));
     def->enum_labels.push_back(L("Aligned Rectilinear"));
+    def->enum_labels.push_back(L("2D Honeycomb"));
     def->enum_labels.push_back(L("3D Honeycomb"));
     def->enum_labels.push_back(L("Hilbert Curve"));
     def->enum_labels.push_back(L("Archimedean Chords"));
@@ -2405,6 +2408,16 @@ void PrintConfigDef::init_fff_params()
     def->max      = 75;
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(45));
+
+    def           = this->add("infill_overhang_angle", coFloat);
+    def->label    = L("Infill overhang angle");
+    def->category = L("Strength");
+    def->tooltip  = L("The angle of the infill angled lines. 60° will result in a pure honeycomb.");
+    def->sidetext = L("°");
+    def->min      = 15;
+    def->max      = 75;
+    def->mode     = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(60));
 
     auto def_infill_anchor_min = def = this->add("infill_anchor", coFloatOrPercent);
     def->label = L("Sparse infill anchor length");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -58,7 +58,7 @@ enum AuthorizationType {
 };
 
 enum InfillPattern : int {
-    ipConcentric, ipRectilinear, ipGrid, ip2DLattice, ipLine, ipCubic, ipTriangles, ipStars, ipGyroid, ipHoneycomb, ipAdaptiveCubic, ipMonotonic, ipMonotonicLine, ipAlignedRectilinear, ip3DHoneycomb,
+    ipConcentric, ipRectilinear, ipGrid, ip2DLattice, ipLine, ipCubic, ipTriangles, ipStars, ipGyroid, ipHoneycomb, ipAdaptiveCubic, ipMonotonic, ipMonotonicLine, ipAlignedRectilinear, ip2DHoneycomb, ip3DHoneycomb,
     ipHilbertCurve, ipArchimedeanChords, ipOctagramSpiral, ipSupportCubic, ipSupportBase, ipConcentricInternal,
     ipLightning, ipCrossHatch, ipQuarterCubic,
     ipCount,
@@ -939,6 +939,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionEnum<InfillPattern>,  sparse_infill_pattern))
     ((ConfigOptionFloat,                lattice_angle_1))
     ((ConfigOptionFloat,                lattice_angle_2))
+    ((ConfigOptionFloat,                infill_overhang_angle))
     ((ConfigOptionEnum<FuzzySkinType>,  fuzzy_skin))
     ((ConfigOptionFloat,                fuzzy_skin_thickness))
     ((ConfigOptionFloat,                fuzzy_skin_point_distance))

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -1090,7 +1090,8 @@ bool PrintObject::invalidate_state_by_config_options(
             || opt_key == "initial_layer_line_width"
             || opt_key == "small_area_infill_flow_compensation"
             || opt_key == "lattice_angle_1"
-            || opt_key == "lattice_angle_2") {
+            || opt_key == "lattice_angle_2"
+            || opt_key == "infill_overhang_angle") {
             steps.emplace_back(posInfill);
         } else if (opt_key == "sparse_infill_pattern") {
             steps.emplace_back(posPrepareInfill);
@@ -3760,7 +3761,8 @@ void PrintObject::combine_infill()
                   infill_pattern == ipGrid          ||
                   infill_pattern == ip2DLattice     ||
                   infill_pattern == ipLine          ||
-                  infill_pattern == ipHoneycomb) ? 1.5f : 0.5f) *
+                  infill_pattern == ipHoneycomb     ||
+                  infill_pattern == ip2DHoneycomb) ? 1.5f : 0.5f) *
                     layerms.back()->flow(frSolidInfill).scaled_width();
             for (ExPolygon &expoly : intersection)
                 polygons_append(intersection_with_clearance, offset(expoly, clearance_offset));

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -793,6 +793,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     bool lattice_options = config->opt_enum<InfillPattern>("sparse_infill_pattern") == InfillPattern::ip2DLattice;
     for (auto el : { "lattice_angle_1", "lattice_angle_2"})
         toggle_line(el, lattice_options);
+
+    toggle_line("infill_overhang_angle", config->opt_enum<InfillPattern>("sparse_infill_pattern") == InfillPattern::ip2DHoneycomb);
 }
 
 void ConfigManipulation::update_print_sla_config(DynamicPrintConfig* config, const bool is_global_config/* = false*/)

--- a/src/slic3r/GUI/GUI_Factories.cpp
+++ b/src/slic3r/GUI/GUI_Factories.cpp
@@ -106,7 +106,7 @@ std::map<std::string, std::vector<SimpleSettingData>>  SettingsFactory::PART_CAT
                     }},
     { L("Strength"), {{"wall_loops", "",1},{"top_shell_layers", L("Top Solid Layers"),1},{"top_shell_thickness", L("Top Minimum Shell Thickness"),1},
                     {"bottom_shell_layers", L("Bottom Solid Layers"),1}, {"bottom_shell_thickness", L("Bottom Minimum Shell Thickness"),1},
-                    {"sparse_infill_density", "",1},{"sparse_infill_pattern", "",1},{"lattice_angle_1", "",1},{"lattice_angle_2", "",1},{"infill_anchor", "",1},{"infill_anchor_max", "",1},{"top_surface_pattern", "",1},{"bottom_surface_pattern", "",1}, {"internal_solid_infill_pattern", "",1},
+                    {"sparse_infill_density", "",1},{"sparse_infill_pattern", "",1},{"lattice_angle_1", "",1},{"lattice_angle_2", "",1},{"infill_overhang_angle", "",1},{"infill_anchor", "",1},{"infill_anchor_max", "",1},{"top_surface_pattern", "",1},{"bottom_surface_pattern", "",1}, {"internal_solid_infill_pattern", "",1},
         {"infill_combination", "",1}, {"infill_combination_max_layer_height", "",1}, {"infill_wall_overlap", "",1},{"top_bottom_infill_wall_overlap", "",1}, {"solid_infill_direction", "",1}, {"rotate_solid_infill_direction", "",1}, {"infill_direction", "",1}, {"bridge_angle", "",1}, {"internal_bridge_angle", "",1}, {"minimum_sparse_infill_area", "",1}
                     }},
     { L("Speed"), {{"outer_wall_speed", "",1},{"inner_wall_speed", "",2},{"sparse_infill_speed", "",3},{"top_surface_speed", "",4}, {"internal_solid_infill_speed", "",5},

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2166,6 +2166,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("sparse_infill_pattern", "fill-patterns#infill types and their properties of sparse");
         optgroup->append_single_option_line("lattice_angle_1");
         optgroup->append_single_option_line("lattice_angle_2");
+        optgroup->append_single_option_line("infill_overhang_angle");
         optgroup->append_single_option_line("infill_anchor_max");
         optgroup->append_single_option_line("infill_anchor");
         optgroup->append_single_option_line("internal_solid_infill_pattern");


### PR DESCRIPTION
# Description
Like 2D lattice, this infill pattern is primarily intended for aircraft wings. Infill in wings keeps the thin skin from bending under aerodynamic loads, similar to ribs and stringers in classic wing structures. Secondary it keeps the skin from oil canning while printing. The spacing of the infill along the skin needs to be sufficiently low enough. 2D lines (aligned rectilinear) at the required spacing would be the lightest option. It does however not provide torsional stiffness (top and bottom layers will provide some stiffness but do not keep the skin from buckling under torsional load). For torsional stiffness closed cells are needed to create a torsion box. 2D lattice does provide the required stiffness, but 2D honeycomb should give the same results at 33% lower weight. In practice the infill lines need to be wider due to the 60 degrees overhang in a pure honeycomb. Therefore a infill overhang parameter is added that stretches the pattern vertically. At lower overhang angles the pattern keeps its weight advantage. 2D honeycomb has some disadvantages too. Its density is not evenly distributed vertically. The pattern can not be subdivided by itself which results in infill line disconnects when density is increased locally using modifiers.

# Screenshots/Recordings/Graphs
![image](https://github.com/user-attachments/assets/f4a7b15d-31d1-44c3-ae52-421bdfd9f91a)

## Tests
- Checked many different infill parameter combinations;
- Checked added parameters in compare presets;
- Checked with modifiers;
- Printed several test parts.

## Notes
- Special thanks to @LoftedAero for #8293 which was a very useful guide.
- I find the "2D" naming somewhat misleading since the (standard) honeycomb is also a 2D pattern but extruded along a different axis. It fits however nicely in the GUI.
- The icon shows the bed with an additional cyan line at the bottom to underline the different orientation.
- 2D isogrid/triangles was implemented experimentally for local reinforcement subdividing the 2D honeycomb pattern without disconnects, but it's density is not spread nicely for support of small details requiring extra increase of density which made it heavier and higher density 2D honeycomb was preferred (OrcaSlicer will anyhow disconnect the infill lines at horizontal modifier boundaries currently).