### PR TITLE
Adjust resonance avoidance speed calculation

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -6186,8 +6186,9 @@ std::string GCode::_extrude(const ExtrusionPath &path, std::string description, 
             );
         }
 
-        // if still in avoidance mode and under “max”, clamp to “min”
-        if (m_resonance_avoidance && speed < m_config.max_resonance_avoidance_speed.value) {
+            // if still in avoidance mode and under "max", adjust speed:
+            // - speeds in lower half of range: clamp down to "min"
+            // - speeds in upper half of range: boost up to "max"        if (m_resonance_avoidance && speed < m_config.max_resonance_avoidance_speed.value) {
             if (speed < m_config.min_resonance_avoidance_speed.value +
                             ((m_config.max_resonance_avoidance_speed.value - m_config.min_resonance_avoidance_speed.value) / 2)) {
                 speed = std::min(speed, m_config.min_resonance_avoidance_speed.value);


### PR DESCRIPTION
Adjust the logic for resonance avoidance.
First, only adjust speed if it's strictly below max.
Second, If the speed is over half of the set speed range, use the max speed to prevent slowdowns.