### PR TITLE
Fix grid lines origin for multiple plates

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -474,7 +474,7 @@ void PartPlate::calc_gridlines(const ExPolygon& poly, const BoundingBox& pp_bbox
 
     // calculate and generate grid
     int   step          = Bed_2D::calculate_grid_step(pp_bbox, scale_(1.00));
-    Vec2d scaled_origin = Vec2d(scale_(m_origin.x()),scale_(m_origin.x()));
+    Vec2d scaled_origin = Vec2d(scale_(m_origin.x()),scale_(m_origin.y()));
     auto  grid_lines    = Bed_2D::generate_grid(poly, pp_bbox, scaled_origin, scale_(step), SCALED_EPSILON);
 
     Lines lines_thin = to_lines(grid_lines[0]);


### PR DESCRIPTION
I sent this in this PR https://github.com/SoftFever/OrcaSlicer/pull/10532 but i assume its better send this as separate PR since we dont make major changes currently

### FIX
fixes my simple mistake on https://github.com/SoftFever/OrcaSlicer/pull/9524 . used x() for both axes 
https://github.com/SoftFever/OrcaSlicer/blob/90a6c53ad57e523fccd7e7658c7f05f1954522a8/src/slic3r/GUI/PartPlate.cpp#L477

all plate gridlines now aligned as expected