### PR TITLE
PhysicalPrinterDialog: Avoid ambiguous call of overloaded fn set_values

### DIFF
--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -374,7 +374,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     // Always fill in the "printhost_port" combo box from the config and select it.
     {
         Choice* choice = dynamic_cast<Choice*>(m_optgroup->get_field("printhost_port"));
-        choice->set_values({ m_config->opt_string("printhost_port") });
+        choice->set_values(wxArrayString({ m_config->opt_string("printhost_port") }));
         choice->set_selection();
     }
 


### PR DESCRIPTION
# Description

When compiling with gcc 13 I get the following compile error:

```gdb
/home/usr/projects/OrcaSlicer/src/slic3r/GUI/PhysicalPrinterDialog.cpp: In member function ‘void Slic3r::GUI::PhysicalPrinterDialog::build_printhost_settings(Slic3r::GUI::ConfigOptionsGroup*)’:
/home/usr/projects/OrcaSlicer/src/slic3r/GUI/PhysicalPrinterDialog.cpp:377: error: call of overloaded ‘set_values(<brace-enclosed initializer list>)’ is ambiguous
  377 |         choice->set_values({ m_config->opt_string("printhost_port") });
      | 
In file included from /home/usr/projects/OrcaSlicer/src/slic3r/GUI/ConfigManipulation.hpp:12,
                 from /home/usr/projects/OrcaSlicer/src/slic3r/GUI/Tab.hpp:35,
                 from /home/usr/projects/OrcaSlicer/src/slic3r/GUI/PhysicalPrinterDialog.cpp:28:
/home/usr/projects/OrcaSlicer/src/slic3r/GUI/Field.hpp:451: note: candidate: ‘void Slic3r::GUI::Choice::set_values(const std::vector<std::__cxx11::basic_string<char> >&)’
  451 |         void                    set_values(const std::vector<std::string> &values);
      | 
/home/usr/projects/OrcaSlicer/src/slic3r/GUI/Field.hpp:452: note: candidate: ‘void Slic3r::GUI::Choice::set_values(const wxArrayString&)’
  452 |         void                    set_values(const wxArrayString &values);
      | 
```
 
This uses wxArrayString to avoid the ambiguity.

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

Compiling.
