### PR TITLE
fix(coreone): adds printer structure

### DIFF
--- a/resources/profiles/Prusa/machine/Prusa CORE One HF 0.4 nozzle.json
+++ b/resources/profiles/Prusa/machine/Prusa CORE One HF 0.4 nozzle.json
@@ -13,6 +13,7 @@
     "extruder_clearance_height_to_rod": "33",
     "extruder_clearance_radius": "75",
     "from": "system",
+    "printer_structure": "corexy",
     "gcode_flavor": "marlin2",
     "host_type": "prusalink",
     "inherits": "fdm_machine_common",


### PR DESCRIPTION
# Description
- Adds `corexy` to CORE One 0.4 nozzle config

Closes #9678 

# Screenshots/Recordings/Graphs

![image](https://github.com/user-attachments/assets/d522c743-d114-4d16-b271-a7551b52c939)

## Tests

