### PR TITLE
add user name placeholder

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2041,6 +2041,7 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     // Prepare the helper object for replacing placeholders in custom G-code and output filename.
     m_placeholder_parser_integration.parser = print.placeholder_parser();
     m_placeholder_parser_integration.parser.update_timestamp();
+    m_placeholder_parser_integration.parser.update_user_name();
     m_placeholder_parser_integration.context.rng = std::mt19937(std::chrono::high_resolution_clock::now().time_since_epoch().count());
     // Enable passing global variables between PlaceholderParser invocations.
     m_placeholder_parser_integration.context.global_config = std::make_unique<DynamicConfig>();

--- a/src/libslic3r/PlaceholderParser.cpp
+++ b/src/libslic3r/PlaceholderParser.cpp
@@ -27,6 +27,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/nowide/convert.hpp>
+#include <boost/nowide/cstdlib.hpp>
 
 // Spirit v2.5 allows you to suppress automatic generation
 // of predefined terminals to speed up complation. With

--- a/src/libslic3r/PlaceholderParser.cpp
+++ b/src/libslic3r/PlaceholderParser.cpp
@@ -71,6 +71,7 @@ PlaceholderParser::PlaceholderParser(const DynamicConfig *external_config) : m_e
     this->set("version", std::string(SoftFever_VERSION));
     this->apply_env_variables();
     this->update_timestamp();
+    this->update_user_name();
 }
 
 void PlaceholderParser::update_timestamp(DynamicConfig &config)
@@ -96,6 +97,12 @@ void PlaceholderParser::update_timestamp(DynamicConfig &config)
     config.set_key_value("hour",   new ConfigOptionInt(timeinfo->tm_hour));
     config.set_key_value("minute", new ConfigOptionInt(timeinfo->tm_min));
     config.set_key_value("second", new ConfigOptionInt(timeinfo->tm_sec));
+}
+
+void PlaceholderParser::update_user_name(DynamicConfig &config)
+{
+    const char* user = getenv("USER") ? getenv("USER") : getenv("USERNAME") ? getenv("USERNAME") : "unknown";
+    config.set_key_value("user", new ConfigOptionString(user));
 }
 
 static inline bool opts_equal(const DynamicConfig &config_old, const DynamicConfig &config_new, const std::string &opt_key)

--- a/src/libslic3r/PlaceholderParser.cpp
+++ b/src/libslic3r/PlaceholderParser.cpp
@@ -101,7 +101,7 @@ void PlaceholderParser::update_timestamp(DynamicConfig &config)
 
 void PlaceholderParser::update_user_name(DynamicConfig &config)
 {
-    const char* user = getenv("USER") ? getenv("USER") : getenv("USERNAME") ? getenv("USERNAME") : "unknown";
+    const char* user = boost::nowide::getenv("USER") ? boost::nowide::getenv("USER") : boost::nowide::getenv("USERNAME") ? boost::nowide::getenv("USERNAME") : "unknown";
     config.set_key_value("user", new ConfigOptionString(user));
 }
 

--- a/src/libslic3r/PlaceholderParser.hpp
+++ b/src/libslic3r/PlaceholderParser.hpp
@@ -71,6 +71,9 @@ public:
     // Update timestamp, year, month, day, hour, minute, second variables at m_config.
     void update_timestamp() { update_timestamp(m_config); }
 
+    static void update_user_name(DynamicConfig &config);
+    void update_user_name() { update_user_name(m_config); }
+
 private:
 	// config has a higher priority than external_config when looking up a symbol.
     DynamicConfig 			 m_config;

--- a/src/libslic3r/PrintBase.cpp
+++ b/src/libslic3r/PrintBase.cpp
@@ -69,6 +69,7 @@ std::string PrintBase::output_filename(const std::string &format, const std::str
     	cfg = *config_override;
     cfg.set_key_value("version", new ConfigOptionString(std::string(SoftFever_VERSION)));
     PlaceholderParser::update_timestamp(cfg);
+    PlaceholderParser::update_user_name(cfg);
     this->update_object_placeholders(cfg, default_ext);
     if (! filename_base.empty()) {
 		cfg.set_key_value("input_filename", new ConfigOptionString(filename_base + default_ext));


### PR DESCRIPTION
# Description

This PR introduces a new placeholder, `{user}`, available for use in G-code and output filenames. This placeholder is replaced with the username of the current user logged into the computer.

The primary goal of this feature is to improve traceability in multi-user environments. In settings where a single 3D printer is shared among multiple people (e.g., in a makerspace, school, or office), it can be difficult to identify who generated a specific print file. By allowing the username to be embedded in the G-code or filename, this feature makes it easy to determine the author of each print job.

There are no breaking changes with this addition.

# Screenshots/Recordings/Graphs

![image](https://github.com/user-attachments/assets/eb5c9612-d96a-4554-8a91-b90249b02909)

## Tests

I have verified that the `{user}` placeholder correctly retrieves the username on the following operating systems:

- [x] Windows
- [x] Ubuntu
