### PR TITLE
[Profiles] Optimize Phrozen Arco 0.4 nozzle.json start up gcode

### DIFF
--- a/resources/profiles/Phrozen/machine/Phrozen Arco 0.4 nozzle.json
+++ b/resources/profiles/Phrozen/machine/Phrozen Arco 0.4 nozzle.json
@@ -139,7 +139,7 @@
         "0"
     ],
     "machine_pause_gcode": "M601",
-    "machine_start_gcode": "M107\nG90\nM140 S65 ; set bed temperature\nM104 S140 ; set temperature\nM190 S65 ; set bed temperature\nM109 S140 ; set temperature\nPG28\nM106 S255 \nG30\n;AUTO_LEVELING_2\nM106 S0\nG21\nM83\nM109 S220\nP0 M1\nP28\nP2 A1",
+    "machine_start_gcode": "M107\nG90\nM140 S65 ; set bed temperature\nM104 S140 ; set temperature\nM190 S65 ; set bed temperature\nM109 S140 ; set temperature\nPG28\nM106 S255 \nG30\n;AUTO_LEVELING_2\nM106 S0\nG21\nM83\nM140 S[bed_temperature_initial_layer_single]\nM104 S[nozzle_temperature_initial_layer]\nM109 S[nozzle_temperature_initial_layer]\nM190 S[bed_temperature_initial_layer_single]\nP0 M1\nP28\nP2 A1",
     "machine_tool_change_time": "0",
     "machine_unload_filament_time": "0",
     "manual_filament_change": "0",
@@ -229,4 +229,5 @@
         "Spiral Lift"
     ],
     "z_offset": "0"
+
 }


### PR DESCRIPTION
Changes M109 S200 in machine_start_gcode to allow printer to properly utilize filament profile temperatures. With original code, the temperature will be stuck at 200c for duration of print despite filament profile having different first layer and other layer temperatures settings.

Fixes https://github.com/SoftFever/OrcaSlicer/issues/10555

# Screenshots/Recordings/Graphs
<img width="2555" height="1383" alt="image" src="https://github.com/user-attachments/assets/23323407-79b5-4a9f-8515-40305f1c4e3d" />
<img width="2559" height="1380" alt="image" src="https://github.com/user-attachments/assets/71ba373b-d5e8-49b1-9d24-b9b99dd0e3dd" />
