### PR TITLE
Fix compare dialog alternate background color on windows

### DIFF
--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -2105,6 +2105,11 @@ void DiffPresetDialog::show(Preset::Type type /* = Preset::TYPE_INVALID*/)
 
     update_tree();
     wxGetApp().UpdateDlgDarkUI(this);
+#ifdef _WIN32 // ORCA ensure row colors updated after opening dialog again after switching Dark Mode
+    wxGetApp().UpdateAllStaticTextDarkUI(this);
+    wxGetApp().UpdateDarkUI(m_show_all_presets);
+    wxGetApp().UpdateDVCDarkUI(m_tree);
+#endif
 
     // if this dialog is shown it have to be Hide and show again to be placed on the very Top of windows
     if (IsShown())


### PR DESCRIPTION
PROBLEM
• Row colors not updating after switching dark mode and opening dialog again
• Fixes https://github.com/SoftFever/OrcaSlicer/issues/9902

IMPORTANT NOTE
• Main source of problem: dialog not destroyed after closing

BEFORE
<img width="769" height="682" alt="Screenshot-20250918134833" src="https://github.com/user-attachments/assets/dd77696c-ad2d-4de7-aaab-f85dd558dbbe" />

AFTER
<img width="757" height="677" alt="Screenshot-20250918134857" src="https://github.com/user-attachments/assets/fd28941d-996d-410f-ab04-b13f1dd0170f" />
