### PR TITLE
Rename colliding Elegoo PLA/ASA/TPU library profiles to avoid vendor conflicts

### DIFF
--- a/resources/profiles/OrcaFilamentLibrary.json
+++ b/resources/profiles/OrcaFilamentLibrary.json
@@ -157,8 +157,8 @@
             "sub_path": "filament/Elas/Elas ASA @base.json"
         },
         {
-            "name": "Elegoo ASA @base",
-            "sub_path": "filament/Elegoo/Elegoo ASA @base.json"
+            "name": "Elegoo Standard ASA @base",
+            "sub_path": "filament/Elegoo/Elegoo Standard ASA @base.json"
         },
         {
             "name": "Eolas Prints ASA @System",
@@ -481,8 +481,8 @@
             "sub_path": "filament/Elas/Elas PLA Pro @base.json"
         },
         {
-            "name": "Elegoo PLA @base",
-            "sub_path": "filament/Elegoo/Elegoo PLA @base.json"
+            "name": "Elegoo Standard PLA @base",
+            "sub_path": "filament/Elegoo/Elegoo Standard PLA @base.json"
         },
         {
             "name": "Elegoo Rapid PLA+ @base",
@@ -805,8 +805,8 @@
             "sub_path": "filament/COEX/COEX TPU 60A @base.json"
         },
         {
-            "name": "Elegoo TPU 95A @base",
-            "sub_path": "filament/Elegoo/Elegoo TPU 95A @base.json"
+            "name": "Elegoo Standard TPU 95A @base",
+            "sub_path": "filament/Elegoo/Elegoo Standard TPU 95A @base.json"
         },
         {
             "name": "Eolas Prints TPU D60 UV Resistant @System",
@@ -893,8 +893,8 @@
             "sub_path": "filament/Elas/Elas ASA @System.json"
         },
         {
-            "name": "Elegoo ASA @System",
-            "sub_path": "filament/Elegoo/Elegoo ASA @System.json"
+            "name": "Elegoo Standard ASA @System",
+            "sub_path": "filament/Elegoo/Elegoo Standard ASA @System.json"
         },
         {
             "name": "Overture ASA @System",
@@ -1145,8 +1145,8 @@
             "sub_path": "filament/Elas/Elas PLA Pro @System.json"
         },
         {
-            "name": "Elegoo PLA @System",
-            "sub_path": "filament/Elegoo/Elegoo PLA @System.json"
+            "name": "Elegoo Standard PLA @System",
+            "sub_path": "filament/Elegoo/Elegoo Standard PLA @System.json"
         },
         {
             "name": "Elegoo Rapid PLA+ @System",
@@ -1393,8 +1393,8 @@
             "sub_path": "filament/COEX/COEX TPU 60A @System.json"
         },
         {
-            "name": "Elegoo TPU 95A @System",
-            "sub_path": "filament/Elegoo/Elegoo TPU 95A @System.json"
+            "name": "Elegoo Standard TPU 95A @System",
+            "sub_path": "filament/Elegoo/Elegoo Standard TPU 95A @System.json"
         },
         {
             "name": "FDplast TPU @System",

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard ASA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard ASA @System.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
-    "name": "Elegoo ASA @System",
-    "inherits": "Elegoo ASA @base",
+    "name": "Elegoo Standard ASA @System",
+    "inherits": "Elegoo Standard ASA @base",
     "from": "system",
     "setting_id": "OGFSE06_00",
     "instantiation": "true",

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard ASA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard ASA @base.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Elegoo ASA @base",
+    "name": "Elegoo Standard ASA @base",
     "inherits": "fdm_filament_asa",
     "from": "system",
     "filament_id": "OGFE06",

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard PLA @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard PLA @System.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
-    "name": "Elegoo PLA @System",
-    "inherits": "Elegoo PLA @base",
+    "name": "Elegoo Standard PLA @System",
+    "inherits": "Elegoo Standard PLA @base",
     "from": "system",
     "setting_id": "OGFSE04_00",
     "instantiation": "true",

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard PLA @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard PLA @base.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Elegoo PLA @base",
+    "name": "Elegoo Standard PLA @base",
     "inherits": "fdm_filament_pla",
     "from": "system",
     "filament_id": "OGFE04",

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard TPU 95A @System.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard TPU 95A @System.json
@@ -1,7 +1,7 @@
 {
     "type": "filament",
-    "name": "Elegoo TPU 95A @System",
-    "inherits": "Elegoo TPU 95A @base",
+    "name": "Elegoo Standard TPU 95A @System",
+    "inherits": "Elegoo Standard TPU 95A @base",
     "from": "system",
     "setting_id": "OGFSE07_00",
     "instantiation": "true",

--- a/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard TPU 95A @base.json
+++ b/resources/profiles/OrcaFilamentLibrary/filament/Elegoo/Elegoo Standard TPU 95A @base.json
@@ -1,6 +1,6 @@
 {
     "type": "filament",
-    "name": "Elegoo TPU 95A @base",
+    "name": "Elegoo Standard TPU 95A @base",
     "inherits": "fdm_filament_tpu",
     "from": "system",
     "filament_id": "OGFE07",


### PR DESCRIPTION
## Summary

Renames 3 Elegoo filament profiles in OrcaFilamentLibrary to resolve name collisions with pre-existing Elegoo vendor profiles, fixing activation failures in OrcaSlicer 2.3.2.

### Problem

PR #12359 added 7 Elegoo filament profiles to OrcaFilamentLibrary. Three of them — **Elegoo PLA**, **Elegoo ASA**, and **Elegoo TPU 95A** — had identical `name` fields to Elegoo vendor profiles already present (added in #11240). This collision prevented users from activating these filaments.

| Profile | Library name (old) | Vendor name | Collision |
|---|---|---|---|
| PLA | `Elegoo PLA @base` | `Elegoo PLA @base` | **Yes** |
| ASA | `Elegoo ASA @base` | `Elegoo ASA @base` | **Yes** |
| TPU 95A | `Elegoo TPU 95A @base` | `Elegoo TPU 95A @base` | **Yes** |

The other 4 profiles (Rapid PETG, PETG Pro, PETG-CF, Rapid PLA+) work fine because their names differ by case from the vendor versions.

### Fix

Rename the 3 colliding OrcaFilamentLibrary profiles:

- `Elegoo PLA` → `Elegoo Standard PLA`
- `Elegoo ASA` → `Elegoo Standard ASA`
- `Elegoo TPU 95A` → `Elegoo Standard TPU 95A`

This keeps the profiles universally available to all printers via OrcaFilamentLibrary while eliminating the name collision. **Vendor profiles are untouched** — zero risk to the 32+ Elegoo printer-specific child profiles.

### Files Changed (7)
- 6 renamed JSON files (`@base` + `@System` for each of the 3 profiles)
- `OrcaFilamentLibrary.json` manifest updated with new names/paths

### Testing
- JSON validation passed
- No remaining name collisions between library and vendor profiles
- All 14 Elegoo library entries intact in manifest (7 filaments × 2 files)

Fixes activation issue reported on #12359.