### PR TITLE
Fix incorrect support style labels in unsaved-changes dialog for Tree supports

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -296,10 +296,10 @@ static t_config_enum_values s_keys_map_SupportMaterialStyle {
     { "default",        smsDefault },
     { "grid",           smsGrid },
     { "snug",           smsSnug },
+    { "organic",        smsTreeOrganic },
     { "tree_slim",      smsTreeSlim },
     { "tree_strong",    smsTreeStrong },
-    { "tree_hybrid",    smsTreeHybrid },
-    { "organic",        smsTreeOrganic }
+    { "tree_hybrid",    smsTreeHybrid }
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(SupportMaterialStyle)
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -160,7 +160,7 @@ enum SupportMaterialPattern {
 };
 
 enum SupportMaterialStyle {
-    smsDefault, smsGrid, smsSnug, smsTreeSlim, smsTreeStrong, smsTreeHybrid, smsTreeOrganic,
+    smsDefault, smsGrid, smsSnug, smsTreeOrganic, smsTreeSlim, smsTreeStrong, smsTreeHybrid,
 };
 
 enum LongRectrationLevel


### PR DESCRIPTION
### Description
The unsaved-changes diff dialog indexes `enum_labels` by enum ordinal value.
`SupportMaterialStyle` enum ordering did not match the enum_values / enum_labels order, causing incorrect old/new labels when Tree supports were selected.

This change reorders `SupportMaterialStyle` to align with `enum_labels`, restoring correct diff display without altering behavior.

### Screenshots
<img width="1534" height="438" alt="image" src="https://github.com/user-attachments/assets/addf157f-bfb2-4930-85bc-b4a065735504" />