### PR TITLE
Match style of checkboxes on Material Settings > Setting Overrides

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3167,11 +3167,8 @@ void TabFilament::add_filament_overrides_page()
         line = optgroup->create_single_option_line(optgroup->get_option(opt_key));
 
         line.near_label_widget = [this, optgroup_wk = ConfigOptionsGroupWkp(optgroup), opt_key, opt_index](wxWindow* parent) {
-            wxCheckBox* check_box = new wxCheckBox(parent, wxID_ANY, "");
-
-            check_box->Bind(
-                wxEVT_CHECKBOX,
-                [this, optgroup_wk, opt_key, opt_index](wxCommandEvent& evt) {
+            auto check_box = new ::CheckBox(parent); // ORCA modernize checkboxes
+            check_box->Bind(wxEVT_TOGGLEBUTTON, [this, optgroup_wk, opt_key, opt_index](wxCommandEvent& evt) {
                 const bool is_checked = evt.IsChecked();
                 if (auto optgroup_sh = optgroup_wk.lock(); optgroup_sh) {
                     if (Field *field = optgroup_sh->get_fieldc(opt_key, opt_index); field != nullptr) {

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -40,6 +40,7 @@
 #include "ParamsPanel.hpp"
 #include "Widgets/RoundedRectangle.hpp"
 #include "Widgets/TextInput.hpp"
+#include "Widgets/CheckBox.hpp" // ORCA
 
 class TabCtrl;
 
@@ -557,7 +558,7 @@ private:
     void            update_filament_overrides_page(const DynamicPrintConfig* printers_config);
 	void 			update_volumetric_flow_preset_hints();
 
-    std::map<std::string, wxCheckBox*> m_overrides_options;
+    std::map<std::string, ::CheckBox*> m_overrides_options;
 
 public:
 	//BBS: GUI refactor


### PR DESCRIPTION
Replaces wxCheckbox with custom class Checkbox like other parameter checkboxes that used on UI
Matches style of checkboxes on all platforms

BEFORE
![Screenshot-20250505113528](https://github.com/user-attachments/assets/f5de7604-cf7b-47e1-a4d2-237522d6a874)


AFTER
![Screenshot-20250505113535](https://github.com/user-attachments/assets/effb7275-3359-4347-8535-e268873b4e0f)
