### PR TITLE
Fix wipe tower skirt alignment by computing bbx from actual first-layer polygon

### DIFF
--- a/src/libslic3r/GCode/WipeTower2.cpp
+++ b/src/libslic3r/GCode/WipeTower2.cpp
@@ -2134,6 +2134,11 @@ WipeTower::ToolChangeResult WipeTower2::finish_layer()
         // Save actual brim width to be later passed to the Print object, which will use it
         // for skirt calculation and pass it to GLCanvas for precise preview box
         m_wipe_tower_brim_width_real = loops_num * spacing;
+
+        // Compute actual first-layer bounding box from the outermost brim polygon,
+        // matching how WipeTower::get_bbx() uses m_outer_wall extents.
+        BoundingBox first_layer_box = get_extents(poly);
+        m_first_layer_bbx = BoundingBoxf(unscale(first_layer_box.min), unscale(first_layer_box.max));
     }
 
     // Now prepare future wipe.

--- a/src/libslic3r/GCode/WipeTower2.hpp
+++ b/src/libslic3r/GCode/WipeTower2.hpp
@@ -61,12 +61,13 @@ public:
 	float get_wipe_tower_height() const { return m_wipe_tower_height; }
     // ORCA: Match WipeTower API used by Print skirt/brim planning.
     // Returned bounding box is in WIPE-TOWER-LOCAL coordinates (before placement on the bed).
-    // Keep this as the nominal tower footprint (including brim), without dynamic y_shift.
+    // Computed from the actual first-layer polygon (including brim), like WipeTower::get_bbx().
     BoundingBoxf get_bbx() const {
+        if (m_first_layer_bbx.defined)
+            return m_first_layer_bbx;
+        // Fallback: nominal rectangle (used if generate() hasn't run yet)
         const float brim = m_wipe_tower_brim_width_real;
-        const Vec2d min(-brim, -brim);
-        const Vec2d max(double(m_wipe_tower_width) + brim, double(m_wipe_tower_depth) + brim);
-        return BoundingBoxf(min, max);
+        return BoundingBoxf(Vec2d(-brim, -brim), Vec2d(double(m_wipe_tower_width) + brim, double(m_wipe_tower_depth) + brim));
     }
     // WT2 doesn't currently compute a rib-origin compensation like WipeTower (m_rib_offset),
     // so expose a zero offset for consistency purposes (to maintain API parity).
@@ -203,6 +204,7 @@ private:
 	float  m_wipe_tower_cone_angle = 0.f;
     float  m_wipe_tower_brim_width      = 0.f; 	// Width of brim (mm) from config
     float  m_wipe_tower_brim_width_real = 0.f; 	// Width of brim (mm) after generation
+    BoundingBoxf m_first_layer_bbx;              // Actual first-layer bounding box (incl. brim/ribs)
 	float  m_wipe_tower_rotation_angle = 0.f; // Wipe tower rotation angle in degrees (with respect to x axis)
     float  m_internal_rotation  = 0.f;
 	float  m_y_shift			= 0.f;  // y shift passed to writer


### PR DESCRIPTION
# Description

Follow-up fix for #12442
Also ref to the discussions here: #12266
@igiannakas I use the actual bounding box calculated from the first layer instead, similar to what we did for the WipeTower.

# Screenshots/Recordings/Graphs
<img width="619" height="503" alt="Screenshot 2026-02-24 at 20 20 45" src="https://github.com/user-attachments/assets/953f8988-1a0a-4f70-bf35-fb018ab86e6d" />

<img width="504" height="554" alt="Screenshot 2026-02-24 at 20 21 13" src="https://github.com/user-attachments/assets/188c8709-6b89-4e88-95fd-93b3667a0743" />


## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
