### PR TITLE
Fix wipe tower Y offset for SEMM

### DIFF
--- a/src/libslic3r/GCode/WipeTower2.hpp
+++ b/src/libslic3r/GCode/WipeTower2.hpp
@@ -61,11 +61,11 @@ public:
 	float get_wipe_tower_height() const { return m_wipe_tower_height; }
     // ORCA: Match WipeTower API used by Print skirt/brim planning.
     // Returned bounding box is in WIPE-TOWER-LOCAL coordinates (before placement on the bed).
-    // Include brim and y-shift to match what WT gcode actually prints.
-    BoundingBoxf get_bbx() const{
+    // Keep this as the nominal tower footprint (including brim), without dynamic y_shift.
+    BoundingBoxf get_bbx() const {
         const float brim = m_wipe_tower_brim_width_real;
-        const Vec2d min(-brim, -brim + double(m_y_shift));
-        const Vec2d max(double(m_wipe_tower_width) + brim, double(m_wipe_tower_depth) + brim + double(m_y_shift));
+        const Vec2d min(-brim, -brim);
+        const Vec2d max(double(m_wipe_tower_width) + brim, double(m_wipe_tower_depth) + brim);
         return BoundingBoxf(min, max);
     }
     // WT2 doesn't currently compute a rib-origin compensation like WipeTower (m_rib_offset),


### PR DESCRIPTION
# Description

Fixes regression on wipe tower placement relative to the skirt for SEMM printers.

Before
<img width="2208" height="1436" alt="image" src="https://github.com/user-attachments/assets/4517f089-d5c3-4056-b733-b7469c14d592" />

After
![image](https://github.com/user-attachments/assets/265e19d0-9eb2-4f14-8a9a-66550c894ece)

## Tests

Testing is needed! I have tested with SEMM (purge in prime tower and disabled purge in prime tower) but validation with multiple extruders and BBL path is needed.