### PR TITLE
Add build definitions for cachyos

### DIFF
--- a/scripts/linux.d/cachyos
+++ b/scripts/linux.d/cachyos
@@ -1,0 +1,45 @@
+#!/bin/bash
+# these are the CachyOS Linux specific build functions
+
+# Additional Dev packages for OrcaSlicer
+export REQUIRED_DEV_PACKAGES=(
+    cmake
+    curl
+    dbus
+    eglexternalplatform
+    extra-cmake-modules
+    file
+    gettext
+    git
+    glew
+    gstreamer
+    gtk3
+    libmspack
+    libsecret
+    libspnav
+    mesa
+    ninja
+    openssl
+    texinfo
+    wayland-protocols
+    webkit2gtk
+    wget
+)
+
+if [[ -n "$UPDATE_LIB" ]]
+then
+    echo -n -e "Updating linux ...\n"
+    NEEDED_PKGS=()
+    for PKG in "${REQUIRED_DEV_PACKAGES[@]}"; do
+        pacman -Q "${PKG}" > /dev/null || NEEDED_PKGS+=("${PKG}")
+    done
+
+    if [[ "${#NEEDED_PKGS[*]}" -gt 0 ]]; then
+        sudo pacman -Syy --noconfirm "${NEEDED_PKGS[@]}"
+    fi
+    echo -e "done\n"
+    exit 0
+fi
+
+export FOUND_GTK3_DEV
+FOUND_GTK3_DEV=$(pacman -Q gtk3)


### PR DESCRIPTION
Derived from Arch linux.d file but changed a bit to build on CachyOS

# Description

Adapted linux.d file for CachyOS derived from arch linux build file

# Screenshots/Recordings/Graphs

none

## Tests

- run ./build_linux.sh -dsi on CachyOS host
- build completes without errors
- application works as intended
