### PR TITLE
  Fix: internal bridge angle calculation for rotated objects

### DIFF
--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -2612,7 +2612,7 @@ void PrintObject::bridge_over_infill()
     };
 
     // LAMBDA do determine optimal bridging angle
-    auto determine_bridging_angle = [](const Polygons &bridged_area, const Lines &anchors, InfillPattern dominant_pattern, double infill_direction, bool infill_combination) {
+    auto determine_bridging_angle = [](const Polygons &bridged_area, const Lines &anchors, InfillPattern dominant_pattern, double infill_direction) {
         AABBTreeLines::LinesDistancer<Line> lines_tree(anchors);
 
         // Check it the infill that require a fixed infill angle.
@@ -2691,9 +2691,7 @@ void PrintObject::bridge_over_infill()
         switch (dominant_pattern) {
         case ipHilbertCurve: bridging_angle += 0.25 * PI; break;
         case ipOctagramSpiral: bridging_angle += (1.0 / 16.0) * PI; break;
-        // ORCA FIX ME: For 3dhoneycomb, you must rotate it 90° from the normal position to adjust the bridging correctly. It doesn't work perfectly, but it's better than dropped bridges.
-        case ip3DHoneycomb: bridging_angle += infill_combination ? (0.5) * PI : 0; break;
-
+        
         default: break;
         }
 
@@ -3009,12 +3007,11 @@ void PrintObject::bridge_over_infill()
                     if (!anchors.empty()) {
                         bridging_angle = determine_bridging_angle(area_to_be_bridge, to_lines(anchors),
                                                                   candidate.region->region().config().sparse_infill_pattern.value,
-                                                                  candidate.region->region().config().infill_direction.value,
-                                                                  candidate.region->region().config().infill_combination.value);
+                                                                  candidate.region->region().config().infill_direction.value);
                     } else {
                         // use expansion boundaries as anchors.
                         // Also, use Infill pattern that is neutral for angle determination, since there are no infill lines.
-                        bridging_angle = determine_bridging_angle(area_to_be_bridge, to_lines(boundary_plines), InfillPattern::ipLine, 0, false);
+                        bridging_angle = determine_bridging_angle(area_to_be_bridge, to_lines(boundary_plines), InfillPattern::ipLine, 0);
                     }
                     
                     // ORCA: Internal bridge angle override


### PR DESCRIPTION
# Description


This PR addresses issues where the automatic internal_bridge_angle calculation (when set to 0) failed to find the
  optimal angle, particularly when the object is rotated in Z or when align_infill_direction_to_model is enabled.

  Changes
   1. Fixed Sliding Window Logic:
      In PrintObject::bridge_over_infill -> determine_bridging_angle, there was a logic error in the sliding window
  algorithm. The condition to handle the wrap-around at the end of the angle range (1.5 * PI) checked window_start_angle
  instead of window_end_angle. This made the code unreachable, causing poor angle detection for bridges oriented near
  the boundary angles. This is now fixed.

   2. Improved CrossHatch & 3D Honeycomb Logic:
      Previously, these patterns returned a fixed angle based solely on the configured infill_direction, ignoring the
  actual object orientation. This caused bridges to align parallel to infill lines if the object was rotated.

      The new logic:
       - Removes the hardcoded early return.
       - Allows the geometry detection to run on the actual underlying anchors (infill lines).
       - Adds a 45-degree (0.25 * PI) offset to the detected angle.

      This ensures the internal bridge is always diagonal to the underlying grid, regardless of Z-rotation or
  align_infill_direction_to_model.

  Related Issues
  Fixes #12002

Before PR:
<img width="1082" height="567" alt="grafik" src="https://github.com/user-attachments/assets/b338234e-b736-4191-ba75-39b2fe2c1738" />
<img width="1110" height="590" alt="grafik" src="https://github.com/user-attachments/assets/6c3115ca-6a70-471e-b2c1-1ee1efdd8ea6" />


After PR:
<img width="784" height="524" alt="grafik" src="https://github.com/user-attachments/assets/908adc1c-b26d-4cd4-99c0-75cbd1a4ec9e" />
<img width="860" height="502" alt="grafik" src="https://github.com/user-attachments/assets/7a1b340c-4cf7-457f-90a7-7e556d4b3618" />


Test file:

[cubes.zip](https://github.com/user-attachments/files/24809242/cubes.zip)

