### PR TITLE
Add perimeter_overlap and internal_perimeter_flow_ratio to enhance perimeter bonding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ src/OrcaSlicer-doc/
 resources/profiles/user/default
 *.code-workspace
 deps_src/build/
+/CMakeSettings.json

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5298,7 +5298,9 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
         _mm3_per_mm *= m_config.bottom_solid_infill_flow_ratio;
     else if (path.role() == erInternalBridgeInfill)
         _mm3_per_mm *= m_config.internal_bridge_flow;
-    else if(sloped)
+    else if (path.role() == erPerimeter)
+        _mm3_per_mm *= m_config.internal_perimeter_flow_ratio;
+    else if (sloped)
         _mm3_per_mm *= m_config.scarf_joint_flow_ratio;
     // Effective extrusion length per distance unit = (filament_flow_ratio/cross_section) * mm3_per_mm / print flow ratio
     // m_writer.extruder()->e_per_mm3() below is (filament flow ratio / cross-sectional area)

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -559,6 +559,10 @@ void PerimeterGenerator::split_top_surfaces(const ExPolygons &orig_polygons, ExP
     coord_t ext_perimeter_width = this->ext_perimeter_flow.scaled_width();
     coord_t ext_perimeter_spacing = this->ext_perimeter_flow.scaled_spacing();
 
+    // Adjusts perimeter spacing according to the configured overlap percentage
+    perimeter_spacing *= (2.0 - (this->config->perimeter_overlap / 100.0f));
+    ext_perimeter_spacing *= (2.0 - (this->config->perimeter_overlap / 100.0f));
+
     bool has_gap_fill = this->config->gap_infill_speed.value > 0;
 
     // split the polygons with top/not_top
@@ -1134,6 +1138,11 @@ void PerimeterGenerator::process_classic()
     else
         ext_perimeter_spacing2 = scaled<coord_t>(0.5f * (this->ext_perimeter_flow.spacing() + this->perimeter_flow.spacing()));
     
+    // Adjusts perimeter spacing according to the configured overlap percentage
+    perimeter_spacing *= (2.0 - (this->config->perimeter_overlap / 100.0f));
+    ext_perimeter_spacing *= (2.0 - (this->config->perimeter_overlap / 100.0f));
+    ext_perimeter_spacing2 *= (2.0 - (this->config->perimeter_overlap / 100.0f));
+
     // overhang perimeters
     m_mm3_per_mm_overhang      		= this->overhang_flow.mm3_per_mm();
     

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -848,6 +848,7 @@ static std::vector<std::string> s_Preset_print_options {
      "small_area_infill_flow_compensation", "small_area_infill_flow_compensation_model",
      "seam_slope_type", "seam_slope_conditional", "scarf_angle_threshold", "scarf_joint_speed", "scarf_joint_flow_ratio", "seam_slope_start_height", "seam_slope_entire_loop", "seam_slope_min_length", "seam_slope_steps", "seam_slope_inner_walls", "scarf_overhang_threshold",
      "interlocking_beam", "interlocking_orientation", "interlocking_beam_layer_count", "interlocking_depth", "interlocking_boundary_avoidance", "interlocking_beam_width","calib_flowrate_topinfill_special_order",
+     "internal_perimeter_flow_ratio", "perimeter_overlap",
 };
 
 static std::vector<std::string> s_Preset_filament_options {

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1621,7 +1621,36 @@ void PrintConfigDef::init_fff_params()
     def->enum_labels.push_back(L("All"));
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<EnsureVerticalShellThickness>(EnsureVerticalShellThickness::evstAll));
-    
+
+    def           = this->add("internal_perimeter_flow_ratio", coFloat);
+    def->label    = L("Internal perimeter flow ratio multiplier");
+    def->category = L("Advanced");
+    def->tooltip  = L(
+         "This factor affects the amount of material extruded for internal perimeter.\n"
+         "The actual internal perimeter flow used is calculated by multiplying this value with the filament flow ratio, and "
+         "if set, the object's flow ratio.\n"
+         "Values above 1.00 will to improve wall bonding without having to increase the overall flow ratio at filament setting level.");
+    def->min  = 0;
+    def->max  = 2;
+    def->mode = comAdvanced;
+    def->set_default_value(new ConfigOptionFloat(1.0f));
+
+    def           = this->add("perimeter_overlap", coPercent);
+    def->label    = L("Perimeter overlap increase");
+    def->category = L("Advanced");
+    def->tooltip  = L("This parameter change the default perimeter overlap by a percentage."
+                      "Increasing this value will improve wall bonding. Together with [Internal perimeter flow ratio multiplier], " 
+                      "these parameters enable precise tuning of perimeter bonding without needing to increasing the overall flow rate,"
+                      "which could otherwise degrade XY dimensional accuracy and cause visual overflow artifacts.\n"
+                      "Works only with classic wall generator."    
+    );
+
+    def->sidetext = "%";
+    def->min      = 100;
+    def->max      = 150;
+    def->mode     = comAdvanced;
+    def->set_default_value(new ConfigOptionPercent(100.0f));
+
     auto def_top_fill_pattern = def = this->add("top_surface_pattern", coEnum);
     def->label = L("Top surface pattern");
     def->category = L("Strength");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -966,6 +966,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloat,                bridge_speed))
     ((ConfigOptionFloatOrPercent,       internal_bridge_speed))
     ((ConfigOptionEnum<EnsureVerticalShellThickness>,   ensure_vertical_shell_thickness))
+    ((ConfigOptionFloat,                internal_perimeter_flow_ratio))
+    ((ConfigOptionPercent,              perimeter_overlap))
     ((ConfigOptionPercent,              top_surface_density))
     ((ConfigOptionPercent,               bottom_surface_density))
     ((ConfigOptionEnum<InfillPattern>,  top_surface_pattern))

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -9933,6 +9933,8 @@ void adjust_settings_for_flowrate_calib(ModelObjectPtrs& objects, bool linear, i
         _obj->config.set_key_value("gap_fill_target", new ConfigOptionEnum<GapFillTarget>(GapFillTarget::gftNowhere));
         print_config->set_key_value("max_volumetric_extrusion_rate_slope", new ConfigOptionFloat(0));
         _obj->config.set_key_value("calib_flowrate_topinfill_special_order", new ConfigOptionBool(true));
+        _obj->config.set_key_value("internal_perimeter_flow_ratio", new ConfigOptionFloat(1.0f));
+        _obj->config.set_key_value("perimeter_overlap", new ConfigOptionPercent(100.0f));
 
         // extract flowrate from name, filename format: flowrate_xxx
         std::string obj_name = _obj->name;

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2271,6 +2271,8 @@ void TabPrint::build()
         optgroup->append_single_option_line("infill_combination_max_layer_height", "strength_settings_advanced#max-layer-height");
         optgroup->append_single_option_line("detect_narrow_internal_solid_infill", "strength_settings_advanced#detect-narrow-internal-solid-infill");
         optgroup->append_single_option_line("ensure_vertical_shell_thickness", "strength_settings_advanced#ensure-vertical-shell-thickness");
+        optgroup->append_single_option_line("internal_perimeter_flow_ratio", "strength_settings_advanced#internal_perimeter_flow_ratio");
+        optgroup->append_single_option_line("perimeter_overlap", "strength_settings_advanced#perimeter_overlap");
 
     page = add_options_page(L("Speed"), "custom-gcode_speed"); // ORCA: icon only visible on placeholders
         optgroup = page->new_optgroup(L("Initial layer speed"), L"param_speed_first", 15);


### PR DESCRIPTION
# Description
Introduces two configuration parameters to improve perimeter bonding in scenarios where other options are ineffective or the printer exhibits slight precision limitations (e.g. with very thin nozzles).

- **perimeter_overlap**: adjusts standard perimeter overlap by a percentage — higher values increase overlap. This parameter applies only to the classic perimeter generator.

- **internal_perimeter_flow_ratio**: scales the flow ratio using a multiplier.

Together, these parameters enable precise tuning of perimeter bonding without increasing the overall flow rate, which could otherwise compromise XY dimensional accuracy and cause visual overflow artifacts.

Both parameters have been added to the Strength tab, as they contribute to improved model robustness.

# Screenshots/Recordings/Graphs
<img width="1607" height="778" alt="image" src="https://github.com/user-attachments/assets/e5a3e5ba-3af4-4bf8-a02f-cd09f22fe652" />

## Tests
The calibration print on the left has perimeter_overlap set to 100% (standard overlap) and internal_perimeter_flow_ratio set to 1.0. 

The print on the right has perimeter_overlap set to 110% (10% more overlap i.e less spacing between perimeters) and internal_perimeter_flow_ratio set to 1.05, while overall flow ratio is set to 0.98.

Perimeter bonding fails along the +X+Y axis in the left print, while it remains strong and consistent in the right print. Note that simply increasing the overall flow ratio to 1.029 (0.98 * 1.05) — without adjusting perimeter_overlap and internal_perimeter_flow_ratio as done in the right-hand example — results in bonding issues, hence the useful combination between those two parameters.

I printed this calibration model many times (at least 30 times) with varying configuration parameters. Tested on Bambulab P1S with 0.2 nozzle, PLA, PETG and DURABIO. 