### PR TITLE
Move adaptive flowrate to developer mode and clarified tooltip

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2461,7 +2461,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("When enabled, the extrusion flow is limited by the smaller of "
         "the fitted value (calculated from line width and layer height) and the user-defined maximum flow."
         " When disabled, only the user-defined maximum flow is applied.\n\n"
-        "Note: Experimental and incomplete feature imported from BBS. Functional for some profiles that already have the variable saved..");
+        "Note: Experimental and incomplete feature imported from BBS. Functional for some profiles that already have the variable saved.");
     def->mode = comDevelop;
     def->nullable = true;
     def->set_default_value(new ConfigOptionBoolsNullable {false});


### PR DESCRIPTION
# Description
Set Adaptive volumetric speed to developer mode only

Addresses point 2 in #12684

Also added the same note from the wiki to the tooltip:
> Note: Experimental and incomplete feature imported from BBS. Functional for some profiles that already have the variable saved.

# Screenshots/Recordings/Graphs
Adaptive volumetric speed setting not in advanced mode
<img width="748" height="605" alt="image" src="https://github.com/user-attachments/assets/a4c49b5b-6f90-40a0-b569-f68156b1bd3b" />
Adaptive volumetric speed setting only in developer mode
<img width="749" height="602" alt="image" src="https://github.com/user-attachments/assets/dd135380-704c-4596-a567-4bffec83d6dc" />

## Tests
Opened the edit filament dialog with developer mode on/off