### PR TITLE
Auto hide/show the ironing angle settings if the selected ironing pattern does not use the user specified angles

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -791,7 +791,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
         toggle_field(el, have_support_material && !(support_is_normal_tree && !have_raft));
 
     bool has_ironing = (config->opt_enum<IroningType>("ironing_type") != IroningType::NoIroning);
-    for (auto el : { "ironing_pattern", "ironing_flow", "ironing_spacing", "ironing_inset"})
+    for (auto el : { "ironing_pattern", "ironing_flow", "ironing_spacing", "ironing_angle", "ironing_inset", "ironing_angle_fixed" })
         toggle_line(el, has_ironing);
     bool has_rectilinear_ironing = (config->opt_enum<InfillPattern>("ironing_pattern") == InfillPattern::ipRectilinear);
     for (auto el : {"ironing_angle", "ironing_angle_fixed"})


### PR DESCRIPTION
# Description

Ironing angle settings are not used for concentric ironing pattern so it is less confusing if the ironing angle setting is hidden when concentric ironing pattern is selected. 
This PR auto hide/show the `ironing_angle` and `ironing_angle_fixed` print settings if the ironing pattern is not rectilinear.

# Screenshots/Recordings/Graphs

The result:
<img width="792" height="460" alt="image" src="https://github.com/user-attachments/assets/b71b1e8a-ab06-444a-bfa3-145daf25e4b6" /><img width="802" height="378" alt="image" src="https://github.com/user-attachments/assets/eafb3131-3a86-48fd-a517-4e694a0d18a2" />

## Tests

I built OrcaSlicer and confirmed that the settings are shown and hidden correctly depending on the ironing pattern selected. 
