### PR TITLE
Fix character spacing issue in GCODE preview for Italian (#9778)

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -362,7 +362,7 @@ void GCodeViewer::SequentialView::Marker::render(int canvas_width, int canvas_he
     std::string layer_time = ImGui::ColorMarkerStart + _u8L("Layer Time: ") + ImGui::ColorMarkerEnd;
     std::string fanspeed = ImGui::ColorMarkerStart + _u8L("Fan: ") + ImGui::ColorMarkerEnd;
     std::string temperature = ImGui::ColorMarkerStart + _u8L("Temperature: ") + ImGui::ColorMarkerEnd;
-    const float item_size = imgui.calc_text_size(std::string_view{"X: 000.000  "}).x;
+    const float item_size = imgui.calc_text_size(std::string_view{"X: 000.000       "}).x;
     const float item_spacing = imgui.get_item_spacing().x;
     const float window_padding = ImGui::GetStyle().WindowPadding.x;
 


### PR DESCRIPTION
# Description

This PR fixes the character spacing issue in the GCODE preview for the Italian language (see #9778).

The issue was caused by insufficient trailing whitespace in the string passed to `calc_text_size()`, which led to misaligned elements in the preview UI when Italian labels (which can be longer or differently spaced) were used.

**Fix applied:**
```cpp
// Before
const float item_size = imgui.calc_text_size(std::string_view{"X: 000.000  "}).x;

// After
const float item_size = imgui.calc_text_size(std::string_view{"X: 000.000       "}).x;

This ensures consistent horizontal spacing regardless of the language used.

Tests
- Manually tested the UI preview with Italian localization enabled.
- Verified that the spacing now matches expectations and aligns correctly.
