### PR TITLE
Fix UTF-8 corruption in Custom G-code editor (°C and other Unicode characters)

### DIFF
--- a/src/slic3r/GUI/EditGCodeDialog.cpp
+++ b/src/slic3r/GUI/EditGCodeDialog.cpp
@@ -75,11 +75,12 @@ EditGCodeDialog::EditGCodeDialog(wxWindow* parent, const std::string& key, const
     m_add_btn = new ScalableButton(this, wxID_ANY, "add_copies");
     m_add_btn->SetToolTip(_L("Add selected placeholder to G-code"));
 
-    m_gcode_editor = new wxTextCtrl(this, wxID_ANY, value, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE
-#ifdef _WIN32
-    | wxBORDER_SIMPLE
-#endif
+    m_gcode_editor = new wxTextCtrl(this, wxID_ANY, wxString::FromUTF8(value), wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE
+    #ifdef _WIN32
+        | wxBORDER_SIMPLE
+    #endif
     );
+
     m_gcode_editor->SetFont(wxGetApp().code_font());
     m_gcode_editor->SetInsertionPointEnd();
     wxGetApp().UpdateDarkUI(m_gcode_editor);
@@ -131,7 +132,8 @@ EditGCodeDialog::~EditGCodeDialog()
 
 std::string EditGCodeDialog::get_edited_gcode() const
 {
-    return into_u8(m_gcode_editor->GetValue());
+    wxString text = m_gcode_editor->GetValue();
+    return std::string(text.ToUTF8());
 }
 
 void EditGCodeDialog::on_search_update()


### PR DESCRIPTION
This PR fixes an issue where certain characters (for example the degree symbol ° used in °C) became corrupted after opening and saving the Custom G-code editor multiple times.

#### What was the problem?

When users added symbols like ° inside Start/End G-code, the editor would show them correctly the first time, but after reopening the dialog a few times the text would slowly change into strange characters.

#### How to reproduce

- Open any Custom G-code field
- Add a line containing °C
- Save the dialog
- Reopen it several times
- The text begins to change into unreadable characters

#### What this PR changes

The Custom G-code editor now properly loads and saves text that contains symbols such as °, so these characters stay exactly as the user typed them. This keeps Custom G-code stable across editing sessions and prevents slow corruption of Unicode characters.

#### Result

- °C and similar symbols remain correct
- No more “weird characters” appearing after multiple reopen/save cycles
- Custom G-code is preserved accurately

Fixes #11502