### PR TITLE
Generate GCode for skirt prior wipe tower.

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4122,6 +4122,10 @@ LayerResult GCode::process_layer(
     // Extrude the skirt, brim, support, perimeters, infill ordered by the extruders.
     for (unsigned int extruder_id : layer_tools.extruders)
     {
+        if (print.config().skirt_type == stCombined && !print.skirt().empty())
+            gcode += generate_skirt(print, print.skirt(), Point(0, 0), layer.object()->config().skirt_start_angle, layer_tools, layer,
+                                    extruder_id);
+
         std::string gcode_toolchange;
         if (has_wipe_tower) {
             if (!m_wipe_tower->is_empty_wipe_tower_gcode(*this, extruder_id, extruder_id == layer_tools.extruders.back())) {
@@ -4155,10 +4159,6 @@ LayerResult GCode::process_layer(
         // let analyzer tag generator aware of a role type change
         if (layer_tools.has_wipe_tower && m_wipe_tower)
             m_last_processor_extrusion_role = erWipeTower;
-        
-        if (print.config().skirt_type == stCombined && !print.skirt().empty())
-            gcode += generate_skirt(print, print.skirt(), Point(0, 0), layer.object()->config().skirt_start_angle, layer_tools, layer,
-                                    extruder_id);
 
         auto objects_by_extruder_it = by_extruder.find(extruder_id);
         if (objects_by_extruder_it == by_extruder.end())


### PR DESCRIPTION
# Description

Generate the GCode for the skirt before the GCode for the wipe tower.

# Screenshots/Recordings/Graphs
Before the change, the GCode for the wipe tower is generated before code generation for the skirt. See,
![image](https://github.com/user-attachments/assets/7820bd08-90e6-4882-a3c6-d52b29e19adb)
After the change, the GCode for the skirt is generated before the code for the wipe tower. See,
![image](https://github.com/user-attachments/assets/bccdc5cb-2651-48c9-8218-6637a75936fb)
On the 2nd+ layer, the filament used as the last on the previous layer will be used to print the skirt. 
![image](https://github.com/user-attachments/assets/fe52206e-05bb-4fde-bfe9-e82a621b92de)

## Tests
Manual checks.

