### PR TITLE
Fix infinite loop with zero  top solid  infill density

### DIFF
--- a/src/libslic3r/Fill/Fill.cpp
+++ b/src/libslic3r/Fill/Fill.cpp
@@ -882,6 +882,7 @@ std::vector<SurfaceFill> group_fills(const Layer &layer, LockRegionParam &lock_p
                         if (surface.is_top()) {
                             params.pattern = region_config.top_surface_pattern.value;
                             params.density = float(region_config.top_surface_density);
+                            if (params.density <= 0.0f) continue;
                         } else { // Surface is bottom
                             params.pattern = region_config.bottom_surface_pattern.value;
                             params.density = float(region_config.bottom_surface_density);


### PR DESCRIPTION
# Description

This pull request fixes the bug where Orca Slicer enters an infinite loop when a density of zero is introduced for the top layer solid infill

# Screenshots/Recordings/Graphs

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/5bf5c220-a398-483f-9f69-63dadbc888af" />

Note: For  bottom solid infill, this is not a problem because the minimum density is 10%.
