### PR TITLE
E Absolute errores when smooth spiral

### DIFF
--- a/doc/print_settings/others/others_settings_special_mode.md
+++ b/doc/print_settings/others/others_settings_special_mode.md
@@ -68,6 +68,9 @@ This creates a smooth, vase-like appearance.
 When enabled, Smooth Spiral smooths out X and Y moves as well, resulting in no visible seams even on non-vertical walls.  
 This produces the smoothest possible spiral print.
 
+> [!NOTE]
+> If you are using absolute e distances, the smoothing may not work as expected.
+
 #### Max XY Smoothing
 
 Maximum distance to move points in XY to achieve a smooth spiral. If expressed as a percentage, it is calculated relative to the nozzle diameter.  

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10258,7 +10258,7 @@ void Plater::calib_input_shaping_freq(const Calib_Params& params)
     print_config->set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config->set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
-    print_config->set_key_value("spiral_mode_smooth", new ConfigOptionBool(true));
+    print_config->set_key_value("spiral_mode_smooth", new ConfigOptionBool(false));
     print_config->set_key_value("bottom_surface_pattern", new ConfigOptionEnum<InfillPattern>(ipRectilinear));
     print_config->set_key_value("outer_wall_speed", new ConfigOptionFloat(200));
     print_config->set_key_value("default_acceleration", new ConfigOptionFloat(2000));
@@ -10306,7 +10306,7 @@ void Plater::calib_input_shaping_damp(const Calib_Params& params)
     print_config->set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config->set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
-    print_config->set_key_value("spiral_mode_smooth", new ConfigOptionBool(true));
+    print_config->set_key_value("spiral_mode_smooth", new ConfigOptionBool(false));
     print_config->set_key_value("bottom_surface_pattern", new ConfigOptionEnum<InfillPattern>(ipRectilinear));
     print_config->set_key_value("outer_wall_speed", new ConfigOptionFloat(200));
     print_config->set_key_value("default_acceleration", new ConfigOptionFloat(2000));
@@ -10355,7 +10355,7 @@ void Plater::calib_junction_deviation(const Calib_Params& params)
     print_config->set_key_value("sparse_infill_density", new ConfigOptionPercent(0));
     print_config->set_key_value("detect_thin_wall", new ConfigOptionBool(false));
     print_config->set_key_value("spiral_mode", new ConfigOptionBool(true));
-    print_config->set_key_value("spiral_mode_smooth", new ConfigOptionBool(true));
+    print_config->set_key_value("spiral_mode_smooth", new ConfigOptionBool(false));
     print_config->set_key_value("bottom_surface_pattern", new ConfigOptionEnum<InfillPattern>(ipRectilinear));
     print_config->set_key_value("outer_wall_speed", new ConfigOptionFloat(200));
     print_config->set_key_value("default_acceleration", new ConfigOptionFloat(2000));


### PR DESCRIPTION
Fixes #10474 

There is apparently a bug when using smooth spiral with absolute distances (use_relative_e_distances = false).

This PR includes:
 - A comment on the Smooth Spiral wiki
 - Smooth Spiral is disabled in calibration tests since it's not absolutely necessary but can cause issues like the bug mentioned above.

**Before**
<img width="1013" height="934" alt="imagen" src="https://github.com/user-attachments/assets/0ecde4c6-7dd9-46b6-ba75-98bb2858a577" />

**After**
<img width="1013" height="934" alt="imagen" src="https://github.com/user-attachments/assets/bc6c2df5-7c96-4bdb-b5b3-bb126d484885" />
