### PR TITLE
Fix project info editor dark mode text color

### DIFF
--- a/src/slic3r/GUI/Auxiliary.cpp
+++ b/src/slic3r/GUI/Auxiliary.cpp
@@ -1083,6 +1083,7 @@ void AuxiliaryPanel::update_all_cover()
 
      wxBoxSizer *m_sizer_license = new wxBoxSizer(wxHORIZONTAL);
      auto m_text_license = new wxStaticText(this, wxID_ANY, _L("License"), wxDefaultPosition, wxSize(180, -1), 0);
+     m_text_license->SetForegroundColour(*wxBLACK);
      m_text_license->Wrap(-1);
      m_sizer_license->Add(m_text_license, 0, wxALIGN_CENTER, 0);
      m_combo_license = new ComboBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(FromDIP(450), -1), 0, NULL, wxCB_READONLY);


### PR DESCRIPTION
Old:
![image](https://github.com/user-attachments/assets/a33f27ed-018a-482a-bbc4-295b6656bb08)



New:
![image](https://github.com/user-attachments/assets/099a1036-f749-4773-8f78-b4c37fa4f084)
