### PR TITLE
Gizmo shortcuts

### DIFF
--- a/localization/i18n/OrcaSlicer.pot
+++ b/localization/i18n/OrcaSlicer.pot
@@ -8242,7 +8242,10 @@ msgstr ""
 msgid "Gizmo cut"
 msgstr ""
 
-msgid "Gizmo Place face on bed"
+msgid "Gizmo place face on bed"
+msgstr ""
+
+msgid "Gizmo mesh boolean"
 msgstr ""
 
 msgid "Gizmo SLA support points"
@@ -8251,7 +8254,16 @@ msgstr ""
 msgid "Gizmo FDM paint-on seam"
 msgstr ""
 
-msgid "Gizmo Text emboss / engrave"
+msgid "Gizmo text emboss/engrave"
+msgstr ""
+
+msgid "Gizmo measure"
+msgstr ""
+
+msgid "Gizmo assemble"
+msgstr ""
+
+msgid "Gizmo brim ears"
 msgstr ""
 
 msgid "Zoom in"

--- a/localization/i18n/ca/OrcaSlicer_ca.po
+++ b/localization/i18n/ca/OrcaSlicer_ca.po
@@ -9015,8 +9015,11 @@ msgstr "Gizmo de Rotació"
 msgid "Gizmo cut"
 msgstr "Gizmo de Tall"
 
-msgid "Gizmo Place face on bed"
-msgstr "Gizmo de Recolzament sobre la Cara a la placa"
+msgid "Gizmo place face on bed"
+msgstr "Gizmo de recolzament sobre la Cara a la placa"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo booleà de malla"
 
 msgid "Gizmo SLA support points"
 msgstr "Gizmo de Punts de suport SLA"
@@ -9024,8 +9027,17 @@ msgstr "Gizmo de Punts de suport SLA"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Eina de Pintat de costures FDM"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Gizmo de Text en relleu / gravat"
+msgid "Gizmo text emboss/engrave"
+msgstr "Gizmo de text en relleu/gravat"
+
+msgid "Gizmo measure"
+msgstr "Gizmo mesurar"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo ensamblar"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo orelles de la Vora d'Adherència"
 
 msgid "Zoom in"
 msgstr "Augmentar zoom"

--- a/localization/i18n/cs/OrcaSlicer_cs.po
+++ b/localization/i18n/cs/OrcaSlicer_cs.po
@@ -8733,8 +8733,11 @@ msgstr "Gizmo rotace"
 msgid "Gizmo cut"
 msgstr "Gizmo řez"
 
-msgid "Gizmo Place face on bed"
-msgstr "Gizmo Umístit plochou na podložku"
+msgid "Gizmo place face on bed"
+msgstr "Gizmo umístit plochou na podložku"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo booleovská síť"
 
 msgid "Gizmo SLA support points"
 msgstr "Gizmo SLA podpěrné body"
@@ -8742,8 +8745,17 @@ msgstr "Gizmo SLA podpěrné body"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Gizmo FDM malování pozice švu"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Gizmo Text emboss / gravírování"
+msgid "Gizmo text emboss/engrave"
+msgstr "Gizmo text emboss/gravírování"
+
+msgid "Gizmo measure"
+msgstr "Gizmo měření"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo sestavit"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo uši límce"
 
 msgid "Zoom in"
 msgstr "Přiblížit"
@@ -16780,10 +16792,10 @@ msgid "Set the brim type to \"painted\""
 msgstr ""
 
 msgid " invalid brim ears"
-msgstr ""
+msgstr " neplatný uši Límce"
 
 msgid "Brim Ears"
-msgstr ""
+msgstr "Uši Límce"
 
 msgid "Please select single object."
 msgstr ""

--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -104,7 +104,7 @@ msgid "Support Generated"
 msgstr "Support generiert"
 
 msgid "Gizmo-Place on Face"
-msgstr "Gizmo auf Fläche platzieren"
+msgstr "Gizmo-auf Fläche platzieren"
 
 msgid "Lay on face"
 msgstr "Auf Fläche legen"
@@ -9087,8 +9087,11 @@ msgstr "Rotieren"
 msgid "Gizmo cut"
 msgstr "Trennen"
 
-msgid "Gizmo Place face on bed"
-msgstr "Fläche auf Druckbett platzieren"
+msgid "Gizmo place face on bed"
+msgstr "Fläche auf druckbett platzieren"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo mesh-boolesche"
 
 msgid "Gizmo SLA support points"
 msgstr "SLA Stützpunkte"
@@ -9096,8 +9099,17 @@ msgstr "SLA Stützpunkte"
 msgid "Gizmo FDM paint-on seam"
 msgstr "FDM Naht aufmalen"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Text prägen / gravieren"
+msgid "Gizmo text emboss/engrave"
+msgstr "Text prägen/gravieren"
+
+msgid "Gizmo measure"
+msgstr "Gizmo messen"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo Zusammenbauen"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo mausohren"
 
 msgid "Zoom in"
 msgstr "Vergrößern"

--- a/localization/i18n/en/OrcaSlicer_en.po
+++ b/localization/i18n/en/OrcaSlicer_en.po
@@ -8477,7 +8477,10 @@ msgstr ""
 msgid "Gizmo cut"
 msgstr ""
 
-msgid "Gizmo Place face on bed"
+msgid "Gizmo place face on bed"
+msgstr ""
+
+msgid "Gizmo mesh boolean"
 msgstr ""
 
 msgid "Gizmo SLA support points"
@@ -8486,7 +8489,16 @@ msgstr ""
 msgid "Gizmo FDM paint-on seam"
 msgstr ""
 
-msgid "Gizmo Text emboss / engrave"
+msgid "Gizmo text emboss/engrave"
+msgstr ""
+
+msgid "Gizmo measure"
+msgstr ""
+
+msgid "Gizmo assemble"
+msgstr ""
+
+msgid "Gizmo brim ears"
 msgstr ""
 
 msgid "Zoom in"

--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -9034,8 +9034,11 @@ msgstr "Herramienta de rotación"
 msgid "Gizmo cut"
 msgstr "Herramienta de corte"
 
-msgid "Gizmo Place face on bed"
+msgid "Gizmo place face on bed"
 msgstr "Herramienta de situar cara en cama"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo buleana de malla"
 
 msgid "Gizmo SLA support points"
 msgstr "Herramienta de puntos de soporte SLA"
@@ -9043,8 +9046,17 @@ msgstr "Herramienta de puntos de soporte SLA"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Herramienta de pintado de costuras FDM"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Herramienta de Texto en relieve / grabado"
+msgid "Gizmo text emboss/engrave"
+msgstr "Herramienta de texto en relieve/grabado"
+
+msgid "Gizmo measure"
+msgstr "Gizmo medir"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo ensamblar"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo orejas de borde"
 
 msgid "Zoom in"
 msgstr "Acercar"
@@ -18103,10 +18115,10 @@ msgid "Set the brim type to \"painted\""
 msgstr ""
 
 msgid " invalid brim ears"
-msgstr ""
+msgstr " orejas de borde invalidos"
 
 msgid "Brim Ears"
-msgstr ""
+msgstr "Orejas de borde"
 
 msgid "Please select single object."
 msgstr ""

--- a/localization/i18n/fr/OrcaSlicer_fr.po
+++ b/localization/i18n/fr/OrcaSlicer_fr.po
@@ -9127,8 +9127,11 @@ msgstr "Gizmo pivoter"
 msgid "Gizmo cut"
 msgstr "Gizmo couper"
 
-msgid "Gizmo Place face on bed"
-msgstr "Gizmo Placer la face sur le plateau"
+msgid "Gizmo place face on bed"
+msgstr "Gizmo placer la face sur le plateau"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo booléennes"
 
 msgid "Gizmo SLA support points"
 msgstr "Gizmo Point de support SLA"
@@ -9136,8 +9139,17 @@ msgstr "Gizmo Point de support SLA"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Gizmo Peinture de la couture FDM"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Gizmo Embosser / graver du texte"
+msgid "Gizmo text emboss/engrave"
+msgstr "Gizmo embosser/graver du texte"
+
+msgid "Gizmo measure"
+msgstr "Gizmo mesurer"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo assembler"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo bordure à oreilles"
 
 msgid "Zoom in"
 msgstr "Zoom avant"

--- a/localization/i18n/hu/OrcaSlicer_hu.po
+++ b/localization/i18n/hu/OrcaSlicer_hu.po
@@ -100,7 +100,7 @@ msgid "Support Generated"
 msgstr "Támasz legenerálva"
 
 msgid "Gizmo-Place on Face"
-msgstr "Gizmo- Felület Tárgyasztalra Illesztése"
+msgstr "Gizmo-Felület Tárgyasztalra Illesztése"
 
 msgid "Lay on face"
 msgstr "Felületre fektetés"
@@ -181,13 +181,13 @@ msgid "Move"
 msgstr "Mozgatás"
 
 msgid "Gizmo-Move"
-msgstr "Gizmo-Mozgatása"
+msgstr "Gizmo-Mozgatás"
 
 msgid "Rotate"
 msgstr "Forgatás"
 
 msgid "Gizmo-Rotate"
-msgstr "Gizmo-Forgatása"
+msgstr "Gizmo-Forgatás"
 
 msgid "Optimize orientation"
 msgstr "Orientáció optimalizálása"
@@ -199,7 +199,7 @@ msgid "Scale"
 msgstr "Átméretezés"
 
 msgid "Gizmo-Scale"
-msgstr "Gizmo-Skála"
+msgstr "Gizmo-Átméretezés"
 
 msgid "Error: Please close all toolbar menus first"
 msgstr "Hiba: Kérjük, először zárd be az összes eszköztár menüt"
@@ -1193,7 +1193,7 @@ msgid "Lock/unlock the aspect ratio of the SVG."
 msgstr ""
 
 msgid "Reset scale"
-msgstr "Skála visszaállítása"
+msgstr "Méretezés visszaállítása"
 
 msgid "Distance of the center of the SVG to the model surface."
 msgstr ""
@@ -1286,7 +1286,7 @@ msgid "Cancel a feature until exit"
 msgstr ""
 
 msgid "Measure"
-msgstr ""
+msgstr "Mérés"
 
 msgid ""
 "Please confirm explosion ratio = 1,and please select at least one object"
@@ -1871,16 +1871,13 @@ msgid "Assemble the selected objects to an object with multiple parts"
 msgstr "Összeállítja a kijelölt objektumot egy több részből álló objektummá"
 
 msgid "Assemble the selected objects to an object with single part"
-msgstr ""
-"Összeállítja a kijelölt objektumokat egy egyetlen részből álló objektummá"
+msgstr "Összeállítja a kijelölt objektumokat egy egyetlen részből álló objektummá"
 
 msgid "Mesh boolean"
-msgstr "Mesh boolean"
+msgstr "Modellháló logikai műveletek"
 
 msgid "Mesh boolean operations including union and subtraction"
-msgstr ""
-"Olyan modellhálóval kapcsolatos logikai műveletek, mint például az egyesítés "
-"és kivonás"
+msgstr "Modellhálóval kapcsolatos logikai műveletek, mint például az egyesítés és kivonás"
 
 msgid "Along X axis"
 msgstr "X-tengely mentén"
@@ -2061,9 +2058,7 @@ msgid "Click the icon to reset all settings of the object"
 msgstr "Kattints az ikonra az objektum összes beállításának visszaállításához"
 
 msgid "Right button click the icon to drop the object printable property"
-msgstr ""
-"Kattints jobb gombbal az ikonra az objektum nyomtatható tulajdonságának "
-"elvetéséhez"
+msgstr "Kattints jobb gombbal az ikonra az objektum nyomtatható tulajdonságának elvetéséhez"
 
 msgid "Click the icon to toggle printable property of the object"
 msgstr ""
@@ -2094,9 +2089,7 @@ msgid "Add Modifier"
 msgstr "Módosító hozzáadása"
 
 msgid "Switch to per-object setting mode to edit modifier settings."
-msgstr ""
-"Válts át objektumonkénti beállítási módba a módosító beállításainak "
-"szerkesztéséhez."
+msgstr "Válts át objektumonkénti beállítási módba a módosító beállításainak szerkesztéséhez."
 
 msgid ""
 "Switch to per-object setting mode to edit process settings of selected "
@@ -8649,28 +8642,40 @@ msgid "Select all objects"
 msgstr "Összes objektum kijelölése"
 
 msgid "Gizmo move"
-msgstr ""
+msgstr "Gizmo mozgatás"
 
 msgid "Gizmo scale"
-msgstr ""
+msgstr "Gizmo átméretezés"
 
 msgid "Gizmo rotate"
-msgstr ""
+msgstr "Gizmo forgatás"
 
 msgid "Gizmo cut"
-msgstr ""
+msgstr "Gizmo vágás"
 
-msgid "Gizmo Place face on bed"
-msgstr ""
+msgid "Gizmo place face on bed"
+msgstr "Gizmo felület tárgyasztalra illesztése"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo modellháló logikai műveletek"
 
 msgid "Gizmo SLA support points"
-msgstr ""
+msgstr "Gizmo SLA támaszpontok"
 
 msgid "Gizmo FDM paint-on seam"
-msgstr ""
+msgstr "Gizmo FDM varrat festés"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr ""
+msgid "Gizmo text emboss/engrave"
+msgstr "Gizmo szöveg dombornyomás/gravírozás"
+
+msgid "Gizmo measure"
+msgstr "Gizmo mérés"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo összeállítás"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo karimás fülek"
 
 msgid "Zoom in"
 msgstr "Zoom közelítés"
@@ -8679,7 +8684,7 @@ msgid "Zoom out"
 msgstr "Zoom távolítás"
 
 msgid "Switch between Prepare/Preview"
-msgstr ""
+msgstr "Váltás előkészítés/előnézet között"
 
 msgid "Plater"
 msgstr ""
@@ -10177,7 +10182,7 @@ msgstr ""
 "eltávolítását"
 
 msgid "Brim ears"
-msgstr ""
+msgstr "Karimás fülek"
 
 msgid "Only draw brim over the sharp edges of the model."
 msgstr ""
@@ -15471,7 +15476,7 @@ msgid "Unable to perform boolean operation on selected parts"
 msgstr "Nem lehet logikai műveletet végrehajtani a kiválasztott tárgyakon"
 
 msgid "Mesh Boolean"
-msgstr "Mesh Boolean"
+msgstr "Modellháló logikai műveletek"
 
 msgid "Union"
 msgstr "Egyesítés"
@@ -16502,10 +16507,10 @@ msgid "Set the brim type to \"painted\""
 msgstr ""
 
 msgid " invalid brim ears"
-msgstr ""
+msgstr " érvénytelen karimás fülek"
 
 msgid "Brim Ears"
-msgstr ""
+msgstr "Karimás Fülek"
 
 msgid "Please select single object."
 msgstr ""

--- a/localization/i18n/it/OrcaSlicer_it.po
+++ b/localization/i18n/it/OrcaSlicer_it.po
@@ -9061,8 +9061,11 @@ msgstr "Strumento Ruota"
 msgid "Gizmo cut"
 msgstr "Strumento Taglia"
 
-msgid "Gizmo Place face on bed"
-msgstr "Strumento Posiziona faccia sul piatto"
+msgid "Gizmo place face on bed"
+msgstr "Strumento posiziona faccia sul piatto"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo maglia booleana"
 
 msgid "Gizmo SLA support points"
 msgstr "Strumento Punti di supporto SLA"
@@ -9070,8 +9073,17 @@ msgstr "Strumento Punti di supporto SLA"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Strumento Dipingi cucitura FDM"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Strumento Testo in rilievo / incisione"
+msgid "Gizmo text emboss/engrave"
+msgstr "Strumento testo in rilievo/incisione"
+
+msgid "Gizmo measure"
+msgstr "Gizmo misura"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo assemblaggio"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo tese ad orecchio"
 
 msgid "Zoom in"
 msgstr "Ingrandisci"

--- a/localization/i18n/ja/OrcaSlicer_ja.po
+++ b/localization/i18n/ja/OrcaSlicer_ja.po
@@ -1889,10 +1889,10 @@ msgid "Assemble the selected objects to an object with single part"
 msgstr "選択したオブジェクトを一つオブジェクトに組み立てます（単パーツ）"
 
 msgid "Mesh boolean"
-msgstr ""
+msgstr "メッシュブール"
 
 msgid "Mesh boolean operations including union and subtraction"
-msgstr ""
+msgstr "結合や減算などのメッシュのブール演算"
 
 msgid "Along X axis"
 msgstr "X軸方向"
@@ -8439,8 +8439,11 @@ msgstr "回転"
 msgid "Gizmo cut"
 msgstr "カット"
 
-msgid "Gizmo Place face on bed"
+msgid "Gizmo place face on bed"
 msgstr "底面選択"
+
+msgid "Gizmo mesh boolean"
+msgstr "メッシュブール"
 
 msgid "Gizmo SLA support points"
 msgstr "SLAサポートポイント"
@@ -8448,8 +8451,17 @@ msgstr "SLAサポートポイント"
 msgid "Gizmo FDM paint-on seam"
 msgstr "継ぎ目ペイント"
 
-msgid "Gizmo Text emboss / engrave"
+msgid "Gizmo text emboss/engrave"
 msgstr "ギズモ・テキストのエンボス/エングレーブ"
+
+msgid "Gizmo measure"
+msgstr "測る"
+
+msgid "Gizmo assemble"
+msgstr "組立てる"
+
+msgid "Gizmo brim ears"
+msgstr "ブリム"
 
 msgid "Zoom in"
 msgstr "ズームイン"
@@ -15089,7 +15101,7 @@ msgid "Unable to perform boolean operation on selected parts"
 msgstr ""
 
 msgid "Mesh Boolean"
-msgstr ""
+msgstr "メッシュブール"
 
 msgid "Union"
 msgstr ""

--- a/localization/i18n/ko/OrcaSlicer_ko.po
+++ b/localization/i18n/ko/OrcaSlicer_ko.po
@@ -8731,8 +8731,11 @@ msgstr "변형도구 회전"
 msgid "Gizmo cut"
 msgstr "변형도구 잘라내기"
 
-msgid "Gizmo Place face on bed"
+msgid "Gizmo place face on bed"
 msgstr "변형도구 바닥면 선택"
+
+msgid "Gizmo mesh boolean"
+msgstr "변형도구 합집합/차집합/교집합"
 
 msgid "Gizmo SLA support points"
 msgstr "변형도구 서포트 칠하기"
@@ -8740,8 +8743,17 @@ msgstr "변형도구 서포트 칠하기"
 msgid "Gizmo FDM paint-on seam"
 msgstr "변형도구 재봉선 칠하기"
 
-msgid "Gizmo Text emboss / engrave"
+msgid "Gizmo text emboss/engrave"
 msgstr "변형도구 - 텍스트 엠보싱/인그레이빙"
+
+msgid "Gizmo measure"
+msgstr "변형도구 측정"
+
+msgid "Gizmo assemble"
+msgstr "변형도구 병합"
+
+msgid "Gizmo brim ears"
+msgstr "변형도구 브림 귀"
 
 msgid "Zoom in"
 msgstr "확대"

--- a/localization/i18n/lt/OrcaSlicer_lt.po
+++ b/localization/i18n/lt/OrcaSlicer_lt.po
@@ -8985,8 +8985,11 @@ msgstr "Gizmo pasukimas"
 msgid "Gizmo cut"
 msgstr "Gizmo pjaustymui"
 
-msgid "Gizmo Place face on bed"
-msgstr "Gizmo Padėti paviršių ant pagrindo"
+msgid "Gizmo place face on bed"
+msgstr "Gizmo padėti paviršių ant pagrindo"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo objektų jungimo/atėmimo/susikirtimo įrankiai"
 
 msgid "Gizmo SLA support points"
 msgstr "Gizmo SLA atramų taškai"
@@ -8994,8 +8997,17 @@ msgstr "Gizmo SLA atramų taškai"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Gizmo FDM siūlių piešimui"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "\"Gizmo\" teksto įspaudimas / graviravimas"
+msgid "Gizmo text emboss/engrave"
+msgstr "Gizmo teksto įspaudimas/graviravimas"
+
+msgid "Gizmo measure"
+msgstr "Gizmo matuoti"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo surinkimo"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo krašto \"ausys\""
 
 msgid "Zoom in"
 msgstr "Padidinti"

--- a/localization/i18n/nl/OrcaSlicer_nl.po
+++ b/localization/i18n/nl/OrcaSlicer_nl.po
@@ -8798,8 +8798,11 @@ msgstr "Gizmo roteren"
 msgid "Gizmo cut"
 msgstr "Gizmo snijden"
 
-msgid "Gizmo Place face on bed"
-msgstr "Gizmo Plaats gebied op het bed"
+msgid "Gizmo place face on bed"
+msgstr "Gizmo plaats gebied op het bed"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo mesh booleaan"
 
 msgid "Gizmo SLA support points"
 msgstr "Gizmo SLA-ondersteuningspunten"
@@ -8807,8 +8810,17 @@ msgstr "Gizmo SLA-ondersteuningspunten"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Gizmo FDM seam schilderen"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr ""
+msgid "Gizmo text emboss/engrave"
+msgstr "Gizmo tekst reliëf/graveren"
+
+msgid "Gizmo measure"
+msgstr "Gizmo maatregel"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo monteren"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo rand oren"
 
 msgid "Zoom in"
 msgstr "Zoom in"
@@ -10330,7 +10342,7 @@ msgstr ""
 "ervoor dat het object eenvoudiger van het printbed kan worden verwijderd."
 
 msgid "Brim ears"
-msgstr ""
+msgstr "Rand oren"
 
 msgid "Only draw brim over the sharp edges of the model."
 msgstr ""
@@ -16761,10 +16773,10 @@ msgid "Set the brim type to \"painted\""
 msgstr ""
 
 msgid " invalid brim ears"
-msgstr ""
+msgstr " ongeldige rand oren"
 
 msgid "Brim Ears"
-msgstr ""
+msgstr "Rand Oren"
 
 msgid "Please select single object."
 msgstr "Selecteer een enkel object."

--- a/localization/i18n/pl/OrcaSlicer_pl.po
+++ b/localization/i18n/pl/OrcaSlicer_pl.po
@@ -8975,8 +8975,11 @@ msgstr "Obracanie za pomocą „uchwytów”"
 msgid "Gizmo cut"
 msgstr "Cięcie za pomocą „uchwytów”"
 
-msgid "Gizmo Place face on bed"
+msgid "Gizmo place face on bed"
 msgstr "Położenie na płaszczyźnie za pomocą „uchwytów”"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo operacje boolowskie na siatce"
 
 msgid "Gizmo SLA support points"
 msgstr "Punkty podpór SLA za pomocą „uchwytów”"
@@ -8984,8 +8987,17 @@ msgstr "Punkty podpór SLA za pomocą „uchwytów”"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Uchwyt malowania szwu FDM"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Uchwyt wytłaczania / grawerowania tekstu"
+msgid "Gizmo text emboss/engrave"
+msgstr "Uchwyt wytłaczania/grawerowania tekstu"
+
+msgid "Gizmo measure"
+msgstr "Gizmo mierzyć"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo montować"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo uszy brim"
 
 msgid "Zoom in"
 msgstr "Przybliżenie"

--- a/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
+++ b/localization/i18n/pt_BR/OrcaSlicer_pt_BR.po
@@ -9004,8 +9004,11 @@ msgstr "Rotacionar gizmo"
 msgid "Gizmo cut"
 msgstr "Cortar gizmo"
 
-msgid "Gizmo Place face on bed"
+msgid "Gizmo place face on bed"
 msgstr "Posicionar face do gizmo na mesa"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo malha booleana"
 
 msgid "Gizmo SLA support points"
 msgstr "Pontos de suporte SLA do gizmo"
@@ -9013,8 +9016,17 @@ msgstr "Pontos de suporte SLA do gizmo"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Costura de pintura FDM do gizmo"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Texturizar / gravar texto no gizmo"
+msgid "Gizmo text emboss/engrave"
+msgstr "Texturizar/gravar texto no gizmo"
+
+msgid "Gizmo measure"
+msgstr "Gizmo medir"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo montar"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo orelhas da borda"
 
 msgid "Zoom in"
 msgstr "Dar zoom"

--- a/localization/i18n/ru/OrcaSlicer_ru.po
+++ b/localization/i18n/ru/OrcaSlicer_ru.po
@@ -9117,8 +9117,11 @@ msgstr "Гизмо вращения"
 msgid "Gizmo cut"
 msgstr "Гизмо разреза"
 
-msgid "Gizmo Place face on bed"
+msgid "Gizmo place face on bed"
 msgstr "Гизмо поверхностью на стол"
+
+msgid "Gizmo mesh boolean"
+msgstr "Гизмо Булевы операции"
 
 msgid "Gizmo SLA support points"
 msgstr "Гизмо точки SLA поддержки"
@@ -9126,8 +9129,17 @@ msgstr "Гизмо точки SLA поддержки"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Гизмо рисования шва (FDM)"
 
-msgid "Gizmo Text emboss / engrave"
+msgid "Gizmo text emboss/engrave"
 msgstr "Гизмо рельефного/выгравированного текста"
+
+msgid "Gizmo measure"
+msgstr "Гизмо измерения"
+
+msgid "Gizmo assemble"
+msgstr "Гизмо собрать"
+
+msgid "Gizmo brim ears"
+msgstr "Гизмо уши границы"
 
 msgid "Zoom in"
 msgstr "Приблизить"
@@ -15807,7 +15819,7 @@ msgstr "Минимальное сохранение"
 msgid "export 3mf with minimum size."
 msgstr "экспорт 3mf файла с минимальным размером."
 
-# мктс, Макс. кол. треугольников на столе 
+# мктс, Макс. кол. треугольников на столе
 msgid "mtcpp"
 msgstr "mtcpp"
 

--- a/localization/i18n/sv/OrcaSlicer_sv.po
+++ b/localization/i18n/sv/OrcaSlicer_sv.po
@@ -8649,8 +8649,11 @@ msgstr "Gizmo rotera"
 msgid "Gizmo cut"
 msgstr "Gizmo skär"
 
-msgid "Gizmo Place face on bed"
-msgstr "Gizmo Placera ansiktet på byggytan"
+msgid "Gizmo place face on bed"
+msgstr "Gizmo placera ansiktet på byggytan"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo mesh boolean"
 
 msgid "Gizmo SLA support points"
 msgstr "Gizmo SLA support punkter"
@@ -8658,17 +8661,26 @@ msgstr "Gizmo SLA support punkter"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Gizmo FDM målad söm"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr ""
+msgid "Gizmo text emboss/engrave"
+msgstr "Gizmo textprägling/gravering"
+
+msgid "Gizmo measure"
+msgstr "Gizmo mäta"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo montera"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo brätte öron"
 
 msgid "Zoom in"
-msgstr ""
+msgstr "Zooma in"
 
 msgid "Zoom out"
-msgstr ""
+msgstr "Zooma ut"
 
 msgid "Switch between Prepare/Preview"
-msgstr ""
+msgstr "Växla mellan Förbered/Förhandsgranska"
 
 msgid "Plater"
 msgstr "Plätering/Förgyllning"
@@ -10133,7 +10145,7 @@ msgstr ""
 "borttagande av brim"
 
 msgid "Brim ears"
-msgstr ""
+msgstr "Brätte öron"
 
 msgid "Only draw brim over the sharp edges of the model."
 msgstr ""
@@ -16400,10 +16412,10 @@ msgid "Set the brim type to \"painted\""
 msgstr ""
 
 msgid " invalid brim ears"
-msgstr ""
+msgstr " ogiltiga öron"
 
 msgid "Brim Ears"
-msgstr ""
+msgstr "Brätte Öron"
 
 msgid "Please select single object."
 msgstr ""

--- a/localization/i18n/tr/OrcaSlicer_tr.po
+++ b/localization/i18n/tr/OrcaSlicer_tr.po
@@ -8915,8 +8915,11 @@ msgstr "Gizmo döndürme"
 msgid "Gizmo cut"
 msgstr "Gizmo kesim"
 
-msgid "Gizmo Place face on bed"
-msgstr "Gizmo Yüzünüzü yatağa yerleştirin"
+msgid "Gizmo place face on bed"
+msgstr "Gizmo yüzünüzü yatağa yerleştirin"
+
+msgid "Gizmo mesh boolean"
+msgstr "Gizmo mesh bölme"
 
 msgid "Gizmo SLA support points"
 msgstr "Gizmo SLA destek noktaları"
@@ -8924,8 +8927,17 @@ msgstr "Gizmo SLA destek noktaları"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Gizmo FDM boyalı dikiş"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Gizmo Metin kabartma / kazıma"
+msgid "Gizmo text emboss/engrave"
+msgstr "Gizmo metin kabartma/kazıma"
+
+msgid "Gizmo measure"
+msgstr "Gizmo ölçüm"
+
+msgid "Gizmo assemble"
+msgstr "Gizmo birleştir"
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo "
 
 msgid "Zoom in"
 msgstr "Yakınlaştır"
@@ -16803,7 +16815,7 @@ msgid "Unable to perform boolean operation on selected parts"
 msgstr "Seçilen parçalarda bölme işlemi gerçekleştirilemiyor"
 
 msgid "Mesh Boolean"
-msgstr "Mesh Boolean"
+msgstr "Mesh Bölme"
 
 msgid "Union"
 msgstr "Union"

--- a/localization/i18n/uk/OrcaSlicer_uk.po
+++ b/localization/i18n/uk/OrcaSlicer_uk.po
@@ -8999,8 +8999,11 @@ msgstr "Поворот Gizmo"
 msgid "Gizmo cut"
 msgstr "Виріз Gizmo"
 
-msgid "Gizmo Place face on bed"
-msgstr "Gizmo Покласти грань на стіл"
+msgid "Gizmo place face on bed"
+msgstr "Покласти грань на стіл Gizmo"
+
+msgid "Gizmo mesh boolean"
+msgstr "Булеві операції Gizmo"
 
 msgid "Gizmo SLA support points"
 msgstr "Точки підтримки Gizmo SL"
@@ -9008,8 +9011,17 @@ msgstr "Точки підтримки Gizmo SL"
 msgid "Gizmo FDM paint-on seam"
 msgstr "Швид, що фарбується Gizmo FDM"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Gizmo Текстове тиснення / гравіювання"
+msgid "Gizmo text emboss/engrave"
+msgstr "Текстове тиснення/гравіювання Gizmo"
+
+msgid "Gizmo measure"
+msgstr "виміряти Gizmo"
+
+msgid "Gizmo assemble"
+msgstr "Зібрати Gizmo"
+
+msgid "Gizmo brim ears"
+msgstr "Краєчки Gizmo"
 
 msgid "Zoom in"
 msgstr "Приблизити"

--- a/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
+++ b/localization/i18n/zh_CN/OrcaSlicer_zh_CN.po
@@ -8504,8 +8504,11 @@ msgstr "旋转物件"
 msgid "Gizmo cut"
 msgstr "剪切物件"
 
-msgid "Gizmo Place face on bed"
+msgid "Gizmo place face on bed"
 msgstr "选择底面"
+
+msgid "Gizmo mesh boolean"
+msgstr "线框网格布尔操作"
 
 msgid "Gizmo SLA support points"
 msgstr "SLA支撑点"
@@ -8513,8 +8516,17 @@ msgstr "SLA支撑点"
 msgid "Gizmo FDM paint-on seam"
 msgstr "FDM涂装接缝"
 
-msgid "Gizmo Text emboss / engrave"
-msgstr "Gizmo文本浮雕/雕刻"
+msgid "Gizmo text emboss/engrave"
+msgstr "线框文本浮雕/雕刻"
+
+msgid "Gizmo measure"
+msgstr "线框测量"
+
+msgid "Gizmo assemble"
+msgstr "线框组合"
+
+msgid "Gizmo brim ears"
+msgstr "线框耳状帽檐"
 
 msgid "Zoom in"
 msgstr "放大"
@@ -16389,10 +16401,10 @@ msgid "Set the brim type to \"painted\""
 msgstr "将Brim类型设置为绘制模式"
 
 msgid " invalid brim ears"
-msgstr "个无效耳状Brim"
+msgstr "个无效耳状帽檐"
 
 msgid "Brim Ears"
-msgstr "耳状Brim"
+msgstr "耳状帽檐"
 
 msgid "Please select single object."
 msgstr "请选中单个对象。"

--- a/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
+++ b/localization/i18n/zh_TW/OrcaSlicer_zh_TW.po
@@ -8547,8 +8547,11 @@ msgstr "旋轉物件"
 msgid "Gizmo cut"
 msgstr "切割物件"
 
-msgid "Gizmo Place face on bed"
+msgid "Gizmo place face on bed"
 msgstr "選擇底面"
+
+msgid "Gizmo mesh boolean"
+msgstr "線框網格布林運算"
 
 msgid "Gizmo SLA support points"
 msgstr "SLA 支撐點"
@@ -8556,8 +8559,17 @@ msgstr "SLA 支撐點"
 msgid "Gizmo FDM paint-on seam"
 msgstr "FDM 塗裝接縫"
 
-msgid "Gizmo Text emboss / engrave"
+msgid "Gizmo text emboss/engrave"
 msgstr "浮雕/雕刻文字工具"
+
+msgid "Gizmo measure"
+msgstr "Gizmo "
+
+msgid "Gizmo assemble"
+msgstr "Gizmo "
+
+msgid "Gizmo brim ears"
+msgstr "Gizmo "
 
 msgid "Zoom in"
 msgstr "放大"

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -628,8 +628,6 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     // non-organic tree support use max_bridge_length instead of bridge_no_support
     toggle_line("max_bridge_length", support_is_normal_tree);
     toggle_line("bridge_no_support", !support_is_normal_tree);
-
-    // This is only supported for auto normal tree
     toggle_line("support_critical_regions_only", is_auto(support_type) && support_is_tree);
 
     for (auto el : { "support_interface_spacing", "support_interface_filament",

--- a/src/slic3r/GUI/Gizmos/GLGizmoAssembly.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAssembly.cpp
@@ -41,6 +41,12 @@ std::string GLGizmoAssembly::on_get_name() const
     }
 }
 
+bool GLGizmoAssembly::on_init()
+{
+    m_shortcut_key = WXK_CONTROL_Y;
+    return true;
+}
+
 bool GLGizmoAssembly::on_is_activable() const
 {
     const Selection& selection = m_parent.get_selection();

--- a/src/slic3r/GUI/Gizmos/GLGizmoAssembly.hpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoAssembly.hpp
@@ -24,7 +24,7 @@ public:
     std::string get_gizmo_entering_text() const override { return _u8L("Entering Assembly gizmo"); }
     std::string get_gizmo_leaving_text() const override { return _u8L("Leaving Assembly gizmo"); }
 protected:
-    //bool on_init() override;
+    bool on_init() override;
     std::string on_get_name() const override;
     bool on_is_activable() const override;
     //void on_render() override;

--- a/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoBrimEars.cpp
@@ -42,8 +42,8 @@ bool GLGizmoBrimEars::on_init()
 {
 
     m_new_point_head_diameter = get_brim_default_radius();
-    
-    m_shortcut_key = WXK_CONTROL_L;
+
+    m_shortcut_key = WXK_CONTROL_E;
 
     m_desc["head_diameter"]    = _L("Head diameter");
     m_desc["max_angle"]        = _L("Max angle");
@@ -168,10 +168,10 @@ void GLGizmoBrimEars::render_points(const Selection &selection)
 
         double radius = (double) brim_point.head_front_radius * RenderPointScale;
         const Transform3d center_matrix =
-            instance_matrix 
-            * Geometry::translation_transform(brim_point.pos.cast<double>()) 
+            instance_matrix
+            * Geometry::translation_transform(brim_point.pos.cast<double>())
             // Inverse matrix of the instance scaling is applied so that the mark does not scale with the object.
-            * instance_scaling_matrix_inverse 
+            * instance_scaling_matrix_inverse
             * q
             * Geometry::scale_transform(Vec3d{radius, radius, .2});
         if (i < m_grabbers.size()) {
@@ -278,7 +278,7 @@ bool GLGizmoBrimEars::on_mouse(const wxMouseEvent& mouse_event)
     if (mouse_event.Moving()) {
         gizmo_event(SLAGizmoEventType::Moving, mouse_pos, mouse_event.ShiftDown(), mouse_event.AltDown(), false);
     }
-    
+
     // when control is down we allow scene pan and rotation even when clicking
     // over some object
     bool control_down           = mouse_event.CmdDown();
@@ -287,14 +287,14 @@ bool GLGizmoBrimEars::on_mouse(const wxMouseEvent& mouse_event)
     const Selection &selection = m_parent.get_selection();
     int selected_object_idx = selection.get_object_idx();
     if (mouse_event.LeftDown()) {
-        if ((!control_down || grabber_contains_mouse) &&            
+        if ((!control_down || grabber_contains_mouse) &&
             gizmo_event(SLAGizmoEventType::LeftDown, mouse_pos, mouse_event.ShiftDown(), mouse_event.AltDown(), false))
             // the gizmo got the event and took some action, there is no need
             // to do anything more
             return true;
     } else if (mouse_event.RightDown()){
         if (!control_down && selected_object_idx != -1 &&
-            gizmo_event(SLAGizmoEventType::RightDown, mouse_pos, false, false, false)) 
+            gizmo_event(SLAGizmoEventType::RightDown, mouse_pos, false, false, false))
             // event was taken care of
             return true;
     } else if (mouse_event.Dragging()) {

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -201,7 +201,7 @@ void KBShortcutsDialog::fill_shortcuts()
 #else
             { ctrl + "M", L("Show/Hide 3Dconnexion devices settings dialog") },
 #endif // __APPLE
-            
+
             // Switch table page
             { ctrl + "Tab", L("Switch table page")},
             //DEL
@@ -257,15 +257,19 @@ void KBShortcutsDialog::fill_shortcuts()
             {ctrl + "Z", L("Undo")},
             {ctrl + "Y", L("Redo")},
             { "M", L("Gizmo move") },
-            { "S", L("Gizmo scale") },
             { "R", L("Gizmo rotate") },
+            { "S", L("Gizmo scale") },
+            { "F", L("Gizmo place face on bed") },
             { "C", L("Gizmo cut") },
-            { "F", L("Gizmo Place face on bed") },
+            { "B", L("Gizmo mesh boolean") },
             { "L", L("Gizmo SLA support points") },
             { "P", L("Gizmo FDM paint-on seam") },
-            { "T", L("Gizmo Text emboss / engrave")},
-            { "I", L("Zoom in")},
-            { "O", L("Zoom out")},
+            { "T", L("Gizmo text emboss/engrave") },
+            { "U", L("Gizmo measure") },
+            { "Y", L("Gizmo assemble") },
+            { "E", L("Gizmo brim ears") },
+            { "I", L("Zoom in") },
+            { "O", L("Zoom out") },
             { "Tab", L("Switch between Prepare/Preview") },
 
         };


### PR DESCRIPTION
# Description

This PR is a work on gizmo shortcuts:
- assigned a shortcut to "Assemble" gizmo (it displayed whatever shortcut was assigned to "Measure")
- changed "Brim Ears" shortcut to "E" (previously it was "L" which collided with "Support Painting")
- updated the list of shortcuts for "Prepare" tab (missing and new shortcuts added)
- updated translation files for the changed/added text (on some files a little more)

Fixes #9476

It is also a follow-up for PR #9587 (deletes an invalid comment - too small of a change for a separate PR)

# Screenshots/Recordings/Graphs

Assemble gizmo before and after:
![{8FEA2EBD-71BA-4526-8C33-F74B8378B5D5}](https://github.com/user-attachments/assets/4679d47b-c768-469b-8779-d39d0699c961) ![{582B776F-749B-48A5-A7F0-E2E9BF206F81}](https://github.com/user-attachments/assets/2867cf0f-3ec7-4d8e-a12c-e8b7279ffc5f)


Brim Ears gizmo before and after:
![{1AFF2FF8-DA5E-4125-ABFF-CD372B564B33}](https://github.com/user-attachments/assets/43126d9a-355e-4308-b379-7fb4a4389bfb) ![{E4A12FAF-1B95-4D12-AAEB-7A6A93307646}](https://github.com/user-attachments/assets/599ea080-25e0-4a16-85a1-a752fad1dd74)

List of shortcuts before and after:
![{5925041C-B105-4AFE-B780-9455F378DBCD}](https://github.com/user-attachments/assets/9a353e30-2837-41f9-840d-d24f8316a542) ![{299E2C0F-FCD3-4B27-BB62-49E2E858EBA5}](https://github.com/user-attachments/assets/1b0e2ecd-2fb9-4aa7-868a-756d33d5bfdc)





