### PR TITLE
Change Ctrl+A behavior from all plates to current plate only

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3273,7 +3273,7 @@ void GLCanvas3D::on_char(wxKeyEvent& evt)
         case WXK_CONTROL_A:
 #endif /* __APPLE__ */
             if (!is_in_painting_mode && !m_layers_editing.is_enabled())
-                post_event(SimpleEvent(EVT_GLCANVAS_SELECT_ALL));
+                post_event(SimpleEvent(EVT_GLCANVAS_SELECT_CURR_PLATE_ALL));
         break;
 #ifdef __APPLE__
         case 'c':


### PR DESCRIPTION
# Description

Ctrl+A currently selects all objects on all plates.

This not only seems impractical in regards to the multiplate workflow, but also inconsistent with the contextual "Select All" right click menu which does selects all objects on current plate only.

This PR simply fixes that to have the hotkey match the context command, selecting all on current plate only.

# Screenshots/Recordings/Graphs

Current: Ctrl+A selects all on all plates
<img width="1072" height="477" alt="image" src="https://github.com/user-attachments/assets/bd86f5ce-f183-4f2d-94b3-bec5253e69d8" />

Propsed: Ctrl+A selects all on current plate only (with selected items highlighting from [my other PR](https://github.com/OrcaSlicer/OrcaSlicer/pull/12115))
<img width="1052" height="486" alt="image" src="https://github.com/user-attachments/assets/13b20365-1e06-48d3-a34d-0c091d3c6bc8" />



## Tests

Built on windows, tested with multiple plates