### PR TITLE
Fix Anycubic Kobra 2 Neo Machine Profile

### DIFF
--- a/resources/profiles/Anycubic/machine/Anycubic Kobra 2 Neo 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/machine/Anycubic Kobra 2 Neo 0.4 nozzle.json
@@ -69,7 +69,7 @@
     "long_retractions_when_cut": [
         "0"
     ],
-    "machine_end_gcode": "M140 S0; Heatbed off\nM107; Fan off \nG91; relative positioning \nM83 ; extruder relative mode\nG1 E-2 F3000 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nM104 S0; Extruder off\nG28 ;move X/Y to min endstops, so the head is out of the way\nG90; absolute positioning \nG1 Y220 F3000\nM84 ;steppers offM300 S1318 P266",
+    "machine_end_gcode": "M140 S0; Heatbed off\nM107; Fan off \nG91; relative positioning \nM83 ; extruder relative mode\nG1 E-2 F3000 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nM104 S0; Extruder off\nG28 ;move X/Y to min endstops, so the head is out of the way\nG90; absolute positioning \nG1 Y220 F3000\nM84 ;steppers off\nM300 S1318 P266",
     "machine_load_filament_time": "42",
     "machine_max_acceleration_e": [
         "2000",

--- a/resources/profiles/Anycubic/machine/Anycubic Kobra 2 Neo 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/machine/Anycubic Kobra 2 Neo 0.4 nozzle.json
@@ -69,7 +69,7 @@
     "long_retractions_when_cut": [
         "0"
     ],
-    "machine_end_gcode": "M104 S0; Extruder off\nM140 S0 Heatbed off\nM107                                       ; Fan off \nG91                                        ; relative positioning \nG1 E-5 F3000  \nG1 Z+0.3 F3000                             ; lift print head \nG28 X0  F3000\nM84                    ",
+    "machine_end_gcode": "M140 S0; Heatbed off\nM107; Fan off \nG91; relative positioning \nG1 E-2 F3000 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nM104 S0; Extruder off\nG28 X0 Y0 F3000 ;move X/Y to min endstops, so the head is out of the way\nG1 Y210 F3000\nM84 ;steppers off\nG90\nM300 S1318 P266",
     "machine_load_filament_time": "42",
     "machine_max_acceleration_e": [
         "2000",
@@ -140,7 +140,7 @@
         "0"
     ],
     "machine_pause_gcode": "M601",
-    "machine_start_gcode": "G90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG28; move X/Y/Z to min endstops\nG1 Z0.28; lift nozzle a bit\nG92 E0\nG1 Y3 F1800                                    ; zero the extruded length \nG1 X60  E25 F500                       ; Extrude 25mm of filament in a 5cm line. \nG92 E0                                     ; zero the extruded length again \nG1 E-2 F500                                ; Retract a little \nG1 X70 F4000                              ; Quickly wipe away from the filament line\nM117",
+    "machine_start_gcode": "G21 ; metric values\nG90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nG28; move X/Y/Z to min endstops\nM300 S1318 P266\nG1 Z5 F5000 ; lift nozzle\nG1 X0 Y0  F3000\nG1 Z0.3; lift nozzle a bit\nG92 E0 ; zero after lift\nG1 Y3 F1800 ; move to purge line start position\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG1 X50 Y5 E20 F500 ; Extrude 20mm of filament in a 5cm line. \nG92 E0 ; zero the extruded length again \nG1 E-4.5 F4000 ; Retract a little \nG92 E0 ; zero the extruded length again \nG1 X120 F4000 ; Quickly wipe away from the filament line\nM117 Printing... ; Display status message",
     "machine_unload_filament_time": "0",
     "manual_filament_change": "0",
     "max_layer_height": [

--- a/resources/profiles/Anycubic/machine/Anycubic Kobra 2 Neo 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/machine/Anycubic Kobra 2 Neo 0.4 nozzle.json
@@ -13,7 +13,7 @@
     "default_print_profile": "0.20mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle",
     "default_filament_profile": [ "Anycubic PLA @Anycubic Kobra 2 Neo 0.4 nozzle" ],
     "disable_m73": "1",
-    "gcode_flavor": "marlin",
+    "gcode_flavor": "marlin2",
     "printable_area": [
         "0x0",
         "220x0",
@@ -36,7 +36,7 @@
     "bed_mesh_max": "0,0",
     "bed_mesh_min": "0,0",
     "bed_mesh_probe_distance": "0,0",
-    "before_layer_change_gcode": "; BEFORE_LAYER_CHANGE [layer_num] @ [layer_z]mm",
+    "before_layer_change_gcode": "G92 E0 ; zero the extruded length again\n; BEFORE_LAYER_CHANGE [layer_num] @ [layer_z]mm",
     "best_object_pos": "0.5,0.5",
     "change_extrusion_role_gcode": "",
     "change_filament_gcode": "",
@@ -69,7 +69,7 @@
     "long_retractions_when_cut": [
         "0"
     ],
-    "machine_end_gcode": "M140 S0; Heatbed off\nM107; Fan off \nG91; relative positioning \nG1 E-2 F3000 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nM104 S0; Extruder off\nG28 X0 Y0 F3000 ;move X/Y to min endstops, so the head is out of the way\nG1 Y210 F3000\nM84 ;steppers off\nG90\nM300 S1318 P266",
+    "machine_end_gcode": "M140 S0; Heatbed off\nM107; Fan off \nG91; relative positioning \nM83 ; extruder relative mode\nG1 E-2 F3000 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nM104 S0; Extruder off\nG28 ;move X/Y to min endstops, so the head is out of the way\nG90; absolute positioning \nG1 Y220 F3000\nM84 ;steppers offM300 S1318 P266",
     "machine_load_filament_time": "42",
     "machine_max_acceleration_e": [
         "2000",
@@ -140,7 +140,7 @@
         "0"
     ],
     "machine_pause_gcode": "M601",
-    "machine_start_gcode": "G21 ; metric values\nG90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nG28; move X/Y/Z to min endstops\nM300 S1318 P266\nG1 Z5 F5000 ; lift nozzle\nG1 X0 Y0  F3000\nG1 Z0.3; lift nozzle a bit\nG92 E0 ; zero after lift\nG1 Y3 F1800 ; move to purge line start position\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG1 X50 Y5 E20 F500 ; Extrude 20mm of filament in a 5cm line. \nG92 E0 ; zero the extruded length again \nG1 E-4.5 F4000 ; Retract a little \nG92 E0 ; zero the extruded length again \nG1 X120 F4000 ; Quickly wipe away from the filament line\nM117 Printing... ; Display status message",
+    "machine_start_gcode": "G21 ; metric values\nG90 ; use absolute coordinates\nM83 ; extruder relative mode\nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nG28; move X/Y/Z to min endstops\nM420 S1\nM300 S1318 P266\nG1 Z5 F5000 ; lift nozzle\nG1 X0 Y0  F3000\nG1 Z0.3; lift nozzle a bit\nG92 E0 ; zero after lift\nG1 X10 Y5 F1800 ; move to purge line start position\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nG1 X60 Y5 E20 F500 ; Extrude 20mm of filament in a 5cm line. \nG92 E0 ; zero the extruded length again \nG1 E-4.5 F4000 ; Retract a little \nG92 E0 ; zero the extruded length again\nG1 X120 F4000 ; Quickly wipe away from the filament line\nM117 Printing... ; Display status message",
     "machine_unload_filament_time": "0",
     "manual_filament_change": "0",
     "max_layer_height": [
@@ -208,7 +208,7 @@
     "time_lapse_gcode": "",
     "upward_compatible_machine": [],
     "use_firmware_retraction": "0",
-    "use_relative_e_distances": "0",
+    "use_relative_e_distances": "1",
     "wipe": [
         "1"
     ],


### PR DESCRIPTION
# Description

This PR addresses several issues with the Anycubic Kobra 2 Neo printer profile that were causing print failures and inconsistent extrusion behavior. Mainly, the machine's start and end G-code instructions to optimize performance and ensure consistency in operation. These changes improve the overall workflow associated with initialization and conclusion of machine tasks.

## Changes

- **Updated G-code flavor**: Changed from `marlin` to `marlin2` for better firmware compatibility
- **Fixed extrusion mode**: Enabled relative E distances (`use_relative_e_distances: 1`) to prevent cumulative positioning errors
- **Enhanced bed leveling**: Added `M420 S1` command to start G-code to properly enable the printer's bed leveling mesh
- **Improved layer transitions**: Added `G92 E0` before layer changes to reset extruder position, preventing over/under-extrusion
- **Corrected end G-code**:
  - Added `M83` to ensure relative extruder mode consistency
  - Fixed formatting issues and missing line break before M300 beep command
  - Improved parking position to Y220 for better accessibility
- **Optimized purge line**: Adjusted starting position from Y3 to X10 Y5 for better adhesion and clearance

## Tests

Tested by printing https://www.printables.com/model/883531-print-in-place-fidget-toggle-switch with transparent PETG.
No longer crashes into bed. And noticable drop in amount of stringing.

## Impact

These changes ensure a good start and end print on Anycubic Kobra 2 Neo printers and resolve issues I experienced using the default profile:
- Nozzle dragging or crashing into bed
- Incorrect extrusion amounts
- Bed leveling may not be applied