### PR TITLE
Fix new project crash on Windows if multi-extruder printer profile is edited

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -590,7 +590,7 @@ Slic3r::GUI::PageShp Tab::add_options_page(const wxString& title, const std::str
     }
     // Initialize the page.
     //BBS: GUI refactor
-    PageShp page(new Page(m_page_view, title, icon_idx, this));
+    PageShp page = std::make_shared<Page>(m_page_view, title, icon_idx, this);
 //	page->SetBackgroundStyle(wxBG_STYLE_SYSTEM);
 #ifdef __WINDOWS__
 //	page->SetDoubleBuffered(true);
@@ -6263,8 +6263,12 @@ void Page::update_visibility(ConfigOptionMode mode, bool update_contolls_visibil
 #ifdef __WXMSW__
     if (!m_show) return;
     // BBS: fix field control position
-    wxTheApp->CallAfter([this]() {
-        for (auto group : m_optgroups) {
+    wxTheApp->CallAfter([wp=std::weak_ptr<Page>(shared_from_this())]() {
+        auto page = wp.lock();
+        if (!page)
+            return;
+
+        for (auto group : page->m_optgroups) {
             if (group->custom_ctrl) group->custom_ctrl->fixup_items_positions();
         }
     });

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -57,7 +57,7 @@ class OG_CustomCtrl;
 // Single Tab page containing a{ vsizer } of{ optgroups }
 // package Slic3r::GUI::Tab::Page;
 using ConfigOptionsGroupShp = std::shared_ptr<ConfigOptionsGroup>;
-class Page// : public wxScrolledWindow
+class Page: public std::enable_shared_from_this<Page>// : public wxScrolledWindow
 {
 	//BBS: GUI refactor
 	wxPanel*		m_tab_owner;


### PR DESCRIPTION
Fix crash illustrated in following gif:

![crash_new_proj](https://github.com/user-attachments/assets/ebab5136-dfd2-434f-a9a8-4306d1511bcc)


This issue only happens that the project 3mf file, but not installed locally; Then when you new project, it will switch to a different printer profile that has only single extruder, which cause the extruder tabs been destroied, but the callback still holds an ref to the old tab, thus cause the crash.