### PR TITLE
Make sure `filament_id` is not longer than 8 chars if the filament can be set in AMS

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-CF @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-CF @base.json
@@ -2,7 +2,7 @@
     "type": "filament",
     "name": "AliZ PETG-CF @base",
     "inherits": "AliZ PETG @base",
-    "filament_id": "AliZ001-1",
+    "filament_id": "AZ01-1",
     "from": "system",
     "instantiation": "false",
     "fan_cooling_layer_time": [

--- a/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-Metal @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/AliZ/AliZ PETG-Metal @base.json
@@ -2,7 +2,7 @@
     "type": "filament",
     "name": "AliZ PETG-Metal @base",
     "inherits": "AliZ PETG @base",
-    "filament_id": "AliZ001-2",
+    "filament_id": "AZ01-2",
     "from": "system",
     "instantiation": "false",
     "fan_cooling_layer_time": [

--- a/resources/profiles/OrcaFilamentLibrary/filament/base/fdm_filament_sbs.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/base/fdm_filament_sbs.json
@@ -4,7 +4,7 @@
     "inherits": "fdm_filament_common",
     "from": "system",
     "instantiation": "false",
-    "filament_id": "OGFLSBS99",
+    "filament_id": "OFLSBS99",
     "fan_cooling_layer_time": [
         "100"
     ],


### PR DESCRIPTION
When set certain filament in AMS slots, such as AliZ PETG-CF, the filament dropdown will reset to empty when you open the setting dialog again. This PR fixes this issue.