### PR TITLE
Fix focus stealing issue in dialog windows (#9874)

### DIFF
--- a/src/slic3r/GUI/ReleaseNote.cpp
+++ b/src/slic3r/GUI/ReleaseNote.cpp
@@ -698,7 +698,9 @@ SecondaryCheckDialog::SecondaryCheckDialog(wxWindow* parent, wxWindowID id, cons
     m_sizer_main->Add(m_sizer_right, 0, wxBOTTOM | wxEXPAND, FromDIP(5));
 
     Bind(wxEVT_CLOSE_WINDOW, [this](auto& e) {this->on_hide();});
-    Bind(wxEVT_ACTIVATE, [this](auto& e) { if (!e.GetActive()) this->RequestUserAttention(wxUSER_ATTENTION_ERROR); });
+    // Fix for #9874: Remove RequestUserAttention on deactivation to prevent focus stealing
+    // This was causing random window activation when multiple instances were running
+    // Bind(wxEVT_ACTIVATE, [this](auto& e) { if (!e.GetActive()) this->RequestUserAttention(wxUSER_ATTENTION_ERROR); });
 
     SetSizer(m_sizer_main);
     Layout();
@@ -891,7 +893,9 @@ PrintErrorDialog::PrintErrorDialog(wxWindow* parent, wxWindowID id, const wxStri
     m_sizer_main->Add(m_sizer_right, 0, wxBOTTOM | wxEXPAND, FromDIP(5));
 
     Bind(wxEVT_CLOSE_WINDOW, [this](auto& e) {this->on_hide(); });
-    Bind(wxEVT_ACTIVATE, [this](auto& e) { if (!e.GetActive()) this->RequestUserAttention(wxUSER_ATTENTION_ERROR); });
+    // Fix for #9874: Remove RequestUserAttention on deactivation to prevent focus stealing
+    // This was causing random window activation when multiple instances were running
+    // Bind(wxEVT_ACTIVATE, [this](auto& e) { if (!e.GetActive()) this->RequestUserAttention(wxUSER_ATTENTION_ERROR); });
     Bind(wxEVT_WEBREQUEST_STATE, &PrintErrorDialog::on_webrequest_state, this);
 
 


### PR DESCRIPTION
## Summary
- Removed RequestUserAttention calls on window deactivation in SecondaryCheckDialog and PrintErrorDialog
- This prevents random window activation when multiple OrcaSlicer instances are running
- Fixes issue #9874 where dialogs would steal focus inappropriately

## Test plan
- [ ] Open multiple OrcaSlicer instances
- [ ] Trigger dialogs in one instance (e.g., error dialogs)
- [ ] Verify that switching between instances doesn't cause unexpected focus changes
- [ ] Confirm dialogs still function normally when activated/deactivated