### PR TITLE
Fix: Grid size calculation wrong on large scale

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -468,16 +468,16 @@ void PartPlate::calc_gridlines(const ExPolygon& poly, const BoundingBox& pp_bbox
 
 	Polylines axes_lines, axes_lines_bolder;
 	int count = 0;
-	int step  = 10;
+	int step  = 10;                   //                Uses up to 599mm    Main Grid:  10 x 5 = 50mm
 	// Orca: use 500 x 500 bed size as baseline.
-    Point grid_counts = pp_bbox.size() / ((coord_t) scale_(step * 50));
     // if the grid is too dense, we increase the step
-    if (grid_counts.minCoeff() > 1) {    // Switch when short edge >= 1000mm
+    auto min_edge_scaled = (pp_bbox.size() / ((coord_t) scale_(1))).minCoeff();
+    if (     min_edge_scaled >= 6000) // Switch when short edge >= 6000mm   Main Grid: 100 x 5 = 500mm
+        step = 100;
+    else if (min_edge_scaled >= 1200) // Switch when short edge >= 1200mm   Main Grid:  50 x 5 = 250mm
         step = 50;
-        grid_counts = pp_bbox.size() / ((coord_t) scale_(step * 50));
-        if (grid_counts.minCoeff() > 1)  // Switch when short edge >= 5000mm
-            step = 100;
-    }
+    else if (min_edge_scaled >= 600)  // Switch when short edge >= 600mm    Main Grid:  20 x 5 = 100mm
+        step = 20;
 
     // ORCA draw grid lines relative to origin
     for (coord_t x = scale_(m_origin.x()); x >= pp_bbox.min(0); x -= scale_(step)) { // Negative X axis

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -472,10 +472,10 @@ void PartPlate::calc_gridlines(const ExPolygon& poly, const BoundingBox& pp_bbox
 	// Orca: use 500 x 500 bed size as baseline.
     Point grid_counts = pp_bbox.size() / ((coord_t) scale_(step * 50));
     // if the grid is too dense, we increase the step
-    if (grid_counts.minCoeff() > 1) {
+    if (grid_counts.minCoeff() > 1) {    // Switch when short edge >= 1000mm
         step = 50;
         grid_counts = pp_bbox.size() / ((coord_t) scale_(step * 50));
-        if (grid_counts.minCoeff() > 1)
+        if (grid_counts.minCoeff() > 1)  // Switch when short edge >= 5000mm
             step = 100;
     }
 

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -470,10 +470,11 @@ void PartPlate::calc_gridlines(const ExPolygon& poly, const BoundingBox& pp_bbox
 	int count = 0;
 	int step  = 10;
 	// Orca: use 500 x 500 bed size as baseline.
-    const Point grid_counts = pp_bbox.size() / ((coord_t) scale_(step * 50));
+    Vec2d grid_counts = pp_bbox.size() / (step * 50);
     // if the grid is too dense, we increase the step
-    if (grid_counts.minCoeff() > 1) {
-        step = static_cast<int>(grid_counts.minCoeff() + 1) * 10;
+    while (grid_counts.minCoeff() > 1) {
+        step *= 10;
+        grid_counts = pp_bbox.size() / (step * 50);
     }
 
     // ORCA draw grid lines relative to origin

--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -470,11 +470,13 @@ void PartPlate::calc_gridlines(const ExPolygon& poly, const BoundingBox& pp_bbox
 	int count = 0;
 	int step  = 10;
 	// Orca: use 500 x 500 bed size as baseline.
-    Vec2d grid_counts = pp_bbox.size() / (step * 50);
+    Point grid_counts = pp_bbox.size() / ((coord_t) scale_(step * 50));
     // if the grid is too dense, we increase the step
-    while (grid_counts.minCoeff() > 1) {
-        step *= 10;
-        grid_counts = pp_bbox.size() / (step * 50);
+    if (grid_counts.minCoeff() > 1) {
+        step = 50;
+        grid_counts = pp_bbox.size() / ((coord_t) scale_(step * 50));
+        if (grid_counts.minCoeff() > 1)
+            step = 100;
     }
 
     // ORCA draw grid lines relative to origin


### PR DESCRIPTION
limited max grid size to 100mm, i can add more if needed. didnt want to use "while"

### CHANGES
• Simplified calculation and standardized steps

| Bed short edge length | Step x Count = Main Grid Size |
| :--- | :--- |
|   < 600mm |  10 x 5 = 50mm |
| >= 600mm |   20 x 5 = 100mm |
| >= 1200mm |  50 x 5 = 250mm |
| >= 6000mm | 100 x 5 = 500mm |

### COMPARISON
1000x1000 bed plate (Ginger G1)

BEFORE - 33 gridlines with non standard step
![Screenshot-20250427235818](https://github.com/user-attachments/assets/f1dacaf0-47de-4452-861f-0537a6d89c28)

AFTER - 50 gridlines with 20mm grid size. Distance between thick lines 10 cm
![Screenshot-20250428020714](https://github.com/user-attachments/assets/cef5f8db-c11e-4d39-b89f-13a02c10e56d)

10000x10000(10mt x 10mt) bed plate
BEFORE
![Screenshot-20250428000909](https://github.com/user-attachments/assets/ddc65f75-2f84-43cb-92aa-daf49e770dc5)

AFTER  - 100 gridlines with 100mm grid size.  Distance between thick lines 50 cm
![Screenshot-20250428020839](https://github.com/user-attachments/assets/026fbb92-8d9a-4967-8dbf-c257ed43107f)
