### PR TITLE
Update Findlibnoise.cmake to work with ubuntu's libnoise-dev package

### DIFF
--- a/cmake/modules/Findlibnoise.cmake
+++ b/cmake/modules/Findlibnoise.cmake
@@ -1,6 +1,6 @@
 find_path(LIBNOISE_INCLUDE_DIR libnoise/noise.h)
-find_library(LIBNOISE_LIBRARY_RELEASE NAMES libnoise libnoise_static liblibnoise_static)
-find_library(LIBNOISE_LIBRARY_DEBUG NAMES libnoised libnoise_staticd liblibnoise_staticd)
+find_library(LIBNOISE_LIBRARY_RELEASE NAMES noise libnoise libnoise_static liblibnoise_static)
+find_library(LIBNOISE_LIBRARY_DEBUG NAMES noised libnoised libnoise_staticd liblibnoise_staticd)
 
 set(libnoise_LIB_FOUND FALSE)
 if (LIBNOISE_LIBRARY_RELEASE OR LIBNOISE_LIBRARY_DEBUG)


### PR DESCRIPTION
# Description

If building without the custom build script on ubuntu I get a configure error because libnoise is not found. Using the name `noise` makes it work with ubuntu's `libnoise-dev` package.

# Screenshots/Recordings/Graphs

N/A

## Tests

Compiling.