### PR TITLE
Create multi-sublayer-walls

### DIFF
--- a/feature/multi-sublayer-walls
+++ b/feature/multi-sublayer-walls
@@ -1,0 +1,164 @@
+import os
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+def parse_xy_e(line):
+    parts = line.strip().split()
+    x = y = e = None
+    for p in parts:
+        if p.lower().startswith('x'):
+            try: x = float(p[1:])
+            except: pass
+        elif p.lower().startswith('y'):
+            try: y = float(p[1:])
+            except: pass
+        elif p.lower().startswith('e'):
+            try: e = float(p[1:])
+            except: pass
+    return x, y, e
+
+def format_g1_line(original, dx, dy, de, factor):
+    parts = original.strip().split()
+    result = []
+    for p in parts:
+        if p.lower().startswith('x'):
+            x = float(p[1:])
+            result.append(f"X{x + dx * factor:.5f}")
+        elif p.lower().startswith('y'):
+            y = float(p[1:])
+            result.append(f"Y{y + dy * factor:.5f}")
+        elif p.lower().startswith('e'):
+            e = float(p[1:])
+            result.append(f"E{e + de * factor:.5f}")
+        else:
+            result.append(p)
+    return ' '.join(result) + '\n'
+
+def process_gcode(file_path, layer_height, sublayers):
+    with open(file_path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    extrusion_mode_absolute = True
+    for line in lines:
+        if 'M83' in line:
+            extrusion_mode_absolute = False
+        elif 'M82' in line:
+            extrusion_mode_absolute = True
+
+    output = []
+    restore_z = []
+    for i, line in enumerate(lines):
+        if 'restore layer z' in line.lower():
+            try:
+                z = float(line.split('Z')[1].split()[0])
+                restore_z.append((i, z))
+            except: pass
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if '; feature: outer wall' in line.lower():
+            block = [line]
+            i += 1
+            while i < len(lines):
+                if any(x in lines[i].lower() for x in ['feature: inner wall', 'change_layer', 'z_height', 'layer_height', 'stop printing']):
+                    break
+                block.append(lines[i])
+                i += 1
+
+            curr_z = None
+            for idx, z in reversed(restore_z):
+                if idx < i:
+                    curr_z = z
+                    break
+
+            # Next block
+            next_block = []
+            next_z = None
+            for j in range(i, len(lines)):
+                if 'restore layer z' in lines[j].lower():
+                    try:
+                        next_z = float(lines[j].split('Z')[1].split()[0])
+                    except: break
+                if '; feature: outer wall' in lines[j].lower():
+                    k = j
+                    while k < len(lines):
+                        if any(x in lines[k].lower() for x in ['feature: inner wall', 'change_layer', 'z_height', 'layer_height', 'stop printing']):
+                            break
+                        next_block.append(lines[k])
+                        k += 1
+                    break
+
+            if curr_z is None or next_z is None or not next_block:
+                output.extend(block)
+                continue
+
+            dz = (next_z - curr_z) / sublayers
+            for s in range(sublayers):
+                z = curr_z + s * dz
+                output.append(f"G1 Z{z:.5f} ; sublayer {s+1}/{sublayers}\n")
+                for l1, l2 in zip(block, next_block):
+                    if not l1.startswith('G1') or '; perimeter' not in l1:
+                        output.append(l1)
+                        continue
+                    x1, y1, e1 = parse_xy_e(l1)
+                    x2, y2, e2 = parse_xy_e(l2)
+                    dx = (x2 - x1) if x1 is not None and x2 is not None else 0
+                    dy = (y2 - y1) if y1 is not None and y2 is not None else 0
+                    de = (e2 - e1) if e1 is not None and e2 is not None else 0
+                    factor = (s + 1) / sublayers
+                    output.append(format_g1_line(l1, dx, dy, de, factor))
+
+            output.append(f"G1 Z{next_z:.5f} ; restore original Z after sublayers\n")
+        else:
+            output.append(line)
+            i += 1
+
+    out_path = os.path.splitext(file_path)[0] + "_chucha_output.gcode"
+    with open(out_path, 'w', encoding='utf-8') as f:
+        f.writelines(output)
+
+    return out_path
+
+# === GUI ===
+def browse_file(entry):
+    path = filedialog.askopenfilename(filetypes=[("G-code files", "*.gcode")])
+    if path:
+        entry.delete(0, tk.END)
+        entry.insert(0, path)
+
+def run():
+    path = entry_file.get()
+    try:
+        h = float(entry_height.get().replace(',', '.'))
+        n = int(entry_sublayers.get())
+    except:
+        messagebox.showerror("Помилка", "Введено некоректні дані.")
+        return
+    if not os.path.isfile(path):
+        messagebox.showerror("Помилка", "Файл не знайдено.")
+        return
+    out = process_gcode(path, h, n)
+    messagebox.showinfo("Готово", f"Файл збережено:\n{out}")
+
+root = tk.Tk()
+root.title("ChuchaTV SubLayer GUI")
+
+tk.Label(root, text="Файл G-code:").pack()
+entry_file = tk.Entry(root, width=60)
+entry_file.pack()
+tk.Button(root, text="Огляд", command=lambda: browse_file(entry_file)).pack()
+
+tk.Label(root, text="Висота шару (наприклад 0.32):").pack()
+entry_height = tk.Entry(root)
+entry_height.insert(0, "0.32")
+entry_height.pack()
+
+tk.Label(root, text="Кількість підшарів (наприклад 4):").pack()
+entry_sublayers = tk.Entry(root)
+entry_sublayers.insert(0, "4")
+entry_sublayers.pack()
+
+tk.Button(root, text="Обробити G-code", command=run).pack(pady=10)
+
+root.mainloop()


### PR DESCRIPTION
This feature was tested using a Python script (ChuchaTV) that post-processes G-code from OrcaSlicer, detects ; FEATURE: outer wall blocks and splits them into sublayers, adjusting XY and E values accordingly for smooth interpolation.

I'm ready to share test files and the script implementation logic if this helps integrate it into OrcaSlicer.

It would be ideal to integrate this as an optional modifier or checkbox in the slicer.

How my program works:

Determine the number of sublayers specified by the user, for example 4 Find the first line of G1 with the note restore layer Z for example (G1 Z.32 ; restore layer Z) , Determine the height, i.e. the value specified in the line with the note restore layer Z for example (G1 Z.32 ; restore layer Z) in our example it will be a height of 0.32mm
Divide the height of the layer specified by the user by the number of parts specified by the user to get the height value of each sublayer (for example 0.08 mm) Find the block responsible for the outer wall of the corresponding layer, i.e. the program, having determined the layer for example (G1 Z.32 ; restore layer Z) looks for the next line with the note ; FEATURE: Outer wall and ignoring spaces or other characters. This will be the block of commands for outer walls This block includes all lines that are after the name ; FEATURE: Outer wall, even commands such as ; LINE_WIDTH: and G1 F i.e. auxiliary commands The end of the block is the presence of any of these notes, ignoring numbers or signs that may be in these names: ; FEATURE: Inner wall
; stop printing object piramida.stl id:
; CHANGE_LAYER
; Z_HEIGHT:
; LAYER_HEIGHT:
to split into sublayers and determine the change in XY coordinates (deviation) between adjacent layers, the program looks for the next line with the next layer and the command block. That is, it finds the next line G1 with the note restore layer Z for example (G1 Z.64 ; restore layer Z) Finds the block that is responsible for the outer wall of the corresponding layer, that is, the program, having determined the layer for example (G1 Z.64 ; restore layer Z) looks for the next line with the note ; FEATURE: Outer wall ignoring spaces or other characters. This will be the outer wall command block This block includes all lines that follow the name ; FEATURE: Outer wall, even commands such as ; LINE_WIDTH: and G1 F i.e. auxiliary commands The end of the block is the presence of any of these notes, ignoring numbers or characters that may be in these names: ; FEATURE: Inner wall
; stop printing object piramida.stl id:
; CHANGE_LAYER
; Z_HEIGHT:
; LAYER_HEIGHT:
Determines the change in XY coordinates (deviation) between these two blocks and makes changes to the XY coordinates by interpolating this displacement proportionally to the sublayers, for each sublayer add a correspondingly shifted version of the coordinates. Also adjust the extrusion, taking into account the absolute or relative length of the extruded filament system used in these blocks and divide the extrusion in these blocks into the number of sublayers so that there is no overextrusion. After the last sublayer, lower the z-axis to zero so that there is no stretching of the model Interpolation work:
NOW IS THE EXCITING MOMENT!
I took two blocks from the original Jikoda,
First block at height Z.32

G1 Z.32; restore layer Z
G1 E1.4 F1800 ; ; unretract
; FEATURE: Outer wall
; LINE_WIDTH: 0.6
G1 F1329
G1 X123.542 Y121.542 E.6176 ; perimeter
G1 X132.458 Y121.542 E.6176 ; perimeter
G1 X132.458 Y130.458 E.6176 ; perimeter
G1 X123.602 Y130.458 E.61344 ; perimeter
G1 X124.074 Y129.926 F30000

Another block at height Z.64

G1 Z.64 ; restore layer Z
G1 E1.4 F1800 ; ; unretract
M204 S5000 ; adjust acceleration
; FEATURE: Outer wall
; LINE_WIDTH: 0.6
G1 F1279
G1 X123.577 Y121.577 E.61278 ; perimeter
G1 X132.423 Y121.577 E.61278 ; perimeter
G1 X132.423 Y130.423 E.61278 ; perimeter
G1 X123.637 Y130.423 E.60863 ; perimeter
M204 S10000 ; adjust acceleration
G1 X124.108 Y129.892 F30000

Then there is a difference of 0.32 mm, which is divided into 4 balls, then 0.08 mm each. You can now remove 5 subblocks 0.32 0.4 0.48 0.56 0.6 in the skin blocks there will be different values of X Y E And here it is important to correctly describe the displacement of the balls: The program can calculate the difference between the lines:

let's align the line of the first block at height Z.32 (G1 X123.542 Y121.542 E.6176 ; perimeter) with a line of another block at a height of 0.64 (G1 X123.577 Y121.577 E.61278 ; perimeter) The program in this phase can raise X123.577-X123.542 = X0.035, which is divided into a number of balls, then by 4 = 0.00875 and this is the difference in the skin balls required add. in this case, the resulting result is rejected

coordinates of the ball 0.32 do not change X123.542 coordinates of the ball 0.4 X123.55075
coordinates of the ball 0.48 X123.5595
coordinates of the ball 0.56 X123.56825
The coordinates of the ball are 0.6 X123.577. This coordinate coincides with block number 2, so the distribution is correct.

This is the same for the Y coordinate
The program in this phase can raise X121.577-X121.542 = X0.035, which is divided into a number of balls, then by 4 = 0.00875 and this is the difference in the skin balls required ADD. in this case, the resulting result is rejected

coordinates of the ball 0.32 do not change Y121.542 coordinates of the ball 0.4 Y121.55075
coordinates of the ball 0.48 Y121.5595
coordinates of the ball 0.56 Y121.56825
The coordinates of the ball are 0.6 Y121.577 This coordinate coincides with block number 2, so the distribution is correct.

ALSO ONE IMPORTANT NUANCE, during the molding process the displacements can vary according to the following values, for example:

let's equalize the other line of the first block at a height of Z.32 (G1 X132.458 Y121.542 E.6176 ; perimeter) with the same line of another block at a height of 0.64 (G1 X132.423 Y121.577 E.61278 ; perimeter)

The program in this case can produce X132.423-X132.458 = -X0.035 as we It is divided into a number of balls, then by 4 = - 0.00875, and since we have a significant difference, then this difference on the skin balls needs to be RECOGNIZED. in this case, the resulting result is rejected

coordinates of the ball 0.32 do not change X132.458 coordinates of the ball 0.4 X132.44925
coordinates of the ball 0.48 X132.4405
coordinates of the ball 0.56 X132.43175
The coordinates of the ball are 0.6 X132.423. This coordinate coincides with block number 2, so the division is correct.

Virach's extrusion is simpler,
The program in this phase can produce E.61278-E.6176 = -E.00482 and this difference is also divided into the number of balls, then by 4 = - 0.001205, otherwise, as we understand If the difference is significant, then this difference on the skin needs to be REMOVED.

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
