### PR TITLE
Fix event table baseclass error

### DIFF
--- a/src/slic3r/GUI/ImageGrid.cpp
+++ b/src/slic3r/GUI/ImageGrid.cpp
@@ -12,7 +12,7 @@
 
 wxDEFINE_EVENT(EVT_ITEM_ACTION, wxCommandEvent);
 
-BEGIN_EVENT_TABLE(Slic3r::GUI::ImageGrid, wxPanel)
+BEGIN_EVENT_TABLE(Slic3r::GUI::ImageGrid, wxWindow)
 
 EVT_MOTION(Slic3r::GUI::ImageGrid::mouseMoved)
 EVT_ENTER_WINDOW(Slic3r::GUI::ImageGrid::mouseEnterWindow)

--- a/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
+++ b/src/slic3r/GUI/Widgets/AxisCtrlButton.cpp
@@ -14,7 +14,7 @@ static const wxColour text_num_color = wxColour(0x898989);
 static const wxColour BUTTON_PRESS_COL = wxColour(172, 172, 172);
 static const double sqrt2 = std::sqrt(2);
 
-BEGIN_EVENT_TABLE(AxisCtrlButton, wxPanel)
+BEGIN_EVENT_TABLE(AxisCtrlButton, wxWindow)
 EVT_LEFT_DOWN(AxisCtrlButton::mouseDown)
 EVT_LEFT_UP(AxisCtrlButton::mouseReleased)
 EVT_MOTION(AxisCtrlButton::mouseMoving)

--- a/src/slic3r/GUI/Widgets/ProgressBar.cpp
+++ b/src/slic3r/GUI/Widgets/ProgressBar.cpp
@@ -7,7 +7,7 @@
 
 
 wxDEFINE_EVENT(wxCUSTOMEVT_SET_TEMP_FINISH, wxCommandEvent);
-BEGIN_EVENT_TABLE(ProgressBar, wxPanel)
+BEGIN_EVENT_TABLE(ProgressBar, wxWindow)
 EVT_PAINT(ProgressBar::paintEvent)
 END_EVENT_TABLE()
 

--- a/src/slic3r/GUI/Widgets/RoundedRectangle.cpp
+++ b/src/slic3r/GUI/Widgets/RoundedRectangle.cpp
@@ -3,7 +3,7 @@
 #include <wx/dcgraph.h>
 #include <wx/dcclient.h>
 
-BEGIN_EVENT_TABLE(RoundedRectangle, wxPanel)
+BEGIN_EVENT_TABLE(RoundedRectangle, wxWindow)
 EVT_PAINT(RoundedRectangle::OnPaint)
 END_EVENT_TABLE()
 

--- a/src/slic3r/GUI/Widgets/SideButton.cpp
+++ b/src/slic3r/GUI/Widgets/SideButton.cpp
@@ -4,7 +4,7 @@
 #include <wx/dcclient.h>
 #include <wx/dcgraph.h>
 
-BEGIN_EVENT_TABLE(SideButton, wxPanel)
+BEGIN_EVENT_TABLE(SideButton, wxWindow)
 EVT_LEFT_DOWN(SideButton::mouseDown)
 EVT_LEFT_UP(SideButton::mouseReleased)
 EVT_PAINT(SideButton::paintEvent)

--- a/src/slic3r/GUI/Widgets/SpinInput.cpp
+++ b/src/slic3r/GUI/Widgets/SpinInput.cpp
@@ -5,7 +5,7 @@
 
 #include <wx/dcgraph.h>
 
-BEGIN_EVENT_TABLE(SpinInput, wxPanel)
+BEGIN_EVENT_TABLE(SpinInput, StaticBox)
 
 EVT_KEY_DOWN(SpinInput::keyPressed)
 //EVT_MOUSEWHEEL(SpinInput::mouseWheelMoved)

--- a/src/slic3r/GUI/Widgets/TempInput.cpp
+++ b/src/slic3r/GUI/Widgets/TempInput.cpp
@@ -8,7 +8,7 @@
 
 wxDEFINE_EVENT(wxCUSTOMEVT_SET_TEMP_FINISH, wxCommandEvent);
 
-BEGIN_EVENT_TABLE(TempInput, wxPanel)
+BEGIN_EVENT_TABLE(TempInput, StaticBox)
 EVT_MOTION(TempInput::mouseMoved)
 EVT_ENTER_WINDOW(TempInput::mouseEnterWindow)
 EVT_LEAVE_WINDOW(TempInput::mouseLeaveWindow)

--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -6,7 +6,7 @@
 #include <wx/dcclient.h>
 #include <wx/dcgraph.h>
 
-BEGIN_EVENT_TABLE(TextInput, wxPanel)
+BEGIN_EVENT_TABLE(TextInput, StaticBox)
 
 EVT_PAINT(TextInput::paintEvent)
 


### PR DESCRIPTION
The second parameter of the `BEGIN_EVENT_TABLE` macro should be the base class of the first parameter.

VS shows error in intellisence, however it still compiles, I'm not sure why. But I'll fix this anyway.
