### PR TITLE
3d honeycomb bug fix (with infill combination) improve bridge direction

### DIFF
--- a/src/libslic3r/Fill/Fill3DHoneycomb.cpp
+++ b/src/libslic3r/Fill/Fill3DHoneycomb.cpp
@@ -224,6 +224,8 @@ void Fill3DHoneycomb::_fill_surface_single(
     // This means that the resultant infill won't be an ideal truncated octahedron,
     // but it should look better than the equivalent quantised version
 
+    //Orca: uses a fixed layer height to avoid inconsistent bridges and variable layer height artifacts.
+    //coordf_t layerHeight = scale_(thickness_layers);
     coordf_t layerHeight = scale_(1.0);
     // ceiling to an integer value of layers per Z
     // (with a little nudge in case it's close to perfect)

--- a/src/libslic3r/PrintObject.cpp
+++ b/src/libslic3r/PrintObject.cpp
@@ -2615,6 +2615,9 @@ void PrintObject::bridge_over_infill()
     auto determine_bridging_angle = [](const Polygons &bridged_area, const Lines &anchors, InfillPattern dominant_pattern, double infill_direction) {
         AABBTreeLines::LinesDistancer<Line> lines_tree(anchors);
 
+        // Orca: since 3D Honeycomb was "fixed" by forcing coordf_t layerHeight = scale_(1.0), this is no longer needed.
+        // CorssHatch also does not need fixed angle.
+        //
         // Check it the infill that require a fixed infill angle.
         //switch (dominant_pattern) {
         //case ip3DHoneycomb:


### PR DESCRIPTION
# Description

PR inspired by #12046
This PR fixes a bug in 3D honeycomb where using infill combination causes the infill to shift, resulting in incorrect bridge detection. This also fix artifacts with variable layer height.
# Screenshots/Recordings/Graphs
# Before:
Bug 1: unsupported bridges
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/22428be0-839e-4d51-9ddd-0b3b6623db8a" />
Bug 2: rotated pattern with infill combination
<img width="1510" height="879" alt="image" src="https://github.com/user-attachments/assets/1e288ba1-2cdd-4980-8ee7-55fc061282dd" />

# After:
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/d1ce8ba6-1703-4cb8-bf45-95831eb813d7" />
<img width="1506" height="928" alt="image" src="https://github.com/user-attachments/assets/ba8d22e2-cf5c-4951-a061-a8b362598b35" />
3D honeycomb and crosshatch infill patterns, bridge direction on top layer.
<img width="1562" height="901" alt="image" src="https://github.com/user-attachments/assets/fcc2a33e-1232-4b55-9919-9c934c67fdf4" />
Fix #12002