### PR TITLE
Fix Line Infill with no anchor

### DIFF
--- a/src/libslic3r/Fill/FillLine.cpp
+++ b/src/libslic3r/Fill/FillLine.cpp
@@ -23,7 +23,7 @@ void FillLine::_fill_surface_single(
     this->_diagonal_distance = this->_line_spacing * 2;
     this->_line_oscillation = this->_line_spacing - this->_min_spacing; // only for Line infill
     BoundingBox bounding_box = expolygon.contour.bounding_box();
-    
+
     // define flow spacing according to requested density
     if (params.density > 0.9999f && !params.dont_adjust) {
         this->_line_spacing = this->_adjust_solid_spacing(bounding_box.size()(0), this->_line_spacing);
@@ -32,8 +32,8 @@ void FillLine::_fill_surface_single(
         // extend bounding box so that our pattern will be aligned with other layers
         // Transform the reference point to the rotated coordinate system.
         bounding_box.merge(align_to_grid(
-            bounding_box.min, 
-            Point(this->_line_spacing, this->_line_spacing), 
+            bounding_box.min,
+            Point(this->_line_spacing, this->_line_spacing),
             direction.second.rotated(- direction.first)));
     }
 
@@ -46,7 +46,7 @@ void FillLine::_fill_surface_single(
     // clip paths against a slightly larger expolygon, so that the first and last paths
     // are kept even if the expolygon has vertical sides
     // the minimum offset for preventing edge lines from being clipped is SCALED_EPSILON;
-    // however we use a larger offset to support expolygons with slightly skewed sides and 
+    // however we use a larger offset to support expolygons with slightly skewed sides and
     // not perfectly straight
     //FIXME Vojtech: Update the intersecton function to work directly with lines.
     Polylines polylines_src;
@@ -76,7 +76,7 @@ void FillLine::_fill_surface_single(
     size_t n_polylines_out_old = polylines_out.size();
 
     // connect lines
-    if (! params.dont_connect() && ! polylines.empty()) { // prevent calling leftmost_point() on empty collections
+    if (! polylines.empty()) { // prevent calling leftmost_point() on empty collections
         // offset the expolygon by max(min_spacing/2, extra)
         ExPolygon expolygon_off;
         {
@@ -96,9 +96,9 @@ void FillLine::_fill_surface_single(
                 const Point &last_point = pts_end.back();
                 // Distance in X, Y.
                 const Vector distance = last_point - first_point;
-                // TODO: we should also check that both points are on a fill_boundary to avoid 
+                // TODO: we should also check that both points are on a fill_boundary to avoid
                 // connecting paths on the boundaries of internal regions
-                if (this->_can_connect(std::abs(distance(0)), std::abs(distance(1))) && 
+                if (this->_can_connect(std::abs(distance(0)), std::abs(distance(1))) &&
                     expolygon_off.contains(Line(last_point, first_point))) {
                     // Append the polyline.
                     pts_end.insert(pts_end.end(), polyline.points.begin(), polyline.points.end());

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -521,8 +521,11 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     bool have_combined_infill = config->opt_bool("infill_combination") && have_infill;
     toggle_line("infill_combination_max_layer_height", have_combined_infill);
 
+    bool infill_anchor = config->opt_enum<InfillPattern>("sparse_infill_pattern") != ipLine;
+    toggle_field("infill_anchor_max",infill_anchor);
+
     // Only allow configuration of open anchors if the anchoring is enabled.
-    bool has_infill_anchors = have_infill && config->option<ConfigOptionFloatOrPercent>("infill_anchor_max")->value > 0;
+    bool has_infill_anchors = have_infill && config->option<ConfigOptionFloatOrPercent>("infill_anchor_max")->value > 0 && infill_anchor;
     toggle_field("infill_anchor", has_infill_anchors);
 
     bool has_spiral_vase         = config->opt_bool("spiral_mode");


### PR DESCRIPTION
Line Infill doesn't work when `Maximum length of the infill anchor` is set below `0.05`, because it's using a condition with `params.dont_connect()` that doesn't make sense in this context.

Before:
![orca-slicer_idJADoQGgb](https://github.com/user-attachments/assets/e4c113d8-71cc-459d-871e-757945bd4dde)
After:
![orca-slicer_4ao7ynnhKy](https://github.com/user-attachments/assets/0daa3807-fd69-4d2c-ad3a-5a39600330d2)
