### PR TITLE
Color & shape improvements for Axes

### DIFF
--- a/src/imguizmo/ImGuizmo.cpp
+++ b/src/imguizmo/ImGuizmo.cpp
@@ -3029,11 +3029,12 @@ namespace IMGUIZMO_NAMESPACE
 
             ImVec4 directionColorV = gContext.mStyle.Colors[DIRECTION_X + i];
             if (!visible) {
-                directionColorV.w *= 0.3f;
+                directionColorV.w *= 0.35f;
             }
-            ImU32 directionColor = ImGui::ColorConvertFloat4ToU32(directionColorV) | IM_COL32(0x80, 0x80, 0x80, 0x00); 
+            ImU32 directionColor = ImGui::ColorConvertFloat4ToU32(directionColorV); // | IM_COL32(0x80, 0x80, 0x80, 0x00);
             drawList->AddLine(baseSSpace, worldDirSSpace, directionColor, gContext.mStyle.TranslationLineThickness);
             
+            /* ORCA Dont draw arrow heads
             // Arrow head begin
             ImVec2 dir(baseSSpace - worldDirSSpace);
             
@@ -3045,9 +3046,10 @@ namespace IMGUIZMO_NAMESPACE
             ImVec2 a(worldDirSSpace + dir);
             drawList->AddTriangleFilled(worldDirSSpace - dir, a + ortogonalDir, a - ortogonalDir, directionColor);
             // Arrow head end
+            */
 
             // Axis text
-            ImVec2 labelSSpace = worldToPos(origin + dirAxis * 1.3f, res, position, size);
+            ImVec2 labelSSpace = worldToPos(origin + dirAxis * 1.2f, res, position, size);
             ImVec2 labelSize   = ImGui::CalcTextSize(gContext.mStyle.AxisLabels[i]);
             drawList->AddText(labelSSpace - labelSize * 0.5, directionColor, gContext.mStyle.AxisLabels[i]);
          }

--- a/src/libslic3r/Color.hpp
+++ b/src/libslic3r/Color.hpp
@@ -69,9 +69,9 @@ public:
     static const ColorRGB ORCA()		{ return {0.0f, 150.f / 255.0f, 136.0f / 255}; }
 	static const ColorRGB WARNING()     { return {241.0f / 255, 117.f / 255.0f, 78.0f / 255}; }
 
-	static const ColorRGB X()           { return { 0.75f, 0.0f, 0.0f }; }
-	static const ColorRGB Y()           { return { 0.0f, 0.75f, 0.0f }; }
-	static const ColorRGB Z()           { return { 0.0f, 0.0f, 0.75f }; }
+	static const ColorRGB X()           { return { 255 / 255.f, 60  / 255.f, 91  / 255.f};}
+	static const ColorRGB Y()           { return { 100 / 255.f, 200 / 255.f, 24  / 255.f};}
+	static const ColorRGB Z()           { return { 47  / 255.f, 136 / 255.f, 233 / 255.f};}
 };
 
 class ColorRGBA
@@ -140,9 +140,9 @@ public:
 	static const ColorRGBA WHITE()       { return { 1.0f, 1.0f, 1.0f, 1.0f }; }
     static const ColorRGBA ORCA()        { return {0.0f, 150.f / 255.0f, 136.0f / 255, 1.0f}; }
 
-	static const ColorRGBA X()           { return { 0.75f, 0.0f, 0.0f, 1.0f }; }
-	static const ColorRGBA Y()           { return { 0.0f, 0.75f, 0.0f, 1.0f }; }
-	static const ColorRGBA Z()           { return { 0.0f, 0.0f, 0.75f, 1.0f }; }
+	static const ColorRGBA X()           { return { ColorRGB::X().r(), ColorRGB::X().g(), ColorRGB::X().b(), 1.f };}
+	static const ColorRGBA Y()           { return { ColorRGB::Y().r(), ColorRGB::Y().g(), ColorRGB::Y().b(), 1.f };}
+	static const ColorRGBA Z()           { return { ColorRGB::Z().r(), ColorRGB::Z().g(), ColorRGB::Z().b(), 1.f };}
 };
 
 ColorRGB operator * (float value, const ColorRGB& other);

--- a/src/slic3r/GUI/2DBed.cpp
+++ b/src/slic3r/GUI/2DBed.cpp
@@ -117,25 +117,25 @@ void Bed_2D::repaint(const std::vector<Vec2d>& shape)
 	auto axes_len = 50;
 	auto arrow_len = 6;
 	auto arrow_angle = Geometry::deg2rad(45.0);
-    dc.SetPen(wxPen(wxColour(255, 0, 0), 2, wxPENSTYLE_SOLID));  // red
+    dc.SetPen(wxPen(wxColour(encode_color(ColorRGB::X())), 2, wxPENSTYLE_SOLID));  // red // ORCA match axis colors
 	auto x_end = Vec2d(origin_px(0) + axes_len, origin_px(1));
 	dc.DrawLine(wxPoint(origin_px(0), origin_px(1)), wxPoint(x_end(0), x_end(1)));
-	for (auto angle : { -arrow_angle, arrow_angle }) {
-		Vec2d end = Eigen::Translation2d(x_end) * Eigen::Rotation2Dd(angle) * Eigen::Translation2d(- x_end) * Eigen::Vector2d(x_end(0) - arrow_len, x_end(1));
-		dc.DrawLine(wxPoint(x_end(0), x_end(1)), wxPoint(end(0), end(1)));
-	}
+	//for (auto angle : { -arrow_angle, arrow_angle }) {  // ORCA dont draw arrows
+	//	Vec2d end = Eigen::Translation2d(x_end) * Eigen::Rotation2Dd(angle) * Eigen::Translation2d(- x_end) * Eigen::Vector2d(x_end(0) - arrow_len, x_end(1));
+	//	dc.DrawLine(wxPoint(x_end(0), x_end(1)), wxPoint(end(0), end(1)));
+	//}
 
-    dc.SetPen(wxPen(wxColour(0, 255, 0), 2, wxPENSTYLE_SOLID));  // green
+    dc.SetPen(wxPen(wxColour(encode_color(ColorRGB::Y())), 2, wxPENSTYLE_SOLID));  // green // ORCA match axis colors
 	auto y_end = Vec2d(origin_px(0), origin_px(1) - axes_len);
 	dc.DrawLine(wxPoint(origin_px(0), origin_px(1)), wxPoint(y_end(0), y_end(1)));
-	for (auto angle : { -arrow_angle, arrow_angle }) {
-		Vec2d end = Eigen::Translation2d(y_end) * Eigen::Rotation2Dd(angle) * Eigen::Translation2d(- y_end) * Eigen::Vector2d(y_end(0), y_end(1) + arrow_len);
-		dc.DrawLine(wxPoint(y_end(0), y_end(1)), wxPoint(end(0), end(1)));
-	}
+	//for (auto angle : { -arrow_angle, arrow_angle }) {  // ORCA dont draw arrows
+	//	Vec2d end = Eigen::Translation2d(y_end) * Eigen::Rotation2Dd(angle) * Eigen::Translation2d(- y_end) * Eigen::Vector2d(y_end(0), y_end(1) + arrow_len);
+	//	dc.DrawLine(wxPoint(y_end(0), y_end(1)), wxPoint(end(0), end(1)));
+	//}
 
 	// draw origin
-    dc.SetPen(wxPen(wxColour(0, 0, 0), 1, wxPENSTYLE_SOLID));
-    dc.SetBrush(wxBrush(wxColour(0, 0, 0), wxBRUSHSTYLE_SOLID));
+    dc.SetPen(wxPen(wxColour(encode_color(ColorRGB::Z())), 1, wxPENSTYLE_SOLID));    // ORCA match axis colors
+    dc.SetBrush(wxBrush(wxColour(encode_color(ColorRGB::Z())), wxBRUSHSTYLE_SOLID)); // ORCA match axis colors
 	dc.DrawCircle(origin_px(0), origin_px(1), 3);
 
 	static const auto origin_label = wxString("(0,0)");

--- a/src/slic3r/GUI/3DBed.cpp
+++ b/src/slic3r/GUI/3DBed.cpp
@@ -216,9 +216,10 @@ void Bed3D::Axes::render()
     };
 
     if (!m_arrow.is_initialized())
-        m_arrow.init_from(stilized_arrow(16, DefaultTipRadius, DefaultTipLength, DefaultStemRadius, m_stem_length));
+        //m_arrow.init_from(stilized_arrow(16, DefaultTipRadius, DefaultTipLength, DefaultStemRadius, m_stem_length));
+        m_arrow.init_from(smooth_cylinder(16, /*Radius*/ m_stem_length / 75.f, m_stem_length)); // ORCA use simple cylinder and scale thickness depends on length
 
-    GLShaderProgram* shader = wxGetApp().get_shader("gouraud_light");
+    GLShaderProgram* shader = wxGetApp().get_shader("flat"); // ORCA dont use shading to get closer color tone
     if (shader == nullptr)
         return;
 

--- a/src/slic3r/GUI/3DBed.hpp
+++ b/src/slic3r/GUI/3DBed.hpp
@@ -74,7 +74,7 @@ public:
             m_stem_length = length;
             m_arrow.reset();
         }
-        float get_total_length() const { return m_stem_length + DefaultTipLength; }
+        float get_total_length() const { return m_stem_length; } // + DefaultTipLength; } // ORCA axis without arrow
         void render();
     };
 

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -5767,9 +5767,9 @@ void GLCanvas3D::_render_3d_navigator()
     style.Colors[ImGuizmo::COLOR::DIRECTION_Z] = ImGuiWrapper::to_ImVec4(ColorRGBA::X());
     style.Colors[ImGuizmo::COLOR::TEXT] = m_is_dark ? ImVec4(224 / 255.f, 224 / 255.f, 224 / 255.f, 1.f) : ImVec4(.2f, .2f, .2f, 1.0f);
     style.Colors[ImGuizmo::COLOR::FACE]        = m_is_dark ? ImVec4(0.23f, 0.23f, 0.23f, 1.f) : ImVec4(0.77f, 0.77f, 0.77f, 1);
-    strcpy(style.AxisLabels[ImGuizmo::Axis::Axis_X], "y");
-    strcpy(style.AxisLabels[ImGuizmo::Axis::Axis_Y], "z");
-    strcpy(style.AxisLabels[ImGuizmo::Axis::Axis_Z], "x");
+    strcpy(style.AxisLabels[ImGuizmo::Axis::Axis_X], "Y"); // ORCA use uppercase to match text on tranform widgets
+    strcpy(style.AxisLabels[ImGuizmo::Axis::Axis_Y], "Z"); // ORCA use uppercase to match text on tranform widgets
+    strcpy(style.AxisLabels[ImGuizmo::Axis::Axis_Z], "X"); // ORCA use uppercase to match text on tranform widgets
     strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_FRONT], _utf8("Front").c_str());
     strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_BACK], _utf8("Back").c_str());
     strcpy(style.FaceLabels[ImGuizmo::FACES::FACE_TOP], _utf8("Top").c_str());

--- a/src/slic3r/GUI/Gizmos/GLGizmoBase.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBase.cpp
@@ -26,16 +26,16 @@ ColorRGBA GLGizmoBase::DEFAULT_BASE_COLOR = { 0.625f, 0.625f, 0.625f, 1.0f };
 ColorRGBA GLGizmoBase::DEFAULT_DRAG_COLOR = { 1.0f, 1.0f, 1.0f, 1.0f };
 ColorRGBA GLGizmoBase::DEFAULT_HIGHLIGHT_COLOR = {1.0f, 0.38f, 0.0f, 1.0f};
 std::array<ColorRGBA, 3> GLGizmoBase::AXES_HOVER_COLOR = {{
-                                                                { 0.7f, 0.0f, 0.0f, 1.0f },
-                                                                { 0.0f, 0.7f, 0.0f, 1.0f },
-                                                                { 0.0f, 0.0f, 0.7f, 1.0f }
-                                                                }};
+    {ColorRGBA::X().r() * 1.2f, ColorRGBA::X().g() * 1.4f, ColorRGBA::X().b() * 1.4f, 1.0f},
+    {ColorRGBA::Y().r() * 1.2f, ColorRGBA::Y().g() * 1.2f, ColorRGBA::Y().b() * 1.2f, 1.0f},
+    {ColorRGBA::Z().r() * 1.2f, ColorRGBA::Z().g() * 1.2f, ColorRGBA::Z().b() * 1.2f, 1.0f},
+}};
 
 std::array<ColorRGBA, 3> GLGizmoBase::AXES_COLOR = {{
-                                                                { 1.0, 0.0f, 0.0f, 1.0f },
-                                                                { 0.0f, 1.0f, 0.0f, 1.0f },
-                                                                { 0.0f, 0.0f, 1.0f, 1.0f }
-                                                                }};
+    ColorRGBA::X(),
+    ColorRGBA::Y(),
+    ColorRGBA::Z()
+}};
 
 ColorRGBA            GLGizmoBase::CONSTRAINED_COLOR   = {0.5f, 0.5f, 0.5f, 1.0f};
 ColorRGBA            GLGizmoBase::FLATTEN_COLOR       = {0.96f, 0.93f, 0.93f, 0.5f};
@@ -257,37 +257,37 @@ void GLGizmoBase::render_cross_mark(const Vec3f &target, bool is_single)
         render_line(
             {target(0) - half_length, target(1), target(2)}, 
             {target(0) + half_length, target(1), target(2)},
-            ColorRGBA::RED());
+            ColorRGBA::X()); // ORCA match axis colors
     }
     else {
         render_line(
             {target(0), target(1), target(2)}, 
             {target(0) + half_length, target(1), target(2)},
-            ColorRGBA::RED());
+            ColorRGBA::X()); // ORCA match axis colors
     }
     // draw line for y axis
     if (!is_single) {
         render_line(
             {target(0), target(1) - half_length, target(2)}, 
             {target(0), target(1) + half_length, target(2)},
-            ColorRGBA::GREEN());
+            ColorRGBA::Y()); // ORCA match axis colors
     } else {
         render_line(
             {target(0), target(1), target(2)}, 
             {target(0), target(1) + half_length, target(2)},
-            ColorRGBA::GREEN());
+            ColorRGBA::Y()); // ORCA match axis colors
     }
     // draw line for z axis
     if (!is_single) {
         render_line(
             {target(0), target(1), target(2) - half_length}, 
             {target(0), target(1), target(2) + half_length},
-            ColorRGBA::BLUE());
+            ColorRGBA::Z()); // ORCA match axis colors
     } else {
         render_line(
             {target(0), target(1), target(2)}, 
             {target(0), target(1), target(2) + half_length},
-            ColorRGBA::BLUE());
+            ColorRGBA::Z()); // ORCA match axis colors
     }
 }
 

--- a/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoCut.cpp
@@ -1046,8 +1046,8 @@ void GLGizmoCut3D::render_cut_plane_grabbers()
 
         // render sphere grabber
         size = m_dragging ? get_dragging_half_size(mean_size) : get_half_size(mean_size);
-        color = m_hover_id == Y ? complementary(ColorRGBA::GREEN()) :                
-                m_hover_id == X ? complementary(ColorRGBA::RED())   :
+        color = m_hover_id == Y ? ColorRGBA::Y() : // ORCA match axis colors
+                m_hover_id == X ? ColorRGBA::X() : // ORCA match axis colors
                 m_hover_id == Z ? GRABBER_COLOR                     :   ColorRGBA::GRAY();
         render_model(m_sphere.model, color, view_matrix * translation_transform(m_grabber_connection_len * Vec3d::UnitZ()) * scale_transform(size));
     }
@@ -1060,7 +1060,8 @@ void GLGizmoCut3D::render_cut_plane_grabbers()
     {
         size = m_dragging && m_hover_id == X ? get_dragging_half_size(mean_size) : get_half_size(mean_size);
         const Vec3d cone_scale = Vec3d(0.75 * size, 0.75 * size, 1.8 * size);
-        color = m_hover_id == X ? complementary(ColorRGBA::RED()) : ColorRGBA::RED();
+        //color = m_hover_id == X ? complementary(ColorRGBA::X()) : ColorRGBA::X();
+        color = ColorRGBA::X(); // ORCA match axis colors
 
         if (m_hover_id == X) {
             render_grabber_connection(color, view_matrix);
@@ -1079,7 +1080,8 @@ void GLGizmoCut3D::render_cut_plane_grabbers()
     {
         size = m_dragging && m_hover_id == Y ? get_dragging_half_size(mean_size) : get_half_size(mean_size);
         const Vec3d cone_scale = Vec3d(0.75 * size, 0.75 * size, 1.8 * size);
-        color = m_hover_id == Y ? complementary(ColorRGBA::GREEN()) : ColorRGBA::GREEN();
+        //color = m_hover_id == Y ? complementary(ColorRGBA::Y()) : ColorRGBA::Y();
+        color = ColorRGBA::Y(); // ORCA match axis colors
 
         if (m_hover_id == Y) {
             render_grabber_connection(color, view_matrix);
@@ -1099,7 +1101,7 @@ void GLGizmoCut3D::render_cut_plane_grabbers()
         if (no_xy_grabber_hovered || m_hover_id == CutPlaneZRotation)
         {
             size = 0.75 * (m_dragging ? get_dragging_half_size(mean_size) : get_half_size(mean_size));
-            color = ColorRGBA::BLUE();
+            color = ColorRGBA::Z(); // ORCA match axis colors
             const ColorRGBA cp_color = m_hover_id == CutPlaneZRotation ? color : m_plane.model.get_color();
 
             const double grabber_shift = -1.75 * m_grabber_connection_len;
@@ -1126,7 +1128,7 @@ void GLGizmoCut3D::render_cut_plane_grabbers()
         if (no_xy_grabber_hovered || m_hover_id == CutPlaneXMove)
         {
             size = (m_dragging ? get_dragging_half_size(mean_size) : get_half_size(mean_size));
-            color = m_hover_id == CutPlaneXMove ? ColorRGBA::RED() : m_plane.model.get_color();
+            color = m_hover_id == CutPlaneXMove ? ColorRGBA::X() : m_plane.model.get_color(); // ORCA match axis colors
 
             render_grabber_connection(GRABBER_COLOR, view_matrix * rotation_transform(0.5 * PI * Vec3d::UnitY()), 0.75);
 
@@ -1144,7 +1146,7 @@ void GLGizmoCut3D::render_cut_plane_grabbers()
         if (m_groove.angle > 0.0f && (no_xy_grabber_hovered || m_hover_id == CutPlaneYMove))
         {
             size = (m_dragging ? get_dragging_half_size(mean_size) : get_half_size(mean_size));
-            color = m_hover_id == CutPlaneYMove ? ColorRGBA::GREEN() : m_plane.model.get_color();
+            color = m_hover_id == CutPlaneYMove ? ColorRGBA::Y() : m_plane.model.get_color(); // ORCA match axis colors
 
             render_grabber_connection(GRABBER_COLOR, view_matrix * rotation_transform(-0.5 * PI * Vec3d::UnitX()), 0.75);
 

--- a/src/slic3r/GUI/Gizmos/GizmoObjectManipulation.cpp
+++ b/src/slic3r/GUI/Gizmos/GizmoObjectManipulation.cpp
@@ -874,15 +874,14 @@ void GizmoObjectManipulation::do_render_move_window(ImGuiWrapper *imgui_wrapper,
     }
     ImGuiWrapper::pop_combo_style();
     caption_max = combox_content_size - 4 * space_size;
-    ImGui::SameLine(caption_max + index * space_size);
-    ImGui::PushItemWidth(unit_size);
-    ImGui::TextAlignCenter("X");
-    ImGui::SameLine(caption_max + unit_size + (++index) * space_size);
-    ImGui::PushItemWidth(unit_size);
-    ImGui::TextAlignCenter("Y");
-    ImGui::SameLine(caption_max + (++index_unit) * unit_size + (++index) * space_size);
-    ImGui::PushItemWidth(unit_size);
-    ImGui::TextAlignCenter("Z");
+    // ORCA use TextColored to match axes color
+    float offset_to_center = (unit_size - ImGui::CalcTextSize("O").x) / 2;
+    ImGui::SameLine(caption_max + index * space_size + offset_to_center);
+    ImGui::TextColored(ImGuiWrapper::to_ImVec4(ColorRGBA::X()),"X");
+    ImGui::SameLine(caption_max + unit_size + (++index) * space_size + offset_to_center);
+    ImGui::TextColored(ImGuiWrapper::to_ImVec4(ColorRGBA::Y()),"Y");
+    ImGui::SameLine(caption_max + (++index_unit) * unit_size + (++index) * space_size + offset_to_center);
+    ImGui::TextColored(ImGuiWrapper::to_ImVec4(ColorRGBA::Z()),"Z");
 
     index      = 1;
     index_unit = 1;
@@ -1003,15 +1002,14 @@ void GizmoObjectManipulation::do_render_rotate_window(ImGuiWrapper *imgui_wrappe
     unsigned int current_active_id = ImGui::GetActiveID();
     ImGui::PushItemWidth(caption_max);
     imgui_wrapper->text(_L("World coordinates"));
-    ImGui::SameLine(caption_max + index * space_size);
-    ImGui::PushItemWidth(unit_size);
-    ImGui::TextAlignCenter("X");
-    ImGui::SameLine(caption_max + unit_size + (++index) * space_size);
-    ImGui::PushItemWidth(unit_size);
-    ImGui::TextAlignCenter("Y");
-    ImGui::SameLine(caption_max + (++index_unit) * unit_size + (++index) * space_size);
-    ImGui::PushItemWidth(unit_size);
-    ImGui::TextAlignCenter("Z");
+    // ORCA use TextColored to match axes color
+    float offset_to_center = (unit_size - ImGui::CalcTextSize("O").x) / 2;
+    ImGui::SameLine(caption_max + index * space_size + offset_to_center);
+    ImGui::TextColored(ImGuiWrapper::to_ImVec4(ColorRGBA::X()),"X");
+    ImGui::SameLine(caption_max + unit_size + (++index) * space_size + offset_to_center);
+    ImGui::TextColored(ImGuiWrapper::to_ImVec4(ColorRGBA::Y()),"Y");
+    ImGui::SameLine(caption_max + (++index_unit) * unit_size + (++index) * space_size + offset_to_center);
+    ImGui::TextColored(ImGuiWrapper::to_ImVec4(ColorRGBA::Z()),"Z");
 
     index      = 1;
     index_unit = 1;
@@ -1224,15 +1222,14 @@ void GizmoObjectManipulation::do_render_scale_input_window(ImGuiWrapper* imgui_w
     ImGuiWrapper::pop_combo_style();
     caption_max = combox_content_size - 4 * space_size;
     //ImGui::Dummy(ImVec2(caption_max, -1));
-    ImGui::SameLine(caption_max + space_size);
-    ImGui::PushItemWidth(unit_size);
-    ImGui::TextAlignCenter("X");
-    ImGui::SameLine(caption_max + unit_size + index * space_size);
-    ImGui::PushItemWidth(unit_size);
-    ImGui::TextAlignCenter("Y");
-    ImGui::SameLine(caption_max + (++index_unit) * unit_size + (++index) * space_size);
-    ImGui::PushItemWidth(unit_size);
-    ImGui::TextAlignCenter("Z");
+    // ORCA use TextColored to match axes color
+    float offset_to_center = (unit_size - ImGui::CalcTextSize("O").x) / 2;
+    ImGui::SameLine(caption_max + space_size + offset_to_center);
+    ImGui::TextColored(ImGuiWrapper::to_ImVec4(ColorRGBA::X()),"X");
+    ImGui::SameLine(caption_max + unit_size + index * space_size + offset_to_center);
+    ImGui::TextColored(ImGuiWrapper::to_ImVec4(ColorRGBA::Y()),"Y");
+    ImGui::SameLine(caption_max + (++index_unit) * unit_size + (++index) * space_size + offset_to_center);
+    ImGui::TextColored(ImGuiWrapper::to_ImVec4(ColorRGBA::Z()),"Z");
 
     index      = 2;
     index_unit = 1;


### PR DESCRIPTION
I will send a separate PR for grabbers when i finish

![Screenshot-20250427184437](https://github.com/user-attachments/assets/4f354fef-3a1e-4a81-bfb1-f938b91ffaf1)

### CHANGES
• Used fine tuned colors instead raw colors for axes
• Matches all axis colors on UI (Navigation cube, axes on plate, gizmos, grabbers, 2D bed on set shape dialog)
• Makes all axes colors controllable from one place. Color.hpp
• Makes navigation cube axis text uppercase like on transform widgets
• Removes arrows from axes of main origin
• Removes arrows from axes of navigation cube
• Removes arrows from axes of 2D bed on set bed shape dialog

About arrows
• Line that drew from origin to a point already shows a direction. so no arrows needed on axes
• Axes looks much more modern without arrows 

About change on transform widgets
• I have to use TextColored instead TextAlignCenter on gizmos otherwise i have to change code on imgui_widgets.cpp to get correct colors. that should break updatability of imgui_widgets

### FIXES
• Cut rotation grabbers not matches with axis color
before - rotation uses different colors
![orca-slicer_ycKPia8U7w](https://github.com/user-attachments/assets/81a89a57-4bfd-4f01-a779-a3454298cda6)
after -  color of rotation axes matches
![orca-slicer_t9Nuyr2P4i](https://github.com/user-attachments/assets/168c9927-fe68-49bf-98b6-a3e03c4a882c)

• Z color now more visible on dark theme
before-after
![Screenshot-20250427183126](https://github.com/user-attachments/assets/507ba3d3-fe76-4a7e-86f9-32833021c332)
![Screenshot-20250427183133](https://github.com/user-attachments/assets/706713a6-569b-40f4-90c0-a4e0440e4023)

### COMPARISON
Before-After
![Screenshot-20250427184614](https://github.com/user-attachments/assets/59ecb15b-4b62-40c3-aad8-aeb2ebadbacc)
![Screenshot-20250427184437](https://github.com/user-attachments/assets/4f354fef-3a1e-4a81-bfb1-f938b91ffaf1)

Before-After > Bed Shape Dialog
![Screenshot-20250427184713](https://github.com/user-attachments/assets/2df01851-6c4c-4824-a45f-494de8526a03)
![Screenshot-20250427184725](https://github.com/user-attachments/assets/200f3e7c-d0e1-4b3e-85c0-44170ed39627)

