### PR TITLE
POC: Parallelize and order preset subfile loading

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <unordered_set>
 #include <future>
+#include <chrono>
 #include <boost/filesystem.hpp>
 #include <boost/algorithm/clamp.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -431,6 +432,7 @@ void PresetBundle::copy_files(const std::string& from)
 PresetsConfigSubstitutions PresetBundle::load_presets(AppConfig &config, ForwardCompatibilitySubstitutionRule substitution_rule,
                                                       const PresetPreferences& preferred_selection/* = PresetPreferences()*/)
 {
+    auto start = std::chrono::steady_clock::now();
     // First load the vendor specific system presets.
     PresetsConfigSubstitutions substitutions;
     std::string errors_cummulative;
@@ -456,6 +458,12 @@ PresetsConfigSubstitutions PresetBundle::load_presets(AppConfig &config, Forward
 
     set_calibrate_printer("");
 
+    auto end = std::chrono::steady_clock::now();
+
+    BOOST_LOG_TRIVIAL(fatal)
+                << "load_presets user Time: "
+                << std::chrono::duration<double, std::milli>(end - start).count()
+                << " ms";
     //BBS: add config related logs
     BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(" finished, returned substitutions %1%")%substitutions.size();
     return substitutions;
@@ -1435,6 +1443,7 @@ void PresetBundle::remove_users_preset(AppConfig &config, std::map<std::string, 
 //BBS: add json related logic, load system presets from json
 std::pair<PresetsConfigSubstitutions, std::string> PresetBundle::load_system_presets_from_json(ForwardCompatibilitySubstitutionRule compatibility_rule)
 {
+    auto start = std::chrono::steady_clock::now();
     //BBS: add config related logs
     BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << boost::format(" enter, compatibility_rule %1%")%compatibility_rule;
     if (compatibility_rule == ForwardCompatibilitySubstitutionRule::EnableSystemSilent)
@@ -1518,6 +1527,12 @@ std::pair<PresetsConfigSubstitutions, std::string> PresetBundle::load_system_pre
 	}
 
 	this->update_system_maps();
+    auto end =  std::chrono::steady_clock::now();
+
+    BOOST_LOG_TRIVIAL(fatal)
+              << "load_system_presets_from_json Time: "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()
+              << " ms";
     //BBS: add config related logs
     BOOST_LOG_TRIVIAL(debug) << __FUNCTION__ << boost::format(" finished, errors_cummulative %1%")%errors_cummulative;
     return std::make_pair(std::move(substitutions), errors_cummulative);


### PR DESCRIPTION
Trying to multithreaded scan_and_sort_subfiles function to efficiently prescan and topologically sort preset subfiles based on inheritance.
The goal is to improve load order and cycle detection for process, filament, and printer presets.