### PR TITLE
Correct OrcaSlicer_profile_validator path

### DIFF
--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -339,7 +339,7 @@ jobs:
         working-directory: ${{ github.workspace }}/build/src
         shell: bash
         run: |
-          ./OrcaSlicer_profile_validator -p ${{ github.workspace }}/resources/profiles -g 1
+          ./build/src/OrcaSlicer_profile_validator -p ${{ github.workspace }}/resources/profiles -g 1
           cd ${{ github.workspace }}/resources/profiles
           zip -r orca_custom_preset_tests.zip user/
 

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -336,10 +336,10 @@ jobs:
 
       - name: Build orca_custom_preset_tests
         if: github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-24.04'
-        working-directory: ${{ github.workspace }}/build/src
+        working-directory: ${{ github.workspace }}/build/src/Release
         shell: bash
         run: |
-          ./build/src/OrcaSlicer_profile_validator -p ${{ github.workspace }}/resources/profiles -g 1
+          ./OrcaSlicer_profile_validator -p ${{ github.workspace }}/resources/profiles -g 1
           cd ${{ github.workspace }}/resources/profiles
           zip -r orca_custom_preset_tests.zip user/
 


### PR DESCRIPTION
# Description

Fixes the path of OrcaSlicer_profile_validator during the orca_custom_preset_tests step

# Screenshots/Recordings/Graphs
<img width="1027" height="117" alt="image" src="https://github.com/user-attachments/assets/76290cb4-2148-4829-bf99-152c1e1fa9fc" />

<https://github.com/SoftFever/OrcaSlicer/actions/runs/17189194833/job/48762463678>

## Tests

<https://github.com/SoftFever/OrcaSlicer/actions/runs/17190909397?pr=10510>

<https://github.com/NanashiTheNameless/OrcaSlicer/actions/runs/17190932412>
