### PR TITLE
Fix Intra-layer "As Object List" not working.

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -4883,7 +4883,10 @@ LayerResult GCode::process_layer(
             if (print.config().print_sequence == PrintSequence::ByObject) {
                 filament_to_print_instances[filament_id] = sort_print_object_instances(objects_by_extruder_it->second, layers, ordering, single_object_instance_idx);
             } else {
-                filament_to_print_instances[filament_id] = sort_print_object_instances(objects_by_extruder_it->second, layers, &new_ordering, single_object_instance_idx);
+                
+                // PrintSequence::ByLayer to use global ordering ( per object ordering ) if intra-layer order PrintOrder::AsObjectList is specified while keeping behaviour of PrintSequence::ByLayer
+                const std::vector<const PrintInstance*>* ordering_for_filament = (print.config().print_order == PrintOrder::AsObjectList && ordering != nullptr) ? ordering: &new_ordering;
+                filament_to_print_instances[filament_id] = sort_print_object_instances(objects_by_extruder_it->second, layers, ordering_for_filament, single_object_instance_idx);
             }
         }
     }


### PR DESCRIPTION
Adjusted by-layer instance ordering so Intra-layer order = As object list is honored during per-filament scheduling. Previously, process_layer always rebuilt a nearest-neighbor new_ordering for each filament, which could override the user-selected object-list order. The update reuses the precomputed global ordering when print_order is AsObjectList, and only falls back to per-filament nearest-neighbor ordering for default mode.

Regression caused by :
https://github.com/bambulab/BambuStudio/commit/7597a4a95e19d882eabb404f20f98955752b5730

JIRA-78