### PR TITLE
Initialize member variables in WipeTower classes

### DIFF
--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -520,17 +520,21 @@ static Polygon generate_rectange_polygon(const Vec2f &wt_box_min ,const Vec2f & 
 class WipeTowerWriter
 {
 public:
-	WipeTowerWriter(float layer_height, float line_width, GCodeFlavor flavor, const std::vector<WipeTower::FilamentParameters>& filament_parameters) :
-		m_current_pos(std::numeric_limits<float>::max(), std::numeric_limits<float>::max()),
-		m_current_z(0.f),
-		m_current_feedrate(0.f),
-		m_layer_height(layer_height),
-		m_extrusion_flow(0.f),
-		m_preview_suppressed(false),
-		m_elapsed_time(0.f),
+    WipeTowerWriter(float layer_height, float line_width, GCodeFlavor flavor, const std::vector<WipeTower::FilamentParameters>& filament_parameters) :
+        m_start_pos(Vec2f::Zero()),
+        m_current_pos(std::numeric_limits<float>::max(), std::numeric_limits<float>::max()),
+        m_current_z(0.f),
+        m_current_feedrate(0.f),
+        m_current_tool(0),
+        m_layer_height(layer_height),
+        m_extrusion_flow(0.f),
+        m_preview_suppressed(false),
+        m_elapsed_time(0.f),
+        m_last_fan_speed(0),
 #if ENABLE_GCODE_VIEWER_DATA_CHECKING
         m_default_analyzer_line_width(line_width),
 #endif // ENABLE_GCODE_VIEWER_DATA_CHECKING
+        m_used_filament_length(0.f),
         m_gcode_flavor(flavor),
         m_filpar(filament_parameters)
         {

--- a/src/libslic3r/GCode/WipeTower.hpp
+++ b/src/libslic3r/GCode/WipeTower.hpp
@@ -83,7 +83,7 @@ public:
         bool                    priming;
 
 		bool                    is_tool_change{false};
-		Vec2f                   tool_change_start_pos;
+        Vec2f                   tool_change_start_pos { Vec2f::Zero() };
 
         // Pass a polyline so that normal G-code generator can do a wipe for us.
         // The wipe cannot be done by the wipe tower because it has to pass back

--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -567,13 +567,17 @@ public:
                      const std::vector<WipeTower2::FilamentParameters>& filament_parameters,
                      bool  enable_arc_fitting)
         :
+        m_start_pos(Vec2f::Zero()),
 		m_current_pos(std::numeric_limits<float>::max(), std::numeric_limits<float>::max()),
 		m_current_z(0.f),
 		m_current_feedrate(0.f),
+		m_current_tool(0),
 		m_layer_height(layer_height),
 		m_extrusion_flow(0.f),
 		m_preview_suppressed(false),
 		m_elapsed_time(0.f),
+        m_last_fan_speed(0),
+        m_used_filament_length(0.f),
         m_gcode_flavor(flavor), m_filpar(filament_parameters)
         //m_enable_arc_fitting(enable_arc_fitting)
     {


### PR DESCRIPTION
Added explicit initialization for several member variables in WipeTowerWriter and related classes, including m_start_pos, m_current_tool, m_last_fan_speed, m_used_filament_length, and tool_change_start_pos. This improves code clarity and prevents potential uninitialized variable issues.