### PR TITLE
Fix artifact classic wall generator  painted fuzzy skin

### DIFF
--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
@@ -301,11 +301,21 @@ Polygon apply_fuzzy_skin(const Polygon& polygon, const PerimeterGenerator& perim
             fuzzified.points.clear();
 
             const auto fuzzy_current_segment = [&segment, &fuzzified, &r, slice_z]() {
-                fuzzified.points.push_back(segment.front());
-                const auto back = segment.back();
+                // Orca: non fuzzy points to isolate fuzzy region
+                const auto front = segment.front();
+                const auto back  = segment.back();
+ 
                 fuzzy_polyline(segment, false, slice_z, r.first);
+                //Orca: only add non fuzzy point if it's not in the polygon closing point.
+                if (!fuzzified.points.empty()
+                    && fuzzified.points.back() != front) {
+                    fuzzified.points.push_back(front);
+                }
                 fuzzified.points.insert(fuzzified.points.end(), segment.begin(), segment.end());
-                fuzzified.points.push_back(back);
+                //Orca: only add non fuzzy point if it's not in the polygon closing point.
+                if (!fuzzified.points.empty() && fuzzified.points.back() != front) {
+                    fuzzified.points.push_back(back);
+                }
                 segment.clear();
             };
 
@@ -328,7 +338,12 @@ Polygon apply_fuzzy_skin(const Polygon& polygon, const PerimeterGenerator& perim
             }
         }
     }
-
+ 
+    // Orca: ensure the loop is closed after fuzzification 
+    if (!fuzzified.points.empty() && fuzzified.points.front() != fuzzified.points.back()) {
+        fuzzified.points.back() = fuzzified.points.front();
+    }
+ 
     return fuzzified;
 }
 


### PR DESCRIPTION
# Description
Another fuzzy skin bugfix:
Same fix made in #11923, but for classic wall generator

# Before
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/65e62859-e0c4-4988-b73a-e59006c6d7fa" />

# After
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/2a105b3f-47cc-499b-bbca-c3a05681aa02" />

## Tests

[test fuzzy flatpak.3mf.txt](https://github.com/user-attachments/files/25780920/test.fuzzy.flatpak.3mf.txt)

