### PR TITLE
Fix link redirection defaulting to Bambu studio

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -37,15 +37,6 @@
         <array>
           <string>orcaslicer</string>
         </array>
-      </dict>
-		<dict>
-        <key>CFBundleURLName</key>
-        <string>BambuStudio Downloads</string>
-        <key>CFBundleURLSchemes</key>
-        <array>
-          <string>bambustudioopen</string>
-        </array>
-      </dict>
     </array>
 	<key>CFBundleDocumentTypes</key>
 	<array>

--- a/src/platform/osx/Info.plist.in
+++ b/src/platform/osx/Info.plist.in
@@ -33,7 +33,6 @@
       <array>
         <string>orcasliceropen</string>
         <string>orcaslicer</string>
-        <string>bambustudioopen</string>
       </array>
     </dict>
   </array>


### PR DESCRIPTION
# Description

  When both Orca Slicer and Bambu Studio are installed on macOS, MakerWorld incorrectly redirects to Orca. 
  According to Apple's developer documentation, two apps cannot use the same URL scheme, as it may lead to undefined conflicts. 
![image](https://github.com/user-attachments/assets/edf3e81a-744a-4412-a084-9022bab49dbf)

# Screenshots/Recordings/Graphs

![img_v3_02me_3484cab9-623d-45e3-8a72-6947914a9e7g](https://github.com/user-attachments/assets/9a1cdfca-f533-4673-ac37-6141457838b9)

## Tests

Can the app built using GitHub Actions run directly on macOS? I don't have a developer account for code signing.
