### PR TITLE
Update 0.18mm Optimal @Sovol SV08.json

### DIFF
--- a/resources/profiles/Sovol/process/0.18mm Optimal @Sovol SV08.json
+++ b/resources/profiles/Sovol/process/0.18mm Optimal @Sovol SV08.json
@@ -112,5 +112,7 @@
     "wall_generator": "classic",
     "gcode_label_objects": "1",
     "slow_down_layers": "3",
-    "compatible_printers": []
+    "compatible_printers": [
+		"Sovol SV08 0.4 nozzle"
+	]
 }


### PR DESCRIPTION
# Description

This file needs `compatible_printers` attribute set to a proper, non-empty value. Otherwise it will show up in the process selection list of every Sovol printer. Official Sovol repository has the same entry (see: [Profiles/Sovol Profile/Sovol/process/0.18mm Optimal @Sovol SV08.json](https://github.com/Sovol3d/Sovol-OrcaSlicer/blob/f1d3dca3394124492762d39bac597912db799ccc/Profiles/Sovol%20Profile/Sovol/process/0.18mm%20Optimal%20%40Sovol%20SV08.json#L116C1-L118C3))

## Tests

I have made this change to my OrcaSlicer installation and it seems to work perfectly fine. Besides, all the other SV08 process profiles have the same line.