### PR TITLE
Fix crash when opening AMS humidity popup

### DIFF
--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
@@ -206,7 +206,7 @@ void uiAmsPercentHumidityDryPopup::DrawGridArea(wxDC &dc, wxPoint start_p)
         }
         else if (header == _L("Temperature"))
         {
-            const wxString &temp_str = wxString::Format(u8"%.1f \u2103", m_current_temperature);
+            const wxString &temp_str = wxString::Format(wxString::FromUTF8(u8"%.1f \u2103"), m_current_temperature);
             dc.DrawText(temp_str, left, start_p.y + row_height);
         }
         else if (header == _L("Left Time"))


### PR DESCRIPTION
Orca crashes if you click the AMS humidity icon:
<img width="355" height="167" alt="image" src="https://github.com/user-attachments/assets/3bc81c0a-8df8-4743-af0a-66017727afbf" />

This PR fixes this issue.