### PR TITLE
Introduce a new seam alignment option: Aligned back

### DIFF
--- a/src/libslic3r/GCode/SeamPlacer.cpp
+++ b/src/libslic3r/GCode/SeamPlacer.cpp
@@ -162,7 +162,7 @@ std::vector<float> raycast_visibility(const AABBTreeIndirect::Tree<3, float> &ra
 
                         const Vec3f &center = samples.positions[s_idx];
                         const Vec3f &normal = samples.normals[s_idx];
-                        if (seam_position == spAlignedAvoidFront) {
+                        if (seam_position == spAlignedBack) {
                             const float front_adjustment = std::clamp((normal.dot(Vec3f(0.0f, -1.0f, 0.0f)) + 1.2f) * 0.5f, 0.0f, 1.0f);
                             result[s_idx] += front_adjustment;
                         }
@@ -748,7 +748,7 @@ struct SeamComparator {
   // should return if a is better seamCandidate than b
   bool is_first_better(const SeamCandidate &a, const SeamCandidate &b, const Vec2f &preffered_location = Vec2f { 0.0f,
                                                                                                                0.0f }) const {
-    if ((setup == SeamPosition::spAligned || setup == SeamPosition::spAlignedAvoidFront) && a.central_enforcer != b.central_enforcer) {
+    if ((setup == SeamPosition::spAligned || setup == SeamPosition::spAlignedBack) && a.central_enforcer != b.central_enforcer) {
       return a.central_enforcer;
     }
 
@@ -797,7 +797,7 @@ struct SeamComparator {
   // Also used by the random seam generator.
   bool is_first_not_much_worse(const SeamCandidate &a, const SeamCandidate &b) const {
     // Blockers/Enforcers discrimination, top priority
-    if ((setup == SeamPosition::spAligned || setup == SeamPosition::spAlignedAvoidFront) && a.central_enforcer != b.central_enforcer) {
+    if ((setup == SeamPosition::spAligned || setup == SeamPosition::spAlignedBack) && a.central_enforcer != b.central_enforcer) {
       // Prefer centers of enforcers.
       return a.central_enforcer;
     }
@@ -1433,7 +1433,7 @@ void SeamPlacer::init(const Print &print, std::function<void(void)> throw_if_can
       GlobalModelInfo global_model_info { };
       gather_enforcers_blockers(global_model_info, po);
       throw_if_canceled_func();
-      if (configured_seam_preference == spAligned || configured_seam_preference == spNearest || configured_seam_preference == spAlignedAvoidFront) {
+      if (configured_seam_preference == spAligned || configured_seam_preference == spNearest || configured_seam_preference == spAlignedBack) {
         compute_global_occlusion(global_model_info, po, throw_if_canceled_func, configured_seam_preference);
       }
       throw_if_canceled_func();
@@ -1443,7 +1443,7 @@ void SeamPlacer::init(const Print &print, std::function<void(void)> throw_if_can
       BOOST_LOG_TRIVIAL(debug)
           << "SeamPlacer: gather_seam_candidates: end";
       throw_if_canceled_func();
-      if (configured_seam_preference == spAligned || configured_seam_preference == spNearest || configured_seam_preference == spAlignedAvoidFront) {
+      if (configured_seam_preference == spAligned || configured_seam_preference == spNearest || configured_seam_preference == spAlignedBack) {
         BOOST_LOG_TRIVIAL(debug)
             << "SeamPlacer: calculate_candidates_visibility : start";
         calculate_candidates_visibility(po, global_model_info);
@@ -1479,7 +1479,7 @@ void SeamPlacer::init(const Print &print, std::function<void(void)> throw_if_can
           << "SeamPlacer: pick_seam_point : end";
     }
     throw_if_canceled_func();
-    if (configured_seam_preference == spAligned || configured_seam_preference == spRear || configured_seam_preference == spAlignedAvoidFront) {
+    if (configured_seam_preference == spAligned || configured_seam_preference == spRear || configured_seam_preference == spAlignedBack) {
       BOOST_LOG_TRIVIAL(debug)
           << "SeamPlacer: align_seam_points : start";
       align_seam_points(po, comparator);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -270,7 +270,7 @@ CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(SupportType)
 static t_config_enum_values s_keys_map_SeamPosition {
     { "nearest",        spNearest },
     { "aligned",        spAligned },
-    { "aligned_avoid_front", spAlignedAvoidFront },
+    { "aligned_back",   spAlignedBack },
     { "back",           spRear },
     { "random",         spRandom }
 };
@@ -4366,12 +4366,12 @@ void PrintConfigDef::init_fff_params()
     def->enum_keys_map = &ConfigOptionEnum<SeamPosition>::get_enum_values();
     def->enum_values.push_back("nearest");
     def->enum_values.push_back("aligned");
-    def->enum_values.push_back("aligned_avoid_front");
+    def->enum_values.push_back("aligned_back");
     def->enum_values.push_back("back");
     def->enum_values.push_back("random");
     def->enum_labels.push_back(L("Nearest"));
     def->enum_labels.push_back(L("Aligned"));
-    def->enum_labels.push_back(L("Aligned (avoid front)"));
+    def->enum_labels.push_back(L("Aligned back"));
     def->enum_labels.push_back(L("Back"));
     def->enum_labels.push_back(L("Random"));
     def->mode = comSimple;

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -176,7 +176,7 @@ inline bool is_auto(SupportType stype)
 };
 
 enum SeamPosition {
-    spNearest, spAligned, spAlignedAvoidFront, spRear, spRandom
+    spNearest, spAligned, spAlignedBack, spRear, spRandom
 };
 
 // Orca


### PR DESCRIPTION
# Description

I encountered this awkward situation a few times, as shown in the screenshot below. I only realized that the seam is placed at the front after I finished printing something quickly.
Aligned seam position is usually my preferred choice in most cases, but not in this case.  
Models like the one below or sculptures typically have a directional preference; you usually view them from the front angle.  
This is the motivation behind implementing this new option. Seams are now prioritized to be placed away from the front, while still aiming to find optimal hidden locations for other orientations (unlike the Back option, which is always placed at the backmost position regardless; see the screenshot for comparison).

<img width="1261" height="1402" alt="image" src="https://github.com/user-attachments/assets/49986efc-60ca-4ab3-8676-1615638196df" />

<img width="442" height="223" alt="Screenshot 2025-07-28 at 11 14 20 PM" src="https://github.com/user-attachments/assets/1407c525-5677-418e-ae2d-81f845be3471" />

# Screenshots/Recordings/Graphs
Compare Aligned with Aligned(avoid front)
Aligned:  
<img width="1466" height="1216" alt="image" src="https://github.com/user-attachments/assets/9f8f9dc1-35ab-49af-9bb7-af59a760d97c" />

Aligned(Aviod Front):  
<img width="1394" height="1136" alt="image" src="https://github.com/user-attachments/assets/8fc6d5c2-43e0-4f19-83be-8966c9446340" />


Compare Back with Aligned(avoid front)

Back:  
<img width="757" height="843" alt="Screenshot 2025-07-28 at 10 58 33 PM" src="https://github.com/user-attachments/assets/788ae3b0-8f74-44bf-9241-138523c2cfb7" />

Aligned(avoid front):  
<img width="765" height="801" alt="Screenshot 2025-07-28 at 11 00 05 PM" src="https://github.com/user-attachments/assets/44d9da17-667a-4000-a7bd-d95c8f1e2774" />

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
