### PR TITLE
Fix missing infill layers (fill_surface_by_multilines & fill_surface_trapezoidal bug fix)

### DIFF
--- a/src/libslic3r/Fill/FillRectilinear.cpp
+++ b/src/libslic3r/Fill/FillRectilinear.cpp
@@ -3024,7 +3024,7 @@ bool FillRectilinear::fill_surface_by_multilines(const Surface *surface, FillPar
     const ExPolygons contracted = offset_ex(surface->expolygon, -float(scale_(0.5 * this->spacing)));
 
     // if contraction results in empty ExPolygons, use original surface
-    const ExPolygons intersection_surface = contracted.empty() ? ExPolygons{surface->expolygon} : contracted;
+    const ExPolygons& intersection_surface = contracted.empty() ? ExPolygons{surface->expolygon} : contracted;
 
     // Intersect polylines with perimeter
     fill_lines = intersection_pl(std::move(fill_lines), intersection_surface);
@@ -3269,7 +3269,7 @@ bool FillRectilinear::fill_surface_trapezoidal(
     ExPolygons contracted = offset_ex(expolygon, -float(scale_(0.5 * this->spacing)));
 
     // if contraction results in empty polygon, use original surface
-    const ExPolygon &intersection_surface = contracted.empty() ? expolygon : contracted.front();
+    const ExPolygons& intersection_surface = contracted.empty() ? ExPolygons{expolygon} : contracted;
 
     // Intersect polylines with offset expolygon
     polylines = intersection_pl(std::move(polylines), intersection_surface);
@@ -3285,7 +3285,14 @@ bool FillRectilinear::fill_surface_trapezoidal(
     // Connect infill lines using offset expolygon
     int infill_start_idx = polylines_out.size();
     if (!polylines.empty()) {
-        Slic3r::Fill::chain_or_connect_infill(std::move(polylines), intersection_surface, polylines_out, this->spacing, params);
+        if (params.dont_connect()) {
+            if (polylines.size() > 1)
+                polylines = chain_polylines(std::move(polylines));
+            append(polylines_out, std::move(polylines));
+        } else {
+            connect_infill(std::move(polylines), to_polygons(intersection_surface), get_extents(intersection_surface), polylines_out,
+                           this->spacing, params);
+        }
 
         // Rotate back the infill lines to original orientation
         if (std::abs(base_angle) >= EPSILON) {


### PR DESCRIPTION
# Description

Problem
When generating rectilinear infill, the surface is contracted by half the line width to avoid excessive overlap with perimeters. This contraction can cause the original ExPolygon to split into multiple separate Polygons. The previous code incorrectly handled this case by:

https://github.com/OrcaSlicer/OrcaSlicer/blob/5c07cb5c397c5d3c973103eb1d3bdbf0fb11f844/src/libslic3r/Fill/FillRectilinear.cpp#L3026-L3027

This returns only the first polygon of the vector, which is why some sectors are left without infill lines.
I used the overloads that accept ExPolygons as an argument to avoid this problem.

# Before:

<img width="1749" height="1017" alt="image" src="https://github.com/user-attachments/assets/b3f23b7a-4d55-4e2c-9ef6-b0a9c19bf9ea" />

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/2d79c6a8-570d-4a1c-a6a7-9e0577f80461" />

# After:

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/72ecb561-cce2-44f2-b0d0-e37788f01a19" />

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/4b459037-1385-4d4b-a03a-62d9e091a80c" />


Fix #12510
