### PR TITLE
Wiki: Added some details for Line Width - Update quality_settings_line_width.md

### DIFF
--- a/doc/print_settings/quality/quality_settings_line_width.md
+++ b/doc/print_settings/quality/quality_settings_line_width.md
@@ -61,3 +61,24 @@ Recommended: **~110%** for good layer adhesion and visual quality.
 ### Support
 
 Typically set to **100%** to balance material usage and functionality. Reducing it too much can lead to weak support structures that may not hold up during printing or break easily during removal leaving debris on the model.
+
+### Default Line Width Multipliers
+When any line width parameter is set to **0**, it will be automatically calculated based on the nozzle diameter using the following rules:
+
+| Feature Type | Multiplier | Example (0.4mm nozzle) |
+|--------------|-----------|----------------------|
+| **Outer wall** | 1.125× | 0.45mm |
+| **Inner wall** | 1.125× | 0.45mm |
+| **Solid infill** | 1.125× | 0.45mm |
+| **Sparse infill** | 1.125× | 0.45mm |
+| **Top surface** | 1.0× | 0.40mm |
+| **Support material** | 1.0× | 0.40mm |
+| **Support interface** | 1.0× | 0.40mm |
+### Examples
+
+- **0.4mm nozzle**: Walls and infill → 0.45mm (0.4 × 1.125)
+- **0.6mm nozzle**: Walls and infill → 0.675mm (0.6 × 1.125)
+
+#### Displayed Precision
+
+In the slicing preview's line width tab, values may display with rounding (0.675mm might show as 0.68mm due to precision limitations).


### PR DESCRIPTION
# Description

noticed there is some difference between layer width and figured this logics out by took a look into the code. There is a x1.125 multiplier if the line width is set to 0 in some cases.

# Screenshots/Recordings/Graphs
<img width="1135" height="984" alt="image" src="https://github.com/user-attachments/assets/671a922f-a304-4e0b-b53a-20ddd3a85eb6" />

## Tests
was using a simple square to see the difference,
Yet there is still something I haven't figured out completely:

Below are the line-width settings for the same print in two slicing modes—Arachne and Classic—using the same inputted line width and different wall loop counts. However, the slicer displays different actual top layer line width values between the two modes. Sometimes there is also a small difference between walls and infill, haven't been testing that enough though.

| Mode      | Loop Index | Line Width |
|-----------|------------|------------|
| Classic   | 0–3        | 0.60 mm    |
| Classic   | 4–6        | 0.61 mm    |
| Classic   | 7–8        | 0.60 mm    |
| Classic   | 9          | 0.61 mm    |
| Arachne   | 0          | 0.61 mm    |
| Arachne   | 1–3        | 0.60 mm    |
| Arachne   | 4–6        | 0.61 mm    |
| Arachne   | 7–8        | 0.60 mm    |
| Arachne   | 9          | 0.61 mm    |


## Source:
https://github.com/OrcaSlicer/OrcaSlicer/blob/21cfc7edeb5ddb330c270f528d2bb6ad9e3b1bd7/src/libslic3r/Flow.cpp#L35

```
float Flow::auto_extrusion_width(FlowRole role, float nozzle_diameter)
{
    switch (role) {
    case frSupportMaterial:
    case frSupportMaterialInterface:
    case frSupportTransition:
    case frTopSolidInfill:
        return nozzle_diameter;
    default:
    case frExternalPerimeter:
    case frPerimeter:
    case frSolidInfill:
    case frInfill:
        return 1.125f * nozzle_diameter;
    }
}
