### PR TITLE
Fix Z offset for 1st layer

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5222,9 +5222,9 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             sloped == nullptr ? DBL_MAX : get_sloped_z(sloped->slope_begin.z_ratio)
         );
         m_need_change_layer_lift_z = false;
-        // Orca: force restore Z after unknown last pos
+        // Orca: ensure Z matches planned layer height
         if (_last_pos_undefined && !slope_need_z_travel) {
-            gcode += this->writer().travel_to_z(m_last_layer_z, "force restore Z after unknown last pos", true);
+            gcode += this->writer().travel_to_z(m_nominal_z, "ensure Z matches planned layer height", true);
         }
     }
 


### PR DESCRIPTION
# Description

Fixes #11002: Z offset for first layer.

Later edit: Actually it fixes more than that, it prevents a possible nozzle crash into the printed object after a toolchange if Z offset is set to non zero in Orca. (it is a bug not to be ignored!)

# Screenshots/Recordings/Graphs

__For the sake of tests let's assume a Z offset of 1mm, layer height 0.2mm.__  

---
Before:
```
G1 X115.18 Y115.27 F18000 ; move to first skirt point
G1 Z1.6 ; move to first skirt point
G1 Z.2 ; force restore Z after unknown last pos
```

After:
```
G1 X115.18 Y115.27 F18000 ; move to first skirt point
G1 Z1.6 ; move to first skirt point
G1 Z1.2 ; ensure Z matches planned layer height
```
---
## Tests

Local build, slicing a test cube.
