### PR TITLE
added skin_infill_line_width and skeleton_infill_line_width to fix Ginger Additive profiles

### DIFF
--- a/resources/profiles/Ginger Additive/process/0.60mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/0.60mm Standard.json
@@ -73,5 +73,7 @@
   "xy_contour_compensation": "0",
   "xy_hole_compensation": "0",
   "instantiation": "true",
+  "skin_infill_line_width": "1.2",
+  "skeleton_infill_line_width": "1.2",
   "compatible_printers": ["Ginger G1 1.2 nozzle"]
 }

--- a/resources/profiles/Ginger Additive/process/0.60mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/0.60mm Standard.json
@@ -67,7 +67,7 @@
   "travel_acceleration": "2500",
   "travel_jerk": "7",
   "travel_speed": "250",
-  "version": "0.0.0.0",
+  "version": "0.0.0.1",
   "wipe_on_loops": "1",
   "wipe_speed": "30",
   "xy_contour_compensation": "0",

--- a/resources/profiles/Ginger Additive/process/1.50mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/1.50mm Standard.json
@@ -64,5 +64,7 @@
   "xy_contour_compensation": "0",
   "xy_hole_compensation": "0",
   "instantiation": "true",
+  "skin_infill_line_width": "3.0",
+  "skeleton_infill_line_width": "3.0",
   "compatible_printers": ["Ginger G1 3.0 nozzle"]
 }

--- a/resources/profiles/Ginger Additive/process/1.50mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/1.50mm Standard.json
@@ -56,7 +56,7 @@
   "travel_acceleration": "2500",
   "travel_jerk": "7",
   "travel_speed": "250",
-  "version": "0.0.0.0",
+  "version": "0.0.0.1",
   "wall_generator": "arachne",
   "wall_loops": "1",
   "wipe_on_loops": "1",

--- a/resources/profiles/Ginger Additive/process/1.80mm Vasemode.json
+++ b/resources/profiles/Ginger Additive/process/1.80mm Vasemode.json
@@ -63,7 +63,7 @@
   "travel_acceleration": "2500",
   "travel_jerk": "7",
   "travel_speed": "250",
-  "version": "0.0.0.0",
+  "version": "0.0.0.1",
   "wall_loops": "1",
   "wipe_on_loops": "1",
   "wipe_speed": "40",

--- a/resources/profiles/Ginger Additive/process/1.80mm Vasemode.json
+++ b/resources/profiles/Ginger Additive/process/1.80mm Vasemode.json
@@ -70,5 +70,7 @@
   "xy_contour_compensation": "0",
   "xy_hole_compensation": "0",
   "instantiation": "true",
+  "skin_infill_line_width": "3.0",
+  "skeleton_infill_line_width": "3.0",
   "compatible_printers": ["Ginger G1 3.0 nozzle"]
 }

--- a/resources/profiles/Ginger Additive/process/2.50mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/2.50mm Standard.json
@@ -71,5 +71,7 @@
   "xy_contour_compensation": "0",
   "xy_hole_compensation": "0",
   "instantiation": "true",
+  "skin_infill_line_width": "5.0",
+  "skeleton_infill_line_width": "5.0",
   "compatible_printers": ["Ginger G1 5.0 nozzle"]
 }

--- a/resources/profiles/Ginger Additive/process/2.50mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/2.50mm Standard.json
@@ -63,7 +63,7 @@
   "travel_acceleration": "2500",
   "travel_jerk": "7",
   "travel_speed": "250",
-  "version": "0.0.0.0",
+  "version": "0.0.0.1",
   "wall_generator": "arachne",
   "wall_loops": "1",
   "wipe_on_loops": "1",

--- a/resources/profiles/Ginger Additive/process/4.00mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/4.00mm Standard.json
@@ -61,7 +61,7 @@
   "travel_acceleration": "2500",
   "travel_jerk": "7",
   "travel_speed": "250",
-  "version": "0.0.0.0",
+  "version": "0.0.0.1",
   "wall_generator": "arachne",
   "wall_loops": "1",
   "wipe_on_loops": "1",

--- a/resources/profiles/Ginger Additive/process/4.00mm Standard.json
+++ b/resources/profiles/Ginger Additive/process/4.00mm Standard.json
@@ -69,5 +69,7 @@
   "xy_contour_compensation": "0",
   "xy_hole_compensation": "0",
   "instantiation": "true",
+  "skin_infill_line_width": "8.0",
+  "skeleton_infill_line_width": "8.0",
   "compatible_printers": ["Ginger G1 8.0 nozzle"]
 }


### PR DESCRIPTION
# Description
This PR add the values for **skin_infill_line_width** and **skeleton_infill_line_width** inside the profiles because having nozzles larger than 0.4mm it cause a bug if not defined as reported in the Issue https://github.com/SoftFever/OrcaSlicer/issues/9993

# Screenshots/Recordings/Graphs
N.A.

## Tests
opened and sliced a project correctly with the default parameters 