### PR TITLE
[Emboss] Fix issue that font search not working on macOS

### DIFF
--- a/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
+++ b/src/slic3r/GUI/Gizmos/GLGizmoEmboss.cpp
@@ -3401,8 +3401,11 @@ bool load(Facenames &facenames) {
 
     facenames.hash = data.hash;
     facenames.faces.reserve(data.good.size());
-    for (const wxString &face : data.good)
+    facenames.faces_names.reserve(data.good.size());
+    for (const wxString &face : data.good) {
         facenames.faces.push_back({face});
+        facenames.faces_names.push_back(face.utf8_string());
+    }
     facenames.bad = data.bad;
     return true;
 }


### PR DESCRIPTION
The font search not working properly when the font faces are loaded from cache:
<img width="531" height="355" alt="image" src="https://github.com/user-attachments/assets/d50a3547-c3cd-4bd6-8d11-f469a9dca313" />

This PR fixes this issue:
<img width="550" height="436" alt="image" src="https://github.com/user-attachments/assets/e2f4d973-cee1-41b5-be91-d12f0ce7b74e" />
