### PR TITLE
Spiral vase seam Bug fix

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6151,7 +6151,7 @@ std::string GCode::travel_to(const Point& point, ExtrusionRole role, std::string
     // use G1 because we rely on paths being straight (G0 may make round paths)
     if (travel.size() >= 2) {
         // Orca: use `travel_to_xyz` to ensure we start at the correct z, in case we moved z in custom/filament change gcode
-        if (m_spiral_vase &&  m_toolchange_count ==0 ) {
+        if (m_spiral_vase && m_toolchange_count == 0 ) {
             // No lazy z lift for spiral vase mode
             for (size_t i = 1; i < travel.size(); ++i) {
                 gcode += m_writer.travel_to_xy(this->point_to_gcode(travel.points[i]), comment);

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6151,7 +6151,7 @@ std::string GCode::travel_to(const Point& point, ExtrusionRole role, std::string
     // use G1 because we rely on paths being straight (G0 may make round paths)
     if (travel.size() >= 2) {
         // Orca: use `travel_to_xyz` to ensure we start at the correct z, in case we moved z in custom/filament change gcode
-        if (false || m_spiral_vase) {
+        if (m_spiral_vase &&  m_toolchange_count ==0 ) {
             // No lazy z lift for spiral vase mode
             for (size_t i = 1; i < travel.size(); ++i) {
                 gcode += m_writer.travel_to_xy(this->point_to_gcode(travel.points[i]), comment);

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6151,7 +6151,7 @@ std::string GCode::travel_to(const Point& point, ExtrusionRole role, std::string
     // use G1 because we rely on paths being straight (G0 may make round paths)
     if (travel.size() >= 2) {
         // Orca: use `travel_to_xyz` to ensure we start at the correct z, in case we moved z in custom/filament change gcode
-        if (m_spiral_vase && m_toolchange_count == 0 ) {
+        if (m_spiral_vase && m_toolchange_count == 0 && !m_writer.multiple_extruders) {
             // No lazy z lift for spiral vase mode
             for (size_t i = 1; i < travel.size(); ++i) {
                 gcode += m_writer.travel_to_xy(this->point_to_gcode(travel.points[i]), comment);

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6151,7 +6151,7 @@ std::string GCode::travel_to(const Point& point, ExtrusionRole role, std::string
     // use G1 because we rely on paths being straight (G0 may make round paths)
     if (travel.size() >= 2) {
         // Orca: use `travel_to_xyz` to ensure we start at the correct z, in case we moved z in custom/filament change gcode
-        if (false/*m_spiral_vase*/) {
+        if (false || m_spiral_vase) {
             // No lazy z lift for spiral vase mode
             for (size_t i = 1; i < travel.size(); ++i) {
                 gcode += m_writer.travel_to_xy(this->point_to_gcode(travel.points[i]), comment);


### PR DESCRIPTION
This pull request addresses the bug reported in [issue #10072](https://github.com/SoftFever/OrcaSlicer/issues/10072#issuecomment-3046055200).
The problem was introduced by commit 9db74c0.
this line is the problem        ` if (false/*m_spiral_vase*/) {`
before:
![image](https://github.com/user-attachments/assets/0430e864-477b-4439-a418-f79150c63a06)
after:
![image](https://github.com/user-attachments/assets/f1f42bb6-fa1b-40c4-b3ee-f49de0689041)
fixes #10072 

~~TODO: fix multimaterial issue~~