### PR TITLE
Fix crash when open AMS 2 humidity popup

### DIFF
--- a/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
+++ b/src/slic3r/GUI/DeviceTab/uiAmsHumidityPopup.cpp
@@ -147,7 +147,7 @@ void uiAmsPercentHumidityDryPopup::UpdateContents()
     // table grid
     const wxString& humidity_str = wxString::Format("%d%%", m_humidity_percent);
     m_humidity_label->SetLabel(humidity_str);
-    const wxString& temp_str = wxString::Format(u8"%d\u2103" /* °C */, (int)std::round(m_current_temperature));
+    const wxString& temp_str = wxString::Format(wxString::FromUTF8(u8"%d\u2103" /* °C */), (int)std::round(m_current_temperature));
     m_temperature_label->SetLabel(temp_str);
 
     if (m_left_dry_time > 0)


### PR DESCRIPTION
App crashes when click the humidity icon when AMS 2 (and probably HT too):
![himid-crash](https://github.com/user-attachments/assets/525941d1-2c1a-461a-ae20-41b0ff5763f9)

Some user may experience this crash during the app startup when using multi-monitor setup.

This PR fix this issue.