### PR TITLE
fix: round flush_volumes_matrix values to integers

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5402,7 +5402,7 @@ void GCode::append_full_config(const Print &print, std::string &str)
                 size_t temp_begin_t = idx * matrix_value_count, temp_end_t = (idx + 1) * matrix_value_count;
                 std::transform(temp_flush_volumes_matrix.begin() + temp_begin_t, temp_flush_volumes_matrix.begin() + temp_end_t,
                                temp_flush_volumes_matrix.begin() + temp_begin_t,
-                               [temp_cfg_flush_multiplier_idx](double inputx) { return inputx * temp_cfg_flush_multiplier_idx; });
+                               [temp_cfg_flush_multiplier_idx](double inputx) { return std::round(inputx * temp_cfg_flush_multiplier_idx); });
             }
             cfg.option<ConfigOptionFloats>("flush_volumes_matrix")->values = temp_flush_volumes_matrix;
         } else if (filament_count_tmp == 1) {


### PR DESCRIPTION
## Summary
- Round `flush_volumes_matrix` values to integers after multiplying by `flush_multiplier`
- Fixes compatibility with Creality K2 and potentially other Klipper-based printers

## Problem
When `flush_multiplier` (default 1.3) is applied to `flush_volumes_matrix` values, the result can be a decimal (e.g., `272 * 1.3 = 353.6`). 

The Creality K2's metadata parser (`metadata.py`) crashes when parsing these decimal values in the G-code CONFIG_BLOCK, causing:
- `metadata.py` exits with code 255
- `gcode_metadata` becomes empty `{}`
- `gcode_start_byte` is not set
- Print gets stuck at "File selected" and never starts

## Root Cause
In `GCode.cpp:5405`, the flush volumes are multiplied by the flush multiplier without rounding:
```cpp
return inputx * temp_cfg_flush_multiplier_idx;  // Can produce 353.6
```

## Solution
Added `std::round()` to ensure integer values:
```cpp
return std::round(inputx * temp_cfg_flush_multiplier_idx);  // Produces 354
```

## Test plan
- [x] Verified that G-code with decimal `flush_volumes_matrix` values fails on Creality K2
- [x] Verified that G-code with integer `flush_volumes_matrix` values works on Creality K2
- [ ] Build and verify the fix produces integer values in the CONFIG_BLOCK

## Impact
This is a minimal, low-risk change that:
- Only affects the serialized output in G-code comments
- Does not affect actual print behavior (flush volumes are the same, just rounded)
- Restores compatibility with firmware that expects integer values

🤖 Generated with [Claude Code](https://claude.com/claude-code)