### PR TITLE
Missing permissions validate-documentation.yml

### DIFF
--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -7,6 +7,11 @@ on:
       - 'doc/**/*.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   validate:
     runs-on: windows-latest


### PR DESCRIPTION
The new Documentation Validation didn't have permission to write the comment with the errors.