### PR TITLE
Set exclude objects to enabled by default to support dynamic MBL

### DIFF
--- a/resources/profiles/Snapmaker/process/fdm_process_U1_common.json
+++ b/resources/profiles/Snapmaker/process/fdm_process_U1_common.json
@@ -14,6 +14,7 @@
     "draft_shield": "disabled",
     "elefant_foot_compensation": "0",
     "enable_arc_fitting": "1",
+    "exclude_object": "1",
     "outer_wall_acceleration": "5000",
     "wall_infill_order": "inner wall/outer wall/infill",
     "line_width": "0.42",


### PR DESCRIPTION
# Description

When exclude objects is not enabled, the U1 will do a full 169pt MBL even with start G-Code set to enable adaptive calibration. Setting this option to default so that users don't need to create a custom profile for this or forget to check the option after a new Orca update.

# Screenshots/Recordings/Graphs

Dynamic 9pt MBL is a WHOLE LOT faster than a 169pt MBL.  😁

![excluded objects](https://github.com/user-attachments/assets/6cc886de-12f4-4d71-ac01-5fba20862b7a)

## Tests

Updated profile on my local machine and exclude objects enabled by default on start up.
