### PR TITLE
Fixes compile error with `SLIC3R_PCH=OFF`

### DIFF
--- a/flatpak/io.github.softfever.OrcaSlicer.yml
+++ b/flatpak/io.github.softfever.OrcaSlicer.yml
@@ -298,7 +298,7 @@ modules:
       - |
         mkdir -p build
         CXXFLAGS=-std=gnu++20 cmake . -B build \
-          -DSLIC3R_PCH=ON \
+          -DSLIC3R_PCH=OFF \
           -DSLIC3R_FHS=ON \
           -DSLIC3R_GTK=3 \
           -DSLIC3R_STATIC=ON \

--- a/src/slic3r/GUI/2DBed.hpp
+++ b/src/slic3r/GUI/2DBed.hpp
@@ -3,6 +3,8 @@
 
 #include <wx/wx.h>
 #include "libslic3r/Config.hpp"
+#include "libslic3r/ExPolygon.hpp"
+#include "libslic3r/Polyline.hpp"
 
 namespace Slic3r {
 namespace GUI {


### PR DESCRIPTION
# Description

Fixes #9544 compile error with `SLIC3R_PCH=OFF`, meaning a successful build could be only achieved with `SLIC3R_PCH=ON` introduced in a91ee67ac7f2936f3ec3fb7522c07d0f7a6b4ca6.

Compiler errors with `SLIC3R_PCH=OFF`:

```bash
orca-slicer/src/OrcaSlicer.cpp:3240: note: at offset 16 into object ‘wipe_tower_y’ of size 16
 3240 |                     ConfigOptionFloat wipe_tower_y(wipe_y_option->get_at(index) + wipe_offset(1));
[468/474] Building CXX object src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/BedShapeDialog.cpp.o
FAILED: src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/BedShapeDialog.cpp.o 
/usr/lib/ccache/c++ -DBOOST_ATOMIC_NO_LIB -DBOOST_ATOMIC_STATIC_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_CHRONO_STATIC_LINK -DBOOST_CONTAINER_NO_LIB -DBOOST_CONTAINER_STATIC_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_DATE_TIME_STATIC_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_FILESYSTEM_STATIC_LINK=1 -DBOOST_IOSTREAMS_NO_LIB -DBOOST_IOSTREAMS_STATIC_LINK -DBOOST_LOCALE_NO_LIB -DBOOST_LOCALE_STATIC_LINK -DBOOST_LOG_NO_LIB -DBOOST_LOG_STATIC_LINK -DBOOST_NOWIDE_NO_LIB -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_PROGRAM_OPTIONS_STATIC_LINK -DBOOST_RANDOM_NO_LIB -DBOOST_RANDOM_STATIC_LINK -DBOOST_SERIALIZATION_NO_LIB -DBOOST_SERIALIZATION_STATIC_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_STATIC_LINK -DBOOST_THREAD_USE_LIB -DCURL_STATICLIB -DGIT_COMMIT_HASH=\"95d63b589\" -DGLEW_STATIC -DHAVE_SPNAV -DLIBNEST2D_GEOMETRIES_libslic3r -DLIBNEST2D_OPTIMIZER_nlopt -DLIBNEST2D_STATIC -DLIBNEST2D_THREADING_tbb -DNDEBUG -DOPENSSL_CERT_OVERRIDE -DOPENVDB_OPENEXR_STATICLIB -DOPENVDB_STATICLIB -DSLIC3R_CURRENTLY_COMPILING_GUI_MODULE -DSLIC3R_DESKTOP_INTEGRATION -DSLIC3R_GUI -DTBB_USE_CAPTURED_EXCEPTION=0 -DUNICODE -DUSE_TBB -DWXINTL_NO_GETTEXT_MACRO -DWXUSINGDLL -D_UNICODE -D__WXGTK3__ -D__WXGTK__ -DwxDEBUG_LEVEL=0 -DwxNO_UNSAFE_WXSTRING_CONV -DwxUSE_UNICODE -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/home/foo/git/orca-slicer/src -I/home/foo/git/orca-slicer/build/src/platform -I/home/foo/git/orca-slicer/src/hidapi/include -I/home/foo/git/orca-slicer/src/slic3r/Utils -I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/sysprof-6 -I/usr/include/harfbuzz -I/home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/freetype2 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/cairo -I/home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/libpng16 -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/gio-unix-2.0 -I/usr/include/atk-1.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/gstreamer-1.0 -I/home/foo/git/orca-slicer/build/src/libslic3r -I/home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/opencascade -I/home/foo/git/orca-slicer/src/libnest2d/include -I/home/foo/git/orca-slicer/src/miniz -I/home/foo/git/orca-slicer/src/glu-libtess/include -I/home/foo/git/orca-slicer/src/clipper2/Clipper2Lib/include -I/home/foo/git/orca-slicer/src/minilzo -isystem /home/foo/git/orca-slicer/src/eigen -isystem /home/foo/git/orca-slicer/src/libigl -isystem /home/foo/git/orca-slicer/deps/build/destdir/usr/local/lib/wx/include/gtk3-unicode-static-3.1 -isystem /home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/wx-3.1 -isystem /home/foo/git/orca-slicer/deps/build/destdir/usr/local/include -isystem /home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/opencv4 -isystem /home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/OpenEXR -fext-numeric-literals -Wall -Wno-reorder -Wno-error=template-id-cdtor -pthread -O3 -DNDEBUG -std=gnu++17 -fPIC -fdiagnostics-color=always -fsigned-char -Werror=return-type -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-label -Wno-unused-local-typedefs -Wno-sign-compare -Wno-misleading-indentation -Wno-switch -Wno-ignored-attributes -Wno-unknown-pragmas -gz=zstd -DOPENVDB_ABI_VERSION_NUMBER=8 -MD -MT src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/BedShapeDialog.cpp.o -MF src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/BedShapeDialog.cpp.o.d -o src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/BedShapeDialog.cpp.o -c /home/foo/git/orca-slicer/src/slic3r/GUI/BedShapeDialog.cpp
In file included from /home/foo/git/orca-slicer/src/slic3r/GUI/BedShapeDialog.hpp:7,
                 from /home/foo/git/orca-slicer/src/slic3r/GUI/BedShapeDialog.cpp:1:
/home/foo/git/orca-slicer/src/slic3r/GUI/2DBed.hpp:29:24: error: ‘Polylines’ was not declared in this scope
   29 |     static std::vector<Polylines> generate_grid(const ExPolygon& poly, const BoundingBox& pp_bbox, const Vec2d& origin, const float& step, const float& scale);

```
```bash
orca-slicer/src/slic3r/GUI/Tab.cpp:4920: warning: converting to non-pointer type ‘int’ from NULL [-Wconversion-null]
 4920 |         m_last_select_item = NULL;
[515/529] Building CXX object src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/BedShapeDialog.cpp.o
FAILED: src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/BedShapeDialog.cpp.o 
/usr/lib/ccache/c++ -DBOOST_ATOMIC_NO_LIB -DBOOST_ATOMIC_STATIC_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_CHRONO_STATIC_LINK -DBOOST_CONTAINER_NO_LIB -DBOOST_CONTAINER_STATIC_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_DATE_TIME_STATIC_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_FILESYSTEM_STATIC_LINK=1 -DBOOST_IOSTREAMS_NO_LIB -DBOOST_IOSTREAMS_STATIC_LINK -DBOOST_LOCALE_NO_LIB -DBOOST_LOCALE_STATIC_LINK -DBOOST_LOG_NO_LIB -DBOOST_LOG_STATIC_LINK -DBOOST_NOWIDE_NO_LIB -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_PROGRAM_OPTIONS_STATIC_LINK -DBOOST_RANDOM_NO_LIB -DBOOST_RANDOM_STATIC_LINK -DBOOST_SERIALIZATION_NO_LIB -DBOOST_SERIALIZATION_STATIC_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_STATIC_LINK -DBOOST_THREAD_USE_LIB -DCURL_STATICLIB -DGIT_COMMIT_HASH=\"95d63b589\" -DGLEW_STATIC -DHAVE_SPNAV -DLIBNEST2D_GEOMETRIES_libslic3r -DLIBNEST2D_OPTIMIZER_nlopt -DLIBNEST2D_STATIC -DLIBNEST2D_THREADING_tbb -DNDEBUG -DOPENSSL_CERT_OVERRIDE -DOPENVDB_OPENEXR_STATICLIB -DOPENVDB_STATICLIB -DSLIC3R_CURRENTLY_COMPILING_GUI_MODULE -DSLIC3R_DESKTOP_INTEGRATION -DSLIC3R_GUI -DTBB_USE_CAPTURED_EXCEPTION=0 -DUNICODE -DUSE_TBB -DWXINTL_NO_GETTEXT_MACRO -DWXUSINGDLL -D_UNICODE -D__WXGTK3__ -D__WXGTK__ -DwxDEBUG_LEVEL=0 -DwxNO_UNSAFE_WXSTRING_CONV -DwxUSE_UNICODE -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/home/foo/git/orca-slicer/src -I/home/foo/git/orca-slicer/build/src/platform -I/home/foo/git/orca-slicer/src/hidapi/include -I/home/foo/git/orca-slicer/src/slic3r/Utils -I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/sysprof-6 -I/usr/include/harfbuzz -I/home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/freetype2 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/cairo -I/home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/libpng16 -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/gio-unix-2.0 -I/usr/include/atk-1.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/gstreamer-1.0 -I/home/foo/git/orca-slicer/build/src/libslic3r -I/home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/opencascade -I/home/foo/git/orca-slicer/src/libnest2d/include -I/home/foo/git/orca-slicer/src/miniz -I/home/foo/git/orca-slicer/src/glu-libtess/include -I/home/foo/git/orca-slicer/src/clipper2/Clipper2Lib/include -I/home/foo/git/orca-slicer/src/minilzo -isystem /home/foo/git/orca-slicer/src/eigen -isystem /home/foo/git/orca-slicer/src/libigl -isystem /home/foo/git/orca-slicer/deps/build/destdir/usr/local/lib/wx/include/gtk3-unicode-static-3.1 -isystem /home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/wx-3.1 -isystem /home/foo/git/orca-slicer/deps/build/destdir/usr/local/include -isystem /home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/opencv4 -isystem /home/foo/git/orca-slicer/deps/build/destdir/usr/local/include/OpenEXR -fext-numeric-literals -Wall -Wno-reorder -Wno-error=template-id-cdtor -pthread -O3 -DNDEBUG -std=gnu++17 -fPIC -fdiagnostics-color=always -fsigned-char -Werror=return-type -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-label -Wno-unused-local-typedefs -Wno-sign-compare -Wno-misleading-indentation -Wno-switch -Wno-ignored-attributes -Wno-unknown-pragmas -gz=zstd -DOPENVDB_ABI_VERSION_NUMBER=8 -MD -MT src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/BedShapeDialog.cpp.o -MF src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/BedShapeDialog.cpp.o.d -o src/slic3r/CMakeFiles/libslic3r_gui.dir/GUI/BedShapeDialog.cpp.o -c /home/foo/git/orca-slicer/src/slic3r/GUI/BedShapeDialog.cpp
In file included from /home/foo/git/orca-slicer/src/slic3r/GUI/BedShapeDialog.hpp:7,
                 from /home/foo/git/orca-slicer/src/slic3r/GUI/BedShapeDialog.cpp:1:
/home/foo/git/orca-slicer/src/slic3r/GUI/2DBed.hpp:30:55: error: ‘ExPolygon’ does not name a type
   30 |     static std::vector<Polylines> generate_grid(const ExPolygon& poly, const BoundingBox& pp_bbox, const Vec2d& origin, const float& step, const float& scale);
      |  
```