### PR TITLE
Raft, support interface fix and overhaul

### DIFF
--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1458,10 +1458,27 @@ SupportGeneratorLayersPtr generate_support_layers(
         }
 
         if (!empty_layer) {
-            // Add this support layer with the current interface ID
-            object.add_support_layer(layer_id++, interface_id, height_min, zavg);
+            // Default: keep the global interface_id counter.
+            int this_iface_id = interface_id;
 
-            // Increment the interface ID only if this group contains interface/contact layers
+            // Special case: TreeOrganic raft-interface layers.
+            // Interface IDs may be unstable here, leading to inconsistent angles.
+            // Use deterministic IDs: alternate 0/1 by distance from the base raft.
+            bool is_tree_organic = (object.config().support_style == SupportMaterialStyle::smsTreeOrganic || 
+                                   (object.config().support_style == SupportMaterialStyle::smsDefault && is_tree(object.config().support_type)));
+
+            if (is_tree_organic &&
+                layer_id >= object.slicing_parameters().base_raft_layers &&
+                layer_id <  object.slicing_parameters().raft_layers())
+            {
+                // Alternate IDs 0,1,0,1... based on distance from base raft.
+                this_iface_id = (layer_id - object.slicing_parameters().base_raft_layers) & 1;
+            }
+            // END special case
+
+            object.add_support_layer(layer_id++, this_iface_id, height_min, zavg);
+
+            // Only increment the global counter if this set actually contains interface/contact layers.
             if (has_interface_layer)
                 interface_id++;
         }

--- a/src/libslic3r/Support/SupportCommon.cpp
+++ b/src/libslic3r/Support/SupportCommon.cpp
@@ -1410,72 +1410,65 @@ SupportGeneratorLayersPtr generate_support_layers(
     // Install support layers into the object.
     // A support layer installed on a PrintObject has a unique print_z.
     SupportGeneratorLayersPtr layers_sorted;
-    layers_sorted.reserve(raft_layers.size() + bottom_contacts.size() + top_contacts.size() + intermediate_layers.size() + interface_layers.size() + base_interface_layers.size());
+    layers_sorted.reserve(raft_layers.size() + bottom_contacts.size() + top_contacts.size()
+                        + intermediate_layers.size() + interface_layers.size() + base_interface_layers.size());
     append(layers_sorted, raft_layers);
     append(layers_sorted, bottom_contacts);
     append(layers_sorted, top_contacts);
     append(layers_sorted, intermediate_layers);
     append(layers_sorted, interface_layers);
     append(layers_sorted, base_interface_layers);
-    // remove dupliated layers
+
+    // remove duplicated layers
     std::sort(layers_sorted.begin(), layers_sorted.end());
     layers_sorted.erase(std::unique(layers_sorted.begin(), layers_sorted.end()), layers_sorted.end());
 
     // Sort the layers lexicographically by a raising print_z and a decreasing height.
     std::sort(layers_sorted.begin(), layers_sorted.end(), [](auto *l1, auto *l2) { return *l1 < *l2; });
+
     int layer_id = 0;
-    int layer_id_interface = 0;
+    int interface_id = 0;
     assert(object.support_layers().empty());
+
     for (size_t i = 0; i < layers_sorted.size();) {
-        // Find the last layer with roughly the same print_z, find the minimum layer height of all.
-        // Due to the floating point inaccuracies, the print_z may not be the same even if in theory they should.
+        // Group layers with nearly the same print_z (floating point fuzz).
         size_t j = i + 1;
         coordf_t zmax = layers_sorted[i]->print_z + EPSILON;
         for (; j < layers_sorted.size() && layers_sorted[j]->print_z <= zmax; ++j) ;
+
         // Assign an average print_z to the set of layers with nearly equal print_z.
-        coordf_t zavg = 0.5 * (layers_sorted[i]->print_z + layers_sorted[j - 1]->print_z);
+        coordf_t zavg       = 0.5 * (layers_sorted[i]->print_z + layers_sorted[j - 1]->print_z);
         coordf_t height_min = layers_sorted[i]->height;
-        bool     empty = true;
-        // For snug supports, layers where the direction of the support interface shall change are accounted for.
-        size_t   num_interfaces = 0;
-        size_t   num_top_contacts = 0;
-        double   top_contact_bottom_z = 0;
+
+        bool empty_layer = true;
+        bool has_interface_layer = false;
+
         for (size_t u = i; u < j; ++u) {
             SupportGeneratorLayer &layer = *layers_sorted[u];
-            if (! layer.polygons.empty()) {
-                empty             = false;
-                num_interfaces   += one_of(layer.layer_type, support_types_interface);
-                if (layer.layer_type == SupporLayerType::TopContact) {
-                    ++ num_top_contacts;
-                    assert(num_top_contacts <= 1);
-                    // All top contact layers sharing this print_z shall also share bottom_z.
-                    //assert(num_top_contacts == 1 || (top_contact_bottom_z - layer.bottom_z) < EPSILON);
-                    top_contact_bottom_z = layer.bottom_z;
-                }
+
+            if (!layer.polygons.empty()) {
+                empty_layer = false;
+
+                if (one_of(layer.layer_type, support_types_interface))
+                    has_interface_layer = true;
             }
+
             layer.print_z = zavg;
-            height_min = std::min(height_min, layer.height);
+            height_min    = std::min(height_min, layer.height);
         }
-        if (! empty) {
-            // Here the upper_layer and lower_layer pointers are left to null at the support layers,
-            // as they are never used. These pointers are candidates for removal.
-            bool   this_layer_contacts_only = num_top_contacts > 0 && num_top_contacts == num_interfaces;
-            size_t this_layer_id_interface  = layer_id_interface;
-            if (this_layer_contacts_only) {
-                // Find a supporting layer for its interface ID.
-                for (auto it = object.support_layers().rbegin(); it != object.support_layers().rend(); ++ it)
-                    if (const SupportLayer &other_layer = **it; std::abs(other_layer.print_z - top_contact_bottom_z) < EPSILON) {
-                        // other_layer supports this top contact layer. Assign a different support interface direction to this layer
-                        // from the layer that supports it.
-                        this_layer_id_interface = other_layer.interface_id() + 1;
-                    }
-            }
-            object.add_support_layer(layer_id ++, this_layer_id_interface, height_min, zavg);
-            if (num_interfaces && ! this_layer_contacts_only)
-                ++ layer_id_interface;
+
+        if (!empty_layer) {
+            // Add this support layer with the current interface ID
+            object.add_support_layer(layer_id++, interface_id, height_min, zavg);
+
+            // Increment the interface ID only if this group contains interface/contact layers
+            if (has_interface_layer)
+                interface_id++;
         }
+
         i = j;
     }
+    
     return layers_sorted;
 }
 
@@ -1651,12 +1644,12 @@ void generate_support_toolpaths(
         if (filler_base_interface)
             filler_base_interface->set_bounding_box(bbox_object);
         filler_support->set_bounding_box(bbox_object);
+        
         for (size_t support_layer_id = range.begin(); support_layer_id < range.end(); ++ support_layer_id)
         {
             SupportLayer &support_layer = *support_layers[support_layer_id];
             LayerCache   &layer_cache   = layer_caches[support_layer_id];
-            const float   support_interface_angle = (support_params.support_style == smsGrid || config.support_interface_pattern == smipRectilinear) ?
-                support_params.interface_angle : support_params.raft_interface_angle(support_layer.interface_id());
+            const float   support_interface_angle = support_params.support_interface_angle(support_layer.interface_id());
 
             // Find polygons with the same print_z.
             SupportGeneratorLayerExtruded &bottom_contact_layer = layer_cache.bottom_contact_layer;
@@ -1749,10 +1742,9 @@ void generate_support_toolpaths(
                     filler->angle = interface_as_base ?
                             // If zero interface layers are configured, use the same angle as for the base layers.
                             angles[support_layer_id % angles.size()] :
-                            // Use interface angle for the interface layers.
                             raft_contact ?
                                 support_params.raft_interface_angle(support_layer.interface_id()) :
-                                support_interface_angle;
+                                support_interface_angle;  // Use interface angle for the interface layers.
                     double density = raft_contact ? support_params.raft_interface_density : interface_as_base ? support_params.support_density : support_params.interface_density;
                     filler->spacing = raft_contact ? support_params.raft_interface_flow.spacing() :
                         interface_as_base ? support_params.support_material_flow.spacing() : support_params.support_material_interface_flow.spacing();
@@ -1768,6 +1760,7 @@ void generate_support_toolpaths(
                         interface_as_base ? ExtrusionRole::erSupportMaterial : ExtrusionRole::erSupportMaterialInterface, interface_flow);
                 }
             };
+            
             const bool top_interfaces = config.support_interface_top_layers.value != 0;
             const bool bottom_interfaces = top_interfaces && config.support_interface_bottom_layers != 0;
             extrude_interface(top_contact_layer,    raft_layer ? InterfaceLayerType::RaftContact : top_interfaces ? InterfaceLayerType::TopContact : InterfaceLayerType::InterfaceAsBase);
@@ -1810,6 +1803,7 @@ void generate_support_toolpaths(
                 bool  sheath  = support_params.with_sheath;
                 bool  no_sort = false;
                 bool  done    = false;
+                
                 if (base_layer.layer->bottom_z < EPSILON) {
                     // Base flange (the 1st layer).
                     filler = filler_first_layer;
@@ -1831,6 +1825,7 @@ void generate_support_toolpaths(
                     tree_supports_generate_paths(base_layer.extrusions, base_layer.polygons_to_extrude(), flow, support_params2);
                     done = true;
                 }
+                
                 if (! done)
                     fill_expolygons_with_sheath_generate_paths(
                         // Destination

--- a/src/libslic3r/Support/TreeSupport.hpp
+++ b/src/libslic3r/Support/TreeSupport.hpp
@@ -427,12 +427,12 @@ private:
     SlicingParameters        m_slicing_params;
     // Various precomputed support parameters to be shared with external functions.
     SupportParameters   m_support_params;
-    size_t          m_raft_layers = 0;  // number of raft layers, including raft base, raft interface, raft gap
-    size_t          m_highest_overhang_layer = 0;
+    size_t m_raft_layers = 0;  // number of raft layers, including raft base, raft interface, raft gap
+    size_t m_highest_overhang_layer = 0;
     std::vector<std::vector<MinimumSpanningTree>> m_spanning_trees;
     std::vector< std::unordered_map<Line, bool, LineHash>> m_mst_line_x_layer_contour_caches;
-    float    DO_NOT_MOVER_UNDER_MM = 0.0;
-    coordf_t base_radius                        = 0.0;
+    float DO_NOT_MOVER_UNDER_MM = 0.0;
+    coordf_t base_radius = 0.0;
     const coordf_t MAX_BRANCH_RADIUS = 10.0;
     const coordf_t MIN_BRANCH_RADIUS = 0.4;
     const coordf_t MAX_BRANCH_RADIUS_FIRST_LAYER = 12.0;
@@ -440,7 +440,7 @@ private:
     double diameter_angle_scale_factor = tan(5.0*M_PI/180.0);
     // minimum roof area (1 mm^2), area smaller than this value will not have interface
     const double minimum_roof_area{SQ(scaled<double>(1.))};
-    float        top_z_distance = 0.0;
+    float top_z_distance = 0.0;
 
     bool  is_strong = false;
     bool  is_slim                            = false;
@@ -459,6 +459,21 @@ private:
      * \param contact_nodes The nodes to draw as support.
      */
     void draw_circles();
+    
+    /*!
+     * \brief Normalize interface IDs for interlaced supports.
+     *
+     * Reassigns sequential IDs to support layers when using
+     * RectilinearInterlaced, alternating (0,1,0,1,…) so consecutive
+     * interface layers never share orientation. Applies to all support
+     * area groups, including transition layers (e.g. TreeStrong
+     * body-to-interface), as well as top and bottom interfaces, so
+     * FillRectilinearInterlaced computes correct extrusion angles.
+     *
+     * \note Call after support layers are built and before toolpaths,
+     * so fillers use the normalized IDs.
+     */
+    void normalize_interface_ids();
 
     /*!
      * \brief Drops down the nodes of the tree support towards the build plate.
@@ -480,8 +495,8 @@ private:
      * \brief Optimize the generation of tree support by pre-planning the layer_heights
      *
     */
-
     std::vector<LayerHeightData> plan_layer_heights();
+
     /*!
      * \brief Creates points where support contacts the model.
      *

--- a/src/libslic3r/Support/TreeSupport3D.cpp
+++ b/src/libslic3r/Support/TreeSupport3D.cpp
@@ -3983,18 +3983,21 @@ void organic_draw_branches(
 
             // Subtract top contact layer polygons from support base.
             SupportGeneratorLayer *top_contact_layer = top_contacts.empty() ? nullptr : top_contacts[layer_idx];
+            
             if (top_contact_layer && ! top_contact_layer->polygons.empty() && ! base_layer_polygons.empty()) {
                 base_layer_polygons = diff(base_layer_polygons, top_contact_layer->polygons);
                 if (! bottom_contact_polygons.empty())
                     //FIXME it may be better to clip bottom contacts with top contacts first after they are propagated to produce interface layers.
                     bottom_contact_polygons = diff(bottom_contact_polygons, top_contact_layer->polygons);
             }
+            
             if (! bottom_contact_polygons.empty()) {
                 base_layer_polygons = diff(base_layer_polygons, bottom_contact_polygons);
                 SupportGeneratorLayer *bottom_contact_layer = bottom_contacts[layer_idx] = &layer_allocate(
                     layer_storage, SupporLayerType::BottomContact, print_object.slicing_parameters(), config, layer_idx);
                 bottom_contact_layer->polygons = std::move(bottom_contact_polygons);
             }
+            
             if (! base_layer_polygons.empty()) {
                 SupportGeneratorLayer *base_layer = intermediate_layers[layer_idx] = &layer_allocate(
                     layer_storage, SupporLayerType::Base, print_object.slicing_parameters(), config, layer_idx);


### PR DESCRIPTION
# Description

- fixed rectilinear interlaced interface pattern not always applied
- fixed rectilinear interlaced interface random layers not always rotated
- support interface layers rotation angle always 0°/90° as opposed to -45°/+45°
  - -45°/+45° is reserved for snug supports
- decoupled raft layers (base + interface) orientation from support orientation
- unified raft support orientation
  - always at 0° except first raft layer that is at 90°; it was like that for tree support, if it was good enough for those, than why not for every type of support
- make raft interface layers always interlaced
- raft interface layers rotation angle always 0°/90° as opposed to -45°/+45°
  - this way it is never aligned to the object bottom layer
- make first raft interface orientation always perpendicular to the support base layer beneath it
    - if raft has only one base layer (it is  at 90°) than the interface above it is at 0°

There are other fixes too that became an issue only on the path to fixing the above mentioned ones.

# Screenshots/Recordings/Graphs

---

## Rectilinear interlaced interface pattern not always applied:

__Before:__
<img width="828" height="727" alt="image" src="https://github.com/user-attachments/assets/13046067-b5de-4952-81ce-01773be5b92d" />

__After:__
<img width="771" height="720" alt="image" src="https://github.com/user-attachments/assets/d09b7f8c-dbf0-4daf-915f-f05ccf9f7301" />

---

## Rectilinear interlaced interface random layers not always rotated:

__Before:__
<img width="1592" height="536" alt="image" src="https://github.com/user-attachments/assets/e30eec37-a200-4a97-9166-7596350a6d58" />

__After:__
<img width="1751" height="673" alt="image" src="https://github.com/user-attachments/assets/6a90379e-fb43-40aa-8b41-eb50a415e9ae" />

---

## Support interface layers rotation angle always 0°/90° as opposed to -45°/+45°:

__Before:__
<img width="911" height="740" alt="image" src="https://github.com/user-attachments/assets/655735cb-6f02-4f6f-a93d-72da43767669" />

__After:__
<img width="863" height="730" alt="image" src="https://github.com/user-attachments/assets/e09f725e-ef0d-4d03-a899-8405db805572" />

---

## Decoupled raft layers orientation from support orientation, unified raft support orientation (always at 0° except first raft layer that is at 90°)
__Before:__
<img width="1966" height="566" alt="image" src="https://github.com/user-attachments/assets/5ab2c9e1-5b57-4254-a776-50a0bd41d9eb" />

__After:__
<img width="1828" height="639" alt="image" src="https://github.com/user-attachments/assets/18de3bf2-0fb6-4c87-aadd-063769640895" />

---

## Raft interface layers always interlaced

__Before:__
<img width="937" height="521" alt="image" src="https://github.com/user-attachments/assets/7d764c9f-ef5c-4131-bc57-ef07ef4d1f13" />

__After:__
<img width="939" height="636" alt="image" src="https://github.com/user-attachments/assets/428f32b0-f606-4550-8ef5-4292bfa8a47f" />

---

## First raft interface orientation always perpendicular to the support base layer beneath it

__Before:__
<img width="903" height="484" alt="image" src="https://github.com/user-attachments/assets/66bdb9d2-4c21-4702-abc1-b6d697212243" />

__After:__
<img width="2045" height="1094" alt="image" src="https://github.com/user-attachments/assets/0e9d3737-e837-4fc4-8c35-3d5b6bc0ac1c" />

---

Fixes #9508
## Tests

Local build, countless slicing.
Project used for tests: [SupportTest.zip](https://github.com/user-attachments/files/22698487/SupportTest.zip)

