### PR TITLE
Disable detect thin wall for VFA test

### DIFF
--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -882,6 +882,7 @@ void CalibUtils::calib_VFA(const CalibInfo &calib_info, wxString &error_message)
     print_config.set_key_value("wall_loops", new ConfigOptionInt(1));
     print_config.set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config.set_key_value("alternate_extra_wall", new ConfigOptionBool(false));
+    print_config.set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config.set_key_value("top_shell_layers", new ConfigOptionInt(0));
     print_config.set_key_value("bottom_shell_layers", new ConfigOptionInt(1));
     print_config.set_key_value("sparse_infill_density", new ConfigOptionPercent(0));


### PR DESCRIPTION
# Description

Disables thin wall detection on VFA test as it can cause incorrect seams to be placed in the model. This makes it consistent with what spiral mode is expecting.


# Screenshots/Recordings/Graphs

![image](https://github.com/user-attachments/assets/95a7b924-9346-4f8b-b22f-8b4bbf6d5bd3)


