### PR TITLE
SideTools: Use default wxHyperlinkCtrl style flags for m_link_network_state

### DIFF
--- a/src/slic3r/GUI/Widgets/SideTools.cpp
+++ b/src/slic3r/GUI/Widgets/SideTools.cpp
@@ -326,7 +326,7 @@ SideTools::SideTools(wxWindow *parent, wxWindowID id, const wxPoint &pos, const 
     wxBoxSizer* sizer_error_desc = new wxBoxSizer(wxHORIZONTAL);
     wxBoxSizer* sizer_extra_info = new wxBoxSizer(wxHORIZONTAL);
 
-    m_link_network_state = new wxHyperlinkCtrl(m_side_error_panel, wxID_ANY,_L("Check the status of current system services"),"",wxDefaultPosition,wxDefaultSize,wxALIGN_CENTER_HORIZONTAL | wxST_ELLIPSIZE_END);
+    m_link_network_state = new wxHyperlinkCtrl(m_side_error_panel, wxID_ANY, _L("Check the status of current system services"), "");
     m_link_network_state->SetMinSize(wxSize(FromDIP(220), -1));
     m_link_network_state->SetMaxSize(wxSize(FromDIP(220), -1));
     m_link_network_state->SetFont(::Label::Body_12);


### PR DESCRIPTION
# Description

The wxHyperlinkCtrl has it's own style flags https://docs.wxwidgets.org/stable/classwx_hyperlink_ctrl.html and the `wxALIGN_CENTER_HORIZONTAL` is causing the following wx assert:

```gdb
../src/common/hyperlnkcmn.cpp(116): assert "alignment == 1" failed in CheckParams(): Specify exactly one align flag!

Thread 1 "orcaslicer_main" received signal SIGTRAP, Trace/breakpoint trap.
0x00007ffff30b2ced in wxHyperlinkCtrlBase::CheckParams(wxString const&, wxString const&, long) () from /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
(gdb) bt
#0  0x00007ffff30b2ced in wxHyperlinkCtrlBase::CheckParams(wxString const&, wxString const&, long) () at /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
#1  0x00007ffff2e53267 in wxHyperlinkCtrl::Create(wxWindow*, int, wxString const&, wxString const&, wxPoint const&, wxSize const&, long, wxString const&) ()
    at /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
#2  0x00007ffff2e53550 in wxHyperlinkCtrl::wxHyperlinkCtrl(wxWindow*, int, wxString const&, wxString const&, wxPoint const&, wxSize const&, long, wxString const&) ()
    at /home/usr/.local/lib/libwx_gtk3u_core-3.2.so.0
#3  0x00005555576f4914 in Slic3r::GUI::SideTools::SideTools (this=0x55556231e250, parent=0x5555625baf90, id=-1, pos=..., size=...)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Widgets/SideTools.cpp:329
#4  0x00005555570b5780 in Slic3r::GUI::MonitorPanel::init_tabpanel (this=0x5555625baf90) at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Monitor.cpp:174
#5  0x00005555570b4479 in Slic3r::GUI::MonitorPanel::MonitorPanel (this=0x5555625baf90, parent=0x555561328340, id=-1, pos=..., size=..., style=524288)
    at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Monitor.cpp:107
#6  0x000055555705563c in Slic3r::GUI::MainFrame::init_tabpanel (this=0x55555b7f9250) at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/MainFrame.cpp:1127
#7  0x000055555705286b in Slic3r::GUI::MainFrame::MainFrame (this=0x55555b7f9250) at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/MainFrame.cpp:270
#8  0x0000555556ef4b79 in Slic3r::GUI::GUI_App::on_init_inner (this=0x55555b3be950) at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/GUI_App.cpp:2638
#9  0x0000555556ef0a64 in Slic3r::GUI::GUI_App::OnInit (this=0x55555b3be950) at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/GUI_App.cpp:2173
#10 0x0000555556f3099f in wxAppConsoleBase::CallOnInit (this=0x55555b3be950) at /home/usr/.local/include/wx-3.2/wx/app.h:93
#11 0x00007ffff3537d22 in wxEntry(int&, wchar_t**) () at /home/usr/.local/lib/libwx_baseu-3.2.so.0
#12 0x0000555556f61dd3 in Slic3r::GUI::GUI_Run (params=...) at /home/usr/projects/OrcaSlicer/src/slic3r/GUI/GUI_Init.cpp:64
#13 0x00005555558db904 in Slic3r::CLI::run (this=0x7fffffffd460, argc=1, argv=0x7fffffffd6a8) at /home/usr/projects/OrcaSlicer/src/OrcaSlicer.cpp:1154
#14 0x000055555592c5fe in main (argc=1, argv=0x7fffffffd6a8) at /home/usr/projects/OrcaSlicer/src/OrcaSlicer.cpp:6344
```

Keeping `wxST_ELLIPSIZE_END` doesn't trigger an assert but I think that flag is for wxStaticText. 

This change makes the link the same as the other network state links in SendToPrinter.cpp and SelectMachine.cpp.

# Screenshots/Recordings/Graphs

<img width="965" height="230" alt="image" src="https://github.com/user-attachments/assets/ffec3b50-79af-425f-83ad-a4b299fec741" />

## Tests

Open Orca
