### PR TITLE
Fix: UI Overriding some settings per object

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1702,7 +1702,7 @@ void PrintConfigDef::init_fff_params()
     def->sidetext = L(u8"mm/s²");	// milimeters per second per second, CIS languages need translation
     def->min = 0;
     def->mode = comAdvanced;
-    def->set_default_value(new ConfigOptionFloat(500));
+    def->set_default_value(new ConfigOptionFloat(500.0));
 
     def = this->add("default_filament_profile", coStrings);
     def->label = L("Default filament profile");
@@ -3377,7 +3377,7 @@ void PrintConfigDef::init_fff_params()
                      "It will get the precise object height by fine-tuning the layer heights of the last few layers. "
                      "Note that this is an experimental parameter.");
     def->mode    = comAdvanced;
-    def->set_default_value(new ConfigOptionBool(false));
+    def->set_default_value(new ConfigOptionBool(0));
 
     // BBS
     def = this->add("enable_arc_fitting", coBool);


### PR DESCRIPTION
# Description

This PR fixes an issue where the "modified" icon (the orange back arrow) and the reset functionality were missing for
  several settings when adjusted on a per-object basis.

Because:
  The slicer interface needs to know which "group" (such as Speed, Quality, or Strength) a setting belongs to in
  order to track it. In the background code, some settings were missing these group labels. Because they were
  unassigned, the interface essentially "overlooked" them when checking if a value had been changed, which meant the
  orange reset arrow would never appear.

fix:
https://github.com/OrcaSlicer/OrcaSlicer/issues/11971

Before:
<img width="511" height="516" alt="grafik" src="https://github.com/user-attachments/assets/14dc4a62-26b3-4929-a7db-2ebb0993ee58" />


After PR:
<img width="499" height="527" alt="grafik" src="https://github.com/user-attachments/assets/e3399b44-da36-4e23-bf82-164a34b9d6b4" />
