### PR TITLE
wxDataViewCtrl fixes 

### DIFF
--- a/src/slic3r/GUI/EditGCodeDialog.cpp
+++ b/src/slic3r/GUI/EditGCodeDialog.cpp
@@ -819,6 +819,9 @@ ParamsViewCtrl::ParamsViewCtrl(wxWindow *parent, wxSize size)
 {
     wxGetApp().UpdateDVCDarkUI(this);
 
+    SetDoubleBuffered(true);
+    SetFont(wxGetApp().code_font());
+
     model = new ParamsModel();
     this->AssociateModel(model);
     model->SetAssociatedControl(this);

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -118,7 +118,7 @@ public:
         wxEllipsizeMode ellipsizeMode = wxELLIPSIZE_END
     ) override
     {   // ORCA draw custom text to improve consistency between platforms
-        dc.SetFont(Label::Body_13);
+        dc.SetFont(win->GetFont());
         dc.SetTextForeground(StateColor::darkModeColorFor(wxColour("#262E30"))); // use same color for selected / non-selected
         dc.DrawText(text,wxPoint(rect.x, rect.y));
     }


### PR DESCRIPTION
QUESTIONS
is there a scenario that `win->GetFont() `null that cause error

**for EditGCodeDialog**
• fixes flickering after scrolling
• fixes font usage

**Before - Uses normal font. Gaps appearing while highlighting text**
![Screenshot-20250606212929](https://github.com/user-attachments/assets/ab4f2924-55b6-4acd-a3a9-7ff694b65efe)
**glitches appear after scroll**
![Screenshot-20250606213030](https://github.com/user-attachments/assets/2c5c3c82-43dc-42c6-b85e-eda9d5d7946c)


**After**
![Screenshot-20250606212901](https://github.com/user-attachments/assets/b48da67b-d756-4f42-a5b5-ec0e6ed5dbde)
No glitches after scroll
![Screenshot-20250606213112](https://github.com/user-attachments/assets/0e03c43b-806f-4580-8e5a-bf7c9d4518c7)


Screenshot from 2.2 version. this uses monospaced font
![Screenshot-20250606212703](https://github.com/user-attachments/assets/3cb97c5f-85c3-4bf9-a971-220fbbb63590)
