### PR TITLE
JD processor upgrade

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -5570,7 +5570,7 @@ float GCodeProcessor::get_axis_max_acceleration(PrintEstimatedStatistics::ETimeM
     }
 }
 
-float GCodeProcessor::get_get_axis_max_jerk_with_jd(PrintEstimatedStatistics::ETimeMode mode, Axis axis) const
+float GCodeProcessor::get_axis_max_jerk_with_jd(PrintEstimatedStatistics::ETimeMode mode, Axis axis) const
 {
     if (axis != X && axis != Y && axis != Z && axis != E)
         return 0.0f;
@@ -5592,7 +5592,7 @@ float GCodeProcessor::get_axis_max_jerk(PrintEstimatedStatistics::ETimeMode mode
     const size_t id = static_cast<size_t>(mode);
     const float jd = get_option_value(m_time_processor.machine_limits.machine_max_junction_deviation, id);
     if (m_flavor == gcfMarlinFirmware && jd > 0.0f) {
-        return get_get_axis_max_jerk_with_jd(mode, axis);
+        return get_axis_max_jerk_with_jd(mode, axis);
     }
 
     switch (axis)
@@ -5623,9 +5623,9 @@ Vec3f GCodeProcessor::get_xyz_max_jerk(PrintEstimatedStatistics::ETimeMode mode)
     }
     else
     {
-        jx = get_get_axis_max_jerk_with_jd(mode, X);
-        jy = get_get_axis_max_jerk_with_jd(mode, Y);
-        jz = get_get_axis_max_jerk_with_jd(mode, Z);
+        jx = get_axis_max_jerk_with_jd(mode, X);
+        jy = get_axis_max_jerk_with_jd(mode, Y);
+        jz = get_axis_max_jerk_with_jd(mode, Z);
     }
 
     return Vec3f(jx, jy, jz);

--- a/src/libslic3r/GCode/GCodeProcessor.hpp
+++ b/src/libslic3r/GCode/GCodeProcessor.hpp
@@ -1074,7 +1074,7 @@ class Print;
         // per-nozzle machine limits (filament_map_2 / get_config_idx_for_filament).
         float get_axis_max_feedrate(PrintEstimatedStatistics::ETimeMode mode, Axis axis) const;
         float get_axis_max_acceleration(PrintEstimatedStatistics::ETimeMode mode, Axis axis) const;
-        float get_get_axis_max_jerk_with_jd(PrintEstimatedStatistics::ETimeMode mode, Axis axis) const;
+        float get_axis_max_jerk_with_jd(PrintEstimatedStatistics::ETimeMode mode, Axis axis) const;
         float get_axis_max_jerk(PrintEstimatedStatistics::ETimeMode mode, Axis axis) const;
         Vec3f get_xyz_max_jerk(PrintEstimatedStatistics::ETimeMode mode) const;
         float get_retract_acceleration(PrintEstimatedStatistics::ETimeMode mode) const;


### PR DESCRIPTION
# Description

This pull request upgrade and fixes a bug from JD processor where the time estimate is influenced by the machine's jerk limits, even when using Junction deviation.

- Update M205 Processor to get JD from gcode.
- JD to Jerk calculation modularized.
- get_axis_max_jerk JD compatible.
- include Z calculation.
<img width="506" height="587" alt="image" src="https://github.com/user-attachments/assets/205438bc-005b-43de-b6d9-e0f7140647c2" />
