### PR TITLE
Fix zigzag symmetry

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -1273,6 +1273,9 @@ void Layer::make_fills(FillAdaptive::Octree* adaptive_fill_octree, FillAdaptive:
 
             params.symmetric_infill_y_axis = surface_fill.params.symmetric_infill_y_axis;
 
+        } else if (surface_fill.params.pattern == ipZigZag) {
+            params.symmetric_infill_y_axis = surface_fill.params.symmetric_infill_y_axis;
+
         }
 		if (surface_fill.params.pattern == ipGrid)
 			params.can_reverse = false;


### PR DESCRIPTION
### Description

ZigZag infill didn't respect the "Symmetric infill Y axis" parameter's setting. This PR fixes it.

Fixes #12015

### Screenshots/Recordings/Graphs
- **Before:**
<img width="611" height="612" alt="image" src="https://github.com/user-attachments/assets/1f6fc3f9-ec37-4974-86fc-fd4fe6dd9329" />

&nbsp;

- **After:**
<img width="587" height="582" alt="image" src="https://github.com/user-attachments/assets/088715c2-5d12-4596-aab6-3a1eca353abe" />
