### PR TITLE
Fix three regressions in the multi-tool extruder tab system:

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -6773,6 +6773,7 @@ void PrintConfigDef::init_extruder_option_keys()
     // ConfigOptionFloats, ConfigOptionPercents, ConfigOptionBools, ConfigOptionStrings
     m_extruder_option_keys = {
         "extruder_type", "nozzle_diameter", "default_nozzle_volume_type", "min_layer_height", "max_layer_height", "extruder_offset",
+        "extruder_printable_height", "nozzle_volume", "nozzle_type", "nozzle_flush_dataset",
         "retraction_length", "z_hop", "z_hop_types", "travel_slope", "retract_lift_above", "retract_lift_below", "retract_lift_enforce", "retraction_speed", "deretraction_speed",
         "retract_before_wipe", "retract_restart_extra", "retraction_minimum_travel", "wipe", "wipe_distance",
         "retract_when_changing_layer", "retract_length_toolchange", "retract_restart_extra_toolchange", "extruder_colour",

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -903,9 +903,21 @@ void Tab::filter_diff_option(std::vector<std::string> &options)
                 break;
             }
         }
-        if (!found) opt = opt.substr(0, hash_pos);
+        if (found) continue;
+
+        // Keep key#index if that exact option is tracked.
+        if (m_options_list.find(opt) != m_options_list.end())
+            continue;
+
+        const std::string base = opt.substr(0, hash_pos);
+        const std::string idx0 = base + "#0";
+        if (m_options_list.find(idx0) != m_options_list.end()) {
+            opt = idx0;
+            continue;
+        }
+        if (m_options_list.find(base) != m_options_list.end())
+            opt = base;
     }
-    options.erase(std::remove(options.begin(), options.end(), ""), options.end());
 }
 
 // Update UI according to changes
@@ -988,10 +1000,15 @@ void TabPrinter::init_options_list()
     if (m_printer_technology == ptFFF)
         m_options_list.emplace("extruders_count", m_opt_status_value);
     for (size_t i = 1; i < m_extruders_count; ++i) {
-        auto extruder_page = m_pages[3 + i];
-        for (auto group : extruder_page->m_optgroups) {
-            for (auto & opt : group->opt_map())
-                m_options_list.emplace(opt.first, m_opt_status_value);
+        wxString target_title = wxString::Format("Extruder %d", int(i + 1));
+        for (auto &page : m_pages) {
+            if (page->title() == target_title) {
+                for (auto group : page->m_optgroups) {
+                    for (auto &opt : group->opt_map())
+                        m_options_list.emplace(opt.first, m_opt_status_value);
+                }
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
1. Dirty flags not showing for extruder options:
2. Crash when switching to non-first extruder tabs:
3. Modifying one extruder's parameter affects other extruders:

# Description

<!--
> Please provide a summary of the changes made in this PR. Include details such as:
  > * What issue does this PR address or fix?
  > * What new features or enhancements does this PR introduce?
  > * Are there any breaking changes or dependencies that need to be considered?
-->

# Screenshots/Recordings/Graphs
[Screencast From 2026-03-08 23-17-01.webm](https://github.com/user-attachments/assets/287909f1-81db-42a4-bb63-bf706dcc8ff3)



## Tests

<!--
> Please describe the tests that you have conducted to verify the changes made in this PR.
-->
