### PR TITLE
bugfix for Invalid speed "G1 F-2147483648"

### DIFF
--- a/src/libslic3r/GCode/CoolingBuffer.cpp
+++ b/src/libslic3r/GCode/CoolingBuffer.cpp
@@ -153,7 +153,8 @@ struct PerExtruderAdjustments
                 assert(line.time_max >= 0.f && line.time_max < FLT_MAX);
                 line.slowdown = true;
                 line.time     = line.time_max;
-                line.feedrate = line.length / line.time;
+                if (line.time > 0.f)
+                    line.feedrate = line.length / line.time;
             }
             time_total += line.time;
         }
@@ -169,7 +170,8 @@ struct PerExtruderAdjustments
             if (line.adjustable(slowdown_external_perimeters)) {
                 line.slowdown = true;
                 line.time     = std::min(line.time_max, line.time * factor);
-                line.feedrate = line.length / line.time;
+                if (line.time > 0.f)
+                    line.feedrate = line.length / line.time;
             }
             time_total += line.time;
         }


### PR DESCRIPTION
# Description
Fixes #10498, also might be same issue in #2067

Added non-zero safety check for feedrate calculation in slow_down_proportional and slowdown_to_minimum_feedrate.

In CoolingBuffer::process_layer sometimes we get 2 identical gcode line:
`G1 F15000;_EXTRUDE_SET_SPEED
G1 F15000;_EXTRUDE_SET_SPEED` 
This causes calculate_layer_slowdown to produce lines with -nan(ind) feedrate and results in G1 F-2147483648


## Tests
[invalid_gcod_line_test.zip](https://github.com/user-attachments/files/22689004/invalid_gcod_line_test.zip)
<img width="1057" height="686" alt="image" src="https://github.com/user-attachments/assets/a6c60994-d684-4473-aa35-e112f7e47b77" />