### PR TITLE
remove OSMesa

### DIFF
--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -634,9 +634,9 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     FIND_LIBRARY(WAYLAND_EGL_LIBRARIES    NAMES wayland-egl)
     FIND_LIBRARY(WAYLAND_CLIENT_LIBRARIES NAMES wayland-client)
     find_package(CURL REQUIRED)
-    target_link_libraries(libslic3r_gui ${DBUS_LIBRARIES} OSMesa)
     target_link_libraries(libslic3r_gui
         OpenGL::EGL
+        ${DBUS_LIBRARIES}
         ${WAYLAND_SERVER_LIBRARIES}
         ${WAYLAND_EGL_LIBRARIES}
         ${WAYLAND_CLIENT_LIBRARIES}


### PR DESCRIPTION
OSMesa is deprecated for quite a while and got removed with Mesa 25.1.0
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33836


I can't test it myself, but it should work with older versions too


should I remove it in all this files? 
https://github.com/search?q=repo%3ASoftFever%2FOrcaSlicer%20osmesa&type=code