### PR TITLE
Wipe Tower Auto Brim bug-fix (Non BBL printers)

### DIFF
--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -1,6 +1,6 @@
 // Orca: WipeTower2 for all non bbl printers, support all MMU device and toolchanger.
 #include "WipeTower2.hpp"
-#include "WipeTower.hpp"
+
 #include <cassert>
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
# Description

Fix application freeze when Prime Tower brim is set to Auto

This PR fixes an issue where enabling Auto brim width for the Prime Tower caused the application to freeze and consume unbounded amounts of memory.

Root cause
https://github.com/OrcaSlicer/OrcaSlicer/blob/0c5f6c9865642f7ba923aee412f54f79f29531a2/src/libslic3r/GCode/WipeTower2.cpp#L2036-L2039
When Auto brim is selected, the brim width was not being computed and the raw configuration value (-1) was used directly.
This resulted in an effectively infinite loop during Prime Tower brim generation, leading to runaway memory allocation instead of a controlled failure or a crash.

Solution

The Auto brim width is now properly computed based on the Prime Tower height, matching the intended behavior and existing logic used in other slicer implementations.
