### PR TITLE
fix for printer time estimate on anker/eufy M5 M5C printers

### DIFF
--- a/resources/profiles/Anker/machine/fdm_marlin_common.json
+++ b/resources/profiles/Anker/machine/fdm_marlin_common.json
@@ -6,7 +6,7 @@
     "instantiation": "false",
     "gcode_flavor": "marlin2",
     "before_layer_change_gcode": ";BEFORE_LAYER_CHANGE\nG92 E0.0\n;[layer_z]\n\n",
-    "machine_start_gcode": "M4899 T3 ; Enable v3 jerk and S-curve acceleration \nM104 S150 ; Set hotend temp to 150 degrees to prevent ooze\nM190 S{first_layer_bed_temperature[0]} ; set and wait for bed temp to stabilize\nM109 S{first_layer_temperature[0]} ; set final nozzle temp to stabilize\nG28 ;Home",
+    "machine_start_gcode": "M4899 T3 ; Enable v3 jerk and S-curve acceleration \nM104 S150 ; Set hotend temp to 150 degrees to prevent ooze\nM190 S{first_layer_bed_temperature[0]} ; set and wait for bed temp to stabilize\nM109 S{first_layer_temperature[0]} ; set final nozzle temp to stabilize\nG28 ;Home\n;LAYER_COUNT:{total_layer_count}",
     "machine_end_gcode": "M104 S0\nM140 S0\n;Retract the filament\nG92 E1\nG1 E-1 F300\nG28 X0 Y0\nM18",
     "change_filament_gcode": "M600",
     "machine_pause_gcode": "M601"


### PR DESCRIPTION
fix for time discrepancy, ;LAYER_COUNT was missing which made it impossible for the anker M5/M5C to have a correct predicted time.

# Description


added a command to the machine g-code to add the LAYER_COUNT into the gcode to make time estimated on ankermake/eufymake printers work again. see PR : #9457

does not  break any code, its a small update to the printer profile
# Screenshots/Recordings/Graphs

no UI changes

## Tests

manually added the ;LAYER_COUNT : 50 into a g-code and verified the result in the printer firmware and display.
