### PR TITLE
Fix Bambu Lab camera feed / Add IsShown() check (#12156)

### DIFF
--- a/src/slic3r/GUI/Monitor.cpp
+++ b/src/slic3r/GUI/Monitor.cpp
@@ -343,7 +343,10 @@ void MonitorPanel::update_all()
         show_status((int)MONITOR_NO_PRINTER);
         m_hms_panel->clear_hms_tag();
         m_tabpanel->GetBtnsListCtrl()->showNewTag(3, false);
-        m_status_info_panel->update(obj);
+        if (m_status_info_panel->IsShown()) {
+            m_status_info_panel->m_media_play_ctrl->SetMachineObject(obj);
+            m_status_info_panel->update(obj);
+        }
         return;
     }
 
@@ -370,9 +373,11 @@ void MonitorPanel::update_all()
 
     auto current_page = m_tabpanel->GetCurrentPage();
     if (current_page == m_status_info_panel) {
-        m_status_info_panel->obj = obj;
-        m_status_info_panel->m_media_play_ctrl->SetMachineObject(obj);
-        m_status_info_panel->update(obj);
+        if (m_status_info_panel->IsShown()) {
+            m_status_info_panel->obj = obj;
+            m_status_info_panel->m_media_play_ctrl->SetMachineObject(obj);
+            m_status_info_panel->update(obj);
+        }
     } else if (current_page == m_upgrade_panel) {
         m_upgrade_panel->update(obj);
     } else if (current_page == m_media_file_panel) {


### PR DESCRIPTION
# Description

Fixes #12156

## Problem
Users reported that the Bambu Lab printer camera feed plays for 0.5-3 seconds, then stops, then restarts repeatedly. This affects multiple printer models (P1S, X1C) and platforms (Windows, Linux).

## Root Cause
The issue was caused by `SetMachineObject()` being called every 1 second (in the timer callback) regardless of whether the status panel was actually visible. This caused unnecessary state machine transitions that interrupted the video stream.

# Screenshots/Recordings/Recordings
N/A - This is a bug fix with no UI changes.
