### PR TITLE
Updated the documentation on how to build OrcaSlicer

### DIFF
--- a/doc/developer-reference/How-to-build.md
+++ b/doc/developer-reference/How-to-build.md
@@ -1,8 +1,31 @@
+<!--
 # How to Build
+-->
+
+This wiki page provides detailed instructions for building OrcaSlicer from source on different operating systems, including Windows, macOS, and Linux. 
+It includes tool requirements, setup commands, and build steps for each platform. Whether you're a contributor or just want a custom build, 
+this guide will help you compile OrcaSlicer successfully.
+
+- [Windows 64-bit](#windows-64-bit)
+  - [Tools Required](#tools-required)
+  - [Instructions](#instructions)
+- [macOS 64-bit](#macos-64-bit)
+  - [Tools Required](#tools-required-1)
+  - [Instructions](#instructions-1)
+  - [Debugging in Xcode](#debugging-in-xcode)
+- [Linux](#linux)
+  - [Using Docker (Recommended)](#using-docker-recommended)
+    - [Dependencies](#dependencies)
+    - [Instructions](#instructions-2)
+  - [Troubleshooting](#troubleshooting)
+- [Ubuntu](#ubuntu)
+  - [Dependencies](#dependencies-1)
+  - [Instructions](#instructions-3)
+- [Portable User Configuration](#portable-user-configuration)
 
 ## Windows 64-bit
 
-This guide is for building your Visual Studio 2022 solution for OrcaSlicer on Windows 64-bit.
+how to building with your Visual Studio 2022 on Windows 64-bit.
 
 ### Tools Required
 
@@ -74,7 +97,9 @@ This guide is for building your Visual Studio 2022 solution for OrcaSlicer on Wi
 > [!NOTE]
 > If the build fails, try deleting the `build/` and `deps/build/` directories to clear any cached build data. Rebuilding after a clean-up is usually sufficient to resolve most issues.
 
-## macOS 64-bit
+## MacOS 64-bit
+
+how to building with your Visual Studio 2022 on MacOS 64-bit.
 
 ### Tools Required
 
@@ -147,6 +172,8 @@ To build and debug directly in Xcode:
 
 ## Linux
 
+how to building with your Visual Studio 2022 on Linux.
+
 ### Using Docker (Recommended)
 
 #### Dependencies
@@ -205,3 +232,21 @@ All required dependencies will be installed automatically by the provided shell 
 `./build_linux.sh -u`      # install dependencies
 `./build_linux.sh -disr`    # build OrcaSlicer
 ```
+
+## Portable User Configuration
+
+If you want OrcaSlicer to use a custom user configuration folder (e.g., for a portable installation), you can simply place a folder named `data_dir` next to the OrcaSlicer executable. OrcaSlicer will automatically use this folder as its configuration directory.
+
+This allows for multiple self-contained installations with separate user data.
+
+> [!TIP]
+> This feature is especially useful if you want to run OrcaSlicer from a USB stick or keep different profiles isolated.
+
+### Example folder structure
+
+```
+OrcaSlicer.exe
+data_dir/
+```
+
+You don’t need to recompile or modify any settings — this works out of the box as long as `data_dir` exists in the same folder as the executable.

--- a/doc/developer-reference/How-to-build.md
+++ b/doc/developer-reference/How-to-build.md
@@ -1,33 +1,33 @@
-<!--
 # How to Build
--->
 
-This wiki page provides detailed instructions for building OrcaSlicer from source on different operating systems, including Windows, macOS, and Linux. 
-It includes tool requirements, setup commands, and build steps for each platform. Whether you're a contributor or just want a custom build, 
-this guide will help you compile OrcaSlicer successfully.
+This wiki page provides detailed instructions for building OrcaSlicer from source on different operating systems, including Windows, macOS, and Linux.  
+It includes tool requirements, setup commands, and build steps for each platform.
+
+Whether you're a contributor or just want a custom build, this guide will help you compile OrcaSlicer successfully.
 
 - [Windows 64-bit](#windows-64-bit)
-  - [Tools Required](#tools-required)
-  - [Instructions](#instructions)
-- [macOS 64-bit](#macos-64-bit)
-  - [Tools Required](#tools-required-1)
-  - [Instructions](#instructions-1)
+  - [Windows Tools Required](#windows-tools-required)
+  - [Windows Instructions](#windows-instructions)
+- [MacOS 64-bit](#macos-64-bit)
+  - [MacOS Tools Required](#macos-tools-required)
+  - [MacOS Instructions](#macos-instructions)
   - [Debugging in Xcode](#debugging-in-xcode)
 - [Linux](#linux)
   - [Using Docker (Recommended)](#using-docker-recommended)
-    - [Dependencies](#dependencies)
-    - [Instructions](#instructions-2)
+    - [Docker Dependencies](#docker-dependencies)
+    - [Docker Instructions](#docker-instructions)
   - [Troubleshooting](#troubleshooting)
 - [Ubuntu](#ubuntu)
-  - [Dependencies](#dependencies-1)
-  - [Instructions](#instructions-3)
+  - [Ubuntu Dependencies](#ubuntu-dependencies)
+  - [Ubuntu Instructions](#ubuntu-instructions)
 - [Portable User Configuration](#portable-user-configuration)
+  - [Example folder structure](#example-folder-structure)
 
 ## Windows 64-bit
 
-how to building with your Visual Studio 2022 on Windows 64-bit.
+How to building with Visual Studio 2022 on Windows 64-bit.
 
-### Tools Required
+### Windows Tools Required
 
 - [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) or Visual Studio 2019
   ```shell
@@ -56,7 +56,7 @@ how to building with your Visual Studio 2022 on Windows 64-bit.
 > winget install --id=GitHub.GitHubDesktop -e
 > ```
 
-### Instructions
+### Windows Instructions
 
 1. Clone the repository:
    - If using GitHub Desktop clone the repository from the GUI.
@@ -99,9 +99,9 @@ how to building with your Visual Studio 2022 on Windows 64-bit.
 
 ## MacOS 64-bit
 
-how to building with your Visual Studio 2022 on MacOS 64-bit.
+How to building with Xcode on MacOS 64-bit.
 
-### Tools Required
+### MacOS Tools Required
 
 - Xcode
 - CMake (version 3.31.x is mandatory)
@@ -139,7 +139,7 @@ cmake --version
 > [!IMPORTANT]
 > If you've recently upgraded Xcode, be sure to open Xcode at least once and install the required macOS build support.
 
-### Instructions
+### MacOS Instructions
 
 1. Clone the repository:
    ```shell
@@ -172,16 +172,18 @@ To build and debug directly in Xcode:
 
 ## Linux
 
-how to building with your Visual Studio 2022 on Linux.
+Linux instructions are available in two formats: using Docker (recommended) or building directly on your system.
 
 ### Using Docker (Recommended)
 
-#### Dependencies
+How to build and run OrcaSlicer using Docker.
+
+#### Docker Dependencies
 
 - Docker
 - Git
 
-#### Instructions
+#### Docker Instructions
 
 ```shell
 git clone https://github.com/SoftFever/OrcaSlicer && cd OrcaSlicer && ./DockerBuild.sh && ./DockerRun.sh
@@ -206,7 +208,9 @@ By uncommenting and using these options as needed, you can often resolve issues 
 
 ## Ubuntu
 
-### Dependencies
+How to build OrcaSlicer on Ubuntu.
+
+### Ubuntu Dependencies
 
 All required dependencies will be installed automatically by the provided shell script, including:
 
@@ -226,7 +230,7 @@ All required dependencies will be installed automatically by the provided shell 
 - git
 - texinfo
 
-### Instructions
+### Ubuntu Instructions
 
 ```shell
 `./build_linux.sh -u`      # install dependencies
@@ -244,7 +248,7 @@ This allows for multiple self-contained installations with separate user data.
 
 ### Example folder structure
 
-```
+```shell
 OrcaSlicer.exe
 data_dir/
 ```


### PR DESCRIPTION
# Description

This PR updates the [How to build](https://github.com/SoftFever/OrcaSlicer/wiki/How-to-build) wiki page with the following improvements:
- Introduced a table of contents at the top for easier navigation across sections (Windows, macOS, Linux, Ubuntu).
- Added an introductory paragraph to clarify the purpose of the page.
- Adds a pragraph on how to use the `data_dir` folder

Co-authored-by: @ianalexis

# Screenshots/Recordings/Graphs

N.A.

## Tests

- Verified that the new section renders correctly in Markdown.
- Validated that the `data_dir` functionality works as described (place data_dir next to OrcaSlicer.exe and it uses it as the configuration folder).
- Checked links and internal anchors in the Table of Contents.