### PR TITLE
Fix: export printer config skipping currently selected preset

### DIFF
--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -4107,8 +4107,8 @@ void ExportConfigsDialog::data_init()
         if (preset_bundle.printers.select_preset_by_name(preset_name, true)) {
             preset_bundle.update_compatible(PresetSelectCompatibleType::Always);
 
-            const std::deque<Preset>& filament_presets = preset_bundle.filaments.get_presets();
-            for (const Preset& filament_preset : filament_presets) {
+            const std::deque<Preset> &filament_presets = preset_bundle.filaments.get_presets();
+            for (const Preset &filament_preset : filament_presets) {
                 if (filament_preset.is_system || filament_preset.is_default || filament_preset.is_project_embedded) continue;
                 if (filament_preset.is_compatible) {
                     Preset *new_filament_preset = new Preset(filament_preset);
@@ -4116,16 +4116,16 @@ void ExportConfigsDialog::data_init()
                 }
             }
 
-            const std::deque<Preset>& process_presets = preset_bundle.prints.get_presets();
-            for (const Preset& process_preset : process_presets) {
+            const std::deque<Preset> &process_presets = preset_bundle.prints.get_presets();
+            for (const Preset &process_preset : process_presets) {
                 if (process_preset.is_system || process_preset.is_default || process_preset.is_project_embedded) continue;
                 if (process_preset.is_compatible) {
                     Preset *new_prpcess_preset = new Preset(process_preset);
                     m_process_presets[preset_name].push_back(new_prpcess_preset);
                 }
             }
-
-            Preset *new_printer_preset = new Preset(printer_preset);
+            
+            Preset *new_printer_preset     = new Preset(printer_preset);
             earse_preset_fields_for_safe(new_printer_preset);
             m_printer_presets[preset_name] = new_printer_preset;
         }

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -4109,25 +4109,23 @@ void ExportConfigsDialog::data_init()
 
             const std::deque<Preset>& filament_presets = preset_bundle.filaments.get_presets();
             for (const Preset& filament_preset : filament_presets) {
-                if (filament_preset.is_system || filament_preset.is_default || filament_preset.is_project_embedded)
-                    continue;
+                if (filament_preset.is_system || filament_preset.is_default || filament_preset.is_project_embedded) continue;
                 if (filament_preset.is_compatible) {
-                    Preset* new_filament_preset = new Preset(filament_preset);
+                    Preset *new_filament_preset = new Preset(filament_preset);
                     m_filament_presets[preset_name].push_back(new_filament_preset);
                 }
             }
 
             const std::deque<Preset>& process_presets = preset_bundle.prints.get_presets();
             for (const Preset& process_preset : process_presets) {
-                if (process_preset.is_system || process_preset.is_default || process_preset.is_project_embedded)
-                    continue;
+                if (process_preset.is_system || process_preset.is_default || process_preset.is_project_embedded) continue;
                 if (process_preset.is_compatible) {
-                    Preset* new_prpcess_preset = new Preset(process_preset);
+                    Preset *new_prpcess_preset = new Preset(process_preset);
                     m_process_presets[preset_name].push_back(new_prpcess_preset);
                 }
             }
 
-            Preset* new_printer_preset = new Preset(printer_preset);
+            Preset *new_printer_preset = new Preset(printer_preset);
             earse_preset_fields_for_safe(new_printer_preset);
             m_printer_presets[preset_name] = new_printer_preset;
         }

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -4103,7 +4103,7 @@ void ExportConfigsDialog::data_init()
     for (const Preset &printer_preset : printer_presets) {
         
         std::string preset_name        = printer_preset.name;
-        if (!printer_preset.is_visible || printer_preset.is_project_embedded) continue;
+        if (!printer_preset.is_visible || printer_preset.is_default || printer_preset.is_project_embedded) continue;
         preset_bundle.update_compatible(PresetSelectCompatibleType::Always);
 
         const std::deque<Preset> &filament_presets = preset_bundle.filaments.get_presets();

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -4103,32 +4103,30 @@ void ExportConfigsDialog::data_init()
     for (const Preset &printer_preset : printer_presets) {
         
         std::string preset_name        = printer_preset.name;
-        if (!printer_preset.is_visible || printer_preset.is_default || printer_preset.is_project_embedded) continue;
-        if (preset_bundle.printers.select_preset_by_name(preset_name, false)) {
-            preset_bundle.update_compatible(PresetSelectCompatibleType::Always);
+        if (!printer_preset.is_visible || printer_preset.is_project_embedded) continue;
+        preset_bundle.update_compatible(PresetSelectCompatibleType::Always);
 
-            const std::deque<Preset> &filament_presets = preset_bundle.filaments.get_presets();
-            for (const Preset &filament_preset : filament_presets) {
-                if (filament_preset.is_system || filament_preset.is_default || filament_preset.is_project_embedded) continue;
-                if (filament_preset.is_compatible) {
-                    Preset *new_filament_preset = new Preset(filament_preset);
-                    m_filament_presets[preset_name].push_back(new_filament_preset);
-                }
+        const std::deque<Preset> &filament_presets = preset_bundle.filaments.get_presets();
+        for (const Preset &filament_preset : filament_presets) {
+            if (filament_preset.is_system || filament_preset.is_default || filament_preset.is_project_embedded) continue;
+            if (filament_preset.is_compatible) {
+                Preset *new_filament_preset = new Preset(filament_preset);
+                m_filament_presets[preset_name].push_back(new_filament_preset);
             }
-
-            const std::deque<Preset> &process_presets = preset_bundle.prints.get_presets();
-            for (const Preset &process_preset : process_presets) {
-                if (process_preset.is_system || process_preset.is_default || process_preset.is_project_embedded) continue;
-                if (process_preset.is_compatible) {
-                    Preset *new_prpcess_preset = new Preset(process_preset);
-                    m_process_presets[preset_name].push_back(new_prpcess_preset);
-                }
-            }
-            
-            Preset *new_printer_preset     = new Preset(printer_preset);
-            earse_preset_fields_for_safe(new_printer_preset);
-            m_printer_presets[preset_name] = new_printer_preset;
         }
+
+        const std::deque<Preset> &process_presets = preset_bundle.prints.get_presets();
+        for (const Preset &process_preset : process_presets) {
+            if (process_preset.is_system || process_preset.is_default || process_preset.is_project_embedded) continue;
+            if (process_preset.is_compatible) {
+                Preset *new_prpcess_preset = new Preset(process_preset);
+                m_process_presets[preset_name].push_back(new_prpcess_preset);
+            }
+        }
+            
+        Preset *new_printer_preset     = new Preset(printer_preset);
+        earse_preset_fields_for_safe(new_printer_preset);
+        m_printer_presets[preset_name] = new_printer_preset;
     }
     const std::deque<Preset> &filament_presets = preset_bundle.filaments.get_presets();
     for (const Preset &filament_preset : filament_presets) {

--- a/src/slic3r/GUI/CreatePresetsDialog.cpp
+++ b/src/slic3r/GUI/CreatePresetsDialog.cpp
@@ -4104,29 +4104,33 @@ void ExportConfigsDialog::data_init()
         
         std::string preset_name        = printer_preset.name;
         if (!printer_preset.is_visible || printer_preset.is_default || printer_preset.is_project_embedded) continue;
-        preset_bundle.update_compatible(PresetSelectCompatibleType::Always);
+        if (preset_bundle.printers.select_preset_by_name(preset_name, true)) {
+            preset_bundle.update_compatible(PresetSelectCompatibleType::Always);
 
-        const std::deque<Preset> &filament_presets = preset_bundle.filaments.get_presets();
-        for (const Preset &filament_preset : filament_presets) {
-            if (filament_preset.is_system || filament_preset.is_default || filament_preset.is_project_embedded) continue;
-            if (filament_preset.is_compatible) {
-                Preset *new_filament_preset = new Preset(filament_preset);
-                m_filament_presets[preset_name].push_back(new_filament_preset);
+            const std::deque<Preset>& filament_presets = preset_bundle.filaments.get_presets();
+            for (const Preset& filament_preset : filament_presets) {
+                if (filament_preset.is_system || filament_preset.is_default || filament_preset.is_project_embedded)
+                    continue;
+                if (filament_preset.is_compatible) {
+                    Preset* new_filament_preset = new Preset(filament_preset);
+                    m_filament_presets[preset_name].push_back(new_filament_preset);
+                }
             }
-        }
 
-        const std::deque<Preset> &process_presets = preset_bundle.prints.get_presets();
-        for (const Preset &process_preset : process_presets) {
-            if (process_preset.is_system || process_preset.is_default || process_preset.is_project_embedded) continue;
-            if (process_preset.is_compatible) {
-                Preset *new_prpcess_preset = new Preset(process_preset);
-                m_process_presets[preset_name].push_back(new_prpcess_preset);
+            const std::deque<Preset>& process_presets = preset_bundle.prints.get_presets();
+            for (const Preset& process_preset : process_presets) {
+                if (process_preset.is_system || process_preset.is_default || process_preset.is_project_embedded)
+                    continue;
+                if (process_preset.is_compatible) {
+                    Preset* new_prpcess_preset = new Preset(process_preset);
+                    m_process_presets[preset_name].push_back(new_prpcess_preset);
+                }
             }
+
+            Preset* new_printer_preset = new Preset(printer_preset);
+            earse_preset_fields_for_safe(new_printer_preset);
+            m_printer_presets[preset_name] = new_printer_preset;
         }
-            
-        Preset *new_printer_preset     = new Preset(printer_preset);
-        earse_preset_fields_for_safe(new_printer_preset);
-        m_printer_presets[preset_name] = new_printer_preset;
     }
     const std::deque<Preset> &filament_presets = preset_bundle.filaments.get_presets();
     for (const Preset &filament_preset : filament_presets) {


### PR DESCRIPTION
Export Preset Bundle->Printer config bundle will not consider the currently selected printer as a valid option. Fixes #10327 

Removed this check `(preset_bundle.printers.select_preset_by_name(preset_name,` false))`


## Tests
Tried out the user config in the bug report. If you create and select another printer, you can get Bambu Lab P1S 0.4 nozzle to show up. 

