### PR TITLE
chore: translate comment for ignoring truncating casts warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,7 +493,8 @@ if (APPLE)
 endif ()
 
 if(MSVC)
-# 添加编译选项，忽略警告 C4305 （格式转换截断）
+# Ignore truncating casts in initializers & constructors
+# https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4305
 add_compile_options(/wd4305)
 endif()
 


### PR DESCRIPTION
# Description

I was just building the project and checked out the CMakeLists to see if there are some optional features I can disable to speed up compilation and tripped on this chinese comment.
This just translates the comment to English for consistency