### PR TITLE
Fix wipe tower loaded outside of plate boundaries

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -381,13 +381,14 @@ class GLCanvas3D
         ToolHeightOutside,
         TPUPrintableError,
         FilamentPrintableError,
-        LeftExtruderPrintableError, // before slice
-        RightExtruderPrintableError, // before slice
-        MultiExtruderPrintableError,      // after slice
-        MultiExtruderHeightOutside,       // after slice
+        LeftExtruderPrintableError,         // before slice
+        RightExtruderPrintableError,        // before slice
+        MultiExtruderPrintableError,        // after slice
+        MultiExtruderHeightOutside,         // after slice
         FilamentUnPrintableOnFirstLayer,
         MixUsePLAAndPETG,
-        PrimeTowerOutside,
+        PrimeTowerOutside,                  // after slice
+        PreviewPrimeTowerOutside,           // before slice 
         NozzleFilamentIncompatible,
         MixtureFilamentIncompatible,
         FlushingVolumeZero


### PR DESCRIPTION
Add checks to snap wipe tower back to origin when it was loaded outside of plate boundaries

JIRA-22 