### PR TITLE
Snapmaker U1: switch wall_generator to arachne

### DIFF
--- a/resources/profiles/Snapmaker/process/fdm_process_U1_common.json
+++ b/resources/profiles/Snapmaker/process/fdm_process_U1_common.json
@@ -72,6 +72,6 @@
     "wipe_tower_extra_rib_length": "0",
     "prime_tower_width": "35",
     "prime_volume": "30",
-    "wall_generator": "classic",
+    "wall_generator": "arachne",
     "compatible_printers": []
 }


### PR DESCRIPTION
# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->
The Snapmaker U1, with its multi-color and multi-material tool-changing capability, is well suited for printing colorful objects such as figures. Most U1 users are not printing parts that require strict dimensional accuracy. The Arachne wall generator better supports this use case than the classic wall generator. This change also brings the U1 process in line with other Snapmaker printers, such as the J1, which inherits fdm_process_common and defaults to Arachne.

# Screenshots/Recordings/Graphs

![arachne](https://github.com/user-attachments/assets/fb61cc34-cfa6-4385-b350-d9b2a1dcfdee)


<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->

This is a default profile change. I made the change to the profile and all Snapmaker U1 processes are now defaulted to Arachne.