### PR TITLE
Feat: #5586 Chamber Temp Control

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2375,14 +2375,14 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
 
     // adds tag for processor
     file.write_format(";%s%s\n", GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Role).c_str(), ExtrusionEntity::role_to_string(erCustom).c_str());
-
-    // Orca: set chamber temperature at the beginning of gcode file
-    if (activate_chamber_temp_control && max_chamber_temp > 0)
-        file.write(m_writer.set_chamber_temperature(max_chamber_temp, true)); // set chamber_temperature
-
+ 
     // Write the custom start G-code
     file.writeln(machine_start_gcode);
 
+    // Orca: set chamber temperature after bed temp set by machine_start_code
+    if (activate_chamber_temp_control && max_chamber_temp > 0)
+        file.write(m_writer.set_chamber_temperature(max_chamber_temp, true)); // set chamber_temperature
+    
     //BBS: gcode writer doesn't know where the real position of extruder is after inserting custom gcode
     m_writer.set_current_position_clear(false);
     m_start_gcode_filament = GCodeProcessor::get_gcode_last_filament(machine_start_gcode);


### PR DESCRIPTION


# Description

Moves setting of chamber temp to after machine_start_code so that bed can heat first. This can speed up chamber heating time and reduce chamber heat timeouts.

## Tests

Compared location of M191 in gcode to ensure it is moved to after bed is heated.