### PR TITLE
Feature/fix fragmented sparse infill paths

### DIFF
--- a/src/libslic3r/Fill/FillBase.cpp
+++ b/src/libslic3r/Fill/FillBase.cpp
@@ -29,11 +29,6 @@
 
 namespace Slic3r {
 
-//BBS: 0% of sparse_infill_line_width, no anchor at the start of sparse infill
-float Fill::infill_anchor = 400;
-//BBS: 20mm
-float Fill::infill_anchor_max = 20;
-
 Fill* Fill::new_from_type(const InfillPattern type)
 {
     switch (type) {

--- a/src/libslic3r/Fill/FillBase.hpp
+++ b/src/libslic3r/Fill/FillBase.hpp
@@ -120,9 +120,6 @@ public:
     // BBS: all no overlap expolygons in same layer
     ExPolygons  no_overlap_expolygons;
 
-    static float infill_anchor;
-    static float infill_anchor_max;
-
 public:
     virtual ~Fill() {}
     virtual Fill* clone() const = 0;

--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -2963,7 +2963,7 @@ bool FillRectilinear::fill_surface_by_multilines(const Surface *surface, FillPar
 Polylines FillRectilinear::fill_surface(const Surface *surface, const FillParams &params)
 {
     Polylines polylines_out;
-    if (params.full_infill()) {
+    if (params.full_infill() || ((2 * this->spacing) < (params.density * params.anchor_length_max))) {
         if (!fill_surface_by_lines(surface, params, 0.f, 0.f, polylines_out))
             BOOST_LOG_TRIVIAL(error) << "FillRectilinear::fill_surface() fill_surface_by_lines() failed to fill a region.";
     } else {


### PR DESCRIPTION
fix #9635

# Description

The infill path generation of sparse infill patterns "Rectilinear" and "Aligned Rectilinear" will be improved when "Maximum length of the infill anchor" is likely to be long enough to connect the infill lines. `FillRectilinear::fill_surface_by_lines()` performs better in connecting non intersecting parallel infill lines compared to `FillRectilinear::fill_surface_by_multilines()` that makes use of `Fill::connect_infill()`. `FillRectilinear::fill_surface_by_lines()` (using `FillRectilinear::connect_segment_intersections_by_contours()`) [connects infill lines when "Maximum length of the infill anchor" is 0.05 mm or higher](https://github.com/SoftFever/OrcaSlicer/blob/main/src/libslic3r/Fill/FillRectilinear.cpp#L1178), not being able to create infill anchors and therefore not respecting "Sparse infill anchor length" and "Maximum length of the infill anchor" to its values. The infill lines will be fully connected when "Maximum length of the infill anchor" is more than twice as long as the infill line pitch, guaranteeing correct infill anchor behavior for infill line boundary angles from 30 to 150 degrees.

## Tests

Tested with local build.
The example shared in #9635 has a infill line pitch of slightly more than 2.647 mm ((110% * 0.40 mm - 0.20 mm * (1 - pi/4)) / 15%) and will have improved infill path generation when "Maximum length of the infill anchor" is set to 5.295 mm or higher.