### PR TITLE
Fix notification position on scaling

### DIFF
--- a/src/slic3r/GUI/NotificationManager.cpp
+++ b/src/slic3r/GUI/NotificationManager.cpp
@@ -2537,19 +2537,19 @@ void NotificationManager::render_notifications(GLCanvas3D &canvas, float overlay
 {
 	sort_notifications();
 
-	float bottom_up_last_y = bottom_margin * m_scale;
+	float bottom_up_last_y = bottom_margin; // ORCA dont scale margins
 
 	int i = 0;
 	for (const auto& notification : m_pop_notifications) {
         if (notification->get_data().level == NotificationLevel::ErrorNotificationLevel || notification->get_data().level == NotificationLevel::SeriousWarningNotificationLevel) {
-            notification->bbl_render_block_notification(canvas, bottom_up_last_y, m_move_from_overlay && !m_in_preview, overlay_width * m_scale, right_margin * m_scale);
+            notification->bbl_render_block_notification(canvas, bottom_up_last_y, m_move_from_overlay && !m_in_preview, overlay_width * m_scale, right_margin);  // ORCA dont scale margins
             if (notification->get_state() != PopNotification::EState::Finished) 
 				bottom_up_last_y = notification->get_top() + GAP_WIDTH;
 		}
 		else {
 			if (notification->get_state() != PopNotification::EState::Hidden && notification->get_state() != PopNotification::EState::Finished) {
 				i++;
-				notification->render(canvas, bottom_up_last_y, m_move_from_overlay && !m_in_preview, overlay_width * m_scale, right_margin * m_scale);
+				notification->render(canvas, bottom_up_last_y, m_move_from_overlay && !m_in_preview, overlay_width * m_scale, right_margin); // ORCA dont scale margins
 				if (notification->get_state() != PopNotification::EState::Finished)
 					bottom_up_last_y = notification->get_top() + GAP_WIDTH;
 			}


### PR DESCRIPTION
on %100 scaling
![Screenshot-20250623091813](https://github.com/user-attachments/assets/15b0a4cc-5470-4aab-b7aa-345899f1041e)

Tested on %150 scaling

BEFORE - Notification not aligns with gCode viewer and leaves extra spacing on bottom
<img alt="Screenshot-20250623091155" src="https://github.com/user-attachments/assets/5ee0f482-ea62-44b5-b8ad-8fd4fc656fd7" />

AFTER
<img alt="Screenshot-20250623091850" src="https://github.com/user-attachments/assets/33cfc0a3-c1c4-4c8f-9d56-43d222d21fcf" />

BEFORE - Notification not aligns with gCode viewer and leaves extra spacing on bottom
<img alt="Screenshot-20250623091235" src="https://github.com/user-attachments/assets/5d6c6de1-319d-4d69-a2c1-134d8923641b" />

AFTER
<img alt="Screenshot-20250623091838" src="https://github.com/user-attachments/assets/843f356d-8f56-421d-ad98-720c5269b72f" />
