### PR TITLE
Fix flushing windows dialog able to move around using trackpad and added esc to close dialog

### DIFF
--- a/resources/web/flush/WipingDialog.html
+++ b/resources/web/flush/WipingDialog.html
@@ -8,13 +8,19 @@
         -webkit-user-select: none;
       }
 
-        html, body {
-          margin: 0px;
-          padding: 0px;
-          height: 100%;
-          background: #f5f5f5;
-          font-family: sans-serif;
-        }
+      html, body {
+        margin: 0px;
+        padding: 0px;
+        height: 100%;
+        background: #f5f5f5;
+        font-family: sans-serif;
+        overscroll-behavior: none;
+      }
+      
+      body {
+          position: fixed;
+          inset: 0;
+      }
 
       .container {
         background: #fff;
@@ -412,6 +418,15 @@
         })
         window.wipingDialog.postMessage(data);
       });
+
+      // Escape should close the dialog even when focus is inside web content.
+      document.addEventListener("keydown", function (event) {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          quit();
+        }
+      }, true);
 
       function buildText(data) {
         document.getElementById('volume_desp_panel').innerText = data.volume_desp_panel

--- a/src/slic3r/GUI/WipeTowerDialog.cpp
+++ b/src/slic3r/GUI/WipeTowerDialog.cpp
@@ -496,6 +496,15 @@ WipingDialog::WipingDialog(wxWindow* parent, const int max_flush_volume) :
             BOOST_LOG_TRIVIAL(error) << __FUNCTION__<< "Failed to parse json message: " << message;
         }
         });
+
+    m_webview->Bind(wxEVT_CHAR_HOOK, [this](wxKeyEvent& e) {
+    if (e.GetKeyCode() == WXK_ESCAPE) {
+            if (IsModal()) EndModal(wxID_CANCEL);
+            else Close();
+            return;
+    }
+        e.Skip();
+    });
 }
 
 


### PR DESCRIPTION
Added entry to wipingdialog.html css to prevent it from being overscrollable and its position fixed.
Added escape button to close dialog event on both javascript and webview events

JIRA-136