### PR TITLE
🔧Setting :Disable pressure advance/Linear advance for infill 

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5025,7 +5025,10 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
     std::string 		 gcode;
     ExtrusionEntitiesPtr extrusions;
     const char*          extrusion_name = ironing ? "ironing" : "infill";
-    const bool disable_infill_pa =this->config().enable_pressure_advance.get_at(m_writer.extruder()->id()) && !this->config().adaptive_pressure_advance.get_at(m_writer.extruder()->id()) && m_config.disable_infill_pressure_advance;
+    const bool disable_infill_pa =this->config().enable_pressure_advance.get_at(m_writer.extruder()->id()) 
+                                  && !this->config().adaptive_pressure_advance.get_at(m_writer.extruder()->id()) 
+                                  && m_config.disable_infill_pressure_advance
+                                  && this->config().sparse_infill_density < 90;
     for (const ObjectByExtruder::Island::Region &region : by_region)
         if (! region.infills.empty()) {
             extrusions.clear();

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5025,6 +5025,7 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
     std::string 		 gcode;
     ExtrusionEntitiesPtr extrusions;
     const char*          extrusion_name = ironing ? "ironing" : "infill";
+    const bool disable_infill_pa =this->config().enable_pressure_advance.get_at(m_writer.extruder()->id()) && !this->config().adaptive_pressure_advance.get_at(m_writer.extruder()->id()) && m_config.disable_infill_pressure_advance;
     for (const ObjectByExtruder::Island::Region &region : by_region)
         if (! region.infills.empty()) {
             extrusions.clear();
@@ -5035,7 +5036,6 @@ std::string GCode::extrude_infill(const Print &print, const std::vector<ObjectBy
             if (! extrusions.empty()) {
                 m_config.apply(print.get_print_region(&region - &by_region.front()).config());
                 chain_and_reorder_extrusion_entities(extrusions, &m_last_pos);
-                bool disable_infill_pa =this->config().enable_pressure_advance.get_at(m_writer.extruder()->id()) && !this->config().adaptive_pressure_advance.get_at(m_writer.extruder()->id()) && m_config.disable_infill_pressure_advance;
                 if(disable_infill_pa){
                     gcode += m_writer.set_pressure_advance(0);
                 }

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -795,7 +795,7 @@ static std::vector<std::string> s_Preset_print_options {
     "seam_position", "staggered_inner_seams", "wall_sequence", "is_infill_first", "sparse_infill_density","fill_multiline", "sparse_infill_pattern", "lateral_lattice_angle_1", "lateral_lattice_angle_2", "infill_overhang_angle", "top_surface_pattern", "bottom_surface_pattern",
     "infill_direction", "solid_infill_direction", "counterbore_hole_bridging","infill_shift_step", "sparse_infill_rotate_template", "solid_infill_rotate_template", "symmetric_infill_y_axis","skeleton_infill_density", "infill_lock_depth", "skin_infill_depth", "skin_infill_density",
     "align_infill_direction_to_model",
-    "minimum_sparse_infill_area", "reduce_infill_retraction","internal_solid_infill_pattern","gap_fill_target",
+    "minimum_sparse_infill_area", "reduce_infill_retraction", "disable_infill_pressure_advance","internal_solid_infill_pattern","gap_fill_target",
     "ironing_type", "ironing_pattern", "ironing_flow", "ironing_speed", "ironing_spacing", "ironing_angle", "ironing_inset",
     "support_ironing", "support_ironing_pattern", "support_ironing_flow", "support_ironing_spacing",
     "max_travel_detour_distance",
@@ -873,7 +873,7 @@ static std::vector<std::string> s_Preset_filament_options {
     "filament_wipe_distance", "additional_cooling_fan_speed",
     "nozzle_temperature_range_low", "nozzle_temperature_range_high",
     //SoftFever
-    "enable_pressure_advance", "pressure_advance","adaptive_pressure_advance","adaptive_pressure_advance_model","adaptive_pressure_advance_overhangs", "adaptive_pressure_advance_bridges","chamber_temperature", "filament_shrink","filament_shrinkage_compensation_z", "support_material_interface_fan_speed","internal_bridge_fan_speed", "filament_notes" /*,"filament_seam_gap"*/,
+    "enable_pressure_advance", "pressure_advance", "adaptive_pressure_advance","adaptive_pressure_advance_model","adaptive_pressure_advance_overhangs", "adaptive_pressure_advance_bridges","chamber_temperature", "filament_shrink","filament_shrinkage_compensation_z", "support_material_interface_fan_speed","internal_bridge_fan_speed", "filament_notes" /*,"filament_seam_gap"*/,
     "ironing_fan_speed",
     "filament_loading_speed", "filament_loading_speed_start",
     "filament_unloading_speed", "filament_unloading_speed_start", "filament_toolchange_delay", "filament_cooling_moves", "filament_stamping_loading_speed", "filament_stamping_distance",

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -146,6 +146,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver & /* n
         "max_volumetric_extrusion_rate_slope_segment_length",
         "extrusion_rate_smoothing_external_perimeter_only",
         "reduce_infill_retraction",
+        "disable_infill_pressure_advance",
         "filename_format",
         "retraction_minimum_travel",
         "retract_before_wipe",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1890,7 +1890,7 @@ void PrintConfigDef::init_fff_params()
     def->max = 2;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloats { 0.02 });
-    
+
     // Orca: Adaptive pressure advance option and calibration values
     def = this->add("adaptive_pressure_advance", coBools);
     def->label = L("Enable adaptive pressure advance (beta)");
@@ -3977,6 +3977,13 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Don't retract when the travel is in infill area absolutely. That means the oozing can't been seen. "
                      "This can reduce times of retraction for complex model and save printing time, but make slicing and "
                      "G-code generating slower.");
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def = this->add("disable_infill_pressure_advance", coBool);
+    def->label = L("Disable infill pressure advance");
+    def->tooltip = L("Disable pressure advance / Linear advance for sparse infill to avoid unnecessary extruder movements."
+                     "Ignored if adaptive pressure advance is enabled");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(false));
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1335,6 +1335,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionFloats,             slow_down_min_speed))
     ((ConfigOptionFloats,             nozzle_diameter))
     ((ConfigOptionBool,               reduce_infill_retraction))
+    ((ConfigOptionBool,               disable_infill_pressure_advance))
     ((ConfigOptionBool,               ooze_prevention))
     ((ConfigOptionString,             filename_format))
     ((ConfigOptionStrings,            post_process))

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2467,6 +2467,7 @@ optgroup->append_single_option_line("skirt_loops", "others_settings_skirt#loops"
 
         optgroup = page->new_optgroup(L("G-code output"), L"param_gcode");
         optgroup->append_single_option_line("reduce_infill_retraction", "others_settings_g_code_output#reduce-infill-retraction");
+        optgroup->append_single_option_line("disable_infill_pressure_advance","");
         optgroup->append_single_option_line("gcode_add_line_number", "others_settings_g_code_output#add-line-number");
         optgroup->append_single_option_line("gcode_comments", "others_settings_g_code_output#verbose-g-code");
         optgroup->append_single_option_line("gcode_label_objects", "others_settings_g_code_output#label-objects");


### PR DESCRIPTION
Linear/Pressure Advance has minimal impact on sparse infill, as it does not affect surface quality or visible details.
This pull request introduces a new setting to disable it for sparse infill. this minimize unnecessary extruder movements, without compromising print quality.
This setting is ignored if adaptive pressure advance is enabled.
<img width="1293" height="722" alt="image" src="https://github.com/user-attachments/assets/a8e71dfa-9397-485c-9c0a-8c8ddcd46eb6" />
<img width="1895" height="933" alt="image" src="https://github.com/user-attachments/assets/ebce03fa-314a-48ec-bd86-c7b4ad87899f" />

No noticeable difference in print quality:
<img width="1280" height="1280" alt="image" src="https://github.com/user-attachments/assets/d9b7f4c9-9db2-4f5a-924a-879562264e24" />
<img width="1280" height="1280" alt="image" src="https://github.com/user-attachments/assets/6005ef2a-cf0f-417b-a7c6-e3fc46285c1d" />
infill with PA active:

https://github.com/user-attachments/assets/1af06e1a-6e5d-4cfc-a7b0-e438139b0450

Infill with PA inactive:

https://github.com/user-attachments/assets/d1458e14-4509-4e6c-8c85-6000f2486b69


this PR may close #10116
