### PR TITLE
Fix filament compatibility by checking full parent printer inheritance chain

### DIFF
--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -686,10 +686,31 @@ bool is_compatible_with_parent_printer(const PresetWithVendorProfile& preset, co
 {
     auto *compatible_printers     = dynamic_cast<const ConfigOptionStrings*>(preset.preset.config.option("compatible_printers"));
     bool  has_compatible_printers = compatible_printers != nullptr && ! compatible_printers->values.empty();
-    //BBS: FIXME only check the parent now, but should check grand-parent as well.
-    return has_compatible_printers &&
-           std::find(compatible_printers->values.begin(), compatible_printers->values.end(), active_printer.preset.inherits()) !=
-               compatible_printers->values.end();
+    if (!has_compatible_printers)
+        return false;
+
+    auto is_compatible_with_name = [&compatible_printers](const std::string& printer_name) {
+        return !printer_name.empty() &&
+               std::find(compatible_printers->values.begin(), compatible_printers->values.end(), printer_name) !=
+                   compatible_printers->values.end();
+    };
+
+    // Keep backward-compatible behavior if collection context is unavailable.
+    if (active_printer.collection == nullptr)
+        return is_compatible_with_name(active_printer.preset.inherits());
+
+    // Walk the whole inheritance chain (parent, grand-parent, ...).
+    const Preset* current = &active_printer.preset;
+    while (current != nullptr && !current->is_system && !current->inherits().empty()) {
+        const Preset* parent = active_printer.collection->get_preset_parent(*current);
+        if (parent == nullptr)
+            break;
+        if (is_compatible_with_name(parent->name))
+            return true;
+        current = parent;
+    }
+
+    return false;
 }
 
 bool is_compatible_with_printer(const PresetWithVendorProfile &preset, const PresetWithVendorProfile &active_printer, const DynamicPrintConfig *extra_config)
@@ -2666,7 +2687,7 @@ PresetWithVendorProfile PresetCollection::get_preset_with_vendor_profile(const P
 		}
 		p = this->get_preset_parent(*p);
 	} while (p != nullptr);
-	return PresetWithVendorProfile(preset, v);
+	return PresetWithVendorProfile(preset, v, this);
 }
 
 const std::string& PresetCollection::get_preset_name_by_alias(const std::string& alias) const

--- a/src/libslic3r/Preset.hpp
+++ b/src/libslic3r/Preset.hpp
@@ -169,14 +169,17 @@ public:
 };
 
 class Preset;
+class PresetCollection;
 
 // Helper to hold a profile with its vendor definition, where the vendor definition may have been extracted from a parent system preset.
 // The parent preset is only accessible through PresetCollection, therefore to allow definition of the various is_compatible_with methods
 // outside of the PresetCollection, this composite is returned by PresetCollection::get_preset_with_vendor_profile() when needed.
 struct PresetWithVendorProfile {
-	PresetWithVendorProfile(const Preset &preset, const VendorProfile *vendor) : preset(preset), vendor(vendor) {}
+	PresetWithVendorProfile(const Preset &preset, const VendorProfile *vendor, const PresetCollection *collection = nullptr)
+        : preset(preset), vendor(vendor), collection(collection) {}
 	const Preset 		&preset;
 	const VendorProfile *vendor;
+    const PresetCollection *collection;
 };
 
 // Note: it is imporant that map is used here rather than unordered_map,


### PR DESCRIPTION
## Summary
- Reverted the previous bulk migration that switched vendor base filaments to OrcaFilamentLibrary inheritance
- Implemented a safer fix in compatibility logic: when matching compatible_printers, walk the full active printer inheritance chain (parent, grand-parent, etc.)
- This keeps vendor/system defaults untouched while allowing inherited printer profiles to match existing compatible system printer entries

## Why
- Maintainer feedback highlighted that bulk inheritance migration can alter effective user settings and risk print quality regressions
- This PR now targets the core compatibility gap from #12162 without changing vendor base profile data

## Scope
- PresetWithVendorProfile now carries optional PresetCollection context
- is_compatible_with_parent_printer() uses that context to resolve parent chain via get_preset_parent()
- Backward-compatible fallback remains when collection context is unavailable

## Notes
- No vendor base filament files are modified in this revision
