### PR TITLE
Fix assign-issue-action: revert to v2.2 (v3.0.0 is broken)

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -14,11 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign the user or unassign stale assignments
-        uses: takanome-dev/assign-issue-action@3.0.0
+        # Note: v3.0.0 is broken (dist/index.mjs vs action.yml expects index.js)
+        # See: https://github.com/takanome-dev/assign-issue-action/issues/426
+        uses: takanome-dev/assign-issue-action@v2.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           maintainers: 'noisyfox,softfever'
           days_until_unassign: 30
           block_assignment: false
-          reminder_days: 20
+          reminder_days: 7
           max_assignments: 12


### PR DESCRIPTION
## Summary

The Assign Issue workflow is failing because v3.0.0 of `takanome-dev/assign-issue-action` has a publishing bug.

### The Problem

- `action.yml` references `dist/index.js`
- But v3.0.0 only contains `dist/index.mjs`
- Every workflow run fails immediately with: `File not found: dist/index.js`

### This PR

- Reverts to v2.2 which works correctly
- Reverts `reminder_days` to 7 (v2.2 behavior: days *before* unassignment, not *after* assignment)
- Adds comment with link to upstream bug report

### Evidence

v3.0.0 only has index.mjs:
```
$ gh api "repos/takanome-dev/assign-issue-action/contents/dist?ref=v3.0.0" --jq '.[].name'
index.mjs
licenses.txt
```

v2.2 has index.js (correct):
```
$ gh api "repos/takanome-dev/assign-issue-action/contents/dist?ref=v2.2" --jq '.[].name'
index.js
licenses.txt
package.json
```

## Test plan

- [x] Verified v2.2 works on fork: https://github.com/okets/OrcaMCP/actions/runs/20880211211

## References

- Bug report filed: https://github.com/takanome-dev/assign-issue-action/issues/426
- Fixes #11873

🤖 Generated with [Claude Code](https://claude.ai/code)