### PR TITLE
Fix assign-issue-action and modify reminder days

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign the user or unassign stale assignments
-        uses: takanome-dev/assign-issue-action@v2.3
+        uses: takanome-dev/assign-issue-action@3.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           maintainers: 'noisyfox,softfever'
           days_until_unassign: 30
           block_assignment: false
-          reminder_days: 7
+          reminder_days: 20
           max_assignments: 12


### PR DESCRIPTION
There's still a bug where it will expire too soon when idle *after* a reminder has been sent.

Fixes #11873 

@SoftFever Every person who pushes a commit will get a dumb email until this merges (uhm, provided it actually works).