### PR TITLE
Fix MVF calibration image refs

### DIFF
--- a/doc/calibration/Calibration.md
+++ b/doc/calibration/Calibration.md
@@ -37,7 +37,7 @@ The recommended order for calibration is as follows:
 
 4. **[Max Volumetric Speed](volumetric-speed-calib):** Calibrate the maximum volumetric speed of the filament. This is important for ensuring that the printer can handle the flow rate of the filament without causing issues such as under-extrusion or over-extrusion.
 
-   <img src="https://github.com/SoftFever/OrcaSlicer/blob/main/doc/images/vmf_measurement_point.jpg?raw=true" alt="Max_Volumetric_Speed" height="200">
+   <img src="https://github.com/SoftFever/OrcaSlicer/blob/main/doc/images/MVF/mvf_measurement_point.jpg?raw=true" alt="Max_Volumetric_Speed" height="200">
 
 5. **[Cornering](cornering-calib):** Calibrate the Jerk/Junction Deviation settings to improve print quality and reduce artifacts caused by sharp corners and changes in direction.
 

--- a/doc/calibration/volumetric-speed-calib.md
+++ b/doc/calibration/volumetric-speed-calib.md
@@ -6,15 +6,15 @@ You will be promted to enter the settings for the test: start volumetric speed, 
 
 Once printed, take note of where the layers begin to fail and where the quality begins to suffer. Pay attention to changes from matte to shiny as well.
 
-![mvf_measurement_point](https://github.com/SoftFever/OrcaSlicer/blob/main/doc/images/mvf/mvf_measurement_point.jpg?raw=true)
+![mvf_measurement_point](https://github.com/SoftFever/OrcaSlicer/blob/main/doc/images/MVF/mvf_measurement_point.jpg?raw=true)
 
 Using calipers or a ruler, measure the height of the print at that point. Use the following calculation to determine the correct max flow value: `start + (height-measured * step)` . For example in the photo below, and using the default setting values, the print quality began to suffer at 19mm measured, so the calculation would be: `5 + (19 * 0.5)` , or `13mm³/s` using the default values. Enter your number into the "Max volumetric speed" value in the filament settings.
 
-![mvf_caliper_sample_mvf](https://github.com/SoftFever/OrcaSlicer/blob/main/doc/images/mvf/mvf_caliper_sample_mvf.jpg?raw=true)
+![mvf_caliper_sample_mvf](https://github.com/SoftFever/OrcaSlicer/blob/main/doc/images/MVF/mvf_caliper_sample_mvf.jpg?raw=true)
 
 You can also return to OrcaSlicer in the "Preview" tab, make sure the color scheme "flow" is selected. Scroll down to the layer height that you measured, and click on the toolhead slider. This will indicate the max flow level for your filament.
 
-![mvf_gui_flow](https://github.com/SoftFever/OrcaSlicer/blob/main/doc/images/mvf/mvf_gui_flow.jpg?raw=true)
+![mvf_gui_flow](https://github.com/SoftFever/OrcaSlicer/blob/main/doc/images/MVF/mvf_gui_flow.jpg?raw=true)
 
 > [!NOTE]
 > You may also choose to conservatively reduce the flow by 5-10% to ensure print quality.


### PR DESCRIPTION
# Description
- images in MVF calibration guide [/doc/calibration/volumetric-speed-calib.md](https://github.com/SoftFever/OrcaSlicer/blob/main/doc/calibration/volumetric-speed-calib.md) were referencing `https://github.com/SoftFever/OrcaSlicer/raw/main/doc/images/mvf/`, but those images were moved to `https://github.com/SoftFever/OrcaSlicer/blob/main/doc/images/MVF` (capital), causing mismatch
- MVF image in main Calibration .md [/doc/calibration/Calibration.md](https://github.com/SoftFever/OrcaSlicer/blob/main/doc/calibration/Calibration.md) was still referencing its old location at `doc/images/vmf_measurement_point.jpg` instead of its new location at `doc/images/MVF/vmf_measurement_point.jpg`

# Changes
- update all 3 images' refs in `/doc/calibration/volumetric-speed-calib.md` 
- update 1 image ref in `/doc/calibration/Calibration.md`
- fixes #10054



