### PR TITLE
Fix Voron profile printable_height value

### DIFF
--- a/resources/profiles/Voron/machine/Voron 2.4 300 0.15 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron 2.4 300 0.15 nozzle.json
@@ -22,6 +22,6 @@
         "300x300",
         "0x300"
     ],
-    "printable_height": "2755",
+    "printable_height": "275",
     "printer_variant": "0.15"
 }

--- a/resources/profiles/Voron/machine/Voron 2.4 300 0.2 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron 2.4 300 0.2 nozzle.json
@@ -22,6 +22,6 @@
         "300x300",
         "0x300"
     ],
-    "printable_height": "2755",
+    "printable_height": "275",
     "printer_variant": "0.2"
 }

--- a/resources/profiles/Voron/machine/Voron 2.4 300 0.25 nozzle.json
+++ b/resources/profiles/Voron/machine/Voron 2.4 300 0.25 nozzle.json
@@ -22,6 +22,6 @@
         "300x300",
         "0x300"
     ],
-    "printable_height": "2755",
+    "printable_height": "275",
     "printer_variant": "0.25"
 }


### PR DESCRIPTION
# Description

some Voron machines had typo in printable_height so i fixed 2755 to 275 which is correct

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
