### PR TITLE
FIX: crash when xy_dist=0 in organic tree

### DIFF
--- a/src/libslic3r/Support/TreeModelVolumes.cpp
+++ b/src/libslic3r/Support/TreeModelVolumes.cpp
@@ -665,6 +665,7 @@ void TreeModelVolumes::calculateAvoidance(const std::vector<RadiusLayerPair> &ke
             // Limiting the offset step so that unioning the shrunk latest_avoidance with the current layer collisions
             // will not create gaps in the resulting avoidance region letting a tree support branch tunneling through an object wall.
             float move_step      = 1.9 * std::max(task.radius, m_current_min_xy_dist);
+            if (move_step < EPSILON) return;
             int   move_steps     = round_up_divide<int>(max_move, move_step);
             assert(move_steps > 0);
             float last_move_step = max_move - (move_steps - 1) * move_step;


### PR DESCRIPTION
Fix crash described here https://github.com/SoftFever/OrcaSlicer/pull/10780#issuecomment-3460006778
<img width="1036" height="1106" alt="image" src="https://github.com/user-attachments/assets/a2e41b38-1699-4224-ab8c-753c02be0b0e" />


cherry picked from commit bambulab/BambuStudio@7ac6cedff80b810350aaf3261c62131ceff4ca75
Thanks BambuLab!