### PR TITLE
Fix memory leak on mac

### DIFF
--- a/src/libvgcode/src/ViewerImpl.cpp
+++ b/src/libvgcode/src/ViewerImpl.cpp
@@ -885,6 +885,9 @@ void ViewerImpl::reset()
 #else
     m_enabled_segments_count = 0;
     m_enabled_options_count = 0;
+    m_colors_tex_size = 0;
+    m_enabled_segments_tex_size = 0;
+    m_enabled_options_tex_size = 0;
 
     m_settings_used_for_ranges = std::nullopt;
 


### PR DESCRIPTION
# Description
fixes #11857 

Vibe coded my way to a fix. Memory no longer blows up when you use the slider in the preview mode on Mac.

One thing I dont understand is that ViewerImpl is ported from PrusaSlicer, but there is no memory leak when sliding in PrusaSlicer.
