### PR TITLE
Fix IS & JD test

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10223,8 +10223,9 @@ void Plater::calib_input_shaping_freq(const Calib_Params& params)
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_min_speed", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_for_layer_cooling", new ConfigOptionBools{false});
-    filament_config->set_key_value("enable_pressure_advance", new ConfigOptionBools {false });
+    filament_config->set_key_value("enable_pressure_advance", new ConfigOptionBools {true});
     filament_config->set_key_value("pressure_advance", new ConfigOptionFloats { 0.0 });
+    filament_config->set_key_value("adaptive_pressure_advance", new ConfigOptionBools{false});
     print_config->set_key_value("layer_height", new ConfigOptionFloat(0.2));
     print_config->set_key_value("enable_overhang_speed", new ConfigOptionBool { false });
     print_config->set_key_value("timelapse_type", new ConfigOptionEnum<TimelapseType>(tlTraditional));
@@ -10270,8 +10271,9 @@ void Plater::calib_input_shaping_damp(const Calib_Params& params)
     filament_config->set_key_value("slow_down_layer_time", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_min_speed", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_for_layer_cooling", new ConfigOptionBools{false});
-    filament_config->set_key_value("enable_pressure_advance", new ConfigOptionBools{false});
-    filament_config->set_key_value("pressure_advance", new ConfigOptionFloats{0.0});
+    filament_config->set_key_value("enable_pressure_advance", new ConfigOptionBools {true});
+    filament_config->set_key_value("pressure_advance", new ConfigOptionFloats { 0.0 });
+    filament_config->set_key_value("adaptive_pressure_advance", new ConfigOptionBools{false});
     print_config->set_key_value("layer_height", new ConfigOptionFloat(0.2));
     print_config->set_key_value("enable_overhang_speed", new ConfigOptionBool{false});
     print_config->set_key_value("timelapse_type", new ConfigOptionEnum<TimelapseType>(tlTraditional));
@@ -10302,7 +10304,7 @@ void Plater::calib_input_shaping_damp(const Calib_Params& params)
 
 void Plater::calib_junction_deviation(const Calib_Params& params)
 {
-    const auto calib_junction_deviation = wxString::Format(L"Input shaping Damping test");
+    const auto calib_junction_deviation = wxString::Format(L"Junction Deviation test");
     new_project(false, false, calib_junction_deviation);
     wxGetApp().mainframe->select_tab(size_t(MainFrame::tp3DEditor));
     if (params.mode != CalibMode::Calib_Junction_Deviation)
@@ -10318,8 +10320,9 @@ void Plater::calib_junction_deviation(const Calib_Params& params)
     filament_config->set_key_value("slow_down_min_speed", new ConfigOptionFloats { 0.0 });
     filament_config->set_key_value("slow_down_for_layer_cooling", new ConfigOptionBools{false});
     filament_config->set_key_value("filament_max_volumetric_speed", new ConfigOptionFloats{200});
-    filament_config->set_key_value("enable_pressure_advance", new ConfigOptionBools{false});
-    filament_config->set_key_value("pressure_advance", new ConfigOptionFloats{0.0});
+    filament_config->set_key_value("enable_pressure_advance", new ConfigOptionBools {true});
+    filament_config->set_key_value("pressure_advance", new ConfigOptionFloats { 0.0 });
+    filament_config->set_key_value("adaptive_pressure_advance", new ConfigOptionBools{false});
     print_config->set_key_value("layer_height", new ConfigOptionFloat(0.2));
     print_config->set_key_value("enable_overhang_speed", new ConfigOptionBool{false});
     print_config->set_key_value("timelapse_type", new ConfigOptionEnum<TimelapseType>(tlTraditional));


### PR DESCRIPTION
Previously, the PA was deactivated, but in reality, a value of 0 is desired. When deactivating it, if it has a value due to FW, that value is used. Now it is forced to 0.
Fixes https://discord.com/channels/1137181739773603922/1407842411572625569