### PR TITLE
MsgDialog: Use correct format specifier

### DIFF
--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -179,9 +179,9 @@ Button* MsgDialog::add_button(wxWindowID btn_id, bool set_focus /*= false*/, con
     bd->button = btn;
     //bd->type   = type;
 
-    mb->id        = wxString::Format("%d", m_buttons.size());
+    mb->id        = wxString::Format("%zu", m_buttons.size());
     mb->buttondata = bd;
-    m_buttons[ wxString::Format("%d", m_buttons.size())] = mb;
+    m_buttons[mb->id] = mb;
     return btn;
 };
 


### PR DESCRIPTION
# Description

After opening a project it shows a message dialog. wx pops up an assert as shown below due to incorrect format specifiers. This changes it to the correct format specifier.

```gdb
#0  0x00007fffec11b4fd in __GI___poll (fds=0x55556467d730, nfds=9, timeout=2000)
    at ../sysdeps/unix/sysv/linux/poll.c:29
#1  0x00007ffff232468e in ??? () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#2  0x00007ffff22c5f87 in g_main_loop_run () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#3  0x00007fffec760de6 in gtk_dialog_run () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#4  0x00007ffff2db535d in wxGUIAppTraits::ShowAssertDialog(wxString const&) ()
    at /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
#5  0x00007ffff34b3787 in ShowAssertDialog(wxString const&, int, wxString const&, wxString const&, wxString const&, wxAppTraits*) () at /home/usr/.local/lib/libwx_baseu-3.2.so.0
#6  0x00007ffff34b3a8b in wxAppConsoleBase::OnAssertFailure(wchar_t const*, int, wchar_t const*, wchar_t const*, wchar_t const*) () at /home/usr/.local/lib/libwx_baseu-3.2.so.0
#7  0x00007ffff2d7c3c4 in wxApp::OnAssertFailure(wchar_t const*, int, wchar_t const*, wchar_t const*, wchar_t const*) () at /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
#8  0x00007ffff34b3ca1 in wxDefaultAssertHandler(wxString const&, int, wxString const&, wxString const&, wxString const&) () at /home/usr/.local/lib/libwx_baseu-3.2.so.0
#9  0x00007ffff34b0e23 in wxOnAssert(char const*, int, char const*, char const*, char const*) ()
    at /home/usr/.local/lib/libwx_baseu-3.2.so.0
#10 0x00005555570a1829 in wxArgNormalizer<unsigned long>::wxArgNormalizer
    (this=0x7fffffff2168, value=0, fmt=0x7fffffff21e0, index=1)
    at /home/usr/.local/include/wx-3.2/wx/strvararg.h:484
#11 0x000055555709f750 in wxArgNormalizerWchar<unsigned long>::wxArgNormalizerWchar
--Type <RET> for more, q to quit, c to continue without paging--
    (this=0x7fffffff2168, value=0, fmt=0x7fffffff21e0, index=1) at /home/usr/.local/include/wx-3.2/wx/strvararg.h:504
#12 0x000055555709dc22 in wxString::Format<unsigned long> (f1=..., a1=0) at /home/usr/.local/include/wx-3.2/wx/string.h:2428
#13 0x00005555570d30ca in Slic3r::GUI::MsgDialog::add_button (this=0x7fffffff3010, btn_id=5100, set_focus=true, label=...)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/MsgDialog.cpp:182
#14 0x00005555570d334e in Slic3r::GUI::MsgDialog::apply_style (this=0x7fffffff3010, style=4)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/MsgDialog.cpp:194
#15 0x00005555570d233e in Slic3r::GUI::MsgDialog::MsgDialog
    (this=0x7fffffff3010, parent=0x55556145ca60, title=..., headline=..., style=4, bitmap=<incomplete type>)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/MsgDialog.cpp:67
#16 0x00005555570d5292 in Slic3r::GUI::MessageDialog::MessageDialog
    (this=0x7fffffff3010, parent=0x55556145ca60, message=..., caption=..., style=4)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/MsgDialog.cpp:338

#17 0x0000555557206585 in Slic3r::GUI::Plater::priv::load_files
    (this=0x555561a10b40, input_files=std::vector of length 1, capacity 1 = {...}, strategy=30, ask_multi=false)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Plater.cpp:4054
#18 0x0000555557249ad3 in Slic3r::GUI::Plater::load_files
    (this=0x55556145ca60, input_files=std::vector of length 1, capacity 1 = {...}, strategy=12, ask_multi=false)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Plater.cpp:10620
#19 0x000055555722f571 in Slic3r::GUI::Plater::load_project (this=0x55556145ca60, filename2=..., originfile=...)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Plater.cpp:9081
#20 0x000055555706f823 in operator() (__closure=0x55556512eac8)
--Type <RET> for more, q to quit, c to continue without paging--
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/MainFrame.cpp:3789
#21 0x00005555570971e0 in wxAsyncMethodCallEventFunctor<Slic3r::GUI::MainFrame::open_recent_project(size_t, const wxString&)::<lambda()> >::Execute(void) (this=0x55556512ea70) at /home/usr/.local/include/wx-3.2/wx/event.h:1576

```

# Screenshots/Recordings/Graphs

<img width="1444" height="297" alt="image" src="https://github.com/user-attachments/assets/cfa82fe3-bf7b-41fc-969f-6690cdf9a056" />


## Tests

Run Orca and Load a project.
