### PR TITLE
Fixed a mistake in Max volumetric flow Wiki

### DIFF
--- a/doc/calibration/volumetric-speed-calib.md
+++ b/doc/calibration/volumetric-speed-calib.md
@@ -29,7 +29,7 @@ Use calipers or a ruler to measure the **height** of the model just before the d
 - Use the following formula
 
   ```math
-  Filament Max Volumetric Speed = start + (height-measured * step)
+  Filament Max Volumetric Speed = start + (HeightMeasured * step)
   ```
 
   In this case (19mm), so the calculation would be: `5 + (19 * 0.5) = 14.5mm³/s`


### PR DESCRIPTION
Updated a mistake in Wiki - Max volumetric flow test - there was a "-" in the math equation as [SPACE]. So I improved it by joining words and changing their initials to capitals.