### PR TITLE
docs: add Flathub install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ winget install --id=SoftFever.OrcaSlicer -e
 ## Linux         
 
 ### Flathub (Recommended)
-OrcaSlicer is available on [Flathub](https://github.com/flathub/com.orcaslicer.OrcaSlicer).
+OrcaSlicer is available through FlatHub:
+
+<a href='https://flathub.org/apps/com.orcaslicer.OrcaSlicer'><img width='240' alt='Download on Flathub' src='https://dl.flathub.org/assets/badges/flathub-badge-en.png'/></a>
 
 Install from the command line:
 


### PR DESCRIPTION
## Summary

Update the Linux installation section in `README.md` to mention that OrcaSlicer is now available on Flathub.

## Changes

- add Flathub as the recommended Linux installation method
- include the `flatpak install` command
- mention that OrcaSlicer can also be installed through graphical software managers on many distributions when Flathub is enabled
- keep the existing AppImage instructions as an alternative installation method

## Why

Now that OrcaSlicer is available on Flathub, the README should reflect the easiest and most discoverable installation method for many Linux users.


<img width="782" height="538" alt="image" src="https://github.com/user-attachments/assets/bf792a02-ee18-4ef1-aa89-e56a55280313" />
