### PR TITLE
 Fillgyroid Bug Fix

### DIFF
--- a/src/libslic3r/Fill/FillGyroid.cpp
+++ b/src/libslic3r/Fill/FillGyroid.cpp
@@ -168,6 +168,10 @@ void FillGyroid::_fill_surface_single(
     // align bounding box to a multiple of our grid module
     bb.merge(align_to_grid(bb.min, Point(2*M_PI*distance, 2*M_PI*distance)));
 
+    // Expand the bounding box to avoid artifacts at the edges
+    coord_t expand = 10 * (scale_(this->spacing));
+    bb.offset(expand); 
+
     // generate pattern
     Polylines polylines = make_gyroid_waves(
         scale_(this->z),


### PR DESCRIPTION
I found a bug in the Gyroid infill: when using low density (e.g., 5%) on cylindrical parts, artifacts appear where the infill connects to the walls. This is caused by the infill's bounding box not being centered. As a result, the infill becomes distorted in regions where it is tangent to the perimeter.
bug:
![image](https://github.com/user-attachments/assets/1e67a3d4-156f-4a35-968e-e7abbd3aa0ef)
bounding box visible ( commenting line: 	`//polylines = intersection_pl(polylines, expolygon);`)
![image](https://github.com/user-attachments/assets/6c2d7681-c5d3-4266-96de-0e9b8466772f)
bounding box expanded 10 line widths:
![image](https://github.com/user-attachments/assets/40af18c3-18f1-48dc-85ac-9109ed219c03)
result:
![image](https://github.com/user-attachments/assets/6f9a67df-c7f6-4e77-a8cf-5cb73888f076)
