### PR TITLE
Remember position for single layer mode in preview

### DIFF
--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -191,6 +191,10 @@ void IMSlider::SetSelectionSpan(const int lower_val, const int higher_val)
     m_higher_value = std::max(std::min(higher_val, m_max_value), m_lower_value);
     if (m_lower_value < m_higher_value) m_is_one_layer = false;
 
+    // ORCA reset single layer position when min max values changed
+    // This will trigger when print height changed. but stays same on reslicing if layer count is same 
+    m_single_value = int((m_higher_value - m_lower_value)/2); 
+
     set_as_dirty();
 }
 
@@ -443,9 +447,20 @@ bool IMSlider::switch_one_layer_mode()
         return false;
 
     m_is_one_layer = !m_is_one_layer;
-    if (!m_is_one_layer) {
+    if (!m_is_one_layer) {                       // DEACTIVATE
+        m_single_value = GetHigherValue();       // ORCA Backup value on deactivate
         SetLowerValue(m_min_value);
-        SetHigherValue(m_max_value);
+        SetHigherValue(m_max_value);             // Higher value resets on toggling off one layer mode to show whole model
+    }else{                                       // ACTIVATE
+                                                 // ORCA Ensure value fits range. value set in IMSlider::SetSelectionSpan but added this just in case
+        if(!m_single_value || m_single_value > m_max_value || m_single_value < m_min_value){
+            m_single_value = int((m_max_value - m_min_value)/2);
+            SetHigherValue(m_single_value);  
+        }
+        else if(GetHigherValue() == m_max_value) // ORCA Prefer backup value if higher value reseted
+            SetHigherValue(m_single_value);      // ORCA Restore value
+        else                                     // ORCA Prefer higher value if user changed higher value. so it will show section on same view
+            SetHigherValue(GetHigherValue());    // ORCA use same position with higher value if user changed its position. visible section stays same when switching one layer mode with this
     }
     m_selection == ssLower ? correct_lower_value() : correct_higher_value();
     if (m_selection == ssUndef) m_selection = ssHigher;
@@ -1487,6 +1502,7 @@ void IMSlider::on_mouse_wheel(wxMouseEvent& evt) {
             if (is_one_layer()) {
                 const int new_pos = GetHigherValue() + wheel;
                 SetHigherValue(new_pos);
+                m_single_value = new_pos; // ORCA backup value for single layer mode
             }
             else {
                 const int new_pos = m_selection == ssLower ? GetLowerValue() + wheel : GetHigherValue() + wheel;

--- a/src/slic3r/GUI/IMSlider.hpp
+++ b/src/slic3r/GUI/IMSlider.hpp
@@ -179,6 +179,7 @@ private:
     int  m_max_value;
     int  m_lower_value;
     int  m_higher_value;
+    int  m_single_value; // ORCA
     bool m_dirty = false;
 
     bool m_render_as_disabled{ false };


### PR DESCRIPTION
PROBLEM
• Single layer mode position resets on every time user toggles it. this makes impossible to make comparison
• Default value for single layer is highest point of model and it doesnt present "section" of model. some users not fully understands what it is

SOLUTION
• Store single layer position. and use it if necessary
• Use mid point as default to present model section better

NOTES
• Kept using resetting slider to min max values to show whole model when single layer mode OFF. its better to present whole model when mode OFF. also resetting slider feels more natural 

BEFORE
• Default position for single layer mode is highest point. it doesnt present well section of model
• Single layer mode value always resets to  highest point of model

https://github.com/user-attachments/assets/159e5194-7d23-4adc-ae87-59539d036776

AFTER
• Default position for single layer mode is mid point of model. it present better section of model
• Single layer mode remembers position for single layer mode this is useful when toggling mode to make comparison
• Uses high value if user changed high value in slider. so section stays at same position
• Uses mid point of model on first toggle

https://github.com/user-attachments/assets/3c4cdf8c-3211-4cec-90df-b23a1cccfc90


