### PR TITLE
Fix building with cmake 4.x on Arch

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -92,6 +92,8 @@ if [ "${DISTRIBUTION}" == "ubuntu" ] || [ "${DISTRIBUTION}" == "linuxmint" ]; th
 # Check if distribution is Debian/Ubuntu-like based on ID_LIKE
 elif [[ "${DISTRIBUTION_LIKE}" == *"debian"* ]] || [[ "${DISTRIBUTION_LIKE}" == *"ubuntu"* ]]; then
     DISTRIBUTION="debian"
+elif [[ "${DISTRIBUTION_LIKE}" == *"arch"* ]]; then
+    DISTRIBUTION="arch"
 fi
 if [ ! -f ./linux.d/${DISTRIBUTION} ]
 then

--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -84,6 +84,10 @@ then
     exit 0
 fi
 
+
+# cmake 4.x compatibility workaround
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 DISTRIBUTION=$(awk -F= '/^ID=/ {print $2}' /etc/os-release | tr -d '"')
 DISTRIBUTION_LIKE=$(awk -F= '/^ID_LIKE=/ {print $2}' /etc/os-release | tr -d '"')
 # Check for direct distribution match to Ubuntu/Debian

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 
-# Verify that your CMake version is exactly 3.13.x or newer
-if(${CMAKE_VERSION} VERSION_LESS "3.13")
-    message(FATAL_ERROR "Only CMake versions >= 3.13.x are supported. Detected version: ${CMAKE_VERSION}")
-endif()
-
 # Verify that your CMake version is exactly 3.31.x series or lower on windows
-if ((MSVC) OR (WIN32))
-    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "4.0")
-        message(FATAL_ERROR "Only CMake versions between 3.13.x and 3.31.x is supported on windows. Detected version: ${CMAKE_VERSION}")
-    endif()
+if ( ((MSVC) OR (WIN32)) AND (${CMAKE_VERSION} VERSION_GREATER_EQUAL "4.0") )
+    message(FATAL_ERROR "Only cmake versions between 3.13.x and 3.31.x is supported on windows. Detected version: ${CMAKE_VERSION}")
 endif()
 
 if (WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,15 @@
 cmake_minimum_required(VERSION 3.13)
 
+# Verify that your CMake version is exactly 3.13.x or newer
+if(${CMAKE_VERSION} VERSION_LESS "3.13")
+    message(FATAL_ERROR "Only CMake versions >= 3.13.x are supported. Detected version: ${CMAKE_VERSION}")
+endif()
+
 # Verify that your CMake version is exactly 3.31.x series or lower on windows
-if(${CMAKE_VERSION} VERSION_LESS "3.13" OR ${CMAKE_VERSION} VERSION_GREATER_EQUAL "4.0")
-    message(FATAL_ERROR "Only CMake versions between 3.13.x and 3.31.x is supported. Detected version: ${CMAKE_VERSION}")
+if ((MSVC) OR (WIN32))
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "4.0")
+        message(FATAL_ERROR "Only CMake versions between 3.13.x and 3.31.x is supported on windows. Detected version: ${CMAKE_VERSION}")
+    endif()
 endif()
 
 if (WIN32)
@@ -44,7 +51,7 @@ You can do this in Environment Variables settings.
         endif()
     endif()
 endif ()
-    
+
 if (APPLE)
     # if CMAKE_OSX_DEPLOYMENT_TARGET is not set, set it to 11.3
     if (NOT CMAKE_OSX_DEPLOYMENT_TARGET)
@@ -354,7 +361,7 @@ if (NOT MSVC AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMP
         add_compile_options(-Wno-unknown-pragmas)
     endif()
 
-    # Bit of a hack for flatpak building: compress the debug info with zstd to save space in CI 
+    # Bit of a hack for flatpak building: compress the debug info with zstd to save space in CI
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13.0)
         add_compile_options(-gz=zstd)
     endif()
@@ -492,7 +499,7 @@ endif()
 function(slic3r_remap_configs targets from_Cfg to_Cfg)
     if(MSVC)
         string(TOUPPER ${from_Cfg} from_CFG)
-    
+
         foreach(tgt ${targets})
             if(TARGET ${tgt})
                 set_target_properties(${tgt} PROPERTIES MAP_IMPORTED_CONFIG_${from_CFG} ${to_Cfg})
@@ -619,7 +626,7 @@ add_custom_target(gettext_make_pot
     COMMAND xgettext --keyword=L --keyword=_L --keyword=_u8L --keyword=L_CONTEXT:1,2c --keyword=_L_PLURAL:1,2 --add-comments=TRN --from-code=UTF-8 --no-location --debug --boost
         -f "${BBL_L18N_DIR}/list.txt"
         -o "${BBL_L18N_DIR}/OrcaSlicer.pot"
-	COMMAND hintsToPot ${SLIC3R_RESOURCES_DIR} ${BBL_L18N_DIR}	
+	COMMAND hintsToPot ${SLIC3R_RESOURCES_DIR} ${BBL_L18N_DIR}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     COMMENT "Generate pot file from strings in the source tree"
 )
@@ -779,7 +786,7 @@ function(orcaslicer_copy_dlls target config postfix output_dlls)
 
         PARENT_SCOPE
     )
-    
+
 endfunction()
 
 
@@ -819,7 +826,7 @@ endif()
 if (WIN32)
     install(DIRECTORY "${SLIC3R_RESOURCES_DIR}/" DESTINATION "./resources")
     set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
-    include(InstallRequiredSystemLibraries) 
+    include(InstallRequiredSystemLibraries)
     install (PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION ".")
 elseif (SLIC3R_FHS)
     # CMAKE_INSTALL_FULL_DATAROOTDIR: read-only architecture-independent data root (share)

--- a/linux.d/arch
+++ b/linux.d/arch
@@ -27,6 +27,9 @@ export REQUIRED_DEV_PACKAGES=(
     wget
 )
 
+# Arch has switched to cmake 4.x, pretend it didn't
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 if [[ -n "$UPDATE_LIB" ]]
 then
     echo -n -e "Updating linux ...\n"

--- a/linux.d/arch
+++ b/linux.d/arch
@@ -27,9 +27,6 @@ export REQUIRED_DEV_PACKAGES=(
     wget
 )
 
-# Arch has switched to cmake 4.x, pretend it didn't
-export CMAKE_POLICY_VERSION_MINIMUM=3.5
-
 if [[ -n "$UPDATE_LIB" ]]
 then
     echo -n -e "Updating linux ...\n"


### PR DESCRIPTION
Arch has switched to cmake 4.x breaking build process again - this PR fixes that for Arch only, because I wasn't sure what would happen if fix was applied with an older version of cmake present. 


This PR alone is not enough to build Orca on Arch - GCC 15 fixes are required too https://github.com/SoftFever/OrcaSlicer/pull/9643

Closes https://github.com/SoftFever/OrcaSlicer/issues/9147