### PR TITLE
FIX: Enable bed/extruder temps for all

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2366,12 +2366,10 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
         }
     }
     std::string machine_start_gcode = this->placeholder_parser_process("machine_start_gcode", print.config().machine_start_gcode.value, initial_extruder_id);
-    if (print.config().gcode_flavor != gcfKlipper) {
-        // Set bed temperature if the start G-code does not contain any bed temp control G-codes.
-        this->_print_first_layer_bed_temperature(file, print, machine_start_gcode, initial_extruder_id, true);
-        // Set extruder(s) temperature before and after start G-code.
-        this->_print_first_layer_extruder_temperatures(file, print, machine_start_gcode, initial_extruder_id, false);
-    }
+    // Set bed temperature if the start G-code does not contain any bed temp control G-codes.
+    this->_print_first_layer_bed_temperature(file, print, machine_start_gcode, initial_extruder_id, true);
+    // Set extruder(s) temperature before and after start G-code.
+    this->_print_first_layer_extruder_temperatures(file, print, machine_start_gcode, initial_extruder_id, false);
 
     // adds tag for processor
     file.write_format(";%s%s\n", GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Role).c_str(), ExtrusionEntity::role_to_string(erCustom).c_str());


### PR DESCRIPTION
Fix #10555
I dont know why in [this BBS change](https://github.com/bambulab/BambuStudio/commit/8905121af581ad3fba3f937dcf0f6e9c20a6866e#diff-cb3d09d2073b6e9032c65d07aa8f10d166324a53136b2aa1288f7b76f7d94319L1787-L1790) they limited the check of temp in Start gcode to non klipper printers and after that it's set to only BBL, so no BBL but klipper will not work.

> [!NOTE]
> I've found that RepRap machines temperature are not shown in the 3D view but are set in the gcode.