### PR TITLE
Organic tree support GUI fix

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -630,7 +630,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     toggle_line("bridge_no_support", !support_is_normal_tree);
 
     // This is only supported for auto normal tree
-    toggle_line("support_critical_regions_only", is_auto(support_type) && support_is_normal_tree);
+    toggle_line("support_critical_regions_only", is_auto(support_type) && support_is_tree);
 
     for (auto el : { "support_interface_spacing", "support_interface_filament",
         "support_interface_loop_pattern", "support_bottom_interface_spacing" })


### PR DESCRIPTION
# Description

This PR makes "Support critical regions only" parameter visible for all auto tree support styles. This parameter was hidden when "Organic" and "Default" style is used although this parameter's setting is taken into account for these styles also.

# Screenshots/Recordings/Graphs
![Critical OFF](https://github.com/user-attachments/assets/b57eb233-5989-409e-982b-144e6b1dbc7d)
![Critical ON](https://github.com/user-attachments/assets/e48a7a61-344b-4d1f-a30e-fbf9ae7f7c12)


