### PR TITLE
Fix 9620

### DIFF
--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.25 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.25 Nozzle.json
@@ -11,7 +11,7 @@
   "printer_variant": "0.25",
   "max_layer_height": ["0.14"],
   "min_layer_height": ["0.08"],
-  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
+  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
   "retraction_length": ["1"],
   "z_hop": ["0.3"],
   "nozzle_type": "stainless_steel"

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.25 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.25 Nozzle.json
@@ -11,7 +11,7 @@
   "printer_variant": "0.25",
   "max_layer_height": ["0.14"],
   "min_layer_height": ["0.08"],
-  "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
+  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
   "retraction_length": ["1"],
   "z_hop": ["0.3"],
   "nozzle_type": "stainless_steel"

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.25 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.25 Nozzle.json
@@ -11,7 +11,7 @@
   "printer_variant": "0.25",
   "max_layer_height": ["0.14"],
   "min_layer_height": ["0.08"],
-  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
+  "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
   "retraction_length": ["1"],
   "z_hop": ["0.3"],
   "nozzle_type": "stainless_steel"

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.8 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.8 Nozzle.json
@@ -9,7 +9,7 @@
   "default_print_profile": "0.40mm Standard @Flashforge AD5M 0.8 Nozzle",
   "nozzle_diameter": ["0.8"],
   "printer_variant": "0.8",
-  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
+  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
   "max_layer_height": ["0.56"],
   "min_layer_height": ["0.24"],
   "retraction_length": ["1.5"],

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.8 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.8 Nozzle.json
@@ -9,7 +9,7 @@
   "default_print_profile": "0.40mm Standard @Flashforge AD5M 0.8 Nozzle",
   "nozzle_diameter": ["0.8"],
   "printer_variant": "0.8",
-  "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
+  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
   "max_layer_height": ["0.56"],
   "min_layer_height": ["0.24"],
   "retraction_length": ["1.5"],

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.8 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M 0.8 Nozzle.json
@@ -9,7 +9,7 @@
   "default_print_profile": "0.40mm Standard @Flashforge AD5M 0.8 Nozzle",
   "nozzle_diameter": ["0.8"],
   "printer_variant": "0.8",
-  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
+  "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
   "max_layer_height": ["0.56"],
   "min_layer_height": ["0.24"],
   "retraction_length": ["1.5"],

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.25 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.25 Nozzle.json
@@ -11,7 +11,7 @@
   "printer_variant": "0.25",
   "max_layer_height": ["0.14"],
   "min_layer_height": ["0.08"],
-  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
+  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
   "retraction_length": ["1"],
   "z_hop": ["0.3"],
   "nozzle_type": "stainless_steel"

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.25 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.25 Nozzle.json
@@ -11,7 +11,7 @@
   "printer_variant": "0.25",
   "max_layer_height": ["0.14"],
   "min_layer_height": ["0.08"],
-  "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
+  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
   "retraction_length": ["1"],
   "z_hop": ["0.3"],
   "nozzle_type": "stainless_steel"

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.25 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.25 Nozzle.json
@@ -11,7 +11,7 @@
   "printer_variant": "0.25",
   "max_layer_height": ["0.14"],
   "min_layer_height": ["0.08"],
-  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
+  "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG90 E0\nM83\nG1 E-1 F600\nG1 E8 F300\nG1 X85 Y110 Z0.2 F1200\nG1 X-110 E15 F2400\nG1 Y0 E4 F2400\nG1 X-109.6 F2400\nG1 Y110 E5 F2400\nG92 E0",
   "retraction_length": ["1"],
   "z_hop": ["0.3"],
   "nozzle_type": "stainless_steel"

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.8 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.8 Nozzle.json
@@ -9,7 +9,7 @@
   "default_print_profile": "0.40mm Standard @Flashforge AD5M Pro 0.8 Nozzle",
   "nozzle_diameter": ["0.8"],
   "printer_variant": "0.8",
-  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
+  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
   "max_layer_height": ["0.56"],
   "min_layer_height": ["0.24"],
   "retraction_length": ["1.5"],

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.8 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.8 Nozzle.json
@@ -9,7 +9,7 @@
   "default_print_profile": "0.40mm Standard @Flashforge AD5M Pro 0.8 Nozzle",
   "nozzle_diameter": ["0.8"],
   "printer_variant": "0.8",
-  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
+  "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
   "max_layer_height": ["0.56"],
   "min_layer_height": ["0.24"],
   "retraction_length": ["1.5"],

--- a/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.8 Nozzle.json
+++ b/resources/profiles/Flashforge/machine/Flashforge Adventurer 5M Pro 0.8 Nozzle.json
@@ -9,7 +9,7 @@
   "default_print_profile": "0.40mm Standard @Flashforge AD5M Pro 0.8 Nozzle",
   "nozzle_diameter": ["0.8"],
   "printer_variant": "0.8",
-  "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
+  "machine_start_gcode": "M190 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nG90\nM83\nG1 Z5 F6000\nG1 E-1.5 F600\nG1 E12 F800\nG1 X85 Y110 Z0.3 F1200\nG1 X-110 E30 F2400\nG1 Y0 E8 F2400\nG1 X-109.6 F2400\nG1 Y110 E10 F2400\nG92 E0",
   "max_layer_height": ["0.56"],
   "min_layer_height": ["0.24"],
   "retraction_length": ["1.5"],


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

Fixes #9620 for FlashForge profiles for ADM 5M / Pro 0.25 and 0.8 nozzles profiles where the initial purge lines retract instead of extruding resulting in failed beginning prints.

The problem is that the GCode does not explicitly set the extruder mode (absolute or relative). If the firmware is in absolute mode (G90 for axes, M82 for extruder), then the extruder moves (E values) behave as absolute, causing retractions when positive values are expected.

The fix (also confirmed by OP) is to set the printer to absolute positioning for axes (G90) and relative positioning for the extruder (M83) before the purge moves.

By adding G90 and M83 before the purge, the extruder will correctly extrude during the purge lines.

I wonder if it is necessary to even have an explicit `machine_start_code` for the 0.25 and 0.8 nozzle profiles or if it can inherit the one defined on  [resources/profiles/FlashForge/machine/fdm_adventurer5m_common.json](https://github.com/SoftFever/OrcaSlicer/blob/4545132a0dd055421a3b8c95706990cd4d18f7a1/resources/profiles/Flashforge/machine/fdm_adventurer5m_common.json#L37) ?

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

N/A 

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

Tested directly with 0.25 and 0.8 nozzles on FF Adventurer 5M Pro. 
