### PR TITLE
Update runtime version to 49 in flatpak manifest

### DIFF
--- a/scripts/flatpak/io.github.softfever.OrcaSlicer.yml
+++ b/scripts/flatpak/io.github.softfever.OrcaSlicer.yml
@@ -1,6 +1,6 @@
 app-id: io.github.softfever.OrcaSlicer
 runtime: org.gnome.Platform
-runtime-version: "48"
+runtime-version: "49"
 sdk: org.gnome.Sdk
 command: entrypoint
 separate-locales: true


### PR DESCRIPTION
# Description

This tiny PR bumps the flatpak runtime version to GNOME 49
