### PR TITLE
Fix emboss crash when displaying warning information

### DIFF
--- a/deps_src/imgui/imgui_widgets.cpp
+++ b/deps_src/imgui/imgui_widgets.cpp
@@ -4415,7 +4415,7 @@ bool ImGui::InputText(const char* label, char* buf, size_t buf_size, ImGuiInputT
 
 bool ImGui::InputTextMultiline(const char* label, char* buf, size_t buf_size, const ImVec2& size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)
 {
-    return InputTextEx(label, NULL, buf, (int) buf_size, size, flags , callback, user_data);//ImGuiInputTextFlags_Multiline should manual input
+    return InputTextEx(label, NULL, buf, (int)buf_size, size, flags | ImGuiInputTextFlags_Multiline, callback, user_data);
 }
 
 bool ImGui::InputTextWithHint(const char* label, const char* hint, char* buf, size_t buf_size, ImGuiInputTextFlags flags, ImGuiInputTextCallback callback, void* user_data)

--- a/src/slic3r/GUI/IMSlider.cpp
+++ b/src/slic3r/GUI/IMSlider.cpp
@@ -1186,8 +1186,8 @@ void IMSlider::render_input_custom_gcode(std::string custom_gcode)
             strcpy(m_custom_gcode, custom_gcode.c_str());
         }
         const int text_height = 6;
-        const ImGuiInputTextFlags flag  = ImGuiInputTextFlags_Multiline;
-        ImGui::InputTextMultiline("##text", m_custom_gcode, sizeof(m_custom_gcode), ImVec2(-1, ImGui::GetTextLineHeight() * text_height), flag);
+
+        ImGui::InputTextMultiline("##text", m_custom_gcode, sizeof(m_custom_gcode), ImVec2(-1, ImGui::GetTextLineHeight() * text_height));
 
         ImGui::NewLine();
         ImGui::SameLine(ImGui::GetStyle().WindowPadding.x * 14);


### PR DESCRIPTION
This reverts commit bb3f59e18fc1dbd639752be345f1dcb386951c72.

Fix issue reported here https://github.com/SoftFever/OrcaSlicer/pull/10780#issuecomment-3501134705
Which can be reproduced by:
1. Click emboss gizmo
2. Delete the default text from the text input
3. Crash
