### PR TITLE
adds `libspnav-dev` dependency to `linux.d/debian`

### DIFF
--- a/linux.d/arch
+++ b/linux.d/arch
@@ -17,6 +17,7 @@ export REQUIRED_DEV_PACKAGES=(
     gtk3
     libmspack
     libsecret
+    libspnav
     mesa
     ninja
     openssl

--- a/linux.d/debian
+++ b/linux.d/debian
@@ -17,6 +17,7 @@ REQUIRED_DEV_PACKAGES=(
     libmspack-dev
     libosmesa6-dev
     libsecret-1-dev
+    libspnav-dev
     libssl-dev
     libtool
     libudev-dev

--- a/linux.d/fedora
+++ b/linux.d/fedora
@@ -18,6 +18,7 @@ REQUIRED_DEV_PACKAGES=(
     libmspack-devel
     libquadmath-devel
     libsecret-devel
+    libspnav-devel
     libtool
     m4
     mesa-libGLU-devel


### PR DESCRIPTION
# Description

Fixes #4965[ SpaceMouse no longer working with Orca Slicer 2.0](https://github.com/SoftFever/OrcaSlicer/issues/4965) (except ClearLinux)

## Tested manually (Ubuntu)

- added missing dependency `libspnav-dev`
- compiled
- started spacenav daemon: `sudo spacenavd`
- started OrcaSlicer
- actuated spacemouse
- build plate moved accordingly