### PR TITLE
Fix crashes when loading old 3MF project

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -3315,6 +3315,13 @@ void PresetBundle::load_config_file_config(const std::string &name_or_path, bool
             filament_self_indice[index] = index + 1;
     }
     std::vector<int> filament_self_indice = std::move(config.option<ConfigOptionInts>("filament_self_index")->values);
+    // ORCA: Initialize filament_extruder_variant for backward compatibility with old 3mf files
+    // that don't have this option saved or have it with default single-element value
+    ConfigOptionStrings* filament_extruder_variant_opt = config.option<ConfigOptionStrings>("filament_extruder_variant");
+    if (!filament_extruder_variant_opt || filament_extruder_variant_opt->size() < num_filaments) {
+        std::vector<std::string>& filament_extruder_variant = config.option<ConfigOptionStrings>("filament_extruder_variant", true)->values;
+        filament_extruder_variant.resize(num_filaments, "Direct Drive Standard");
+    }
     if (config.option("extruder_variant_list")) {
         //3mf support multiple extruder logic
         size_t extruder_count = config.option<ConfigOptionFloats>("nozzle_diameter")->values.size();

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -8041,6 +8041,10 @@ size_t DynamicPrintConfig::get_parameter_size(const std::string& param_name, siz
 static void extend_extruder_variant(DynamicPrintConfig& config, const unsigned int num_extruders)
 {
     // 1. Make sure the `extruder_variant_list` is the same length as extruder cnt
+    if (!config.has("extruder_variant_list")) {
+        config.set_key_value("extruder_variant_list",
+                             new ConfigOptionStrings(std::vector<std::string>(num_extruders, "Direct Drive Standard")));
+    }
     auto extruder_variant_opt = dynamic_cast<ConfigOptionStrings*>(config.option("extruder_variant_list"));
     assert(extruder_variant_opt != nullptr);
     extruder_variant_opt->resize(num_extruders, extruder_variant_opt); // Use the first option as the default value, so all extruders have the same variant

--- a/task.md
+++ b/task.md
@@ -1,0 +1,12 @@
+Analyze the bug that it failed to load project(3mf) from old version.
+It failed pass below check in PresetBundle::load_config_file_config function, hence throw error.
+    if (config.option("extruder_variant_list")) {
+        //3mf support multiple extruder logic
+        size_t extruder_count = config.option<ConfigOptionFloats>("nozzle_diameter")->values.size();
+        extruder_variant_count = config.option<ConfigOptionStrings>("filament_extruder_variant", true)->size();
+        if ((extruder_variant_count != filament_self_indice.size())
+            || (extruder_variant_count < num_filaments)) {
+            assert(false);
+            BOOST_LOG_TRIVIAL(error) << __FUNCTION__ << boost::format(": invalid config file %1%, can not find suitable filament_extruder_variant or filament_self_index") % name_or_path;
+            throw Slic3r::RuntimeError(std::string("Invalid configuration file: ") + name_or_path);
+        }


### PR DESCRIPTION
Enhance backward compatibility for filament extruder variants in 3MF project files

Fix crashes when loading old 3MF project

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
