### PR TITLE
Fixes / Improvements for Label colors

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2923,10 +2923,10 @@ void GUI_App::init_label_colours()
 {
     bool is_dark_mode = dark_mode();
     m_color_label_modified = is_dark_mode ? wxColour("#F1754E") : wxColour("#F1754E");
-    m_color_label_sys      = is_dark_mode ? wxColour("#B2B3B5") : wxColour("#363636");
+    m_color_label_sys      = is_dark_mode ? wxColour("#CCCCCC") : wxColour("#363636");
 
 #if defined(_WIN32) || defined(__linux__) || defined(__APPLE__)
-    m_color_label_default           = is_dark_mode ? wxColour(250, 250, 250) : m_color_label_sys; // wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+    m_color_label_default           = is_dark_mode ? wxColour("#ADADD8") : wxColour("#464A84"); // ORCA text color for modified preset value
     m_color_highlight_label_default = is_dark_mode ? wxColour(230, 230, 230): wxSystemSettings::GetColour(/*wxSYS_COLOUR_HIGHLIGHTTEXT*/wxSYS_COLOUR_WINDOWTEXT);
     m_color_highlight_default       = is_dark_mode ? wxColour("#36363B") : wxColour("#F1F1F1"); // ORCA row highlighting
     m_color_hovered_btn_label       = is_dark_mode ? wxColour(255, 255, 254) : wxColour(0,0,0);

--- a/src/slic3r/GUI/Widgets/StateColor.cpp
+++ b/src/slic3r/GUI/Widgets/StateColor.cpp
@@ -35,7 +35,7 @@ static std::map<wxColour, wxColour> gDarkColors{
     {"#303A3C", "#E5E5E5"}, // rgb(48, 58, 60)     Object Table > Column header text color | StaticBox Border Color
     {"#FEFFFF", "#242428"}, // rgb(254, 255, 255)  Side Tabbar bg | 
     {"#A6A9AA", "#2D2D29"}, // rgb(166, 169, 170)  Seperator color
-    {"#363636", "#B2B3B5"}, // rgb(54, 54, 54)     Sidebar > Parameter Label/Title color | Sidebar tab text | Create Filament window text
+    {"#363636", "#CCCCCC"}, // rgb(54, 54, 54)     Sidebar > Parameter Label/Title color | Sidebar tab text | Create Filament window text
     {"#F0F0F1", "#333337"}, // rgb(240, 240, 241)  Disabled element background // ORCA Used better background color for dark mode
     {"#9E9E9E", "#53545A"}, // rgb(158, 158, 158)  ???
     {"#D7E8DE", "#1F2B27"}, // rgb(215, 232, 222)  Not Used anymore // Leftover from BBS

--- a/src/slic3r/GUI/Widgets/TabCtrl.cpp
+++ b/src/slic3r/GUI/Widgets/TabCtrl.cpp
@@ -101,8 +101,8 @@ int TabCtrl::AppendItem(const wxString &item,
     btn->Create(this, item, "", wxBORDER_NONE);
     btn->SetFont(GetFont());
     btn->SetTextColor(StateColor(
-        std::make_pair(0x6B6B6C, (int) StateColor::NotChecked),
-        std::make_pair(*wxLIGHT_GREY, (int) StateColor::Normal)));
+        std::make_pair(wxColour("#6B6B6C"), (int) StateColor::NotChecked),
+        std::make_pair(wxColour("#363636"), (int) StateColor::Normal)));
     btn->SetBackgroundColor(StateColor());
     btn->SetCornerRadius(0);
     btn->SetPaddingSize({TAB_BUTTON_PADDING});


### PR DESCRIPTION
### TODO
• Simplify solution / fix conditions

### FIXES
• Modified preset value not visible on light theme
• Tab colors broken after using "reset all settings" button
before
![orca-slicer_YhVRS7To05](https://github.com/user-attachments/assets/e3eefa3e-48e4-4d2e-8f2d-27de48684fad)
after
![orca-slicer_cjBVJoYS5k](https://github.com/user-attachments/assets/20db0b6d-434c-400e-bf3d-34e0a4cd1e3f)

removed usage of `if (page->set_item_colour(clr))` and `p->get_item_colour()` so it always sets value. let me know if it has any advantage

didnt understand condition for `m_type >= Preset::TYPE_COUNT`. i can provide a better solution if you inform me

### CHANGES / COMPARISON
• Used a purplish color for modified value to make it obvious. many people (including me) couldnt get its a feature. ex.  https://github.com/SoftFever/OrcaSlicer/issues/9985
or we can completely ignore using second color on labels
Before - Light theme
![Screenshot-20250624160534](https://github.com/user-attachments/assets/e9bb2640-6217-49dc-912b-32cfd1863bac)
After
![Screenshot-20250624160505](https://github.com/user-attachments/assets/7d1ea610-a08f-4974-b159-eff5948d62aa)

Before - Dark theme
![Screenshot-20250624171012](https://github.com/user-attachments/assets/7aa81edc-2b34-4a94-b551-85fcf1be6997)
After
![Screenshot-20250624154106](https://github.com/user-attachments/assets/68483ce0-0de6-43d3-90dd-5a7a22cd4dde)

• Made Label colors slightly brighter for dark theme
Before
![Screenshot-20250624171140](https://github.com/user-attachments/assets/b952a1bb-67b4-4c08-9701-28dcfbe76341)

After
![Screenshot-20250624171131](https://github.com/user-attachments/assets/fcf69ed9-a650-44c4-b821-7b852c37d9af)

