### PR TITLE
Added 0.12, 0.16 and 0.28mm Anycubic Kobra 2 neo profiles

### DIFF
--- a/resources/profiles/Anycubic/process/0.12mm Detail @Anycubic Kobra 2 Neo 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.12mm Detail @Anycubic Kobra 2 Neo 0.4 nozzle.json
@@ -1,0 +1,26 @@
+{
+    "bridge_speed": "60",
+    "enable_arc_fitting": "0",
+    "from": "system",
+    "inherits": "0.20mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle",
+    "initial_layer_infill_speed": "45",
+    "initial_layer_print_height": "0.12",
+    "initial_layer_speed": "45",
+    "inner_wall_speed": "65",
+    "layer_height": "0.12",
+    "name": "0.12mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle",
+    "outer_wall_speed": "45",
+    "overhang_2_4_speed": "45",
+    "overhang_3_4_speed": "28",
+    "print_extruder_id": [
+        "1"
+    ],
+    "print_extruder_variant": [
+        "Direct Drive Standard"
+    ],
+    "print_settings_id": "0.12mm Detail @Anycubic Kobra 2 Neo 0.4 nozzle",
+    "seam_gap": "5%",
+    "solid_infill_rotate_template": "",
+    "version": "2.3.1.10",
+    "xy_hole_compensation": "0"
+}

--- a/resources/profiles/Anycubic/process/0.16mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.16mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle.json
@@ -1,0 +1,22 @@
+{
+    "bottom_shell_layers": "4",
+    "from": "system",
+    "inherits": "0.20mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle",
+    "initial_layer_infill_speed": "45",
+    "initial_layer_print_height": "0.2",
+    "initial_layer_speed": "45",
+    "layer_height": "0.16",
+    "name": "0.16mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle",
+    "overhang_1_4_speed": "50",
+    "overhang_2_4_speed": "30",
+    "overhang_3_4_speed": "20",
+    "print_extruder_id": [
+        "1"
+    ],
+    "print_extruder_variant": [
+        "Direct Drive Standard"
+    ],
+    "print_settings_id": "0.16mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle",
+    "top_shell_layers": "4",
+    "version": "2.3.1.10"
+}

--- a/resources/profiles/Anycubic/process/0.28mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/process/0.28mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle.json
@@ -1,0 +1,21 @@
+{
+    "from": "system",
+    "gap_infill_speed": "80",
+    "inherits": "0.20mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle",
+    "initial_layer_infill_speed": "45",
+    "initial_layer_print_height": "0.28",
+    "initial_layer_speed": "45",
+    "layer_height": "0.28",
+    "name": "0.28mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle",
+    "outer_wall_speed": "55",
+    "overhang_1_4_speed": "50",
+    "print_extruder_id": [
+        "1"
+    ],
+    "print_extruder_variant": [
+        "Direct Drive Standard"
+    ],
+    "print_settings_id": "0.28mm Standard @Anycubic Kobra 2 Neo 0.4 nozzle",
+    "sparse_infill_speed": "120",
+    "version": "2.3.1.10"
+}


### PR DESCRIPTION
Added 0.12mm, 0.16mm and 0.28mm for **Anycubic Kobra 2 Neo**.

They are inherited on the 0.2mm profile and based on the _Anycubic Slicer Next_ profiles