### PR TITLE
FIX: Open provided file at startup

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -903,9 +903,10 @@ void GUI_App::post_init()
         if (app_config->get("default_page") == "1")
             mainframe->select_tab(size_t(1));
         mainframe->Thaw();
-        plater_->trigger_restore_project(1);
         BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << ", end load_gl_resources";
     }
+
+    plater_->trigger_restore_project(1);
     //#endif
 
     //BBS: remove GCodeViewer as seperate APP logic

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -5105,14 +5105,19 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
                     return;
                 }
             }
+
             try {
                 if (originfile != "<lock>") // see bbs_3mf.cpp for lock detail
                     boost::filesystem::remove_all(last);
             }
+
             catch (...) {}
-            int skip_confirm = e.GetInt();
-            this->q->new_project(skip_confirm, true);
-            });
+            
+            if (this->q->get_project_filename().IsEmpty() && this->q->is_empty_project()) {
+                int skip_confirm = e.GetInt();
+                this->q->new_project(skip_confirm, true);
+            }
+        });
         //wxPostEvent(this->q, wxCommandEvent{EVT_RESTORE_PROJECT});
     }
 
@@ -15078,6 +15083,9 @@ void Plater::export_toolpaths_to_obj() const
     p->preview->get_canvas3d()->export_toolpaths_to_obj(into_u8(path).c_str());
 }
 
+bool Plater::is_empty_project() {
+    return model().objects.empty();
+}
 bool Plater::is_multi_extruder_ams_empty()
 {
     std::vector<std::string>        extruder_ams_count_str = p->config->option<ConfigOptionStrings>("extruder_ams_count", true)->values;

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -350,6 +350,7 @@ public:
         m_exported_file = exported_file;
     }
 
+    bool is_empty_project();
     bool is_multi_extruder_ams_empty();
     // BBS
     bool is_new_project_and_check_state() { return m_new_project_and_check_state; }


### PR DESCRIPTION
Opening OrcaSlicer by double-clicking an STL/3MF (or sending a model from Fusion360) caused the model to appear for a split second and then vanish, leaving an empty build plate.

This regression came from porting [a change](https://github.com/kisslorand/OrcaSlicer/commit/7eaabc485660a26e19ecbb63c1e7ef9e92f27473) from Bambu Studio. The fix was correct for their codebase, but since OrcaSlicer doesn't have that issue, bringing it over ended up causing startup files to be ignored.

This PR restores the correct behavior:
 - If OrcaSlicer is launched with a file, that file now loads and stays visible.
 - If OrcaSlicer is launched without a file, the normal “restore previous project” behavior still works.

This makes file-based launching reliable again.

Fixes #11438