### PR TITLE
Fix: Reset object settings not working for plate's Skirt Start Angle and Other Layers Sequence

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -235,6 +235,11 @@ void PartPlate::reset_bed_type()
     m_config.erase("curr_bed_type");
 }
 
+void PartPlate::reset_skirt_start_angle()
+{
+    m_config.erase("skirt_start_angle");
+}
+
 void PartPlate::set_print_seq(PrintSequence print_seq)
 {
     std::string print_seq_key = "print_sequence";

--- a/src/slic3r/GUI/PartPlate.hpp
+++ b/src/slic3r/GUI/PartPlate.hpp
@@ -227,6 +227,9 @@ public:
     BedType get_bed_type(bool load_from_project = false) const;
     void set_bed_type(BedType bed_type);
     void reset_bed_type();
+
+    void reset_skirt_start_angle();
+
     DynamicPrintConfig* config() { return &m_config; }
 
     // set print sequence per plate

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2930,8 +2930,10 @@ void TabPrintPlate::reset_model_config()
         }
         auto plate = dynamic_cast<PartPlate*>(plate_item.first);
         plate->reset_bed_type();
+        plate->reset_skirt_start_angle();
         plate->set_print_seq(PrintSequence::ByDefault);
         plate->set_first_layer_print_sequence({});
+        plate->set_other_layers_print_sequence({});
         plate->set_spiral_vase_mode(false, true);
         notify_changed(plate_item.first);
     }


### PR DESCRIPTION
Before
<img width="664" height="473" alt="Screenshot-20250822013021" src="https://github.com/user-attachments/assets/dbafb22a-a739-4e91-806a-d4f411b5c145" />

After
working as expected
