### PR TITLE
Allow top surface pattern for spiral_vase

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -589,7 +589,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     bool has_top_shell    = config->opt_int("top_shell_layers") > 0;
     bool has_bottom_shell = config->opt_int("bottom_shell_layers") > 0;
     bool has_solid_infill = has_top_shell || has_bottom_shell;
-    toggle_field("top_surface_pattern", has_top_shell);
+    // When using spiral_vase, the topmost layer of the bottom shell uses top_surface_pattern.
+    toggle_field("top_surface_pattern", has_top_shell || has_spiral_vase);
     toggle_field("bottom_surface_pattern", has_bottom_shell);
     toggle_field("top_surface_density", has_top_shell);
     toggle_field("bottom_surface_density", has_bottom_shell);


### PR DESCRIPTION
When spiral_vase is enabled, the topmost surface of the bottom shell takes on the pattern of top_surface_pattern. This is good since with vase mode the bottom shell is also the top shell.
ConfigManipulation however does not consider this and does not allow chaning the top_surface_pattern even though the value itself is used.

With this commit chaning the top_surface_pattern option is allowed when spiral_vase is enabled.

I have built and run this commit and I have manually tested this change.
![screenshot_2025-07-08-180145_grim](https://github.com/user-attachments/assets/91b76e20-d254-4b76-aecc-63c72a7f196c)
