### PR TITLE
Add FILL3D PLA Turbo filament profile

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -393,6 +393,10 @@
             "sub_path": "filament/AliZ/AliZ PLA @base.json"
         },
         {
+            "name": "FILL3D PLA Turbo @base",
+            "sub_path": "filament/FILL3D/FILL3D PLA Turbo @base.json"
+        },
+        {
             "name": "Bambu PLA Aero @base",
             "sub_path": "filament/Bambu/Bambu PLA Aero @base.json"
         },
@@ -1051,6 +1055,10 @@
         {
             "name": "AliZ PLA @System",
             "sub_path": "filament/AliZ/AliZ PLA @System.json"
+        },
+        {
+            "name": "FILL3D PLA Turbo @System",
+            "sub_path": "filament/FILL3D/FILL3D PLA Turbo @System.json"
         },
         {
             "name": "Bambu PLA Aero @System",

--- a/resources/profiles/OrcaFilamentLibrary/filament/FILL3D/FILL3D PLA Turbo @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FILL3D/FILL3D PLA Turbo @System.json
@@ -1,0 +1,9 @@
+{
+    "type": "filament",
+    "setting_id": "FILL3D001SYS",
+    "name": "FILL3D PLA Turbo @System",
+    "from": "system",
+    "instantiation": "true",
+    "inherits": "FILL3D PLA Turbo @base",
+    "compatible_printers": []
+}

--- a/resources/profiles/OrcaFilamentLibrary/filament/FILL3D/FILL3D PLA Turbo @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/FILL3D/FILL3D PLA Turbo @base.json
@@ -1,0 +1,95 @@
+{
+    "type": "filament",
+    "name": "FILL3D PLA Turbo @base",
+    "from": "system",
+    "filament_id": "FILL3D001",
+    "instantiation": "false",
+    "inherits": "fdm_filament_pla",
+    "adaptive_pressure_advance": [
+        "1"
+    ],
+    "adaptive_pressure_advance_model": [
+        "0.03,23.43,5000\n0.028,25.31,5000\n0.025,28.12,5000\n0.025,23.43,12000\n0.020,25.31,12000\n0.018,28.12,12000"
+    ],
+    "additional_cooling_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "35"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "35"
+    ],
+    "enable_pressure_advance": [
+        "1"
+    ],
+    "fan_cooling_layer_time": [
+        "100"
+    ],
+    "fan_max_speed": [
+        "100"
+    ],
+    "fan_min_speed": [
+        "100"
+    ],
+    "filament_cost": [
+        "25.4"
+    ],
+    "filament_density": [
+        "1.31"
+    ],
+    "filament_flow_ratio": [
+        "0.98"
+    ],
+    "filament_max_volumetric_speed": [
+        "32"
+    ],
+    "filament_type": [
+        "PLA"
+    ],
+    "filament_vendor": [
+        "FILL3D"
+    ],
+    "hot_plate_temp": [
+        "55"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "55"
+    ],
+    "nozzle_temperature": [
+        "235"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "230"
+    ],
+    "nozzle_temperature_range_high": [
+        "240"
+    ],
+    "nozzle_temperature_range_low": [
+        "190"
+    ],
+    "pressure_advance": [
+        "0.036"
+    ],
+    "slow_down_layer_time": [
+        "4"
+    ],
+    "slow_down_min_speed": [
+        "10"
+    ],
+    "supertack_plate_temp": [
+        "45"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "45"
+    ],
+    "temperature_vitrification": [
+        "45"
+    ],
+    "textured_plate_temp": [
+        "55"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "55"
+    ]
+}


### PR DESCRIPTION
Add FILL3D PLA Turbo filament profile to OrcaFilamentLibrary.

Vendor: FILL3D
Type: PLA
Nozzle temp: 230°C (first layer) / 235°C
Bed temp: 55°C (hot plate)
Pressure advance: 0.036 (adaptive PA enabled)
Max volumetric speed: 32 mm³/s
Validated with OrcaSlicer_profile_validator.exe and orca_extra_profile_check.py — no errors