### PR TITLE
Fixed a spelling mistake

### DIFF
--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -685,7 +685,7 @@ msgstr ""
 "ahora?"
 
 msgid "Repairing model object"
-msgstr "Raparando modelo"
+msgstr "Reparando modelo"
 
 msgid "Cut by line"
 msgstr "Corte por Línea"


### PR DESCRIPTION
# Description
Fixes issue #11510 
Changed "Raparando" to "Reparando"

The issue author (SoamBuild) says
> I checked the RAE (Royal Spanish Academy dictionary) and "raparando" isn't there. The correct forms are "reparar" or "reparando."