### PR TITLE
BUG-FIX avoid crossing perimeters ingonore holes <=2mm

### DIFF
--- a/src/libslic3r/GCode/AvoidCrossingPerimeters.cpp
+++ b/src/libslic3r/GCode/AvoidCrossingPerimeters.cpp
@@ -1019,7 +1019,7 @@ static ExPolygons inner_offset(const ExPolygons &ex_polygons, double offset_dis)
     // remove too small holes from the ex_poly
     for (ExPolygon &ex_poly : ex_poly_result) {
         for (auto iter = ex_poly.holes.begin(); iter != ex_poly.holes.end();) {
-            auto out_offset_holes = offset(*iter, scale_(1.0f));
+            auto out_offset_holes = offset(*iter, scale_(0.1f));
             if (out_offset_holes.empty()) {
                 iter = ex_poly.holes.erase(iter);
             } else {


### PR DESCRIPTION
# Description

This pull request fixes a bug described in #10936, where perimeters of holes smaller than 2 mm in diameter are crossed. The issue is caused by the logic introduced in #10220.
https://github.com/SoftFever/OrcaSlicer/blob/737948be1f5b108b191420d4c670b511f8118604/src/libslic3r/GCode/AvoidCrossingPerimeters.cpp#L1019-L1029
# Screenshots/Recordings/Graphs


<img width="1623" height="986" alt="image" src="https://github.com/user-attachments/assets/fd435628-b47e-483d-a8fe-ba3f9da15a6f" />


## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
Fix #10936