### PR TITLE
Fix emulated spiral Z-hop XY offset on multi-plate slicing

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -769,30 +769,33 @@ std::string GCodeWriter::_spiral_travel_to_z(double z, const Vec2d &ij_offset, c
 
     if (!this->config.enable_arc_fitting) { // Orca: if arc fitting is disabled, approximate the arc with small linear segments
         std::ostringstream oss;
-        const double z_start = m_pos(2);
-        const int segments = 24;
-        const double cx = m_pos(0) + ij_offset(0);
-        const double cy = m_pos(1) + ij_offset(1);
-        const double radius = ij_offset.norm();
-        const double a0 = std::atan2(m_pos(1) - cy, m_pos(0) - cx);
-        const double delta = 2.0 * M_PI;
+        const double z_start = m_pos(2);                // starting Z height
+        const int segments = 24;                        // number of linear segments to use for approximating the arc
+        const double px = m_pos(0) - m_x_offset;        // take plate offset into consideration
+        const double py = m_pos(1) - m_y_offset;        // take plate offset into consideration
+        const double cx = px + ij_offset(0);            // center x
+        const double cy = py + ij_offset(1);            // center y
+        const double radius = ij_offset.norm();         // radius
+        const double a0 = std::atan2(py - cy, px - cx); // start angle
+        const double delta = 2.0 * M_PI;                // CCW full circle
 
         if (full_gcode_comment)
             oss << ";" << comment << "\n";
 
-        oss << "G1 F" << (speed * 60.0) << "\n";
+        oss << "G1 F" << (speed * 60.0) << "\n";  // set feedrate
 
+        // approximate the arc with small linear segments (without the last point which is added later to ensure exactness)
         for (int i = 1; i < segments; ++i) {
-            double t = double(i) / segments;
-            double a = a0 + delta * t;   // CCW arc param
-            double x = cx + radius * std::cos(a);
-            double y = cy + radius * std::sin(a);
-            double zz = z_start + (z - z_start) * t;
+            double t = double(i) / segments;            // parametric position along arc
+            double a = a0 + delta * t;                  // CCW arc param
+            double x = cx + radius * std::cos(a);       // point on circle
+            double y = cy + radius * std::sin(a);       // point on circle
+            double zz = z_start + (z - z_start) * t;    // interpolated Z height
 
             oss << "G1 X" << x << " Y" << y << " Z" << zz << "\n";
         }
 
-        oss << "G1 X" << m_pos(0) << " Y" << m_pos(1) << " Z" << z << "\n";
+        oss << "G1 X" << px << " Y" << py << " Z" << z << "\n";  // final point to ensure exactness
         output = oss.str();
     } else { // Orca: if arc fitting is enabled emit a G2/G3 command for the spiral lift
         output = std::string("G17") + (full_gcode_comment ? " ; XY plane for arc\n" : "\n");


### PR DESCRIPTION
This PR fixes an issue where the emulated spiral Z-hop produced incorrect XY positions when slicing objects on plates other than the first one.

#### What was wrong

The emulated spiral Z-hop (the linear-segment fallback used when arc fitting is disabled) mixed world coordinates with plate-local coordinates.
On multi-plate layouts this caused the generated XY points of the spiral to be shifted by the plate offset, so the lift arc appeared outside the build plate.

#### What’s changed

The spiral is now computed entirely in plate-local coordinates, matching how all other travel moves are emitted.
This keeps the start and end XY identical and prevents XY drift when slicing on additional plates.

Fixes #11465