### PR TITLE
Fix: Bring back "Only lift Z below" can be disabled

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -565,7 +565,7 @@ std::string GCodeWriter::lazy_lift(LiftType lift_type, bool spiral_vase)
         int filament_id = filament()->id();
         double above = this->config.retract_lift_above.get_at(extruder_id);
         double below = this->config.retract_lift_below.get_at(extruder_id);
-        if (m_pos.z() >= above && m_pos.z() <= below)
+        if (m_pos.z() >= above && (m_pos.z() <= below || below == 0.))
             target_lift = this->config.z_hop.get_at(filament_id);
     }
     // BBS
@@ -593,7 +593,7 @@ std::string GCodeWriter::eager_lift(const LiftType type) {
         int filament_id = filament()->id();
         double above = this->config.retract_lift_above.get_at(extruder_id);
         double below = this->config.retract_lift_below.get_at(extruder_id);
-        if (m_pos.z() >= above && m_pos.z() <= below)
+        if (m_pos.z() >= above && (m_pos.z() <= below || below == 0.))
             target_lift = this->config.z_hop.get_at(filament_id);
     }
 


### PR DESCRIPTION
Setting `Only lift Z below` to 0 meant that this option is disabled, ZHop would be active at any layer height above what `Only lift Z above` was set to. This is explained in the tooltip also:
"If you set this to a positive value, Z lift will only take place below the specified absolute Z."

This option was lost, setting  `Only lift Z below` to 0 resulted in no ZHop at all.

This PR brings back the old behaviour, nothing less, nothing  more.

Fixes #11437
Fixes #11932