### PR TITLE
 Fix  netfab  model repair service in github compilation

### DIFF
--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -61,6 +61,13 @@ jobs:
 
 
       # Build Dependencies
+      - name: Install Windows 10 SDK (for Netfabb STL fixing)
+        if: inputs.os == 'windows-latest'
+        run: |
+          choco install windows-sdk-10-version-2004-all -y
+          echo "WIN10SDK_PATH=C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0" >> $env:GITHUB_ENV
+        shell: pwsh
+
       - name: Build on Windows
         if: inputs.os == 'windows-latest'
         working-directory: ${{ github.workspace }}
@@ -69,6 +76,7 @@ jobs:
             .\build_release_vs2022.bat deps
             .\build_release_vs2022.bat pack
             cd ${{ github.workspace }}/deps/build
+
 
       - name: Build on Mac ${{ inputs.arch }}
         if: inputs.os == 'macos-14'

--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -61,13 +61,6 @@ jobs:
 
 
       # Build Dependencies
-      - name: Install Windows 10 SDK (for Netfabb STL fixing)
-        if: inputs.os == 'windows-latest'
-        run: |
-          choco install windows-sdk-10-version-2004-all -y
-          echo "WIN10SDK_PATH=C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0" >> $env:GITHUB_ENV
-        shell: pwsh
-
       - name: Build on Windows
         if: inputs.os == 'windows-latest'
         working-directory: ${{ github.workspace }}
@@ -76,7 +69,6 @@ jobs:
             .\build_release_vs2022.bat deps
             .\build_release_vs2022.bat pack
             cd ${{ github.workspace }}/deps/build
-
 
       - name: Build on Mac ${{ inputs.arch }}
         if: inputs.os == 'macos-14'

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -217,7 +217,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         env:
           WindowsSdkDir: 'C:\Program Files (x86)\Windows Kits\10\'
-          WindowsSDKVersion: '10.0.22000.0\'
+          WindowsSDKVersion: '10.0.26100.0\'
         run: .\build_release_vs2022.bat slicer
 
       - name: Create installer Win


### PR DESCRIPTION
# Description

This PR addresses a build issue in GitHub Actions where STL repair via Netfabb is skipped due to missing Windows SDK detection.
Although local builds work correctly, the GitHub CI output shows:

WIN10SDK_PATH is invalid: C:\Program Files (x86)\Windows Kits\10\Include\10.0.22000.0\ -- PROJECT_SOURCE_DIR: D:/a/OrcaSlicer/OrcaSlicer C:\Program Files (x86)\Windows Kits\10\Include\10.0.22000.0\/winrt/windows.graphics.printing3d.h was not found STL fixing by the Netfabb service will not be compiled Building without Win10 Netfabb STL fixing service support
<img width="786" height="848" alt="image" src="https://github.com/user-attachments/assets/a8e7d1c6-2e4f-4ba4-88b2-400bfebf0192" />

fix #10461
fix #10463
