### PR TITLE
Update documentation links in hints.ini

### DIFF
--- a/resources/data/hints.ini
+++ b/resources/data/hints.ini
@@ -64,26 +64,26 @@
 
 [hint:Precise wall]
 text = Precise wall\nDid you know that turning on precise wall can improve precision and layer consistency?
-documentation_link = https://github.com/OrcaSlicer/OrcaSlicer/wiki/quality_settings_precision
+documentation_link = https://www.orcaslicer.com/wiki/quality_settings_precision#precise-wall
 
 [hint:Sandwich mode]
 text = Sandwich mode\nDid you know that you can use sandwich mode (inner-outer-inner) to improve precision and layer consistency if your model doesn't have very steep overhangs?
 
 [hint:Chamber temperature]
 text = Chamber temperature\nDid you know that OrcaSlicer supports chamber temperature?
-documentation_link = https://github.com/OrcaSlicer/OrcaSlicer/wiki/Chamber-temperature
+documentation_link = https://www.orcaslicer.com/wiki/material_temperatures#print-chamber-temperature
 
 [hint:Calibration]
 text = Calibration\nDid you know that calibrating your printer can do wonders? Check out our beloved calibration solution in OrcaSlicer.
-documentation_link = https://github.com/OrcaSlicer/OrcaSlicer/wiki/Calibration
+documentation_link = https://www.orcaslicer.com/wiki/calibration
 
 [hint:Auxiliary fan]
 text = Auxiliary fan\nDid you know that OrcaSlicer supports Auxiliary part cooling fan?
-documentation_link = https://github.com/OrcaSlicer/OrcaSlicer/wiki/Auxiliary-fan
+documentation_link = https://www.orcaslicer.com/wiki/material_cooling#auxiliary-part-cooling-fan
 
 [hint:Air filtration]
 text = Air filtration/Exhaust Fan\nDid you know that OrcaSlicer can support Air filtration/Exhaust Fan?
-documentation_link = https://github.com/OrcaSlicer/OrcaSlicer/wiki/air-filtration
+documentation_link = https://www.orcaslicer.com/wiki/material_cooling#activate-air-filtration
 
 [hint:G-code window]
 text = G-code window\nYou can turn on/off the G-code window by pressing the <b>C</b> key.


### PR DESCRIPTION
Replaced GitHub wiki URLs with new orcaslicer.com documentation links for several hints to provide more accurate and up-to-date references.