### PR TITLE
Wiki 16 (MiniUpdate): Updated by Stable cmake 4.2 release + VS2026 First

### DIFF
--- a/doc/developer-reference/How-to-build.md
+++ b/doc/developer-reference/How-to-build.md
@@ -156,7 +156,7 @@ How to building with Xcode on MacOS 64-bit.
 
 Homebrew currently only offers the latest version of CMake (e.g. **4.X**), which is not compatible. To install the required version **3.31.X**, follow these steps:
 
-1. Download CMake **3.31.7** from: [https://cmake.org/download/](https://cmake.org/download/)
+1. Download CMake **3.31.10** from: [https://cmake.org/download/](https://cmake.org/download/)
 2. Install the application (drag it to `/Applications`).
 3. Add the following line to your shell configuration file (`~/.zshrc` or `~/.bash_profile`):
 


### PR DESCRIPTION
As [Cmake 4.2 stable was released](https://github.com/Kitware/CMake/releases/tag/v4.2.0) and pushed to winget now i removed some old clarifications.

+ Reorder Visual Studio version recommendations to VS2026 first.

---

Wiki TODOs:

- Flow Calib https://github.com/SoftFever/OrcaSlicer/discussions/9609#discussioncomment-14203341
- #10447 
- Improve one by one process settings groups.
  - ~~Speed~~ - #10173 
  - ~~Quality~~ - #10301 
  - ~~Strength~~ - #10369 
  - ~~Others~~ - #10452 
  - **Support**
  - **Multimaterial** - Help Needed (i've never used multimaterial)
- Keep an eye on this when merged.
  - #11017
  - #11053
  - #9346 
    - Check Naming.
    - Add to main github page.
    - General Review.
  - #10314 
- Remove BBS links
  - bambulab.com
  - wiki.bambulab.com
- Home.md
  - Add missing SVGs
- Prepare menu
- Printer settings
- Filament settings
- Guides or FAQ
- Improve Arachnee documentation