### PR TITLE
Remove leftover Bambu warning caption from dialogs

### DIFF
--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -5947,7 +5947,7 @@ void GUI::ObjectList::smooth_mesh()
         if (cur_face_count > limit_face_count) {
             auto name_str = wxString::FromUTF8(name);
             auto content = wxString::Format(_L("\"%s\" will exceed 1 million faces after this subdivision, which may increase slicing time. Do you want to continue?"), name_str);
-            WarningDialog dlg(static_cast<wxWindow *>(wxGetApp().mainframe), (is_part ? _L("Part") : _L("Object")) + " " + content, _L("BambuStudio warning"), wxYES_NO);
+            WarningDialog dlg(static_cast<wxWindow *>(wxGetApp().mainframe), (is_part ? _L("Part") : _L("Object")) + " " + content, wxEmptyString, wxYES_NO);
             if (dlg.ShowModal() == wxID_NO) {
                 return true;
             }
@@ -5958,7 +5958,7 @@ void GUI::ObjectList::smooth_mesh()
     auto show_smooth_mesh_error_dlg = [this](std::string name) {
         auto name_str = wxString::FromUTF8(name);
         auto content  = wxString::Format(_L("\"%s\" part's mesh contains errors. Please repair it first."), name_str);
-        WarningDialog dlg(static_cast<wxWindow *>(wxGetApp().mainframe), content, _L("BambuStudio warning"), wxOK);
+        WarningDialog dlg(static_cast<wxWindow *>(wxGetApp().mainframe), content, wxEmptyString, wxOK);
         dlg.ShowModal();
     };
     bool has_show_smooth_mesh_error_dlg = false;


### PR DESCRIPTION
### Description
A couple of warning dialogs still used a caption containing "**BambuStudio warning**". It is a leftover from the original BambuStudio codebase.

### This PR
- removes the explicit caption so the dialogs use the standard application warning title instead.

### Result
- removes the remaining Bambu reference while keeping the visible behavior consistent with the rest of the UI.
- addresses point 1. of  "New ports from Bambu Studio" section from #12684

### Screenshots

- **Before:**
<img width="1352" height="277" alt="image" src="https://github.com/user-attachments/assets/d107acaa-f159-496a-b14e-93cd149bf355" />

- **After:**
<img width="1356" height="278" alt="image" src="https://github.com/user-attachments/assets/e111b5b3-9b3e-4b13-b20d-f98e5173ea16" />
