### PR TITLE
DRAFT: Build CI with Ubuntu 25.10

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -60,7 +60,7 @@ jobs:
     if: ${{ !cancelled() && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer') }}
     uses: ./.github/workflows/build_check_cache.yml
     with:
-      os: ubuntu-24.04
+      os: ubuntu-25.10
       build-deps-only: ${{ inputs.build-deps-only || false }}
     secrets: inherit
   build_all:
@@ -83,7 +83,7 @@ jobs:
     secrets: inherit
   unit_tests:
     name: Unit Tests
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-25.10
     needs: build_linux
     if: ${{ !cancelled() && success() }}
     steps:
@@ -134,9 +134,9 @@ jobs:
       matrix:
         variant:
           - arch: x86_64
-            runner: ubuntu-24.04
+            runner: ubuntu-25.10
           - arch: aarch64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-25.10-arm
     # Don't run scheduled builds on forks:
     if: ${{ !cancelled() && (github.event_name != 'schedule' || github.repository == 'OrcaSlicer/OrcaSlicer') }}
     runs-on: ${{ matrix.variant.runner }}

--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -92,11 +92,11 @@ jobs:
 
 
       - name: Apt-Install Dependencies
-        if: inputs.os == 'ubuntu-24.04'
+        if: inputs.os == 'ubuntu-25.10'
         uses: ./.github/actions/apt-install-deps
 
       - name: Build on Ubuntu
-        if: inputs.os == 'ubuntu-20.04' || inputs.os == 'ubuntu-24.04'
+        if: inputs.os == 'ubuntu-20.04' || inputs.os == 'ubuntu-24.04' || inputs.os == 'ubuntu-25.10'
         working-directory: ${{ github.workspace }}
         run: |
             mkdir -p ${{ github.workspace }}/deps/build/destdir

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -316,16 +316,16 @@ jobs:
 
 # Ubuntu
       - name: Apt-Install Dependencies
-        if: inputs.os == 'ubuntu-24.04'
+        if: inputs.os == 'ubuntu-25.10'
         uses: ./.github/actions/apt-install-deps
 
         # Tests must built at the same time as the slicer;
         # if you untangle them feel free to separate them here too
       - name: Build slicer and tests
-        if: inputs.os == 'ubuntu-20.04' || inputs.os == 'ubuntu-24.04'
+        if: inputs.os == 'ubuntu-20.04' || inputs.os == 'ubuntu-24.04' || inputs.os == 'ubuntu-25.10'
         shell: bash
         env:
-          ubuntu-ver-str: ${{ (inputs.os == 'ubuntu-24.04' && '_Ubuntu2404') || '' }}
+          ubuntu-ver-str: ${{ (inputs.os == 'ubuntu-25.10' && '_Ubuntu2510') || '' }}
         run: |
           ./build_linux.sh -istr
           mv -n ./build/OrcaSlicer_Linux_V${{ env.ver_pure }}.AppImage ./build/OrcaSlicer_Linux_AppImage${{ env.ubuntu-ver-str }}_${{ env.ver }}.AppImage
@@ -345,7 +345,7 @@ jobs:
           if-no-files-found: error
 
       - name: Build orca_custom_preset_tests
-        if: github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-24.04'
+        if: github.ref == 'refs/heads/main' && inputs.os == 'ubuntu-25.10'
         working-directory: ${{ github.workspace }}/build/src/Release
         shell: bash
         run: |

--- a/.github/workflows/check_profiles.yml
+++ b/.github/workflows/check_profiles.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   check_translation:
     name: Check profiles
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-25.10
     steps:  
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/scripts/linux.d/debian
+++ b/scripts/linux.d/debian
@@ -26,6 +26,18 @@ REQUIRED_DEV_PACKAGES=(
     wget
 )
 
+REQUIRED_DEV_PACKAGES_2510=(
+    libcereal-dev
+    libboost-all-dev
+    libboost-locale-dev
+    libboost-log-dev
+    libnlopt-dev
+    libopenvdb-ax-dev
+    libopenvdb-dev
+    libopenvdb-tools
+    libtbb-dev
+)
+
 if [[ -n "$UPDATE_LIB" ]]
 then
     # shellcheck source=/dev/null
@@ -37,6 +49,11 @@ then
             # Some extra packages needed on Ubuntu 22.x and 23.x:
             REQUIRED_DEV_PACKAGES+=(curl libfuse-dev m4)
         fi
+        if dpkg --compare-versions "${VERSION_ID}" eq 25 ;
+          then
+              # Some extra packages needed on Ubuntu 22.x and 23.x:
+              REQUIRED_DEV_PACKAGES+=("${REQUIRED_DEV_PACKAGES_2510[@]}")
+          fi
     fi
 
     if [[ -n "$BUILD_DEBUG" ]]


### PR DESCRIPTION
# Description

Attempt to update the `.yml` files to build on Ubuntu 25.10 with GNU 15.2 rather than Ubuntu 24.04 + GNU 13.3 because 
it reveals about 403 new `-Woverloaded-virtual=` warnings coming from `src/libslic3r/Config.hpp` and removes many false-positives.

With gnu 15.2 (still old `std=gnu++17`) diff to GNU 13.3 is:
```
   +403 [-Woverloaded-virtual=]
    +32 [-Wold-style-definition]
    -19 [-Wmaybe-uninitialized]
     -1 [-Wclass-memaccess]
     -5 [-Warray-bounds=]
```

The `-Woverloaded-virtual=` warnings coming from `src/libslic3r/Config.hpp` [can be broken down to](https://godbolt.org/z/h1qMTKcoE):

```c++
class A {
public:
    virtual void foo(const A &x) const = 0;
};

class B : public A {
public:

    // either polymorphism is
    // a.) intended, then this shall match the interface signature ( and type is runtime-casted or better double-dispatched), or
    // b.) not required, the remove `virtual`
    void foo(const B &x) const override { }  // <-- the signature shall match: void A::void foo(const A& x) const
};

int main()  { return 0; }
```
