### PR TITLE
Fix: Trim whitespace from access code to prevent LAN auth failures

### DIFF
--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -16,6 +16,7 @@
 #include <codecvt>
 #include <boost/foreach.hpp>
 #include <boost/typeof/typeof.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -410,6 +411,7 @@ std::string MachineObject::get_access_code() const
 
 void MachineObject::set_access_code(std::string code, bool only_refresh)
 {
+    boost::algorithm::trim(code);
     this->access_code = code;
     if (only_refresh) {
         AppConfig* config = GUI::wxGetApp().app_config;
@@ -436,6 +438,7 @@ void MachineObject::erase_user_access_code()
 
 void MachineObject::set_user_access_code(std::string code, bool only_refresh)
 {
+    boost::algorithm::trim(code);
     this->user_access_code = code;
     if (only_refresh && !code.empty()) {
         AppConfig* config = GUI::wxGetApp().app_config;


### PR DESCRIPTION
Fixes LAN connection failures caused by trailing whitespace in access codes received from Bambu printers via MQTT.

### The Problem

When connecting to a Bambu printer in LAN mode, the printer sends the access code via MQTT with a trailing newline character (e.g., `"9de74498\n"`). This gets stored directly to the config file, causing
authentication to fail on subsequent connections because the 8-character code becomes 9 characters.

This manifests as OrcaSlicer repeatedly prompting for the LAN access code on every launch, even when credentials are correctly saved.

### When This Started

The bug became visible after the Bambu Studio 1.8 beta merge (commit `d8dd8fa634`, Dec 2023), which added logic to refresh the access code from the printer via MQTT on every connection. The printer firmware
 likely always sent the newline, but it wasn't stored until this refresh behavior was added.

### Screenshots

Every Time I Opened

<img width="287" height="196" alt="image" src="https://github.com/user-attachments/assets/848aa51b-a2c8-4939-90ac-75f455af586e" />

## Video


https://github.com/user-attachments/assets/c4de806f-010a-43f6-9fa0-a1efcfcf68c3


### The Fix

Trim whitespace in `set_access_code()` and `set_user_access_code()` before storing. This follows existing patterns in the codebase where `boost::algorithm::trim()` is used to sanitize input strings.

### Related Issues

- #6169 - "Orcaslicer forgets access code for X1C in LAN mode constantly" (closed, but root cause was not addressed)
- #10534 - "Can't send prints to X1c in LAN mode" (possibly related)

## Tests

### Test 1: Upgrading from corrupted config
1. Created corrupted config in OrcaSlicer 2.3.1:
   - Logged into Bambu cloud and synced
   - This created `access_code` with newline: `"9de74498\n"`
   - Both `access_code` and `user_access_code` became corrupted with `\n`
2. Closed 2.3.1
3. Opened fixed 2.3.2-dev build
4. Printer connected successfully (trim fix cleaned the value on load)
5. Close/reopen cycles - remained stable

### Test 2: Fresh install with fix
1. Deleted OrcaSlicer config directory completely
2. Opened fixed 2.3.2-dev build
3. Completed setup wizard
4. Logged into Bambu cloud and synced
5. Connected to printer via SSDP
6. Config stored clean `user_access_code` without newline
7. Multiple close/reopen cycles - remained stable

### Test 3: Reproduced original bug in 2.3.1
Confirmed the bug exists in 2.3.1:
1. Fresh config, logged into Bambu cloud, synced
2. `access_code` stored with `\n` suffix
3. Close/reopen resulted in "Incorrect password" error
4. Re-entering code manually only temporarily fixed it
5. `user_access_code` would get deleted or re-corrupted on subsequent close/reopen cycles