### PR TITLE
Disable filament grouping button logic when when not Bambu H2D

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -1485,7 +1485,12 @@ void PartPlate::register_raycasters_for_picking(GLCanvas3D &canvas)
     canvas.remove_raycasters_for_picking(SceneRaycaster::EType::Bed, picking_id_component(6));
     register_model_for_picking(canvas, m_plate_name_edit_icon, picking_id_component(6));
     register_model_for_picking(canvas, m_move_front_icon, picking_id_component(7));
-    register_model_for_picking(canvas, m_plate_filament_map_icon, picking_id_component(PLATE_FILAMENT_MAP_ID));
+
+    // Only register filament map button for H2D (dual-extruder Bambu Lab) printers
+    PresetBundle* preset = wxGetApp().preset_bundle;
+    bool dual_bbl = (preset && preset->is_bbl_vendor() && preset->get_printer_extruder_count() == 2);
+    if (dual_bbl)
+        register_model_for_picking(canvas, m_plate_filament_map_icon, picking_id_component(PLATE_FILAMENT_MAP_ID));
 }
 
 int PartPlate::picking_id_component(int idx) const


### PR DESCRIPTION
# Description
When using the Bambu H2D, users can use Filament Grouping, a button found next to the bed preview. When not on a H2D profile, the button is hidden. However, it remained usable, and clicking an empty space below all the buttons causes the dialog to appear.

This PR fixes that by adding a check before the button is registered.

Addresses point 9 (focusing on the 2nd bullet) in #12684 

## Tests
Tried to click on the empty area right below the column of buttons (see the below images)
Made sure to have the H2D profile loaded as well, and checked that the dialog still opens for that printer.

H2D active
<img width="1635" height="949" alt="image" src="https://github.com/user-attachments/assets/da6fb03b-e3c8-4504-ac60-b96ecc6347dc" />
Area to click for the invisible button
<img width="935" height="788" alt="image" src="https://github.com/user-attachments/assets/1f001bcf-0224-4922-b5bf-47a95820e536" />

