### PR TITLE
Fix scaling on Plates toolbar for Windows

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -7911,11 +7911,11 @@ void GLCanvas3D::_render_imgui_select_plate_toolbar()
         m_render_preview = true;
 
     // places the toolbar on the top_left corner of the 3d scene
-#if ENABLE_RETINA_GL
-    float f_scale  = m_retina_helper->get_scale_factor();
-#else
-    float f_scale  = wxGetApp().em_unit() / 10; // ORCA add scaling support
-#endif
+    float f_scale = get_scale();
+    #ifdef WIN32
+        const int dpi = get_dpi_for_window(wxGetApp().GetTopWindow());
+        f_scale *= (float) dpi / (float) DPI_DEFAULT;
+    #endif // WIN32
     Size cnv_size = get_canvas_size();
     auto canvas_w = float(cnv_size.get_width());
     auto canvas_h = float(cnv_size.get_height());
@@ -7935,16 +7935,15 @@ void GLCanvas3D::_render_imgui_select_plate_toolbar()
     // Make sure the window does not overlap the 3d navigator
     auto window_height_max = canvas_h - y_offset;
     if (wxGetApp().show_3d_navigator()) {
-        float sc = get_scale();
-#ifdef WIN32
-        const int dpi = get_dpi_for_window(wxGetApp().GetTopWindow());
-        sc *= (float) dpi / (float) DPI_DEFAULT;
-#endif // WIN32
-        window_height_max -= (128 * sc + 5);
+        window_height_max -= (128 * f_scale + 5);
     }
 
     // ORCA simplify and correct window size and margin calculations and get values from style
     ImGuiWrapper& imgui = *wxGetApp().imgui();
+
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(8.0f, 8.0f) * f_scale);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,   ImVec2(4.0f, 4.0f) * f_scale);
+
     int item_count           = m_sel_plate_toolbar.m_items.size() + (m_sel_plate_toolbar.show_stats_item ? 1 : 0);
     float window_height_calc = (item_count * (button_height + (margin_size + button_margin) * 2.0f) + (item_count - 1) * ImGui::GetStyle().ItemSpacing.y + ImGui::GetStyle().WindowPadding.y * 2.0f);
     bool  show_scroll        = m_sel_plate_toolbar.is_display_scrollbar && (window_height_calc > window_height_max);
@@ -8180,7 +8179,7 @@ void GLCanvas3D::_render_imgui_select_plate_toolbar()
     }
     ImGui::SetWindowFontScale(1.0f);
     ImGui::PopStyleColor(8);
-    ImGui::PopStyleVar(5);
+    ImGui::PopStyleVar(7);
 
     if (ImGui::IsWindowHovered() || is_hovered) {
         m_sel_plate_toolbar.is_display_scrollbar = true;


### PR DESCRIPTION
Tested on windows 11
Before - After at %150 scaling
<img alt="Screenshot-20250519033536" src="https://github.com/user-attachments/assets/6e653787-0b40-4cce-a150-6cc708626fe2" />
```
float f_scale = get_scale();
#ifdef WIN32
    const int dpi = get_dpi_for_window(wxGetApp().GetTopWindow());
    f_scale *= (float) dpi / (float) DPI_DEFAULT;
#endif // WIN32
```
btw if this one proper method we can apply to
```
const float GLCanvas3D::get_scale() const
{
#if ENABLE_RETINA_GL
    return m_retina_helper->get_scale_factor();
#else
    return 1.0f;
#endif
}
```
so all gizmos scaled properly (at least on windows). most of them uses `imgui.push_toolbar_style(m_scale);` already but they not scaling because get_scale() returns 1.0 on non apple systems

not sure correct method for linux

alternatively we can create a new function then replace existing ones with testing

```
#include <wx/wx.h>
#include <wx/display.h>

float GetDisplayScaleFactor(wxWindow* win = nullptr)
{
    if (window)
    {   // Works for macOS
        float f_scale = win->GetContentScaleFactor();
        if (f_scale > 0.0)
            return f_scale;
    }

    try
    {
        // Maybe Works for Linux
        wxDisplay display(win ? wxDisplay(win) : wxDisplay());
        float f_scale = display.GetScaleFactor();
        if (f_scale > 0.0)
            return f_scale;

        // Works for Windows
        wxSize ppi = display.GetPPI();
        if (ppi.GetWidth() > 0)
            return static_cast<float>(ppi.GetWidth()) / DPI_DEFAULT;
    }

    return 1.f;
}
```