### PR TITLE
Fix no toolchange: Init PA

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -2811,6 +2811,12 @@ void GCode::_do_export(Print& print, GCodeOutputStream &file, ThumbnailsGenerato
     m_start_gcode_filament = GCodeProcessor::get_gcode_last_filament(machine_start_gcode);
 
     m_writer.init_extruder(initial_non_support_extruder_id);
+    if (m_config.enable_pressure_advance.get_at(initial_non_support_extruder_id)) {
+        file.write(m_writer.set_pressure_advance(m_config.pressure_advance.get_at(initial_non_support_extruder_id)));
+        // Orca: Adaptive PA
+        // Reset Adaptive PA processor last PA value
+        m_pa_processor->resetPreviousPA(m_config.pressure_advance.get_at(initial_non_support_extruder_id));
+    }
     // add the missing filament start gcode in machine start gcode
     {
         DynamicConfig config;


### PR DESCRIPTION
fixes #11158
In printers that wont need "toolchange" the PA is never set.

Since 5fda94a53b713522db9f4b61334748d9a938b51b the extruder is initialized with:
https://github.com/SoftFever/OrcaSlicer/blob/a7adeb6305fe31b62072e80ef0021b17c77b213a/src/libslic3r/GCode.cpp#L2813-L2823

The original set PA will never work because before it was working thanks to a nullptr in the extruder:
https://github.com/SoftFever/OrcaSlicer/blob/a7adeb6305fe31b62072e80ef0021b17c77b213a/src/libslic3r/GCodeWriter.cpp#L1026-L1029

Now i set the PA after initialize the extruder.

Debuged with @RF47 