### PR TITLE
Fix save custom machine profiles with different extruder count

### DIFF
--- a/src/libslic3r/Config.hpp
+++ b/src/libslic3r/Config.hpp
@@ -596,20 +596,20 @@ public:
             this->values = rhs_opt->values;
 
             const size_t overlap_size = std::min(rhs_opt->size(), inherits_opt->size());
-            const size_t aligned_overlap_size = overlap_size - (overlap_size % size_t(stride));
 
-            for (size_t i = 0; i < aligned_overlap_size; i = i + stride) {
+            for (size_t i = 0; i < overlap_size; i += size_t(stride)) {
+                const size_t group_size = std::min(size_t(stride), overlap_size - i);
                 bool set_nil = true;
-                for (size_t j = 0; j < stride; j++) {
-                    if (inherits_opt->values[i +j] != rhs_opt->values[i +j]) {
+                for (size_t j = 0; j < group_size; ++j) {
+                    if (inherits_opt->values[i + j] != rhs_opt->values[i + j]) {
                         set_nil = false;
                         break;
                     }
                 }
 
-                for (size_t j = 0; j < stride; j++) {
+                for (size_t j = 0; j < group_size; ++j) {
                     if (set_nil) {
-                        this->set_at_to_nil(i +j);
+                        this->set_at_to_nil(i + j);
                     }
                 }
             }


### PR DESCRIPTION
# Description

Fix "unhanded unknown exception'' when try to save a modified printer preset.
The root cause of this bug is that this function was cherry picked from Bambu Studio.
Bambu Studio does not allow you to change the number of extruders, so it does not have this problem.


<img width="762" height="619" alt="image" src="https://github.com/user-attachments/assets/7ac0a309-5b89-4b75-b5d5-abd2a3ca3dad" />

Fix #12949
Fix #12994
