### PR TITLE
Fix Flatpak build: Add fallback URL for MPFR source download

### DIFF
--- a/deps/MPFR/MPFR.cmake
+++ b/deps/MPFR/MPFR.cmake
@@ -25,7 +25,8 @@ else ()
     endif ()
 
     ExternalProject_Add(dep_MPFR
-        URL https://www.mpfr.org/mpfr-4.2.2/mpfr-4.2.2.tar.bz2
+        URL https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.bz2
+            https://www.mpfr.org/mpfr-4.2.2/mpfr-4.2.2.tar.bz2
         URL_HASH SHA256=9ad62c7dc910303cd384ff8f1f4767a655124980bb6d8650fe62c815a231bb7b
         DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/MPFR
         BUILD_IN_SOURCE ON


### PR DESCRIPTION
Fix the flatpak build error.
Updated MPFR.cmake to include both the GNU FTP and mpfr.org URLs for downloading the MPFR source while maintaining the old as fallback.