### PR TITLE
Improvements for Default color button in filament settings 

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1948,7 +1948,8 @@ void PrintConfigDef::init_fff_params()
 
     def           = this->add("default_filament_colour", coStrings);
     def->label    = L("Default color");
-    def->tooltip  = L("Default filament color");
+    def->tooltip  = L("Default filament color"
+                      "\nRight click to reset value to system default.");
     def->gui_type = ConfigOptionDef::GUIType::color;
     def->mode     = comAdvanced;
     def->set_default_value(new ConfigOptionStrings{""});

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -1861,11 +1861,15 @@ void ColourPicker::msw_rescale()
 
 void ColourPicker::sys_color_changed()
 {
-#ifdef _WIN32
-	if (wxWindow* win = this->getWindow())
-		if (wxColourPickerCtrl* picker = dynamic_cast<wxColourPickerCtrl*>(win))
-			wxGetApp().UpdateDarkUI(picker->GetPickerCtrl(), true);
-#endif
+    if (wxWindow* win = this->getWindow()){
+        if (wxColourPickerCtrl* picker = dynamic_cast<wxColourPickerCtrl*>(win)){
+            #ifdef _WIN32
+                wxGetApp().UpdateDarkUI(picker->GetPickerCtrl(), true);
+            #endif
+            draw_button(picker, picker->GetColour());
+        }
+    }
+
 }
 
 void ColourPicker::on_button_click(wxCommandEvent &event) {

--- a/src/slic3r/GUI/Field.hpp
+++ b/src/slic3r/GUI/Field.hpp
@@ -467,7 +467,7 @@ public:
 class ColourPicker : public Field {
 	using Field::Field;
 
-    void            set_undef_value(wxColourPickerCtrl* field);
+    void            draw_button(wxColourPickerCtrl* field, wxColour color);
 public:
 	ColourPicker(const ConfigOptionDef& opt, const t_config_option_key& id) : Field(opt, id) {}
 	ColourPicker(wxWindow* parent, const ConfigOptionDef& opt, const t_config_option_key& id) : Field(parent, opt, id) {}

--- a/src/slic3r/GUI/Field.hpp
+++ b/src/slic3r/GUI/Field.hpp
@@ -467,7 +467,8 @@ public:
 class ColourPicker : public Field {
 	using Field::Field;
 
-    void            draw_button(wxColourPickerCtrl* field, wxColour color);
+    void            set_undef_value(wxColourPickerCtrl* field);
+    void            draw_bmp_btn(wxColourPickerCtrl* field, wxColour color);
 public:
 	ColourPicker(const ConfigOptionDef& opt, const t_config_option_key& id) : Field(opt, id) {}
 	ColourPicker(wxWindow* parent, const ConfigOptionDef& opt, const t_config_option_key& id) : Field(parent, opt, id) {}


### PR DESCRIPTION
tested on windows 11

### CHANGES
• Matches width with other parameters on all platforms
• Adds a function for resetting value system default (no color / transparent) with right click
• Matches UI style of button on Windows
---- • Matched style with buttons and used "Pick ..." as label. used 3 dots because its opens a dialog like on other buttons
---- • Added support for focus border and hover effects

### COMPARISON (WINDOWS ONLY)
BEFORE-AFTER - No color chosen
![Screenshot-20250508210022](https://github.com/user-attachments/assets/d2e4c1c8-d179-41ae-89e4-8dbd0c44dbfb)
![Screenshot-20250508205957](https://github.com/user-attachments/assets/f9e001fe-92f2-4180-9a61-f6eaa93cca52)

BEFORE-AFTER - Color chosen
![Screenshot-20250508210033](https://github.com/user-attachments/assets/937601ff-de39-4d04-8bef-0ff287e6283a)
![Screenshot-20250508210048](https://github.com/user-attachments/assets/2c1d621d-d889-4d98-ace5-7c5c234c3de9)

