### PR TITLE
Correct gap fill width bounds in outer-only and mixed-wall cases

### DIFF
--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -1562,9 +1562,9 @@ void PerimeterGenerator::process_classic()
         } // for each loop of an island
 
         // fill gaps
-        if (! gaps.empty()) {
-            // collapse
-            double min = 0.2 * perimeter_width * (1 - INSET_OVERLAP_TOLERANCE);
+        if (! gaps.empty()) { // collapse
+            // ORCA: Use the smaller width as the lower bound to avoid overestimating safe overlap
+            double min = 0.2 * std::min(perimeter_width, ext_perimeter_width) * (1 - INSET_OVERLAP_TOLERANCE);
             double max = 2. * perimeter_spacing;
             ExPolygons gaps_ex = diff_ex(
                 //FIXME offset2 would be enough and cheaper.


### PR DESCRIPTION
### Summary

This PR corrects how gap fill width bounds are derived in cases where internal and external wall geometry differ.

Previously, internal wall geometry was used unconditionally when computing gap fill bounds, which could misrepresent safe overlap or spacing when external and internal walls differ in thickness or spacing.

### Changes

- **Minimum gap fill width**
  - Now derived from the **smaller of internal and external wall widths**
  - Prevents overestimating safe overlap when the adjacent walls differ in thickness

### Reasoning

- The **minimum** gap fill width is constrained by wall **width**, as it represents the amount of overlap that can be accommodated. When internal and external walls differ in thickness, using the smaller applicable width avoids overestimating
the allowable overlap.
- Selecting the appropriate internal or external wall geometry for bound ensures correct behavior in outer-only and mixed-wall configurations.

### Overview and impact

- This is a **geometry reference correction**, not a change in gap fill strategy.
- No changes to overlap tolerance, nozzle assumptions, or gap fill policy.
- **Existing gap fill behavior is unchanged, except where wall geometry references were incorrect.**

Fixes #12030

### Screenshots

- **Before:**
<img width="621" height="613" alt="image" src="https://github.com/user-attachments/assets/91b514ce-8e52-4cef-b6fe-a983933fb0fc" />

<br><br>

- **After:**
<img width="602" height="601" alt="image" src="https://github.com/user-attachments/assets/8f4aed32-3b64-4d89-a855-6868402f0881" />
