### PR TITLE
FIX: Refresh filament setting overrides on preset change

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -4143,6 +4143,9 @@ void TabFilament::reload_config()
     this->compatible_widget_reload(m_compatible_printers);
     this->compatible_widget_reload(m_compatible_prints);
     Tab::reload_config();
+
+    // Recompute derived override UI from the newly loaded config
+    update_filament_overrides_page(&m_preset_bundle->printers.get_edited_preset().config);
 }
 
 //void TabFilament::update_volumetric_flow_preset_hints()


### PR DESCRIPTION
**_Filament → Setting Overrides_** panel derives its displayed values from multiple configuration sources. After changing a filament preset, this derived state was not refreshed immediately, which could leave override fields temporarily out of sync.

---
<img width="371" height="617" alt="image" src="https://github.com/user-attachments/assets/2955407c-f428-438e-9220-1c05fd712693" />

---
This pull request ensures the override values are refreshed as soon as a new filament preset is applied.

**What was happening**
- Changing a filament preset while the Setting Overrides panel was visible could leave some override fields showing stale values.
- The UI would correct itself only after switching tabs or editing a value.
- Other filament-related UI elements already updated correctly.

**What this PR does**
- Refreshes the derived override state immediately after a filament preset change.
- Ensures the overrides always reflect the active preset without requiring user interaction.
- Leaves all existing UI behavior and visibility rules unchanged.

**Result**
The Setting Overrides panel now always reflects the correct filament preset state immediately after a preset change, with no reliance on tab switching or manual edits.