### PR TITLE
Security Fix : CVE-2024-45492 in libexpat library.

### DIFF
--- a/src/expat/xmlparse.c
+++ b/src/expat/xmlparse.c
@@ -6333,6 +6333,15 @@ nextScaffoldPart(XML_Parser parser)
   int next;
 
   if (!dtd->scaffIndex) {
+    /* Detect and prevent integer overflow.
+     * The preprocessor guard addresses the "always false" warning
+     * from -Wtype-limits on platforms where
+     * sizeof(unsigned int) < sizeof(size_t), e.g. on x86_64. */
+#if UINT_MAX >= SIZE_MAX
+    if (parser->m_groupSize > ((size_t)(-1) / sizeof(int))) {
+      return -1;
+    }
+#endif
     dtd->scaffIndex = (int *)MALLOC(groupSize * sizeof(int));
     if (!dtd->scaffIndex)
       return -1;


### PR DESCRIPTION
### Description
Fixes [CVE-2024-45492](https://nvd.nist.gov/vuln/detail/cve-2024-45492) integer overflow vulnerability in bundled libexpat library's nextScaffoldPart function. Adds overflow check to prevent buffer overflow when parsing maliciously crafted XML data on 32-bit platforms.

- Added integer overflow check in nextScaffoldPart function
- Applied upstream patch from libexpat commit [9bf0f2c](https://github.com/libexpat/libexpat/pull/892/commits/9bf0f2c16ee86f644dd1432507edff94c08dc232)
- Prevents potential RCE through XML parsing

**Security Impact:**
- Fixes HIGH severity vulnerability (CVSS 7.3)
- Prevents buffer overflow on 32-bit systems
- No breaking changes to existing functionality