### PR TITLE
IF-enable PA in IS and Cornering Calibs

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -12479,6 +12479,7 @@ void Plater::calib_input_shaping_freq(const Calib_Params& params)
     if (!filament_config->option<ConfigOptionBools>("enable_pressure_advance")->get_at(0)) {
         filament_config->set_key_value("enable_pressure_advance", new ConfigOptionBools {true});
         filament_config->set_key_value("pressure_advance", new ConfigOptionFloats { 0.0 });
+        filament_config->set_key_value("adaptive_pressure_advance", new ConfigOptionBools{false});
     }
 
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
@@ -12539,6 +12540,7 @@ void Plater::calib_input_shaping_damp(const Calib_Params& params)
     if (!filament_config->option<ConfigOptionBools>("enable_pressure_advance")->get_at(0)) {
         filament_config->set_key_value("enable_pressure_advance", new ConfigOptionBools {true});
         filament_config->set_key_value("pressure_advance", new ConfigOptionFloats { 0.0 });
+        filament_config->set_key_value("adaptive_pressure_advance", new ConfigOptionBools{false});
     }
 
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});
@@ -12600,6 +12602,7 @@ void Plater::Calib_Cornering(const Calib_Params& params)
     if (!filament_config->option<ConfigOptionBools>("enable_pressure_advance")->get_at(0)) {
         filament_config->set_key_value("enable_pressure_advance", new ConfigOptionBools {true});
         filament_config->set_key_value("pressure_advance", new ConfigOptionFloats { 0.0 });
+        filament_config->set_key_value("adaptive_pressure_advance", new ConfigOptionBools{false});
     }
 
     printer_config->set_key_value("resonance_avoidance", new ConfigOptionBool{false});


### PR DESCRIPTION
# Description

Closes #11061

If a PA was enables keep it that way, but if it wasn't it will be override to 0 to avoid previous issue (#10481).

Thanks @lemonhole