### PR TITLE
Remove to Ignore small overhangs: Full update

### DIFF
--- a/doc/print_settings/support/support_settings_support.md
+++ b/doc/print_settings/support/support_settings_support.md
@@ -20,7 +20,7 @@ Support structures are used in 3D printing to provide stability to overhangs and
 - [Initial layer density](#initial-layer-density)
 - [Initial layer expansion](#initial-layer-expansion)
 - [On build plate only](#on-build-plate-only)
-- [Remove small overhangs](#remove-small-overhangs)
+- [Ignore small overhangs](#ignore-small-overhangs)
 
 ## Type
 
@@ -95,6 +95,6 @@ Expand the first raft or support layer to improve bed plate adhesion.
 
 Don't create support on model surface, only on build plate.
 
-## Remove small overhangs
+## Ignore small overhangs
 
-Remove small overhangs that possibly need no supports.
+With this setting small overhangs that possibly need no supports will be ignored from support generation.

--- a/localization/i18n/OrcaSlicer.pot
+++ b/localization/i18n/OrcaSlicer.pot
@@ -12802,10 +12802,10 @@ msgid ""
 "etc."
 msgstr ""
 
-msgid "Remove small overhangs"
+msgid "Ignore small overhangs"
 msgstr ""
 
-msgid "Remove small overhangs that possibly need no supports."
+msgid "Ignore small overhangs that possibly don't require support."
 msgstr ""
 
 msgid "Top Z distance"

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5017,9 +5017,9 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("support_remove_small_overhang", coBool);
-    def->label = L("Remove small overhangs");
+    def->label = L("Ignore small overhangs");
     def->category = L("Support");
-    def->tooltip = L("Remove small overhangs that possibly need no supports.");
+    def->tooltip = L("Ignore small overhangs that possibly don't require support.");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionBool(true));
 

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -2359,7 +2359,7 @@ void TabPrint::build()
         optgroup->append_single_option_line("raft_first_layer_expansion", "support_settings_support#initial-layer-expansion");
         optgroup->append_single_option_line("support_on_build_plate_only", "support_settings_support#on-build-plate-only");
         optgroup->append_single_option_line("support_critical_regions_only", "support_settings_support#support-critical-regions-only");
-        optgroup->append_single_option_line("support_remove_small_overhang", "support_settings_support#remove-small-overhangs");
+        optgroup->append_single_option_line("support_remove_small_overhang", "support_settings_support#ignore-small-overhangs");
         //optgroup->append_single_option_line("enforce_support_layers", "support_settings_support");
 
         optgroup = page->new_optgroup(L("Raft"), L"param_raft");


### PR DESCRIPTION
According and fixing #11034 Using "Ignore small overhangs" is a better description.
Updated:

- Code Strings
- Variable names
  - Profiles
  - handle_legacy profiles

In #11071 @BriellaBugs tried to do it via translation doc but i thing that the change must be done in the code and the english translation shouldnt "correct" text.

With this approach, if we change something in the English “translation” and not the original text for a real translation into another language, the ‘msgid’ will not match what should be translated in its “msgstr,” so I think we should clean up the English “translation” by adjusting the messages in the code.

PS: The document validation error is inherited and is fixed in wiki update 13 #10677 , which is waiting to be merged.