### PR TITLE
Fix "Access Violation" (#12704)

### DIFF
--- a/src/libslic3r/GCode/GCodeProcessor.cpp
+++ b/src/libslic3r/GCode/GCodeProcessor.cpp
@@ -5354,8 +5354,10 @@ void GCodeProcessor::process_M1020(const GCodeReader::GCodeLine &line)
                 BOOST_LOG_TRIVIAL(error) << "Invalid M1020 command (" << line.raw() << ").";
         }
         else {
-            if (eid >= m_result.filaments_count)
+            if (eid >= m_result.filaments_count) {
                 BOOST_LOG_TRIVIAL(error) << "Invalid M1020 command (" << line.raw() << ").";
+                return;
+            }
             process_filament_change(eid);
         }
     }
@@ -5383,8 +5385,10 @@ void GCodeProcessor::process_T(const std::string_view command)
                 BOOST_LOG_TRIVIAL(error) << "Invalid T command (" << command << ").";
         }
         else {
-            if (eid >= m_result.filaments_count)
+            if (eid >= m_result.filaments_count) {
                 BOOST_LOG_TRIVIAL(error) << "Invalid T command (" << command << ").";
+                return;
+            }
             process_filament_change(eid);
         }
     }
@@ -5404,8 +5408,6 @@ void GCodeProcessor::init_filament_maps_and_nozzle_type_when_import_only_gcode()
 void GCodeProcessor::process_filament_change(int id)
 {
     assert(id < m_result.filaments_count);
-    if (id < 0 || id >= m_result.filaments_count)//Safeguard against invalid filament id, TODO: find the root cause of this issue.
-        return;
     int prev_extruder_id = get_extruder_id(false);
     int prev_filament_id = get_filament_id(false);
     int next_extruder_id = m_filament_maps[id];


### PR DESCRIPTION
# Description

Add early returns in process_M1020 and process_T when the parsed extruder/filament id is out of range to avoid calling process_filament_change with an invalid index.


# Screenshots/Recordings/Graphs
<img width="1461" height="928" alt="image" src="https://github.com/user-attachments/assets/366b0b0c-276a-42ea-8d88-5dbf25c8cbff" />

<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/1b5bc21e-a196-4ee1-83b5-87a5d5e2423c" />

## Tests

[Cube.zip](https://github.com/user-attachments/files/26159038/Cube.zip)


Fix #12704
Related to #12684
