### PR TITLE
💥Fix Crash with painted Line in  some corrupted models

### DIFF
--- a/src/libslic3r/EdgeGrid.hpp
+++ b/src/libslic3r/EdgeGrid.hpp
@@ -224,6 +224,8 @@ public:
 						iy += 1;
 						assert(iy <= iyb);
 					}
+					if (ix < 0 || iy < 0 || ix >= (int64_t)m_cols || iy >= (int64_t)m_rows)
+						return; 
 					if (! visitor(iy, ix))
 						return;
 				} while (ix != ixb || iy != iyb);
@@ -245,6 +247,8 @@ public:
 						iy -= 1;
 						assert(iy >= iyb);
 					}
+					if (ix < 0 || iy < 0 || ix >= (int64_t)m_cols || iy >= (int64_t)m_rows)
+						return; 
 					if (! visitor(iy, ix))
 						return;
 				} while (ix != ixb || iy != iyb);
@@ -270,6 +274,8 @@ public:
 						iy += 1;
 						assert(iy <= iyb);
 					}
+					if (ix < 0 || iy < 0 || ix >= (int64_t)m_cols || iy >= (int64_t)m_rows)
+						return; 
 					if (! visitor(iy, ix))
 						return;
 				} while (ix != ixb || iy != iyb);
@@ -307,6 +313,8 @@ public:
 						iy -= 1;
 						assert(iy >= iyb);
 					}
+					if (ix < 0 || iy < 0 || ix >= (int64_t)m_cols || iy >= (int64_t)m_rows)
+						return; 
 					if (! visitor(iy, ix))
 						return;
 				} while (ix != ixb || iy != iyb);


### PR DESCRIPTION
# Description

•	Fix an infinite/hang condition that could occur when rasterizing a line across the edge grid.

# Screenshots/Recordings/Graphs

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/62bd346e-be27-4510-99cc-16afcaef32ee" />
<img width="1920" height="1079" alt="image" src="https://github.com/user-attachments/assets/e13bf520-fbe4-457b-9665-9aa3ed166077" />

## Tests
[Plate.zip](https://github.com/user-attachments/files/26038561/Plate.zip)

Fix #12648
Fix #13083


