### PR TITLE
Fix combo box vertical text alignment

### DIFF
--- a/src/slic3r/GUI/Widgets/TextInput.cpp
+++ b/src/slic3r/GUI/Widgets/TextInput.cpp
@@ -313,8 +313,8 @@ void TextInput::messureSize()
 {
     wxSize size = GetSize();
     wxClientDC dc(this);
-    bool   align_right = GetWindowStyle() & wxRIGHT;
-    if (align_right || static_tips.empty())
+    bool   align_right = GetWindowStyle() & wxALIGN_RIGHT;
+    if (align_right)
         dc.SetFont(GetFont());
     else
         dc.SetFont(Label::Body_12);


### PR DESCRIPTION
PROBLEM
Text extent calculated for Label::Body_12 but text uses Label::Body_14

BEFORE
<img width="631" height="85" alt="Screenshot-20251031215444" src="https://github.com/user-attachments/assets/9e1c7d37-b692-4411-8ae4-dcd82f28d780" />

AFTER
<img width="530" height="86" alt="Screenshot-20251031224538" src="https://github.com/user-attachments/assets/935c6b1c-2978-410d-8935-e7f29fd228b8" />

BEFORE
<img width="440" height="187" alt="Screenshot-20251031225025" src="https://github.com/user-attachments/assets/8f2ac891-91f1-492b-bc1d-3f1ac298f165" />

AFTER
<img width="409" height="190" alt="Screenshot-20251031224742" src="https://github.com/user-attachments/assets/e5214782-c270-4b75-9e06-86cc7d6204db" />
