### PR TITLE
Add missing translation markers

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2290,14 +2290,16 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionInts{1});
 
     def = this->add("physical_extruder_map",coInts);
+    // internal use only, don't need translation
     def->label = "Map the logical extruder to physical extruder";
     def->tooltip = "Map the logical extruder to physical extruder.";
     def->mode = comDevelop;
     def->set_default_value(new ConfigOptionInts{0});
 
-    def                = this->add("filament_map_mode", coEnum);
-    def->label         = L("filament mapping mode");
-    def->tooltip = ("Filament mapping mode used as plate param.");
+    def = this->add("filament_map_mode", coEnum);
+    // internal use only, don't need translation
+    def->label = "filament mapping mode";
+    def->tooltip = "Filament mapping mode used as plate param.";
     def->enum_keys_map = &ConfigOptionEnum<FilamentMapMode>::get_enum_values();
     def->enum_values.push_back("Auto For Flush");
     def->enum_values.push_back("Auto For Match");
@@ -4716,8 +4718,9 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionEnumsGeneric{RetractLiftEnforceType ::rletAllSurfaces});
 
     def = this->add("extruder_type", coEnums);
-    def->label = L("Type");
-    def->tooltip = ("This setting is only used for initial value of manual calibration of pressure advance. Bowden extruder usually has larger pa value. This setting doesn't influence normal slicing.");
+    // internal use only, don't need translation
+    def->label = "Type";
+    def->tooltip = "This setting is only used for initial value of manual calibration of pressure advance. Bowden extruder usually has larger PA value. This setting doesn't influence normal slicing.";
     def->enum_keys_map = &ConfigOptionEnum<ExtruderType>::get_enum_values();
     def->enum_values.push_back("Direct Drive");
     def->enum_values.push_back("Bowden");
@@ -4728,8 +4731,9 @@ void PrintConfigDef::init_fff_params()
 
     //BBS
     def = this->add("nozzle_volume_type", coEnums);
-    def->label = L("Nozzle Volume Type");
-    def->tooltip = ("Nozzle volume type.");
+    // internal use only, don't need translation
+    def->label = "Nozzle Volume Type";
+    def->tooltip = "Nozzle volume type for extruders.";
     def->enum_keys_map = &ConfigOptionEnum<NozzleVolumeType>::get_enum_values();
     def->enum_values.push_back(L("Standard"));
     def->enum_values.push_back(L("High Flow"));
@@ -4739,8 +4743,9 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionEnumsGeneric{ NozzleVolumeType::nvtStandard });
 
     def = this->add("default_nozzle_volume_type", coEnums);
-    def->label = L("Default Nozzle Volume Type.");
-    def->tooltip = ("Default Nozzle volume type for extruders in this printer.");
+    // internal use only, don't need translation
+    def->label = "Default Nozzle Volume Type.";
+    def->tooltip = "Default Nozzle volume type for extruders in this printer.";
     def->enum_keys_map = &ConfigOptionEnum<NozzleVolumeType>::get_enum_values();
     def->enum_values.push_back(L("Standard"));
     def->enum_values.push_back(L("High Flow"));
@@ -4750,40 +4755,47 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionEnumsGeneric{ NozzleVolumeType::nvtStandard });
 
     def = this->add("extruder_variant_list", coStrings);
+    // internal use only, don't need translation
     def->label = "Extruder variant list";
     def->tooltip = "Extruder variant list.";
     def->set_default_value(new ConfigOptionStrings { "Direct Drive Standard" });
     def->cli = ConfigOptionDef::nocli;
 
     def = this->add("extruder_ams_count", coStrings);
-    def->label = "Extruder ams count";
-    def->tooltip = "Ams counts of per extruder.";
+    // internal use only, don't need translation
+    def->label = "Extruder AMS count";
+    def->tooltip = "AMS counts per extruder.";
     def->set_default_value(new ConfigOptionStrings { });
 
     def = this->add("printer_extruder_id", coInts);
+    // internal use only, don't need translation
     def->label = "Printer extruder id";
     def->tooltip = "Printer extruder id.";
     def->set_default_value(new ConfigOptionInts { 1 });
     def->cli = ConfigOptionDef::nocli;
 
     def = this->add("printer_extruder_variant", coStrings);
+    // internal use only, don't need translation
     def->label = "Printer's extruder variant";
     def->tooltip = "Printer's extruder variant.";
     def->set_default_value(new ConfigOptionStrings { "Direct Drive Standard" });
     def->cli = ConfigOptionDef::nocli;
 
     def = this->add("master_extruder_id", coInt);
+    // internal use only, don't need translation
     def->label = "Master extruder id";
     def->tooltip = "Default extruder id to place filament.";
     def->set_default_value(new ConfigOptionInt{ 1 });
 
     def = this->add("print_extruder_id", coInts);
+    // internal use only, don't need translation
     def->label = "Print extruder id";
     def->tooltip = "Print extruder id.";
     def->set_default_value(new ConfigOptionInts { 1 });
     def->cli = ConfigOptionDef::nocli;
 
     def = this->add("print_extruder_variant", coStrings);
+    // internal use only, don't need translation
     def->label = "Print's extruder variant";
     def->tooltip = "Print's extruder variant.";
     def->set_default_value(new ConfigOptionStrings { "Direct Drive Standard" });
@@ -4796,12 +4808,14 @@ void PrintConfigDef::init_fff_params()
     def->cli = ConfigOptionDef::nocli;*/
 
     def = this->add("filament_extruder_variant", coStrings);
+    // internal use only, don't need translation
     def->label = "Filament's extruder variant";
     def->tooltip = "Filament's extruder variant.";
     def->set_default_value(new ConfigOptionStrings { "Direct Drive Standard" });
     def->cli = ConfigOptionDef::nocli;
 
     def = this->add("filament_self_index", coInts);
+    // internal use only, don't need translation
     def->label = "Filament self index";
     def->tooltip = "Filament self index.";
     def->set_default_value(new ConfigOptionInts { 1 });
@@ -9939,8 +9953,9 @@ CLIMiscConfigDef::CLIMiscConfigDef()
     def->set_default_value(new  ConfigOptionBool(false));
 
     def = this->add("allow_mix_temp", coBool);
+    // internal use only, don't need translation
     def->label = "Allow filaments with high/low temperature to be printed together";
-    def->tooltip = "Allow filaments with high/low temperature to be printed together";
+    def->tooltip = "Allow filaments with high/low temperature to be printed together.";
     def->cli_params = "option";
     def->set_default_value(new  ConfigOptionBool(false));
 }


### PR DESCRIPTION
# Description
Some GUI strings were missing the translation markers.