### PR TITLE
Bug fix: avoid crossing perimeters

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4146,8 +4146,8 @@ LayerResult GCode::process_layer(
                         pos(2) = temp_z_after_timepals_gcode;
                         m_writer.set_position(pos);
                     }
+		            }
                     has_insert_timelapse_gcode = true;
-                    }
                 }
                 gcode_toolchange = m_wipe_tower->tool_change(*this, extruder_id, extruder_id == layer_tools.extruders.back());
             }
@@ -4393,9 +4393,8 @@ LayerResult GCode::process_layer(
                                 pos(2) = temp_z_after_timepals_gcode;
                                 m_writer.set_position(pos);
                             }
-
-                            has_insert_timelapse_gcode = true;
                             }
+                            has_insert_timelapse_gcode = true;
                         }
                         // Then print infill
                         gcode += this->extrude_infill(print, by_region_specific, false);

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3721,8 +3721,8 @@ LayerResult GCode::process_layer(
     if(is_BBL_Printer()){
         if (printer_structure == PrinterStructure::psI3 && !need_insert_timelapse_gcode_for_traditional && !m_spiral_vase && print.config().print_sequence == PrintSequence::ByLayer) {
             std::string timepals_gcode = insert_timelapse_gcode();
-            gcode += timepals_gcode;
             if(!timepals_gcode.empty()){
+            gcode += timepals_gcode;
             m_writer.set_current_position_clear(false);
             //BBS: check whether custom gcode changes the z position. Update if changed
             double temp_z_after_timepals_gcode;
@@ -4136,8 +4136,8 @@ LayerResult GCode::process_layer(
                     m_writer.add_object_change_labels(gcode);
 
                     std::string timepals_gcode = insert_timelapse_gcode();
-                    gcode += timepals_gcode;
                     if(!timepals_gcode.empty()){
+                    gcode += timepals_gcode;
                     m_writer.set_current_position_clear(false);
                     //BBS: check whether custom gcode changes the z position. Update if changed
                     double temp_z_after_timepals_gcode;
@@ -4383,9 +4383,9 @@ LayerResult GCode::process_layer(
                             gcode += this->retract(false, false, LiftType::NormalLift);
 
                             std::string timepals_gcode = insert_timelapse_gcode();
-                            gcode += timepals_gcode;
                             if(!timepals_gcode.empty()){
-                            m_writer.set_current_position_clear(false);                        
+                            gcode += timepals_gcode;
+                            m_writer.set_current_position_clear(false);
                             //BBS: check whether custom gcode changes the z position. Update if changed
                             double temp_z_after_timepals_gcode;
                             if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {
@@ -4470,9 +4470,9 @@ LayerResult GCode::process_layer(
         m_writer.add_object_change_labels(gcode);
 
         std::string timepals_gcode = insert_timelapse_gcode();
-        gcode += timepals_gcode;
         if(!timepals_gcode.empty()){
-        m_writer.set_current_position_clear(false);        
+        gcode += timepals_gcode;
+        m_writer.set_current_position_clear(false);
         //BBS: check whether custom gcode changes the z position. Update if changed
         double temp_z_after_timepals_gcode;
         if (GCodeProcessor::get_last_z_from_gcode(timepals_gcode, temp_z_after_timepals_gcode)) {

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4146,7 +4146,7 @@ LayerResult GCode::process_layer(
                         pos(2) = temp_z_after_timepals_gcode;
                         m_writer.set_position(pos);
                     }
-		            }
+                    }
                     has_insert_timelapse_gcode = true;
                 }
                 gcode_toolchange = m_wipe_tower->tool_change(*this, extruder_id, extruder_id == layer_tools.extruders.back());

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -79,20 +79,6 @@ using namespace std::literals::string_view_literals;
 
 #include <assert.h>
 
-static bool gcode_has_xyz(const std::string& gcode_line){
-    std::string::size_type comment_pos = gcode_line.find(';');
-    std::string code_only = gcode_line.substr(0, comment_pos);
-
-    return code_only.find('G') != std::string::npos ||
-           code_only.find('g') != std::string::npos ||
-           code_only.find('X') != std::string::npos ||
-           code_only.find('x') != std::string::npos ||
-           code_only.find('Y') != std::string::npos ||
-           code_only.find('y') != std::string::npos ||
-           code_only.find('Z') != std::string::npos ||
-           code_only.find('z') != std::string::npos;
- }
-
 namespace Slic3r {
 
     //! macro used to mark string used at localization,
@@ -3736,6 +3722,7 @@ LayerResult GCode::process_layer(
         if (printer_structure == PrinterStructure::psI3 && !need_insert_timelapse_gcode_for_traditional && !m_spiral_vase && print.config().print_sequence == PrintSequence::ByLayer) {
             std::string timepals_gcode = insert_timelapse_gcode();
             gcode += timepals_gcode;
+            if(!timepals_gcode.empty()){
             m_writer.set_current_position_clear(false);
             //BBS: check whether custom gcode changes the z position. Update if changed
             double temp_z_after_timepals_gcode;
@@ -3743,6 +3730,7 @@ LayerResult GCode::process_layer(
                 Vec3d pos = m_writer.get_position();
                 pos(2) = temp_z_after_timepals_gcode;
                 m_writer.set_position(pos);
+            }
             }
         }
     } else {
@@ -4149,6 +4137,7 @@ LayerResult GCode::process_layer(
 
                     std::string timepals_gcode = insert_timelapse_gcode();
                     gcode += timepals_gcode;
+                    if(!timepals_gcode.empty()){
                     m_writer.set_current_position_clear(false);
                     //BBS: check whether custom gcode changes the z position. Update if changed
                     double temp_z_after_timepals_gcode;
@@ -4158,6 +4147,7 @@ LayerResult GCode::process_layer(
                         m_writer.set_position(pos);
                     }
                     has_insert_timelapse_gcode = true;
+                    }
                 }
                 gcode_toolchange = m_wipe_tower->tool_change(*this, extruder_id, extruder_id == layer_tools.extruders.back());
             }
@@ -4394,7 +4384,7 @@ LayerResult GCode::process_layer(
 
                             std::string timepals_gcode = insert_timelapse_gcode();
                             gcode += timepals_gcode;
-                            if (gcode_has_xyz(timepals_gcode)){
+                            if(!timepals_gcode.empty()){
                             m_writer.set_current_position_clear(false);                        
                             //BBS: check whether custom gcode changes the z position. Update if changed
                             double temp_z_after_timepals_gcode;
@@ -4481,7 +4471,7 @@ LayerResult GCode::process_layer(
 
         std::string timepals_gcode = insert_timelapse_gcode();
         gcode += timepals_gcode;
-        if (gcode_has_xyz(timepals_gcode)){
+        if(!timepals_gcode.empty()){
         m_writer.set_current_position_clear(false);        
         //BBS: check whether custom gcode changes the z position. Update if changed
         double temp_z_after_timepals_gcode;


### PR DESCRIPTION
This pull request partially addresses the issue described in #5217.

Problem:
At the end of a perimeter, after retraction, the following travel move does not respect the restriction that prevents crossing other perimeters. 

Notes:

Works best when using Arachne perimeter generator.

Spiral Z-hop should be avoided for better results.


## Tests
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/31387df6-8f0d-41d1-a2a8-8c901931020e" />
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/c31efb22-7f29-487d-bbbf-5fa81a3cca46" />
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/3ea3f07f-481c-4ab6-8e09-e9dd6bc89037" />
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/9e73ac96-69a5-4de8-ba58-e7249ee40db9" />
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/4c30835f-ae35-43b8-87ab-c3dca507761a" />


this PR may close #5217 
this PR may close #9770 

