### PR TITLE
Fix AMS Material Selection to sort by both filament vendor and type

### DIFF
--- a/src/slic3r/GUI/AMSMaterialsSetting.cpp
+++ b/src/slic3r/GUI/AMSMaterialsSetting.cpp
@@ -858,7 +858,7 @@ static void _collect_filament_info(const wxString& shown_name,
                                    unordered_map<wxString, wxString>& query_filament_types)
 {
     query_filament_vendors[shown_name] = filament.config.get_filament_vendor();
-    query_filament_vendors[shown_name] = filament.config.get_filament_type();
+    query_filament_types[shown_name] = filament.config.get_filament_type();
 }
 
 void AMSMaterialsSetting::Popup(wxString filament, wxString sn, wxString temp_min, wxString temp_max, wxString k, wxString n)


### PR DESCRIPTION
# Description

`_collect_filament_info()` in `AMSMaterialsSetting.cpp` was assigning both filament vendor and type to `query_filament_vendors` map so that the filament was only being sorted by type which led to a case where Bambu options where shown before and after other vendors' options. 

# Screenshots/Recordings/Graphs

_Old incorrect sorting_

<img width="860" height="865" alt="image" src="https://github.com/user-attachments/assets/02d3d01e-758f-4039-afde-d6deb03d3f5b" />


_New correct sorting_ - It's not entirely alphabetically because Bambu has promoted certain vendor+type combinations to the top

<img width="870" height="865" alt="image" src="https://github.com/user-attachments/assets/89f087be-da78-458f-af29-a0e8e9df0055" />

## Tests

Verified correct sorting by running OrcaSlicer and viewing the combobox in the AMS Material Selection window
