### PR TITLE
Use non-deprecated triangulate_hole method

### DIFF
--- a/src/libslic3r/MeshBoolean.cpp
+++ b/src/libslic3r/MeshBoolean.cpp
@@ -343,7 +343,7 @@ void segment(CGALMesh& src, std::vector<CGALMesh>& dst, double smoothing_alpha =
             std::cout << "* Number of facets in constructed patch: " << patch_facets.size() << std::endl;
             std::cout << "  Number of vertices in constructed patch: " << patch_vertices.size() << std::endl;
 #else
-            CGAL::Polygon_mesh_processing::triangulate_hole(out, h, std::back_inserter(patch_facets));
+            CGAL::Polygon_mesh_processing::triangulate_hole(out, h, CGAL::parameters::default_values().face_output_iterator(std::back_inserter(patch_facets)));
 #endif
         }
 


### PR DESCRIPTION
Fix deprecate warning
Following CGAL 6.1.1 documentation recommendation:
https://doc.cgal.org/latest/Polygon_mesh_processing/group__PMP__hole__filling__grp.html#gad2d3c43bce0ef90a16530478196d7f42