### PR TITLE
Update Anycubic Kobra 2 Neo machine profile fine tune end gcode

### DIFF
--- a/resources/profiles/Anycubic/machine/Anycubic Kobra 2 Neo 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/machine/Anycubic Kobra 2 Neo 0.4 nozzle.json
@@ -72,7 +72,7 @@
     "long_retractions_when_cut": [
         "0"
     ],
-    "machine_end_gcode": "M140 S0; Heatbed off\nM107; Fan off \nG91; relative positioning \nM83 ; extruder relative mode\nG1 E-2 F3000 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nM104 S0; Extruder off\nG28 ;move X/Y to min endstops, so the head is out of the way\nG90; absolute positioning \nG1 Y220 F3000\nM84 ;steppers off\nM300 S1318 P266",
+    "machine_end_gcode": "M140 S0; Heatbed off\nM107; Fan off \nG91; relative positioning \nM83 ; extruder relative mode\nG1 E-3 F3000 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 F3000 ;move Z up a bit and retract filament even more\nM104 S0; Extruder off\nG28 X Y;move X/Y to min endstops, so the head is out of the way\nG90; absolute positioning \nG1 Y220 F3000\nM84 ;steppers off\nM300 S1318 P266",
     "machine_load_filament_time": "42",
     "machine_max_acceleration_e": [
         "2000",


### PR DESCRIPTION
# Description

This PR updates the end g-code in Anycubic Kobra 2 Neo printer profile. The machine's end G-code instructions to home X and Y only instead of Z to prevent crashing into final prints, and reduce the amount of retraction to avoid melting the stock PTFE. These changes improves the end of print step.

# Changes

- Reduced total amount of retraction as stock PTFE liner may not be able to take the heat. (7mm to 3mm)
- Added X Y to final G28 to avoid crashing into prints.

# Tests

Tested by printing https://www.printables.com/model/594620-cute-low-poly-cat-no-supports. Originally, experienced a near miss where print head could have crashed into print.

# Impact

These changes ensure end step on Anycubic Kobra 2 Neo printers does not crash into print and reduce amount of molten filament going into PTFE.
