### PR TITLE
Fix typo in German translation for "Number of slow layers"

### DIFF
--- a/localization/i18n/de/OrcaSlicer_de.po
+++ b/localization/i18n/de/OrcaSlicer_de.po
@@ -14499,7 +14499,7 @@ msgid "Travel speed of initial layer."
 msgstr "Bewegungsgeschwindigkeit der ersten Schicht"
 
 msgid "Number of slow layers"
-msgstr "Anzahl der lansamen Schichten"
+msgstr "Anzahl der langsamen Schichten"
 
 msgid ""
 "The first few layers are printed slower than normal. The speed is gradually "


### PR DESCRIPTION
# Description

This PR fixes a typo in the German translation for the message with the ID "Number of slow layers".

Before: `Anzahl der lansamen Schichten`
After: `Anzahl der langsamen Schichten`

No functional changes — translation fix only.