### PR TITLE
Fix title bar resize grabber on Windows

### DIFF
--- a/src/slic3r/GUI/BBLTopbar.cpp
+++ b/src/slic3r/GUI/BBLTopbar.cpp
@@ -748,6 +748,18 @@ wxAuiToolBarItem* BBLTopbar::FindToolByCurrentPosition()
 }
 
 #ifdef __WIN32__
+WXLRESULT CenteredTitle::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
+{
+    switch (nMsg) {
+    case WM_NCHITTEST: {
+        // Pass all mouse event to parent
+        return HTTRANSPARENT;
+    }
+    }
+
+    return wxControl::MSWWindowProc(nMsg, wParam, lParam);
+}
+
 WXLRESULT BBLTopbar::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
 {
     switch (nMsg) {

--- a/src/slic3r/GUI/BBLTopbar.hpp
+++ b/src/slic3r/GUI/BBLTopbar.hpp
@@ -18,6 +18,11 @@ public:
 
     wxSize DoGetBestSize() const override;
 
+protected:
+#ifdef __WIN32__
+    WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;
+#endif
+
 private:
     wxString m_title;
 };


### PR DESCRIPTION
Makes the grabber zone larger so it's easier to use:

Old:
![old](https://github.com/user-attachments/assets/6702056d-f46a-43c2-8485-014f77df54aa)

New:
![new](https://github.com/user-attachments/assets/0d4e2128-d879-4286-872f-3bc96adb614f)
