### PR TITLE
Fix single-instance IPC by preserving "OrcaSlicer" suffix in Win32 title

### DIFF
--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10448,7 +10448,7 @@ void Plater::priv::update_title_dirty_status()
     wxGetApp().mainframe->SetTitle(title);
     wxGetApp().mainframe->update_title_colour_after_set_title();
 #else
-    wxGetApp().mainframe->SetTitle(title);
+    wxGetApp().mainframe->SetTitle(title + " - OrcaSlicer");
     wxGetApp().mainframe->topbar()->SetTitle(title);
 #endif    
 }


### PR DESCRIPTION
# Description

`update_title_dirty_status()` was setting the Win32 frame title to the bare project name (e.g. "*Untitled") without the " - OrcaSlicer" suffix, while `set_project_name()` correctly appended it. When a second OrcaSlicer process detects an existing instance via `wxSingleInstanceChecker`, it calls `EnumWindowsProc` to locate the running instance's window by filtering for class `wxWindowNR` with a title containing "OrcaSlicer". With the suffix missing, the window is never found and the file is never handed off via `WM_COPYDATA`.

This also fixes the dirty title not showing "OrcaSlicer" suffix in Task Manager, with Alt+Tab, and on the taskbar.

Fixes #12925


# Screenshots/Recordings/Graphs

TBA

## Tests
Without the fix, with added logging, the second window says:
```
[info]	...:gui mode, Current OrcaSlicer Version 2.3.2-dev build fb28e4a4
[debug]	...:full path: 9224341893555169054
[error]	...:Instance check: argc=2
[error]	...:Instance check: argv[0]=[C:\Program Files\OrcaSlicer\orca-slicer.exe]
[error]	...:Instance check: argv[1]=[C:/Users/.../Body2.stl]
[debug]	...:single instance: undefined. other params: "C:\\Program Files\\OrcaSlicer\\orca-slicer.exe";C:/Users/.../Body2.stl
[debug]	...:init wx instance checker 9224341893555169054.lock C:\Users\...\OrcaSlicer\cache\
[error]	...:Instance check: lock_name=[9224341893555169054]
[error]	...:Instance check: cl_string=["C:\\Program Files\\OrcaSlicer\\orca-slicer.exe";C:/Users/.../Body2.stl]
[error]	...:Instance check: should_send=[true]
[error]	...:send_message: message=["C:\\Program Files\\OrcaSlicer\\orca-slicer.exe";C:/Users/.../Body2.stl] version=[9224341893555169054]
[error]	...:send_message: EnumWindows found NO matching window!
[error]	...:Instance check: Another instance found. This instance will terminate. Lock file of current running instance is located at C:\Users\...\OrcaSlicer\cache\9224341893555169054.lock
```

With the fix, with added logging, the second windows says:
```
[info]	...:gui mode, Current OrcaSlicer Version 2.4.0-dev build d22d1668
[debug]	...:full path: 9224341893555169054
[error]	...:Instance check: argc=2
[error]	...:Instance check: argv[0]=[C:\Program Files\OrcaSlicer\orca-slicer.exe]
[error]	...:Instance check: argv[1]=[C:/Users/.../Body2.stl]
[debug]	...:single instance: undefined. other params: "C:\\Program Files\\OrcaSlicer\\orca-slicer.exe";C:/Users/.../Body2.stl
[debug]	...:init wx instance checker 9224341893555169054.lock C:\Users\...\OrcaSlicer\cache\
[error]	...:Instance check: lock_name=[9224341893555169054]
[error]	...:Instance check: cl_string=["C:\\Program Files\\OrcaSlicer\\orca-slicer.exe";C:/Users/.../Body2.stl]
[error]	...:Instance check: should_send=[true]
[error]	...:send_message: message=["C:\\Program Files\\OrcaSlicer\\orca-slicer.exe";C:/Users/.../Body2.stl] version=[9224341893555169054]
[error]	...:win enum - found correct instance, hash=9224341893555169054
[error]	...:send_message: found window, sending WM_COPYDATA
[error]	...:Instance check: Another instance found. This instance will terminate. Lock file of current running instance is located at C:\Users\...\OrcaSlicer\cache\9224341893555169054.lock
```
