### PR TITLE
Fix:  live dark mode update for Compare Presets dialog

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2281,6 +2281,8 @@ void MainFrame::on_sys_color_changed()
         m_monitor->on_sys_color_changed();
     if(m_calibration)
         m_calibration->on_sys_color_changed();
+    // ORCA: update compare presets dialog
+    diff_dialog.on_sys_color_changed();
     // update Tabs
     for (auto tab : wxGetApp().tabs_list)
         tab->sys_color_changed();

--- a/src/slic3r/GUI/UnsavedChangesDialog.hpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.hpp
@@ -462,10 +462,11 @@ public:
     std::vector<std::string> get_selected_options(Preset::Type type) const { return m_tree->options(type, true); }
 
     std::array<Preset::Type, 3>         types_list() const;
+    // ORCA: move to public to be called by MainFrame
+    void on_sys_color_changed() override;
 
 protected:
     void on_dpi_changed(const wxRect& suggested_rect) override;
-    void on_sys_color_changed() override;
 };
 
 }


### PR DESCRIPTION
# Description

  Fixed an issue where the "Compare Presets" dialog would show inconsistent or partial colors after switching between
  light and dark mode. This occurred even if the dialog was closed when the theme was toggled. Once the colors became
  inconsistent, the only way to restore the correct UI appearance was to restart OrcaSlicer.

  This PR ensures that the dialog correctly updates its internal color state whenever the application theme changes. The
  UI now remains consistent and readable without requiring a restart.

Before PR:
![whitebug](https://github.com/user-attachments/assets/49ab9477-1dc0-459a-a420-b76035e0ed2c)

With PR:
![whitefix](https://github.com/user-attachments/assets/bcb8357f-73fd-431b-8960-8ca66e0b1b40)
