### PR TITLE
Restrict infill combination for line, rectilinear, zigzag, crosszag & lockedzag patterns

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -550,7 +550,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     // Avoid combining stacked infill patterns
     bool          not_combine_infill_pattern = pattern == ipLine || pattern == ipRectilinear || pattern == ipZigZag || pattern == ipCrossZag || pattern == ipLockedZag ;
 
-    toggle_line("infill_combination", !not_combine_infill_pattern);
+    toggle_field("infill_combination", !not_combine_infill_pattern);
 
     if (not_combine_infill_pattern == true){
         config->set("infill_combination", ConfigOptionBool(false));

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -546,6 +546,17 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     bool have_combined_infill = config->opt_bool("infill_combination") && have_infill;
     toggle_line("infill_combination_max_layer_height", have_combined_infill);
 
+    InfillPattern pattern = config->opt_enum<InfillPattern>("sparse_infill_pattern");
+    // Avoid combining stacked infill patterns
+    bool          not_combine_infill_pattern = pattern == ipLine || pattern == ipRectilinear || pattern == ipZigZag || pattern == ipCrossZag || pattern == ipLockedZag ;
+
+    toggle_line("infill_combination", !not_combine_infill_pattern);
+
+    if (not_combine_infill_pattern == true){
+        config->set("infill_combination", ConfigOptionBool(false));
+    }
+
+    // Hide infill anchor max if sparse_infill_pattern is not line or if sparse_infill_pattern is line but infill_anchor_max is 0.
     bool infill_anchor = config->opt_enum<InfillPattern>("sparse_infill_pattern") != ipLine;
     toggle_field("infill_anchor_max",infill_anchor);
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -553,7 +553,9 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     toggle_field("infill_combination", !not_combine_infill_pattern);
 
     if (not_combine_infill_pattern == true){
-        config->set("infill_combination", ConfigOptionBool(false));
+      DynamicPrintConfig new_conf = *config;
+      new_conf.set_key_value("infill_combination", new ConfigOptionBool(false));
+      apply(config, &new_conf); 
     }
 
     // Hide infill anchor max if sparse_infill_pattern is not line or if sparse_infill_pattern is line but infill_anchor_max is 0.


### PR DESCRIPTION
Added logic to disable and reset the 'infill_combination' option for specific infill patterns (line, rectilinear, zigzag, crosszag, lockedzag) to prevent combining stacked infill patterns.

# Description
Linear, rectilinear, zigzag, cross zigzag and locked zigzag infill patterns are not suitable for combining, because combining 2 layers removes lines in one direction.
This modification grayed out the option and disables the fill combination to avoid this inconvenience.
Rectilinear infill (not combined):
![image](https://github.com/user-attachments/assets/75e038a3-d1d8-4720-8757-223eaf17ed3c)
Rectilinear infill (combined):
![image](https://github.com/user-attachments/assets/2d6c391a-8a27-43c3-b5a2-076331a97069)
Modified menu:
![image](https://github.com/user-attachments/assets/5e0acf24-48bf-44ca-bdaf-77ff0b6e9f47)
