### PR TITLE
ProgressDialog:  Fix DoSetSize using incorrect superclass

### DIFF
--- a/src/slic3r/GUI/Widgets/ProgressDialog.cpp
+++ b/src/slic3r/GUI/Widgets/ProgressDialog.cpp
@@ -813,7 +813,7 @@ void ProgressDialog::DoSetSize(int x, int y, int width, int height, int sizeFlag
     //    m_block_right->SetPosition(wxPoint(PROGRESSDIALOG_GAUGE_SIZE.x - 2, 0));
     //}
 #endif
-    wxWindow::DoSetSize(x, y, width, height, sizeFlags);
+    wxDialog::DoSetSize(x, y, width, height, sizeFlags);
 }
 
 void ProgressDialog::DisableOtherWindows()


### PR DESCRIPTION
# Description

This fixes the following wx assert on linux & wayland: 

```gdb
../src/gtk/toplevel.cpp(1231): assert ""Assert failure"" failed in DoMoveWindow(): DoMoveWindow called for wxTopLevelWindowGTK

Thread 1 "orcaslicer_main" received signal SIGTRAP, Trace/breakpoint trap.
0x00007ffff2db00bb in wxTopLevelWindowGTK::DoMoveWindow(int, int, int, int) ()
   from /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
(gdb) bt
#0  0x00007ffff2db00bb in wxTopLevelWindowGTK::DoMoveWindow(int, int, int, int) ()
    at /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
#1  0x00007ffff2db7fa9 in wxWindow::DoSetSize(int, int, int, int, int) ()
    at /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
#2  0x00005555576dd3ae in Slic3r::GUI::ProgressDialog::DoSetSize
    (this=0x7fffffff3490, x=-1, y=-1, width=376, height=127, sizeFlags=0)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Widgets/ProgressDialog.cpp:816
#3  0x00005555576dae92 in Slic3r::GUI::ProgressDialog::Create
    (this=0x7fffffff3490, title=..., message=..., maximum=100, parent=0x55555cc657a0, style=7)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Widgets/ProgressDialog.cpp:270
#4  0x00005555576d8dc5 in Slic3r::GUI::ProgressDialog::ProgressDialog
    (this=0x7fffffff3490, title=..., message=..., maximum=100, parent=0x55555cc657a0, style=7, adaptive=false) at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Widgets/ProgressDialog.cpp:77

#5  0x0000555557202e72 in Slic3r::GUI::Plater::priv::load_files
    (this=0x5555619fe590, input_files=std::vector of length 1, capacity 1 = {...}, strategy=12, ask_multi=false) at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Plater.cpp:3680
#6  0x0000555557249ac9 in Slic3r::GUI::Plater::load_files
    (this=0x55556144d8c0, input_files=std::vector of length 1, capacity 1 = {...}, strategy=12, ask_multi=false) at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Plater.cpp:10620
#7  0x000055555722f567 in Slic3r::GUI::Plater::load_project
    (this=0x55556144d8c0, filename2=..., originfile=...)
--Type <RET> for more, q to quit, c to continue without paging--
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Plater.cpp:9081
#8  0x000055555706f819 in operator() (__closure=0x5555650c3148) at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/MainFrame.cpp:3789
#9  0x00005555570971d6 in wxAsyncMethodCallEventFunctor<Slic3r::GUI::MainFrame::open_recent_project(size_t, const wxString&)::<lambda()> >::Execute(void) (this=0x5555650c30f0) at /home/usr/.local/include/wx-3.2/wx/event.h:1576
#10 0x00007ffff3632640 in wxEvtHandler::TryHereOnly(wxEvent&) () at /home/usr/.local/lib/libwx_baseu-3.2.so.0

```

# Screenshots/Recordings/Graphs

<img width="1018" height="226" alt="image" src="https://github.com/user-attachments/assets/2a146eea-17a1-4d45-b1df-b47f136927ef" />

## Tests

Open Orca an load a project so the progress dialog shows up.
