### PR TITLE
feat(MoonrakerPrinterAgent): support Happy Hare as alternative to AFC for filament sync

### DIFF
--- a/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
+++ b/src/slic3r/Utils/MoonrakerPrinterAgent.hpp
@@ -160,6 +160,17 @@ private:
                                    const std::string& api_key,
                                    uint64_t generation);
 
+    // System-specific filament fetch methods
+    bool fetch_hh_filament_info(std::vector<AmsTrayData>& trays, int& max_lane_index);
+    bool fetch_afc_filament_info(std::vector<AmsTrayData>& trays, int& max_lane_index);
+
+    // JSON helper methods
+    static std::string safe_json_string(const nlohmann::json& obj, const char* key);
+    static int safe_json_int(const nlohmann::json& obj, const char* key);
+    static std::string safe_array_string(const nlohmann::json& arr, int idx);
+    static int safe_array_int(const nlohmann::json& arr, int idx);
+    static std::string normalize_color_value(const std::string& color);
+
     std::string                        ssdp_announced_host;
     std::string                        ssdp_announced_id;
     std::shared_ptr<ICloudServiceAgent> m_cloud_agent;


### PR DESCRIPTION

# Description


# Screenshots/Recordings/Graphs


https://github.com/user-attachments/assets/5558b4be-24eb-4f2d-83fd-8482560a0014

<img width="445" height="285" alt="Screenshot 2026-02-14 at 7 31 57 PM" src="https://github.com/user-attachments/assets/e71fee66-05da-4f9c-8123-0f52e93f0ebb" />


## Tests

Removed configured filaments and pressed the sync button. Observed the filaments configured in my system were populated.