### PR TITLE
Fix: GCodeViewer displaying inconsistent data in title and body

### DIFF
--- a/src/slic3r/GUI/GCodeViewer.cpp
+++ b/src/slic3r/GUI/GCodeViewer.cpp
@@ -295,6 +295,9 @@ void GCodeViewer::SequentialView::Marker::render_position_window(const libvgcode
     static float last_window_width = 0.0f;
     static size_t last_text_length = 0;
     static bool properties_shown = false;
+    
+    const std::string NA_TXT = _u8L("N/A");
+    const char* NA_CSTR = NA_TXT.c_str();
 
     if (viewer != nullptr) {
         ImGuiWrapper& imgui = *wxGetApp().imgui();
@@ -316,28 +319,32 @@ void GCodeViewer::SequentialView::Marker::render_position_window(const libvgcode
             vertex = viewer->get_vertex_at(vertex_id);
         }
 
-        char buf[1024];
+        const bool is_extrusion = vertex.is_extrusion();
+        char buf[1024]; char valBuf[32];
         sprintf(buf, "X: %.3f, Y: %.3f, Z: %.3f Speed: %.0f ", vertex.position[0], vertex.position[1], vertex.position[2], vertex.feedrate);
         switch (view_type) {
             case libvgcode::EViewType::Height: {
-                if (vertex.is_extrusion())
-                    sprintf(buf, "%s %s%.2f", buf, _u8L("Height: ").c_str(), vertex.height);
+                if (is_extrusion)
+                    sprintf(valBuf, "%.2f", vertex.height);
                 else
-                    sprintf(buf, "%s %s%s", buf, _u8L("Height: ").c_str(), _u8L("N/A").c_str());
+                    sprintf(valBuf, "%s", NA_CSTR);
+                sprintf(buf, "%s %s%s", buf, _u8L("Height: ").c_str(), valBuf);
                 break;
             }
             case libvgcode::EViewType::Width: {
-                if (vertex.is_extrusion())
-                    sprintf(buf, "%s %s%.2f", buf, _u8L("Width: ").c_str(), vertex.width);
+                if (is_extrusion)
+                    sprintf(valBuf, "%.2f", vertex.width);
                 else
-                    sprintf(buf, "%s %s%s", buf, _u8L("Width: ").c_str(), _u8L("N/A").c_str());
+                    sprintf(valBuf, "%s", NA_CSTR);
+                sprintf(buf, "%s %s%s", buf, _u8L("Width: ").c_str(), valBuf);
                 break;
             }
             case libvgcode::EViewType::VolumetricFlowRate: {
-                if (vertex.is_extrusion())
-                    sprintf(buf, "%s %s%.2f", buf, _u8L("Flow: ").c_str(), vertex.volumetric_rate());
+                if (is_extrusion)
+                    sprintf(valBuf, "%.2f", vertex.volumetric_rate());
                 else
-                    sprintf(buf, "%s %s%s", buf, _u8L("Flow: ").c_str(), _u8L("N/A").c_str());
+                    sprintf(valBuf, "%s", NA_CSTR);
+                sprintf(buf, "%s %s%s", buf, _u8L("Flow: ").c_str(), valBuf);
                 break;
             }
             case libvgcode::EViewType::FanSpeed: {
@@ -377,7 +384,7 @@ void GCodeViewer::SequentialView::Marker::render_position_window(const libvgcode
         ImGuiWrapper::text(std::string(buf));
         if (view_type == libvgcode::EViewType::FeatureType) {
             ImGui::SameLine();
-            ImGuiWrapper::text_colored(ImGuiWrapper::COL_ORANGE_LIGHT, vertex.is_extrusion() ? to_string(vertex.role).c_str() : _u8L("N/A").c_str());
+            ImGuiWrapper::text_colored(ImGuiWrapper::COL_ORANGE_LIGHT, vertex.is_extrusion() ? to_string(vertex.role).c_str() : NA_CSTR);
         }
         ImGui::SameLine();
         if (imgui.image_button(properties_shown ? ImGui::HorizontalHide : ImGui::HorizontalShow, properties_shown ? _u8L("Hide properties") : _u8L("Show properties"))) {
@@ -400,32 +407,32 @@ void GCodeViewer::SequentialView::Marker::render_position_window(const libvgcode
                 append_table_row(_u8L("Type"), [&vertex]() {
                     ImGuiWrapper::text(_u8L(to_string(vertex.type)));
                 });
-                append_table_row(_u8L("Feature type"), [&vertex]() {
+                append_table_row(_u8L("Feature type"), [&vertex, NA_TXT]() {
                     std::string text;
                     if (vertex.is_extrusion())
                         text = _u8L(to_string(vertex.role));
                     else
-                        text = _u8L("N/A");
+                        text = NA_TXT;
                     ImGuiWrapper::text(text);
                 });
-                append_table_row(_u8L("Width") + " (" + _u8L("mm") + ")", [&vertex, &buff]() {
+                append_table_row(_u8L("Width") + " (" + _u8L("mm") + ")", [&vertex, &buff, NA_TXT]() {
                     std::string text;
                     if (vertex.is_extrusion()) {
                         sprintf(buff, "%.3f", vertex.width);
                         text = std::string(buff);
                     }
                     else
-                        text = _u8L("N/A");
+                        text = NA_TXT;
                     ImGuiWrapper::text(text);
                 });
-                append_table_row(_u8L("Height") + " (" + _u8L("mm") + ")", [&vertex, &buff]() {
+                append_table_row(_u8L("Height") + " (" + _u8L("mm") + ")", [&vertex, &buff, NA_TXT]() {
                     std::string text;
                     if (vertex.is_extrusion()) {
                         sprintf(buff, "%.3f", vertex.height);
                         text = std::string(buff);
                     }
                     else
-                        text = _u8L("N/A");
+                        text = NA_TXT;
                     ImGuiWrapper::text(text);
                 });
                 append_table_row(_u8L("Layer"), [&vertex, &buff]() {
@@ -438,14 +445,14 @@ void GCodeViewer::SequentialView::Marker::render_position_window(const libvgcode
                     const std::string text = std::string(buff);
                     ImGuiWrapper::text(text);
                 });
-                  append_table_row(_u8L("Volumetric flow rate") + " (" + _u8L("mm³/s") + ")", [&vertex, &buff]() {
+                  append_table_row(_u8L("Volumetric flow rate") + " (" + _u8L("mm³/s") + ")", [&vertex, &buff, NA_TXT]() {
                     std::string text;
                     if (vertex.is_extrusion()) {
                         sprintf(buff, "%.3f", vertex.volumetric_rate());
                         text = std::string(buff);
                     }
                     else
-                        text = _u8L("N/A");
+                        text = NA_TXT;
                     ImGuiWrapper::text(text);
                   });
                 append_table_row(_u8L("Fan speed") + " (" + _u8L("%") + ")", [&vertex, &buff]() {


### PR DESCRIPTION
# Description
Previously, the GCodeViewer would display stats in for flow, width, height, and line type in the title/summarized view even while there was no extrusion (e.g., travelling). It has been fixed to only show N/A, matching the display in the detailed view.

Additionally, actual flow is no longer displayed in the title. It only shows the actual flow for the end of a segment, and so may give the wrong impression that the actual flow is consistently low. It is also more consistent with its absence in the detailed view.

Fixes #11910 

# Screenshots/Recordings/Graphs

Line/Feature Type Bef/Aft
<img width="386" height="433" alt="image" src="https://github.com/user-attachments/assets/d6f974b8-f82c-44c5-8d7b-966c26e402f9" /><img width="346" height="432" alt="image" src="https://github.com/user-attachments/assets/27af9972-e9ea-4229-a292-49c5875e8fea" />

Line Height Bef/Aft
<img width="377" height="438" alt="image" src="https://github.com/user-attachments/assets/cad3eb6e-a755-41d9-8b3b-52d1a8f366ea" /><img width="372" height="439" alt="image" src="https://github.com/user-attachments/assets/cf601c39-8c32-400c-b27c-e98456175542" />

Line Width Bef/Aft
<img width="375" height="436" alt="image" src="https://github.com/user-attachments/assets/0ddd65fc-3931-43d2-91e2-e2e8fcaad39e" /><img width="372" height="438" alt="image" src="https://github.com/user-attachments/assets/eb390bc9-4231-4eda-a223-a18574ad6877" />

Flow Bef/Aft
<img width="376" height="440" alt="image" src="https://github.com/user-attachments/assets/46a20f75-bb51-4e04-a5c9-cf952675f782" /><img width="371" height="433" alt="image" src="https://github.com/user-attachments/assets/3f545cdd-ec2c-48b0-a839-0cb89f42af96" />

Actual Flow Removed
<img width="1180" height="1296" alt="image" src="https://github.com/user-attachments/assets/1e792a3f-8457-425f-9faa-664241b02798" />

## Tests
Checked the GCodeViewer on the same project file on pre- and post- fix builds
