### PR TITLE
flatpak: update libspnav to version 1.2

### DIFF
--- a/flatpak/io.github.softfever.OrcaSlicer.yml
+++ b/flatpak/io.github.softfever.OrcaSlicer.yml
@@ -110,8 +110,8 @@ modules:
   - name: libspnav
     sources:
       - type: archive
-        url: https://github.com/FreeSpacenav/libspnav/releases/download/v1.1/libspnav-1.1.tar.gz
-        sha256: 04b297f68a10db4fa40edf68d7f823ba7b9d0442f2b665181889abe2cea42759
+        url: https://github.com/FreeSpacenav/libspnav/releases/download/v1.2/libspnav-1.2.tar.gz
+        sha256: 093747e7e03b232e08ff77f1ad7f48552c06ac5236316a5012db4269951c39db
  
   - name: orca_wxwidgets
     buildsystem: simple


### PR DESCRIPTION
Updates the link and checksum to the recently released version 1.2 of libspnav in the flatpak build.

Note that I currently don't have the resources to compile orca. so this is untested.
