### PR TITLE
Fix: Init Serialized options

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -974,7 +974,8 @@ void Tab::init_options_list()
             m_options_list.emplace(opt_key, m_opt_status_value);
             continue;
         }
-        if (m_config->option(opt_key)->is_vector())
+        const ConfigOptionDef* opt_def = m_config->def()->get(opt_key);
+        if (m_config->option(opt_key)->is_vector() && !(opt_def && opt_def->gui_flags == "serialized"))
             m_options_list.emplace(opt_key + "#0", m_opt_status_value);
         else
             m_options_list.emplace(opt_key, m_opt_status_value);


### PR DESCRIPTION
This pull request makes a small but important adjustment to how vector options are handled in the `init_options_list()` method. The change ensures that only non-serialized vector options are treated as individual entries.

This was causing that fields like `small area compensation model` didnt get the revert option if modified.