### PR TITLE
feat: fixed flushing volume table width and icon gap

### DIFF
--- a/src/slic3r/GUI/WipeTowerDialog.cpp
+++ b/src/slic3r/GUI/WipeTowerDialog.cpp
@@ -21,7 +21,7 @@ using namespace Slic3r;
 using namespace Slic3r::GUI;
 
 int scale(const int val) { return val * Slic3r::GUI::wxGetApp().em_unit() / 10; }
-int ITEM_WIDTH() { return scale(30); }
+int ITEM_WIDTH() { return scale(50); }
 static const wxColour g_text_color = wxColour(107, 107, 107, 255);
 
 #undef  ICON_SIZE
@@ -29,7 +29,7 @@ static const wxColour g_text_color = wxColour(107, 107, 107, 255);
 #define TABLE_BORDER            FromDIP(28)
 #define HEADER_VERT_PADDING     FromDIP(12)
 #define HEADER_BEG_PADDING      FromDIP(30)
-#define ICON_GAP                FromDIP(44)
+#define ICON_GAP                FromDIP(69)
 #define HEADER_END_PADDING      FromDIP(24)
 #define ROW_VERT_PADDING        FromDIP(6)
 #define ROW_BEG_PADDING         FromDIP(20)


### PR DESCRIPTION
# Description

This PR fixes https://github.com/SoftFever/OrcaSlicer/issues/10585. It also fixes the offset of the numbering to ensure it works even with large numbers of filaments.

# Screenshots/Recordings/Graphs

## Before
<img width="1634" height="1060" alt="before" src="https://github.com/user-attachments/assets/addc6142-1899-4e8b-8bf3-299bdb65ba04" />

## After
<img width="2415" height="1160" alt="after" src="https://github.com/user-attachments/assets/b8736a4b-3c65-41c5-ab20-88807fb57024" />

## Tests

None, only visual inspection