### PR TITLE
updates CMAKE_CXX_STANDARD from 17 to 20

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(OrcaSlicer-native)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Include dev-utils for encoding check and other utilities


### PR DESCRIPTION
# Description
This PR just tests the consequence (pipeline run) of updating `CMAKE_CXX_STANDARD` from 17 to 20.
Do not merge.
