### PR TITLE
Run shellcheck on build_linux.sh and add it to workflows

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,38 @@
+on:
+  push:
+    paths:
+      - build_linux.sh
+  pull_request:
+    paths:
+      - build_linux.sh
+  workflow_dispatch: # allows for manual dispatch
+
+name: "Shellcheck"
+permissions: {}
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache shellcheck download
+        id: cache-shellcheck-v0_11
+        uses: actions/cache@v4
+        with:
+          path: ~/shellcheck
+          key: ${{ runner.os }}-shellcheck-v0_11
+
+      - name: Download shellcheck
+        if: steps.cache-shellcheck-v0_11.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          INPUT_VERSION: "v0.11.0"
+        run: |
+          curl -L#o ~/sc.tar.xz "https://github.com/koalaman/shellcheck/releases/download/${INPUT_VERSION}/shellcheck-${INPUT_VERSION}.linux.x86_64.tar.xz"
+          tar -xvf ~/sc.tar.xz -C ~
+          mv ~/shellcheck-"${INPUT_VERSION}"/shellcheck ~/shellcheck
+
+      - uses: actions/checkout@v4
+
+      - name: Shellcheck build_linux.sh
+        run: ~/shellcheck -e SC1090 build_linux.sh

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 SCRIPT_NAME=$(basename "$0")
-SCRIPT_PATH=$(dirname $(readlink -f ${0}))
+SCRIPT_PATH=$(dirname "$(readlink -f "${0}")")
 
-pushd ${SCRIPT_PATH} > /dev/null
+pushd "${SCRIPT_PATH}" > /dev/null
 
 set -e # Exit immediately if a command exits with a non-zero status.
 
@@ -22,7 +22,7 @@ function check_available_memory_and_disk() {
     fi
 
     if [[ ${FREE_DISK_KB} -le ${MIN_DISK_KB} ]] ; then
-        echo -e "\nERROR: Orca Slicer Builder requires at least $(echo ${MIN_DISK_KB} |awk '{ printf "%.1fG\n", $1/1024/1024; }') (system has only $(echo ${FREE_DISK_KB} | awk '{ printf "%.1fG\n", $1/1024/1024; }') disk free)"
+        echo -e "\nERROR: Orca Slicer Builder requires at least $(echo "${MIN_DISK_KB}" |awk '{ printf "%.1fG\n", $1/1024/1024; }') (system has only $(echo "${FREE_DISK_KB}" | awk '{ printf "%.1fG\n", $1/1024/1024; }') disk free)"
         echo && df --human-readable . && echo
         echo "Invoke with -r to skip ram and disk checks."
         exit 1
@@ -72,7 +72,7 @@ while getopts ":1j:bcCdhiprsul" opt ; do
         BUILD_DEPS="1"
         ;;
     h ) usage
-        exit 0
+        exit 1
         ;;
     i )
         BUILD_IMAGE="1"
@@ -87,17 +87,21 @@ while getopts ":1j:bcCdhiprsul" opt ; do
         BUILD_ORCA="1"
         ;;
     u )
-        UPDATE_LIB="1"
+        export UPDATE_LIB="1"
         ;;
     l )
         USE_CLANG="1"
         ;;
+    * )
+	echo "Unknown argument '${opt}', aborting."
+	exit 1
+	;;
   esac
 done
 
 if [ ${OPTIND} -eq 1 ] ; then
     usage
-    exit 0
+    exit 1
 fi
 
 # cmake 4.x compatibility workaround
@@ -115,13 +119,13 @@ elif [[ "${DISTRIBUTION_LIKE}" == *"arch"* ]] ; then
     DISTRIBUTION="arch"
 fi
 
-if [ ! -f ./linux.d/${DISTRIBUTION} ] ; then
+if [ ! -f "./linux.d/${DISTRIBUTION}" ] ; then
     echo "Your distribution \"${DISTRIBUTION}\" is not supported by system-dependency scripts in ./linux.d/"
     echo "Please resolve dependencies manually and contribute a script for your distribution to upstream."
     exit 1
 else
     echo "resolving system dependencies for distribution \"${DISTRIBUTION}\" ..."
-    source ./linux.d/${DISTRIBUTION}
+    source "./linux.d/${DISTRIBUTION}"
 fi
 
 echo "FOUND_GTK3=${FOUND_GTK3}"
@@ -139,7 +143,7 @@ echo "Changing date in version..."
 echo "done"
 
 
-if ! [[ -n "${SKIP_RAM_CHECK}" ]] ; then
+if [[ -z "${SKIP_RAM_CHECK}" ]] ; then
     check_available_memory_and_disk
 fi
 
@@ -155,29 +159,28 @@ if [[ -n "${BUILD_DEPS}" ]] ; then
     then
         rm -fr deps/build
     fi
-    if [ ! -d "deps/build" ]
-    then
-        mkdir deps/build
-    fi
+    mkdir -p deps/build
     if [[ -n "${BUILD_DEBUG}" ]] ; then
         # build deps with debug and release else cmake will not find required sources
-        if [ ! -d "deps/build/release" ] ; then
-            mkdir deps/build/release
-        fi
-        cmake ${CMAKE_C_CXX_COMPILER_CLANG} -S deps -B deps/build/release -DSLIC3R_PCH=${SLIC3R_PRECOMPILED_HEADERS} -G Ninja -DDESTDIR="${SCRIPT_PATH}/deps/build/destdir" -DDEP_DOWNLOAD_DIR="${SCRIPT_PATH}/deps/DL_CACHE" ${COLORED_OUTPUT} ${BUILD_ARGS}
+        mkdir -p deps/build/release
+	CMAKE_CMD="cmake ${CMAKE_C_CXX_COMPILER_CLANG} -S deps -B deps/build/release -DSLIC3R_PCH=${SLIC3R_PRECOMPILED_HEADERS} -G Ninja -DDESTDIR=${SCRIPT_PATH}/deps/build/destdir -DDEP_DOWNLOAD_DIR=${SCRIPT_PATH}/deps/DL_CACHE ${COLORED_OUTPUT} ${BUILD_ARGS}"
+	echo "${CMAKE_CMD}"
+	${CMAKE_CMD}
         cmake --build deps/build/release
         BUILD_ARGS="${BUILD_ARGS} -DCMAKE_BUILD_TYPE=Debug"
     fi
 
-    echo "cmake -S deps -B deps/build ${CMAKE_C_CXX_COMPILER_CLANG} -G Ninja ${BUILD_ARGS}"
-    cmake -S deps -B deps/build ${CMAKE_C_CXX_COMPILER_CLANG} -G Ninja ${COLORED_OUTPUT} ${BUILD_ARGS}
+    # If this isn't in one quote, then empty variables can add two single quotes and mess up argument parsing for cmake.
+    CMAKE_CMD="cmake -S deps -B deps/build ${CMAKE_C_CXX_COMPILER_CLANG} -G Ninja ${COLORED_OUTPUT} ${BUILD_ARGS}"
+    echo "${CMAKE_CMD}"
+    ${CMAKE_CMD}
     cmake --build deps/build
 fi
 
 if [[ -n "${BUILD_ORCA}" ]] ; then
     echo "Configuring OrcaSlicer..."
     if [[ -n "${CLEAN_BUILD}" ]] ; then
-        rm --force --recursive build
+        rm -fr build
     fi
     BUILD_ARGS="${ORCA_EXTRA_BUILD_ARGS}"
     if [[ -n "${FOUND_GTK3_DEV}" ]] ; then
@@ -191,12 +194,12 @@ if [[ -n "${BUILD_ORCA}" ]] ; then
 
     CMAKE_CMD="cmake -S . -B build ${CMAKE_C_CXX_COMPILER_CLANG} -G Ninja \
 -DSLIC3R_PCH=${SLIC3R_PRECOMPILED_HEADERS} \
--DCMAKE_PREFIX_PATH="${SCRIPT_PATH}/deps/build/destdir/usr/local" \
+-DCMAKE_PREFIX_PATH=${SCRIPT_PATH}/deps/build/destdir/usr/local \
 -DSLIC3R_STATIC=1 \
 -DORCA_TOOLS=ON \
 ${COLORED_OUTPUT} \
 ${BUILD_ARGS}"
-    echo -e "${CMAKE_CMD}"
+    echo "${CMAKE_CMD}"
     ${CMAKE_CMD}
     echo "done"
     echo "Building OrcaSlicer ..."

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,33 +1,10 @@
 #!/usr/bin/env bash
+set -e # Exit immediately if a command exits with a non-zero status.
 
 SCRIPT_NAME=$(basename "$0")
 SCRIPT_PATH=$(dirname "$(readlink -f "${0}")")
 
 pushd "${SCRIPT_PATH}" > /dev/null
-
-set -e # Exit immediately if a command exits with a non-zero status.
-
-function check_available_memory_and_disk() {
-    FREE_MEM_GB=$(free --gibi --total | grep 'Mem' | rev | cut --delimiter=" " --fields=1 | rev)
-    MIN_MEM_GB=10
-
-    FREE_DISK_KB=$(df --block-size=1K . | tail -1 | awk '{print $4}')
-    MIN_DISK_KB=$((10 * 1024 * 1024))
-
-    if [[ ${FREE_MEM_GB} -le ${MIN_MEM_GB} ]] ; then
-        echo -e "\nERROR: Orca Slicer Builder requires at least ${MIN_MEM_GB}G of 'available' mem (system has only ${FREE_MEM_GB}G available)"
-        echo && free --human && echo
-        echo "Invoke with -r to skip RAM and disk checks."
-        exit 2
-    fi
-
-    if [[ ${FREE_DISK_KB} -le ${MIN_DISK_KB} ]] ; then
-        echo -e "\nERROR: Orca Slicer Builder requires at least $(echo "${MIN_DISK_KB}" |awk '{ printf "%.1fG\n", $1/1024/1024; }') (system has only $(echo "${FREE_DISK_KB}" | awk '{ printf "%.1fG\n", $1/1024/1024; }') disk free)"
-        echo && df --human-readable . && echo
-        echo "Invoke with -r to skip ram and disk checks."
-        exit 1
-    fi
-}
 
 function usage() {
     echo "Usage: ./${SCRIPT_NAME} [-1][-b][-c][-d][-h][-i][-j N][-p][-r][-s][-u][-l]"
@@ -103,6 +80,28 @@ if [ ${OPTIND} -eq 1 ] ; then
     usage
     exit 1
 fi
+
+function check_available_memory_and_disk() {
+    FREE_MEM_GB=$(free --gibi --total | grep 'Mem' | rev | cut --delimiter=" " --fields=1 | rev)
+    MIN_MEM_GB=10
+
+    FREE_DISK_KB=$(df --block-size=1K . | tail -1 | awk '{print $4}')
+    MIN_DISK_KB=$((10 * 1024 * 1024))
+
+    if [[ ${FREE_MEM_GB} -le ${MIN_MEM_GB} ]] ; then
+        echo -e "\nERROR: Orca Slicer Builder requires at least ${MIN_MEM_GB}G of 'available' mem (system has only ${FREE_MEM_GB}G available)"
+        echo && free --human && echo
+        echo "Invoke with -r to skip RAM and disk checks."
+        exit 2
+    fi
+
+    if [[ ${FREE_DISK_KB} -le ${MIN_DISK_KB} ]] ; then
+        echo -e "\nERROR: Orca Slicer Builder requires at least $(echo "${MIN_DISK_KB}" |awk '{ printf "%.1fG\n", $1/1024/1024; }') (system has only $(echo "${FREE_DISK_KB}" | awk '{ printf "%.1fG\n", $1/1024/1024; }') disk free)"
+        echo && df --human-readable . && echo
+        echo "Invoke with -r to skip ram and disk checks."
+        exit 1
+    fi
+}
 
 # cmake 4.x compatibility workaround
 export CMAKE_POLICY_VERSION_MINIMUM=3.5


### PR DESCRIPTION
This is the beginning of adding some safety nets for making
changes. This one just runs shellcheck against `build_linux.sh`.

You can see it working at
https://github.com/coryrc/OrcaSlicer/actions/workflows/shellcheck.yml
I forked and tested it running in PRs and against pushes to HEAD. An
[example PR](https://github.com/coryrc/OrcaSlicer/pull/2) is running it as
a "Check" and it passes it.

`shellcheck -e SC1090 build_linux.sh` and fixed the issues.

Also fixed the usage command to return an error, simplify directory
creation to use `mkdir -p`, and made printing of the cmake commands
consistent instead of having three different ways of doing it.

I'm trying to make the Linux build work as well as the Windows one, so
I've started to refactor build_linux.sh to look more like the windows
script. Currently it does not act any different.