### PR TITLE
fix: typo "Glidlines" → "Gridlines" in View menu tooltip

### DIFF
--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2825,7 +2825,7 @@ void MainFrame::init_menubar_as_editor()
             this, [this]() { return m_tabpanel->GetSelection() == TabPosition::tp3DEditor || m_tabpanel->GetSelection() == TabPosition::tpPreview; },
             [this]() { return wxGetApp().show_3d_navigator(); }, this);
 
-        append_menu_check_item(viewMenu, wxID_ANY, _L("Show Gridlines"), _L("Show Glidlines on plate"),
+        append_menu_check_item(viewMenu, wxID_ANY, _L("Show Gridlines"), _L("Show Gridlines on plate"),
             [this](wxCommandEvent&) {
                 wxGetApp().toggle_show_plate_gridlines();
                 m_plater->get_current_canvas3D()->post_event(SimpleEvent(wxEVT_PAINT));


### PR DESCRIPTION
## Summary
- Fix typo in `MainFrame.cpp:2828`: tooltip reads "Show Glidlines on plate" → "Show Gridlines on plate"

## Test plan
- [ ] Open View menu, hover "Show Gridlines" — tooltip should say "Show Gridlines on plate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)