### PR TITLE
Make top resizing grabber larger on Windows

### DIFF
--- a/src/slic3r/GUI/BBLTopbar.cpp
+++ b/src/slic3r/GUI/BBLTopbar.cpp
@@ -696,3 +696,22 @@ wxAuiToolBarItem* BBLTopbar::FindToolByCurrentPosition()
     wxPoint client_pos = this->ScreenToClient(mouse_pos);
     return this->FindToolByPosition(client_pos.x, client_pos.y);
 }
+
+#ifdef __WIN32__
+WXLRESULT BBLTopbar::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
+{
+    switch (nMsg) {
+    case WM_NCHITTEST: {
+        const wxAuiToolBarItem* current_item = this->FindToolByCurrentPosition();
+        if (current_item != nullptr && current_item != m_title_item) {
+            break;
+        }
+
+        // Pass the event to main window if mouse is on the top bar and not on any of the buttons
+        return HTTRANSPARENT;
+    }
+    }
+
+    return wxAuiToolBar::MSWWindowProc(nMsg, wParam, lParam);
+}
+#endif

--- a/src/slic3r/GUI/BBLTopbar.hpp
+++ b/src/slic3r/GUI/BBLTopbar.hpp
@@ -56,6 +56,11 @@ public:
 
     void ShowCalibrationButton(bool show = true);
 
+protected:
+#ifdef __WIN32__
+    WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;
+#endif
+
 private:
     wxFrame* m_frame;
     wxAuiToolBarItem* m_file_menu_item;


### PR DESCRIPTION
Currently the top resize border on Windows is only 1px high, makes it really hard to click on:
![resize_old](https://github.com/user-attachments/assets/3a7173f1-e5e1-40e1-9832-ef53fd963ada)

This PR extends it to around 7px (on 100% display scaling), make it matches most of the regular Windows apps and much easier to use:
![resize_new](https://github.com/user-attachments/assets/313334dc-1d81-40dd-a804-d44949b70460)
