### PR TITLE
Enable ironing and shell options for spiral vase mode

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -1302,11 +1302,9 @@ void Layer::make_ironing()
 		if (! layerm->slices.empty()) {
 			IroningParams ironing_params;
 			const PrintRegionConfig &config = layerm->region().config();
-			// Check if we're in spiral vase mode
-			bool is_spiral_mode = this->object()->print()->config().spiral_mode;
 			if (config.ironing_type != IroningType::NoIroning &&
 				(config.ironing_type == IroningType::AllSolid ||
-				 	((config.top_shell_layers > 0 || is_spiral_mode) &&
+				 	((config.top_shell_layers > 0 || this->object()->print()->config().spiral_mode) &&
 						(config.ironing_type == IroningType::TopSurfaces ||
 					 	(config.ironing_type == IroningType::TopmostOnly && layerm->layer()->upper_layer == nullptr))))) {
 				if (config.wall_filament == config.solid_infill_filament || config.wall_loops == 0) {
@@ -1344,9 +1342,6 @@ void Layer::make_ironing()
 	for (size_t i = 0; i < by_extruder.size();) {
 		// Find span of regions equivalent to the ironing operation.
 		IroningParams &ironing_params = by_extruder[i];
-		// Check if we're in spiral vase mode (needed for surface processing)
-		bool is_spiral_mode = this->object()->print()->config().spiral_mode;
-		
 		// Create the filler object.
 		if( f_pattern != ironing_params.pattern )
 		{
@@ -1393,7 +1388,7 @@ void Layer::make_ironing()
 						polygons_append(polys, surface.expolygon);
 				} else {
 					for (const Surface &surface : ironing_params.layerm->slices.surfaces)
-						if ((surface.surface_type == stTop && (region_config.top_shell_layers > 0 || is_spiral_mode)) || (iron_everything && surface.surface_type == stBottom && region_config.bottom_shell_layers > 0))
+						if ((surface.surface_type == stTop && (region_config.top_shell_layers > 0 || this->object()->print()->config().spiral_mode)) || (iron_everything && surface.surface_type == stBottom && region_config.bottom_shell_layers > 0))
 							// stBottomBridge is not being ironed on purpose, as it would likely destroy the bridges.
 							polygons_append(polys, surface.expolygon);
 				}

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -1303,10 +1303,10 @@ void Layer::make_ironing()
 			IroningParams ironing_params;
 			const PrintRegionConfig &config = layerm->region().config();
 			if (config.ironing_type != IroningType::NoIroning &&
-				(config.ironing_type == IroningType::AllSolid ||
-				 	((config.top_shell_layers > 0 || this->object()->print()->config().spiral_mode) &&
-						(config.ironing_type == IroningType::TopSurfaces ||
-					 	(config.ironing_type == IroningType::TopmostOnly && layerm->layer()->upper_layer == nullptr))))) {
+			    (config.ironing_type == IroningType::AllSolid ||
+				    ((config.top_shell_layers > 0 || (this->object()->print()->config().spiral_mode && config.bottom_shell_layers > 1)) &&
+					    (config.ironing_type == IroningType::TopSurfaces ||
+					        (config.ironing_type == IroningType::TopmostOnly && layerm->layer()->upper_layer == nullptr))))) {
 				if (config.wall_filament == config.solid_infill_filament || config.wall_loops == 0) {
 					// Iron the whole face.
 					ironing_params.extruder = config.solid_infill_filament;

--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -1302,9 +1302,11 @@ void Layer::make_ironing()
 		if (! layerm->slices.empty()) {
 			IroningParams ironing_params;
 			const PrintRegionConfig &config = layerm->region().config();
+			// Check if we're in spiral vase mode
+			bool is_spiral_mode = this->object()->print()->config().spiral_mode;
 			if (config.ironing_type != IroningType::NoIroning &&
 				(config.ironing_type == IroningType::AllSolid ||
-				 	(config.top_shell_layers > 0 &&
+				 	((config.top_shell_layers > 0 || is_spiral_mode) &&
 						(config.ironing_type == IroningType::TopSurfaces ||
 					 	(config.ironing_type == IroningType::TopmostOnly && layerm->layer()->upper_layer == nullptr))))) {
 				if (config.wall_filament == config.solid_infill_filament || config.wall_loops == 0) {
@@ -1342,6 +1344,9 @@ void Layer::make_ironing()
 	for (size_t i = 0; i < by_extruder.size();) {
 		// Find span of regions equivalent to the ironing operation.
 		IroningParams &ironing_params = by_extruder[i];
+		// Check if we're in spiral vase mode (needed for surface processing)
+		bool is_spiral_mode = this->object()->print()->config().spiral_mode;
+		
 		// Create the filler object.
 		if( f_pattern != ironing_params.pattern )
 		{
@@ -1388,7 +1393,7 @@ void Layer::make_ironing()
 						polygons_append(polys, surface.expolygon);
 				} else {
 					for (const Surface &surface : ironing_params.layerm->slices.surfaces)
-						if ((surface.surface_type == stTop && region_config.top_shell_layers > 0) || (iron_everything && surface.surface_type == stBottom && region_config.bottom_shell_layers > 0))
+						if ((surface.surface_type == stTop && (region_config.top_shell_layers > 0 || is_spiral_mode)) || (iron_everything && surface.surface_type == stBottom && region_config.bottom_shell_layers > 0))
 							// stBottomBridge is not being ironed on purpose, as it would likely destroy the bridges.
 							polygons_append(polys, surface.expolygon);
 				}

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -586,8 +586,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     toggle_line("spiral_mode_max_xy_smoothing", has_spiral_vase && config->opt_bool("spiral_mode_smooth"));
     toggle_line("spiral_starting_flow_ratio", has_spiral_vase);
     toggle_line("spiral_finishing_flow_ratio", has_spiral_vase);
-    bool has_top_shell    = config->opt_int("top_shell_layers") > 0 || has_spiral_vase;
-    bool has_bottom_shell = config->opt_int("bottom_shell_layers") > 0  || has_spiral_vase;
+    bool has_top_shell    = config->opt_int("top_shell_layers") > 0 || (has_spiral_vase && config->opt_int("bottom_shell_layers") > 1);
+    bool has_bottom_shell = config->opt_int("bottom_shell_layers") > 0;
     bool has_solid_infill = has_top_shell || has_bottom_shell;
     toggle_field("top_surface_pattern", has_top_shell);
     toggle_field("bottom_surface_pattern", has_bottom_shell);

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -586,7 +586,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     toggle_line("spiral_mode_max_xy_smoothing", has_spiral_vase && config->opt_bool("spiral_mode_smooth"));
     toggle_line("spiral_starting_flow_ratio", has_spiral_vase);
     toggle_line("spiral_finishing_flow_ratio", has_spiral_vase);
-        bool has_top_shell    = config->opt_int("top_shell_layers") > 0 || has_spiral_vase;
+    bool has_top_shell    = config->opt_int("top_shell_layers") > 0 || has_spiral_vase;
     bool has_bottom_shell = config->opt_int("bottom_shell_layers") > 0  || has_spiral_vase;
     bool has_solid_infill = has_top_shell || has_bottom_shell;
     toggle_field("top_surface_pattern", has_top_shell);

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -586,8 +586,8 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     toggle_line("spiral_mode_max_xy_smoothing", has_spiral_vase && config->opt_bool("spiral_mode_smooth"));
     toggle_line("spiral_starting_flow_ratio", has_spiral_vase);
     toggle_line("spiral_finishing_flow_ratio", has_spiral_vase);
-    bool has_top_shell    = config->opt_int("top_shell_layers") > 0;
-    bool has_bottom_shell = config->opt_int("bottom_shell_layers") > 0;
+        bool has_top_shell    = config->opt_int("top_shell_layers") > 0 || has_spiral_vase;
+    bool has_bottom_shell = config->opt_int("bottom_shell_layers") > 0  || has_spiral_vase;
     bool has_solid_infill = has_top_shell || has_bottom_shell;
     toggle_field("top_surface_pattern", has_top_shell);
     toggle_field("bottom_surface_pattern", has_bottom_shell);
@@ -609,7 +609,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     toggle_field("gap_infill_speed", have_perimeters);
 
     for (auto el : { "top_surface_line_width", "top_surface_speed" })
-        toggle_field(el, has_top_shell || (has_spiral_vase && has_bottom_shell));
+        toggle_field(el, has_top_shell || has_bottom_shell);
 
     bool have_default_acceleration = config->opt_float("default_acceleration") > 0;
 

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -594,7 +594,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     toggle_field("top_surface_density", has_top_shell);
     toggle_field("bottom_surface_density", has_bottom_shell);
 
-    for (auto el : { "infill_direction", "sparse_infill_line_width",
+    for (auto el : { "infill_direction", "sparse_infill_line_width", "fill_multiline","gap_fill_target","filter_out_gap_fill","infill_wall_overlap",
         "sparse_infill_speed", "bridge_speed", "internal_bridge_speed", "bridge_angle", "internal_bridge_angle",
         "solid_infill_direction", "solid_infill_rotate_template", "internal_solid_infill_pattern", "solid_infill_filament",
         })

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -609,7 +609,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     toggle_field("gap_infill_speed", have_perimeters);
 
     for (auto el : { "top_surface_line_width", "top_surface_speed" })
-        toggle_field(el, has_top_shell || has_bottom_shell);
+        toggle_field(el, has_top_shell);
 
     bool have_default_acceleration = config->opt_float("default_acceleration") > 0;
 


### PR DESCRIPTION
# Description

Based in #10097 from @KaarelP2rtel to allow edition in "Top surface" pattern and density when using vase mode.

Created a new PR because i needed to test this different implementation and enabling ironing when using "top surface".

<img width="1637" height="823" alt="imagen" src="https://github.com/user-attachments/assets/0b1deaa8-210f-4db2-be5b-1e12cb3dacda" />

<img width="1637" height="823" alt="imagen" src="https://github.com/user-attachments/assets/1d603a81-d254-4e9c-8b77-0188365e4f7c" />

<img width="1637" height="823" alt="imagen" src="https://github.com/user-attachments/assets/3d607f9a-c0f3-437a-b6a5-18f42d0e6b66" />
