### PR TITLE
Use backticks instead of single quotes on code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Explore the latest developments in Orca Slicer with our nightly builds. Feedback
                 - For most common errors, open `DockerRun.sh` and read the comments.  
     - Ubuntu 
       - Dependencies **Will be auto installed with the shell script**: `libmspack-dev libgstreamerd-3-dev libsecret-1-dev libwebkit2gtk-4.0-dev libosmesa6-dev libssl-dev libcurl4-openssl-dev eglexternalplatform-dev libudev-dev libdbus-1-dev extra-cmake-modules libgtk2.0-dev libglew-dev libudev-dev libdbus-1-dev cmake git texinfo`
-      - run 'sudo ./BuildLinux.sh -u'
-      - run './BuildLinux.sh -dsi'
+      - run `sudo ./BuildLinux.sh -u`
+      - run `./BuildLinux.sh -dsi`
 
 # Note: 
 If you're running Klipper, it's recommended to add the following configuration to your `printer.cfg` file.


### PR DESCRIPTION
Instructions for building on Ubuntu used single quotes. Changed to use backticks so that Github applies the `code` style

# Description

Extremely small tweak. Just properly formats two places in the README with `code` styling.

# Screenshots/Recordings/Graphs

N/A

## Tests

 N/A
