### PR TITLE
Fix machine envelope G-code emitting wrong limits due to broken extruder_id indexing

### DIFF
--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -640,7 +640,7 @@ private:
     double      calc_max_volumetric_speed(const double layer_height, const double line_width, const std::string co_str);
     std::string _extrude(const ExtrusionPath &path, std::string description = "", double speed = -1);
     bool _needSAFC(const ExtrusionPath &path);
-    void print_machine_envelope(GCodeOutputStream& file, Print& print, int extruder_id);
+    void print_machine_envelope(GCodeOutputStream& file, Print& print);
     void _print_first_layer_bed_temperature(GCodeOutputStream &file, Print &print, const std::string &gcode, unsigned int first_printing_extruder_id, bool wait);
     void _print_first_layer_extruder_temperatures(GCodeOutputStream &file, Print &print, const std::string &gcode, unsigned int first_printing_extruder_id, bool wait);
     // On the first printing layer. This flag triggers first layer speeds.

--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -124,7 +124,7 @@ static void set_option_value(ConfigOptionFloats& option, size_t id, float value)
 static float get_option_value(const ConfigOptionFloats& option, size_t id)
 {
     return option.values.empty() ? 0.0f :
-        ((id < option.values.size()) ? static_cast<float>(option.values[id]) : static_cast<float>(option.values.back()));
+        ((id < option.values.size()) ? static_cast<float>(option.values[id]) : static_cast<float>(option.values.front()));
 }
 
 static float estimated_acceleration_distance(float initial_rate, float target_rate, float acceleration)


### PR DESCRIPTION
# Description

Follow-up to #12411. `print_machine_envelope()` had the same `extruder_id * 2` indexing bug on the G-code **writer** side:

- `get_extruder_id(extruder_id) * 2` was used to index machine limit arrays that only hold 2 entries `[Normal, Stealth]`. For multi-extruder setups this went out-of-bounds, causing wrong M201/M203 values to be emitted into the G-code, which the time estimator then reads and uses to override its initially-correct limits.
- Removed the unused `extruder_id` parameter and switched to `.values.front()` (Normal mode), consistent with M204/M205 in the same function.
- Changed `get_option_value()` fallback from `.back()` (Stealth) to `.front()` (Normal) so any future out-of-bounds index defaults to Normal mode instead of silently using Stealth values.

# Screenshots/Recordings/Graphs

N/A — no UI changes.

## Tests
