### PR TITLE
Check instances for collision

### DIFF
--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1194,7 +1194,7 @@ StringObjectException Print::validate(StringObjectException *warning, Polygons* 
         }
     }
 
-    if (m_config.print_sequence == PrintSequence::ByObject && m_objects.size() > 1) {
+    if (m_config.print_sequence == PrintSequence::ByObject && (m_objects.size() > 1 || m_objects[0]->instances().size() > 1)) {
         if (m_config.timelapse_type == TimelapseType::tlSmooth)
             return {L("Smooth mode of timelapse is not supported when \"by object\" sequence is enabled.")};
 


### PR DESCRIPTION
Check instances for collision when printing by object. Currently it's skipped for instances:

<img width="476" height="228" alt="image" src="https://github.com/user-attachments/assets/98b10bcd-d237-4908-9a41-0e716a2a6756" />

Fix:

<img width="400" height="173" alt="image" src="https://github.com/user-attachments/assets/29a829ed-19ac-4fb5-ac26-575f388831dd" />


