### PR TITLE
Fix aligned back seam positioning for mirrored objects

### DIFF
--- a/src/libslic3r/GCode/SeamPlacer.cpp
+++ b/src/libslic3r/GCode/SeamPlacer.cpp
@@ -636,7 +636,7 @@ void compute_global_occlusion(GlobalModelInfo &result, const PrintObject *po,
         || model_volume->type() == ModelVolumeType::NEGATIVE_VOLUME) {
       auto model_transformation = model_volume->get_matrix();
       indexed_triangle_set model_its = model_volume->mesh().its;
-      its_transform(model_its, model_transformation);
+      its_transform(model_its, model_transformation, true);
       if (model_volume->type() == ModelVolumeType::MODEL_PART) {
         its_merge(triangle_set, model_its);
       } else {
@@ -656,7 +656,7 @@ void compute_global_occlusion(GlobalModelInfo &result, const PrintObject *po,
 
   size_t negative_volumes_start_index = triangle_set.indices.size();
   its_merge(triangle_set, negative_volumes_set);
-  its_transform(triangle_set, obj_transform);
+  its_transform(triangle_set, obj_transform, true);
   BOOST_LOG_TRIVIAL(debug)
       << "SeamPlacer: decimate: end";
 
@@ -717,11 +717,11 @@ void gather_enforcers_blockers(GlobalModelInfo &result, const PrintObject *po) {
       auto model_transformation = obj_transform * mv->get_matrix();
 
       indexed_triangle_set enforcers = mv->seam_facets.get_facets(*mv, EnforcerBlockerType::ENFORCER);
-      its_transform(enforcers, model_transformation);
+      its_transform(enforcers, model_transformation, true);
       its_merge(result.enforcers, enforcers);
 
       indexed_triangle_set blockers = mv->seam_facets.get_facets(*mv, EnforcerBlockerType::BLOCKER);
-      its_transform(blockers, model_transformation);
+      its_transform(blockers, model_transformation, true);
       its_merge(result.blockers, blockers);
     }
   }

--- a/src/libslic3r/GCode/SeamPlacer.cpp
+++ b/src/libslic3r/GCode/SeamPlacer.cpp
@@ -636,6 +636,7 @@ void compute_global_occlusion(GlobalModelInfo &result, const PrintObject *po,
         || model_volume->type() == ModelVolumeType::NEGATIVE_VOLUME) {
       auto model_transformation = model_volume->get_matrix();
       indexed_triangle_set model_its = model_volume->mesh().its;
+      // ORCA: Mirrored transforms flip winding, keep normals outward
       its_transform(model_its, model_transformation, true);
       if (model_volume->type() == ModelVolumeType::MODEL_PART) {
         its_merge(triangle_set, model_its);
@@ -656,6 +657,7 @@ void compute_global_occlusion(GlobalModelInfo &result, const PrintObject *po,
 
   size_t negative_volumes_start_index = triangle_set.indices.size();
   its_merge(triangle_set, negative_volumes_set);
+  // ORCA: Mirroring flips normals, keep them outward for visibility sampling
   its_transform(triangle_set, obj_transform, true);
   BOOST_LOG_TRIVIAL(debug)
       << "SeamPlacer: decimate: end";
@@ -717,10 +719,12 @@ void gather_enforcers_blockers(GlobalModelInfo &result, const PrintObject *po) {
       auto model_transformation = obj_transform * mv->get_matrix();
 
       indexed_triangle_set enforcers = mv->seam_facets.get_facets(*mv, EnforcerBlockerType::ENFORCER);
+      // ORCA: Keep normals outward when mirroring seam enforcers
       its_transform(enforcers, model_transformation, true);
       its_merge(result.enforcers, enforcers);
 
       indexed_triangle_set blockers = mv->seam_facets.get_facets(*mv, EnforcerBlockerType::BLOCKER);
+      // ORCA: Keep normals outward when mirroring seam blockers
       its_transform(blockers, model_transformation, true);
       its_merge(result.blockers, blockers);
     }


### PR DESCRIPTION
### Description

This PR makes “Aligned back” seams behave the same on mirrored models as on normal models. Mirroring flips the model’s surface directions, so the slicer treated the back as the front. Now it corrects those directions when calculating seam visibility, so seams still line up on the back after mirroring.

### Screenshots
- **Before:**
<img width="1293" height="605" alt="image" src="https://github.com/user-attachments/assets/501ed525-9e1d-4f7c-9d32-781e43b9faa8" />
<br><br>

- **After:**
<img width="1287" height="605" alt="image" src="https://github.com/user-attachments/assets/35b1a5c8-71d9-4838-af4a-16fea436250b" />
<br><br>

Fixes #12017