### PR TITLE
  Multiline infill support  for 2D lattice and 2DHoneycomb patterns

### DIFF
--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3011,7 +3011,7 @@ bool FillRectilinear::fill_surface_by_multilines(const Surface *surface, FillPar
         }
     }
 
-if (params.pattern == ip2DLattice && params.multiline >1 )
+if ((params.pattern == ip2DLattice || params.pattern == ip2DHoneycomb ) && params.multiline >1 )
     remove_overlapped(fill_lines, line_width);
 
     if (!fill_lines.empty()) {
@@ -3173,7 +3173,7 @@ Polylines Fill2DHoneycomb::fill_surface(const Surface *surface, const FillParams
     using namespace boost::math::float_constants;
 
     // lets begin calculating some base properties of the honeycomb pattern
-    const float half_horizontal_period = .5f * (1*(2/3.f) + 2*(1/3.f)) * float(spacing) / params.density;
+    const float half_horizontal_period = .5f * (1*(2/3.f) + 2*(1/3.f)) * float(spacing) * params.multiline / params.density;
     const float vertical_period = 3 * half_horizontal_period / tanf(degree * float(params.infill_overhang_angle));
 
     // we want to align the base pattern with its knot on height 0

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -549,7 +549,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
 
     // Infill patterns that support multiline infill.
     InfillPattern pattern = config->opt_enum<InfillPattern>("sparse_infill_pattern");
-    bool          have_multiline_infill_pattern = pattern == ipGyroid || pattern == ipGrid || pattern == ipRectilinear || pattern == ipTpmsD || pattern == ipCrossHatch || pattern == ipHoneycomb || pattern == ip2DLattice || 
+    bool          have_multiline_infill_pattern = pattern == ipGyroid || pattern == ipGrid || pattern == ipRectilinear || pattern == ipTpmsD || pattern == ipCrossHatch || pattern == ipHoneycomb || pattern == ip2DLattice || pattern == ip2DHoneycomb ||
                                                   pattern == ipCubic || pattern == ipStars || pattern == ipAlignedRectilinear || pattern == ipLightning || pattern == ip3DHoneycomb || pattern == ipAdaptiveCubic || pattern == ipSupportCubic;
     toggle_line("fill_multiline", have_multiline_infill_pattern);
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -549,12 +549,12 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
 
     // Infill patterns that support multiline infill.
     InfillPattern pattern = config->opt_enum<InfillPattern>("sparse_infill_pattern");
-    bool          have_multiline_infill_pattern = pattern == ipGyroid || pattern == ipGrid || pattern == ipRectilinear || pattern == ipTpmsD || pattern == ipCrossHatch || pattern == ipHoneycomb ||
+    bool          have_multiline_infill_pattern = pattern == ipGyroid || pattern == ipGrid || pattern == ipRectilinear || pattern == ipTpmsD || pattern == ipCrossHatch || pattern == ipHoneycomb || pattern == ip2DLattice || 
                                                   pattern == ipCubic || pattern == ipStars || pattern == ipAlignedRectilinear || pattern == ipLightning || pattern == ip3DHoneycomb || pattern == ipAdaptiveCubic || pattern == ipSupportCubic;
     toggle_line("fill_multiline", have_multiline_infill_pattern);
 
     // If the infill pattern does not support multiline infill, set fill_multiline to 1.
-    if (have_multiline_infill_pattern==false) {
+    if (!have_multiline_infill_pattern) {
         DynamicPrintConfig new_conf = *config;
         new_conf.set_key_value("fill_multiline", new ConfigOptionInt(1));
         apply(config, &new_conf);


### PR DESCRIPTION
In this pull request, I add support for 2D lattice and 2D honeycomb infill patterns. Previously, I couldn't provide multiline support for them due to the issue of overlapping lines. To solve this, a function was added that removes overlapping lines, allowing the generation of multiline patterns without problems.
![image](https://github.com/user-attachments/assets/74423a96-0a5d-42b4-a1fd-21a455e6ad36)
![image](https://github.com/user-attachments/assets/6c0a5281-c328-442d-9f50-8df9996b872c)
![image](https://github.com/user-attachments/assets/5518a7fe-8b7c-49fa-9fc0-065b07b68537)
![image](https://github.com/user-attachments/assets/8c336496-56ab-47eb-9642-b228042daf8b)
