### PR TITLE
Fix a regression where the login panel is displayed even when the plugin is disabled

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -499,6 +499,10 @@ void AppConfig::set_defaults()
         set_bool("is_split_compound", false);
     }
 
+    if(get("installed_networking").empty()) {
+        set_bool("installed_networking", false);
+    }
+
     // Remove legacy window positions/sizes
     erase("app", "main_frame_maximized");
     erase("app", "main_frame_pos");

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4439,7 +4439,11 @@ void GUI_App::get_login_info()
                 GUI::wxGetApp().run_script(strJS);
             }
         }
-        mainframe->m_webview->SetLoginPanelVisibility(true);
+        if(app_config->get_bool("installed_networking")) {
+            mainframe->m_webview->SetLoginPanelVisibility(true);
+        } else {
+            mainframe->m_webview->SetLoginPanelVisibility(false);
+        }
     }
 }
 

--- a/src/slic3r/GUI/WebViewDialog.cpp
+++ b/src/slic3r/GUI/WebViewDialog.cpp
@@ -487,24 +487,24 @@ void WebViewPanel::SendLoginInfo()
 
 void WebViewPanel::ShowNetpluginTip()
 {
-    const auto bblnetwork_enabled = wxGetApp().app_config->get_bool("installed_networking");
-
-    // Show tip if: plugin is enabled but incompatible, OR BBL printer selected but plugin not loaded
-    bool need_show = false;
-    if (bblnetwork_enabled) {
-        need_show = !wxGetApp().is_compatibility_version();
-    } else if (wxGetApp().preset_bundle && wxGetApp().preset_bundle->is_bbl_vendor()) {
-        need_show = true;
+    // Install Network Plugin
+    const auto bblnetwork_enabled =wxGetApp().app_config->get_bool("installed_networking");
+    if(!bblnetwork_enabled) {
+        return;
     }
+    bool        bValid       = wxGetApp().is_compatibility_version();
 
-    BOOST_LOG_TRIVIAL(info) << __FUNCTION__ << boost::format(": need_show=%1%") % need_show;
+    int nShow = 0;
+    if (!bValid) nShow = 1;
 
-    json res = json::object();
-    res["command"] = "network_plugin_installtip";
-    res["sequence_id"] = "10001";
-    res["show"] = need_show ? 1 : 0;
+    BOOST_LOG_TRIVIAL(info) << __FUNCTION__<< boost::format(": bValid=%1%, nShow=%2%")%bValid %nShow;
 
-    wxString strJS = wxString::Format("window.postMessage(%s)", res.dump(-1, ' ', false, json::error_handler_t::ignore));
+    json m_Res           = json::object();
+    m_Res["command"]     = "network_plugin_installtip";
+    m_Res["sequence_id"] = "10001";
+    m_Res["show"]        = nShow;
+
+    wxString strJS = wxString::Format("window.postMessage(%s)", m_Res.dump(-1, ' ', false, json::error_handler_t::ignore));
 
     RunScript(strJS);
 }


### PR DESCRIPTION
# Description

Fix a regression that login panel is displayed even though the plugin is disabled
https://github.com/OrcaSlicer/OrcaSlicer/pull/12086#issuecomment-3841715304

# Screenshots/Recordings/Graphs

<!--
> Please attach relevant screenshots to showcase the UI changes.
> Please attach images that can help explain the changes.
-->

## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
