### PR TITLE
Enable IPv6 usage in curls resolve code

### DIFF
--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -189,7 +189,6 @@ Http::priv::priv(const std::string &url)
 #ifdef __WINDOWS__
 	::curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_MAX_TLSv1_2);
 #endif
-	::curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 	::curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
 	::curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 


### PR DESCRIPTION

# Description
Before this change OrcaSlicer would fail to resolve the IPv6 addresses
of printers when trying to interact with them via HTTP.

For context: I'm running my Klipper based printers with only IPv6
addresses being assigned to them. That works fine for
everything (including other slicers such as prusa-slic3r).

A few years ago I did debug this and figured that it came down to the
single line in the code base that this commit removes. I've since
patched every single OrcaSlicer version with this change and never
noticed a downside. It should be fine to remove the restriction.
