### PR TITLE
Density adjusted for multiline infill for lightning and adaptative cubic and support cubic patterns.

### DIFF
--- a/src/libslic3r/Fill/FillAdaptive.cpp
+++ b/src/libslic3r/Fill/FillAdaptive.cpp
@@ -349,8 +349,9 @@ std::pair<double, double> adaptive_fill_line_spacing(const PrintObject &print_ob
             } else
                 return 0.;
         };
-        adaptive_line_spacing = to_line_spacing(adaptive_cnt, adaptive_fill_density, adaptive_infill_extrusion_width);
-        support_line_spacing  = to_line_spacing(support_cnt, support_fill_density, support_infill_extrusion_width);
+        const int n_multiline = print_object.printing_region(0).config().fill_multiline.value;
+        adaptive_line_spacing = to_line_spacing(adaptive_cnt, adaptive_fill_density, adaptive_infill_extrusion_width) * n_multiline;
+        support_line_spacing  = to_line_spacing(support_cnt, support_fill_density, support_infill_extrusion_width) * n_multiline;
     }
 
     return std::make_pair(adaptive_line_spacing, support_line_spacing);

--- a/src/libslic3r/Fill/FillLightning.cpp
+++ b/src/libslic3r/Fill/FillLightning.cpp
@@ -19,6 +19,7 @@ void Filler::_fill_surface_single(
     // Apply multiline offset if needed
     multiline_fill(fill_lines, params, spacing);
 
+    fill_lines = intersection_pl(fill_lines, expolygon);
 
     chain_or_connect_infill(std::move(fill_lines), expolygon, polylines_out, this->spacing, params);
 }

--- a/src/libslic3r/Fill/Lightning/Generator.cpp
+++ b/src/libslic3r/Fill/Lightning/Generator.cpp
@@ -70,6 +70,7 @@ Generator::Generator(const PrintObject &print_object, const std::function<void()
     const PrintRegionConfig   &region_config        = print_object.shared_regions()->all_regions.front()->config();
     const std::vector<double> &nozzle_diameters     = print_config.nozzle_diameter.values;
     double                     max_nozzle_diameter  = *std::max_element(nozzle_diameters.begin(), nozzle_diameters.end());
+    const int                  n_multiline          = region_config.fill_multiline.value;
 //    const int                  infill_extruder      = region_config.infill_extruder.value;
     const double               default_infill_extrusion_width = Flow::auto_extrusion_width(FlowRole::frInfill, float(max_nozzle_diameter));
     // Note: There's not going to be a layer below the first one, so the 'initial layer height' doesn't have to be taken into account.
@@ -86,7 +87,7 @@ Generator::Generator(const PrintObject &print_object, const std::function<void()
             object_config.line_width.get_abs_value(max_nozzle_diameter)
         );
     
-    m_supporting_radius = coord_t(m_infill_extrusion_width) * 100 / region_config.sparse_infill_density;
+    m_supporting_radius = coord_t(m_infill_extrusion_width) * 100 * n_multiline / region_config.sparse_infill_density;
 
     const double lightning_infill_overhang_angle      = M_PI / 4; // 45 degrees
     const double lightning_infill_prune_angle         = M_PI / 4; // 45 degrees


### PR DESCRIPTION
# Description


I forgot to adjust the fill density for these patterns when using multiline infill (sorry).
I realized this while watching this video:
https://www.youtube.com/watch?v=2FI39LruBdo&t=3s
I'm correcting it in this pull request to maintain consistency with the behavior of the other patterns.
It is important to ensure that the density multiplied by the number of lines does not exceed 100% to avoid excessive overlap.

# Screenshots/Recordings/Graphs
before:
<img width="1169" height="1109" alt="image" src="https://github.com/user-attachments/assets/def15040-33ae-4a0c-abe3-52927c85c407" />
<img width="1332" height="1003" alt="image" src="https://github.com/user-attachments/assets/b4f5297a-d3cc-40d1-896d-288371934f54" />

After:
<img width="1190" height="981" alt="image" src="https://github.com/user-attachments/assets/de1ca23d-9b98-4d1e-b655-e62318df2f8c" />
<img width="1387" height="975" alt="image" src="https://github.com/user-attachments/assets/acac9c89-3776-45fd-95dc-ff40f4fd4716" />


