### PR TITLE
CalibrationWizardPresetPage: Skip adding null combobox

### DIFF
--- a/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
+++ b/src/slic3r/GUI/CalibrationWizardPresetPage.cpp
@@ -766,7 +766,8 @@ void CalibrationPresetPage::create_page(wxWindow* parent)
     m_top_sizer->Add(m_selection_panel, 0);
     m_top_sizer->Add(m_filament_list_panel, 0);
     m_top_sizer->Add(m_ext_spool_panel, 0);
-    m_top_sizer->Add(m_pa_cali_method_combox, 0);
+    if (m_pa_cali_method_combox)
+        m_top_sizer->Add(m_pa_cali_method_combox, 0);
     m_top_sizer->Add(m_custom_range_panel, 0);
     m_top_sizer->AddSpacer(FromDIP(15));
     m_top_sizer->Add(m_warning_panel, 0);


### PR DESCRIPTION
# Description

I'm working on getting Orca running with linux & wayland and this was hitting wx assert causing a modal to popup.  The `m_pa_cali_method_combox` is only initialized in certain cases but is always being added to the sizer.


<img width="974" height="560" alt="image" src="https://github.com/user-attachments/assets/6fefde81-a4f2-4521-84bb-b96382b7cc5c" />


```gdb
Thread 1 "orcaslicer_main" received signal SIGTRAP, Trace/breakpoint trap.
0x00007ffff2f73e8f in wxSizerItem::DoSetWindow(wxWindow*) ()
   from /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
(gdb) bt
#0  0x00007ffff2f73e8f in wxSizerItem::DoSetWindow(wxWindow*) ()
    at /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
#1  0x00007ffff2f7aa78 in wxSizerItem::wxSizerItem(wxWindow*, int, int, int, wxObject*) ()
    at /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
#2  0x0000555556fafe7a in wxSizer::Add
    (this=0x5555637fb570, window=0x0, proportion=0, flag=0, border=0, userData=0x0)
    at /home/usr/.local/include/wx-3.2/wx/sizer.h:1194
#3  0x000055555796dbe6 in Slic3r::GUI::CalibrationPresetPage::create_page
    (this=0x5555637f9f90, parent=0x5555637f9f90)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/CalibrationWizardPresetPage.cpp:770
#4  0x0000555557969fc2 in Slic3r::GUI::CalibrationPresetPage::CalibrationPresetPage
    (this=0x5555637f9f90, parent=0x555563418380, cali_mode=Slic3r::CalibMode::Calib_Flow_Rate, custom_range=false, id=-1, pos=..., size=..., style=524288)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/CalibrationWizardPresetPage.cpp:488
#5  0x0000555557947921 in Slic3r::GUI::FlowRateWizard::create_pages (this=0x5555634457f0)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/CalibrationWizard.cpp:840
#6  0x000055555794780d in Slic3r::GUI::FlowRateWizard::FlowRateWizard
    (this=0x5555634457f0, parent=0x555562f54b60, id=-1, pos=..., size=..., style=524288)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/CalibrationWizard.cpp:834
#7  0x0000555557939881 in Slic3r::GUI::CalibrationPanel::init_tabpanel (this=0x555562f99820)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/CalibrationPanel.cpp:480

```

## Tests

Running Orca.