### PR TITLE
Add support for esthetic filament sub-types in Snapmaker Printer Agent

### DIFF
--- a/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
+++ b/src/slic3r/Utils/SnapmakerPrinterAgent.cpp
@@ -43,10 +43,16 @@ std::string SnapmakerPrinterAgent::combine_filament_type(const std::string& type
         return base + "-CF";
     if (sub == "GF")
         return base + "-GF";
-    if (sub == "SILK")
-        return base + " SILK";
     if (sub == "SNAPSPEED" || sub == "HS")
         return base + " HIGH SPEED";
+    if (sub == "SILK")
+        return base + " SILK";
+    if (sub == "WOOD")
+        return base + " WOOD";
+    if (sub == "MATTE")
+        return base + " MATTE";
+    if (sub == "MARBLE")
+        return base + " MARBLE";
 
     // Unrecognized sub-type (brand names like Polylite, Basic, etc.) -- use base type only
     return base;


### PR DESCRIPTION
# Description
Esthetic filaments such as wood-infused, matte and marble filaments will now be handled by the Snapmaker printer agent so that they could be matched to more appropriate print profiles instead of generic PLA. 
