### PR TITLE
Fix Setup Wizard stuck on "Loading..." on Wayland

### DIFF
--- a/resources/web/guide/0/load.js
+++ b/resources/web/guide/0/load.js
@@ -7,7 +7,8 @@ function OnInit()
 
 	TargetPage=GetQueryString("target");
 	
-	//setTimeout("JumpToTarget()",20*1000);
+	// Fallback timeout in case the C++ -> JS signal fails (e.g., WebKit issues)
+	setTimeout("JumpToTarget()",20*1000);
 }
 
 function HandleStudio( pVal )

--- a/src/OrcaSlicer.cpp
+++ b/src/OrcaSlicer.cpp
@@ -1186,6 +1186,11 @@ int CLI::run(int argc, char **argv)
     // instruct the window manager to fall back to X server mode.
     ::setenv("GDK_BACKEND", "x11", /* replace */ true);
 
+    // WebKit2GTK's compositing mode can fail under XWayland, causing WebViews
+    // (like the Setup Wizard) to render blank or freeze. Disabling compositing
+    // mode forces software rendering, which works reliably on all backends.
+    ::setenv("WEBKIT_DISABLE_COMPOSITING_MODE", "1", /* replace */ false);
+
     // Also on Linux, we need to tell Xlib that we will be using threads,
     // lest we crash when we fire up GStreamer.
     XInitThreads();


### PR DESCRIPTION
# Description

Fixes the Setup Wizard getting stuck on the "Loading......" screen when running on Wayland sessions.

**Root Cause:** When OrcaSlicer runs under XWayland (Wayland sessions with `GDK_BACKEND=x11`), WebKit2GTK's compositing mode can fail silently, causing the Setup Wizard WebView to freeze or render blank. The JavaScript signal from C++ (`userguide_profile_load_finish`) either fails to execute or its rendering result never displays, leaving users permanently stuck.

**Solution:**
1. Set `WEBKIT_DISABLE_COMPOSITING_MODE=1` environment variable to force software rendering for WebKit2GTK - this is the same fix used by BambuStudio
2. Enable the 20-second timeout fallback in `load.js` so the wizard proceeds automatically even if the C++ → JavaScript communication fails

**Files changed:**
- `src/OrcaSlicer.cpp` - Added `WEBKIT_DISABLE_COMPOSITING_MODE` env var (4 lines)
- `resources/web/guide/0/load.js` - Enabled timeout fallback (2 lines)

---update---
Duplicated effort with #7591
Based on the test results, it seems we don’t need to disable `WEBKIT_DISABLE_DMABUF_RENDERER`. Keep as is for now

Fixes #3479
Fixes #4132
Fixes #4935
Fixes #7581
# Screenshots/Recordings/Graphs

N/A - This is a Linux/Wayland-specific fix that addresses a rendering issue. The visual result is simply that the Setup Wizard proceeds past "Loading......" as expected.

## Tests

1. **On Wayland session (e.g., GNOME on Wayland):**
   - Remove existing config (`~/.config/OrcaSlicer/`) to simulate first launch
   - Launch OrcaSlicer
   - Verify Setup Wizard proceeds past "Loading......" to the actual wizard page

2. **On X11 session:**
   - Same test as above to verify no regression

3. **Verify env var is set:**
   - Check that `WEBKIT_DISABLE_COMPOSITING_MODE=1` is in the process environment on Linux builds