### PR TITLE
Don't overwrite config if the new one was not successfully written

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -837,6 +837,10 @@ void AppConfig::save()
 #endif
 
     c.close();
+    if (c.fail()) {
+      BOOST_LOG_TRIVIAL(error) << "Failed to write new configuration to " << path_pid << "; aborting attempt to overwrite original configuration";
+      return;
+    }
 
 #ifdef WIN32
     // Make a backup of the configuration file before copying it to the final destination.
@@ -1042,6 +1046,10 @@ void AppConfig::save()
     c << appconfig_md5_hash_line(config_str);
 #endif
     c.close();
+    if (c.fail()) {
+      BOOST_LOG_TRIVIAL(error) << "Failed to write new configuration to " << path_pid << "; aborting attempt to overwrite original configuration";
+      return;
+    }
 
 #ifdef WIN32
     // Make a backup of the configuration file before copying it to the final destination.


### PR DESCRIPTION
The errors weren't being checked, now they are. Unfortunately there's no indication to the user that preferences aren't being saved, but there wasn't before either.

Fixes #10283

## Tests

I compiled with my fix, then did the following.

```
# Finished going through the tutorial
cory@peanut:~/.config/OrcaSlicer$ cp OrcaSlicer.conf OrcaSlicer.conf.throughTutorial
# I opened preferences and clicked to reverse mouse zoom
cory@peanut:~/.config/OrcaSlicer$ diff -u OrcaSlicer.conf OrcaSlicer.conf.throughTutorial
--- OrcaSlicer.conf	2025-07-30 17:59:53.351057992 -0700
+++ OrcaSlicer.conf.throughTutorial	2025-07-30 17:59:36.199056398 -0700
@@ -42,7 +42,7 @@
         "project_load_behaviour": "ask_when_relevant",
         "region": "North America",
         "remember_printer_config": true,
-        "reverse_mouse_wheel_zoom": true,
+        "reverse_mouse_wheel_zoom": false,
         "rotate_view": "none/mouse left",
         "sending_interval": "5",
         "show_3d_navigator": true,
# I clicked again so it's back to the no-diff state, then I fill my drive:
cory@peanut:~/.config/OrcaSlicer$ dd if=/dev/zero of=log/fill_me_up bs=1M
dd: error writing 'log/fill_me_up': No space left on device
3143+0 records in
3142+0 records out
3294679040 bytes (3.3 GB, 3.1 GiB) copied, 4.71416 s, 699 MB/s
# I toggle the mouse zoom setting
cory@peanut:~/.config/OrcaSlicer$ diff -u OrcaSlicer.conf OrcaSlicer.conf.throughTutorial
# I toggle the mouse zoom setting
cory@peanut:~/.config/OrcaSlicer$ diff -u OrcaSlicer.conf OrcaSlicer.conf.throughTutorial
# I toggle the mouse zoom setting
cory@peanut:~/.config/OrcaSlicer$ diff -u OrcaSlicer.conf OrcaSlicer.conf.throughTutorial
cory@peanut:~/.config/OrcaSlicer$ ls -l
total 144
-rw-rw-r-- 1 cory cory   768 Jul 30 14:15 BambuNetworkEngine.conf
drwxrwxr-x 2 cory cory  4096 Jul 30 18:01 cache
drwxrwxr-x 2 cory cory  4096 Jul 18 13:46 hms
drwxrwxr-x 2 cory cory  4096 Jul 30 18:01 log
-rw-rw-r-- 1 cory cory 48229 Jul 30 18:00 OrcaSlicer.conf
-rw-rw-r-- 1 cory cory  3750 Jul 30 17:56 OrcaSlicer.conf~
-rw-rw-r-- 1 cory cory     0 Jul 30 18:01 OrcaSlicer.conf.182861
-rw-rw-r-- 1 cory cory 48229 Jul 30 17:59 OrcaSlicer.conf.throughTutorial
drwxrwxr-x 2 cory cory  4096 Jul 16 19:08 ota
drwxrwxr-x 3 cory cory  4096 Jul 16 19:11 plugins
drwxrwxr-x 2 cory cory  4096 Jul 16 19:08 printers
drwxrwxr-x 5 cory cory  4096 Jul 30 17:59 system
drwxrwxr-x 4 cory cory  4096 Jul 26 11:13 user
drwxrwxr-x 2 cory cory  4096 Jul 16 19:08 user_backup-v2.3.1-dev
```

As you can see, it creates `OrcaSlicer.conf.$PID` file, which it cannot write to (size `0`). This time it identified the file cannot be written, so it returned instead of deleting `OrcaSlicer.conf` and renaming `OrcaSlicer.conf.182861` to it.