### PR TITLE
Set NSWindow color space to sRGB on macOS

### DIFF
--- a/src/slic3r/Utils/RetinaHelperImpl.mm
+++ b/src/slic3r/Utils/RetinaHelperImpl.mm
@@ -53,6 +53,11 @@ float RetinaHelper::get_scale_factor()
             [nc addObserver:self selector:@selector(windowDidChangeBackingProperties:)
                 name:NSWindowDidChangeBackingPropertiesNotification object:nil];
         }
+
+        NSWindow* window = [aView window];
+        if (window) {
+            [window setColorSpace:[NSColorSpace sRGBColorSpace]];
+        }
     }
     return self;
 }


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

This PR addresses an issue where colors in the 3D view are over-saturated on displays with a wide color gamut and also fixes flickering colors after the window is dragged between displays with different color profiles. 

Note: this change does not affect Windows or Linux.

# Screenshots/Recordings/Graphs

Left is with this change, right is original

<img width="1915" height="841" alt="Screenshot 2025-09-21 at 12 29 36 PM" src="https://github.com/user-attachments/assets/2a1d8324-cc6d-4f79-94cc-d3890acf88ce" />

If you do not have a display that supports a wide color gamut or your system's color management is not properly configured, you may find it difficult to see the difference in this screenshot. (Try viewing it on a recent smartphone)

## Tests

Tested on macOS

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
