### PR TITLE
💥Fix crash - inconsistent draft shield layer height

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5104,6 +5104,8 @@ LayerResult GCode::process_layer(
             if (is_anything_overridden && print_wipe_extrusions == 0)
                 gcode+="; PURGING FINISHED\n";
 
+            bool skirt_generated_for_current_print_z = false;
+
             for (InstanceToPrint &instance_to_print : instances_to_print) {
                 if (print.config().skirt_type == stPerObject && 
                     !instance_to_print.print_object.object_skirt().empty() &&
@@ -5117,15 +5119,21 @@ LayerResult GCode::process_layer(
                     }
 
                     if (skirt_layer != nullptr &&
-                        (skirt_layer->id() < print.config().skirt_height || print.config().draft_shield == DraftShield::dsEnabled))
-                    {
+                        (skirt_layer->id() < print.config().skirt_height || print.config().draft_shield == DraftShield::dsEnabled)) {
                         const bool skirt_first_layer = (skirt_layer->id() == 0 && std::abs(skirt_layer->bottom_z()) < EPSILON);
                         if (skirt_first_layer)
                             m_skirt_done.clear();
-                        const Point& offset = instance_to_print.print_object.instances()[instance_to_print.instance_id].shift;
-                        gcode += generate_skirt(print, instance_to_print.print_object.object_skirt(), offset, instance_to_print.print_object.config().skirt_start_angle, layer_tools, *skirt_layer, extruder_id);
-                        if (instances_to_print.size() > 1 && &instance_to_print != &*(instances_to_print.end() - 1))
+
+                        if (skirt_generated_for_current_print_z && !m_skirt_done.empty())
                             m_skirt_done.pop_back();
+
+                        const Point& offset      = instance_to_print.print_object.instances()[instance_to_print.instance_id].shift;
+                        std::string  skirt_gcode = generate_skirt(print, instance_to_print.print_object.object_skirt(), offset,
+                                                                  instance_to_print.print_object.config().skirt_start_angle, layer_tools,
+                                                                  *skirt_layer, extruder_id);
+                        if (!skirt_gcode.empty())
+                            skirt_generated_for_current_print_z = true;
+                        gcode += std::move(skirt_gcode);
                     }
                 }
                 


### PR DESCRIPTION
# Description

Fix erratic draft layer height caused by independent support layer height

This pull request fixes an issue where the draft layer height becomes inconsistent when using independent support layer height.

The problem occurs under the following conditions:

Multiple objects are present
Independent support layer height is enabled
Draft shield is set per object

Under these circumstances, the draft layer height could be incorrectly influenced by the support layer height, resulting in erratic layer generation.

Additionally, when the number of objects is large, this issue could also lead to a crash.

This fix ensures that support layer height remains properly isolated and does not interfere with the draft layer height, improving both stability and correctness in multi-object scenarios.

# Screenshots/Recordings/Graphs
Before:
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/41e7e551-32d4-4f3a-a01f-85d1a881c5b1" />
After:
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/38171b66-dc6d-4efc-acc0-1fce92cf3c8d" />

## Tests
(before crashes)
<img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/78b7f71e-9c4b-49fb-b15d-02c7ed92e2e7" />

[chain-links.zip](https://github.com/user-attachments/files/26228724/chain-links.zip)
[test draft shield heght.zip](https://github.com/user-attachments/files/26228740/test.draft.shield.heght.zip)

Fix #10950 
Fix  #10788