### PR TITLE
Fix error when drag-n-drop a file from network location to home screen

### DIFF
--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -552,6 +552,8 @@ void WebViewPanel::OnNavigationRequest(wxWebViewEvent& evt)
 #ifdef _WIN32
             if (file.StartsWith('/'))
                 file = file.Mid(1);
+            else
+                file = "//" + file; // When file from network location
 #endif
             wxGetApp().plater()->load_files(wxArrayString{1, &file});
             evt.Veto();


### PR DESCRIPTION
Fix error when drag-n-drop a file from network location to home screen on Windows:

![nas-drag](https://github.com/user-attachments/assets/97b935c2-5886-4042-b51c-08a9d8ce6b26)
