### PR TITLE
better version check in linux build script

### DIFF
--- a/linux.d/debian
+++ b/linux.d/debian
@@ -27,12 +27,16 @@ REQUIRED_DEV_PACKAGES=(
 
 if [[ -n "$UPDATE_LIB" ]]
 then
-    # for ubuntu 22+ and 23+:
-    ubu_major_version="$(grep VERSION_ID /etc/os-release | cut -d "=" -f 2 | cut -d "." -f 1 | tr -d /\"/)"
-    if [ $ubu_major_version == "22" ] || [ $ubu_major_version == "23" ]
-    then
-        REQUIRED_DEV_PACKAGES+=(curl libfuse-dev libssl-dev libcurl4-openssl-dev m4)
+    source /etc/os-release
+    if [ "${ID}" == "ubuntu" ] && [ -n "${VERSION_ID}" ]; then
+        # It's ubuntu and we have a VERSION_ID like "24.04".
+        if dpkg --compare-versions "${VERSION_ID}" ge 22 && dpkg --compare-versions "${VERSION_ID}" lt 24 ;
+        then
+            # Some extra packages needed on Ubuntu 22.x and 23.x:
+            REQUIRED_DEV_PACKAGES+=(curl libfuse-dev libssl-dev libcurl4-openssl-dev m4)
+        fi
     fi
+
     if [[ -n "$BUILD_DEBUG" ]]
     then
         REQUIRED_DEV_PACKAGES+=(libssl-dev libcurl4-openssl-dev)


### PR DESCRIPTION
# Description

Running `BuildLinux.sh` on Debian Trixie (and probably on other platforms) results in this warning:
```
$ sudo ./BuildLinux.sh -u
./linux.d/debian: line 32: [: ==: unary operator expected
./linux.d/debian: line 32: [: ==: unary operator expected
...
```

The script is looking for the `VERSION_ID` variable in `/etc/os-release`, but that variable is optional (see https://www.linux.org/docs/man5/os-release.html) and is not present in my install of Debian Trixie.  The script handles the missing variable incorrectly, resulting in the above warning.

This commit fixes the version check to be more tolerant and IMO clearer.

# Screenshots/Recordings/Graphs

## Tests

Tested on Ubuntu 22.04, 24.04, and Debian Trixie.  The required packages get installed with no warnings from the version check.
