### PR TITLE
add official Twitter/X account in security alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Join our Discord community here:<br>
  
  <h3>🚨🚨🚨Important Security Alert🚨🚨🚨</h3> 
 
-The only official platforms for OrcaSlicer are **our GitHub project page**, <a href="https://orcaslicer.com/">**orcaslicer.com**</a>, and the <a href="https://discord.gg/P4VE9UY9gJ">**official Discord channel**</a>.
+The only official platforms for OrcaSlicer are **our GitHub project page**, <a href="https://orcaslicer.com/">**orcaslicer.com**</a>, the <a href="https://discord.gg/P4VE9UY9gJ">**official Discord channel**</a>, and the <a href="https://twitter.com/real_OrcaSlicer>**official Twitter/X account**</a>"
 
 Please be aware that "**orcaslicer.net**", "**orcaslicer.co**" or "**orca-slicer.com**" are NOT an official website for OrcaSlicer and may be potentially malicious. These sites appear to use AI-generated content, lacking genuine context and seems to exist solely to profit from advertisements. Worse, it may redirect download links to harmful sources. For your safety, avoid downloading OrcaSlicer from this site as the links may be compromised. 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Join our Discord community here:<br>
  
  <h3>🚨🚨🚨Important Security Alert🚨🚨🚨</h3> 
 
-The only official platforms for OrcaSlicer are **our GitHub project page**, <a href="https://orcaslicer.com/">**orcaslicer.com**</a>, the <a href="https://discord.gg/P4VE9UY9gJ">**official Discord channel**</a>, and the <a href="https://twitter.com/real_OrcaSlicer>**official Twitter/X account**</a>"
+The only official platforms for OrcaSlicer are **our GitHub project page**, <a href="https://orcaslicer.com/">**orcaslicer.com**</a>, the <a href="https://discord.gg/P4VE9UY9gJ">**official Discord channel**</a>, and the <a href="https://twitter.com/real_OrcaSlicer">**official Twitter/X account**</a>.
 
 Please be aware that "**orcaslicer.net**", "**orcaslicer.co**" or "**orca-slicer.com**" are NOT an official website for OrcaSlicer and may be potentially malicious. These sites appear to use AI-generated content, lacking genuine context and seems to exist solely to profit from advertisements. Worse, it may redirect download links to harmful sources. For your safety, avoid downloading OrcaSlicer from this site as the links may be compromised. 
 


### PR DESCRIPTION
# Description

This PR adds the official Twitter/X account mentioned in the README and https://orcaslicer.com to the fake website security alert (might have been missed in #9375) to clarify that real_OrcaSlicer is the only real account.

# Screenshots/Recordings/Graphs

<img width="833" alt="Screenshot 2025-05-27 at 4 05 17 PM" src="https://github.com/user-attachments/assets/2139ab67-8b01-42e3-bef6-e38469a87ecc" />

## Tests

Previewed on GitHub