### PR TITLE
Fix overhang reverse threshold being ignored

### DIFF
--- a/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
+++ b/src/libslic3r/Feature/FuzzySkin/FuzzySkin.cpp
@@ -196,7 +196,7 @@ void group_region_by_fuzzify(PerimeterGenerator& g)
             surfaces.push_back(&surface);
         }
 
-        if (cfg.type != FuzzySkinType::None) {
+        if (cfg.type != FuzzySkinType::None && cfg.type != FuzzySkinType::Disabled_fuzzy) {
             g.has_fuzzy_skin = true;
             if (cfg.type != FuzzySkinType::External) {
                 g.has_fuzzy_hole = true;


### PR DESCRIPTION
## Symptom

Wall direction consistently reversed on alternating layers even in simple cases (e.g. a cube), even with a very high threshold.

## Cause

The issue was not in the threshold logic itself, but in how fuzzy skin was handled internally.

A profile with fuzzy skin disabled was still treated as if fuzzy skin was active. This unintentionally triggered a different wall-generation path.

When that happened, the normal overhang-threshold behavior was skipped and wall reversal was still applied, making the threshold appear ineffective.

## Fix

Make fuzzy-skin state handling consistent so that the disabled fuzzy-skin mode is correctly treated as off.

## Result
- Disabled fuzzy skin no longer activates fuzzy-skin behavior internally
- The alternative wall-generation path is no longer triggered by mistake
- Overhang reverse threshold now behaves as expected in normal (non-fuzzy) cases

Fixes #13055

> Note
>
> This issue could also affect arc fitting and contour simplification.
>
> The internal fuzzy-skin flag is used to control simplification resolution when arc fitting is enabled. Because the disabled fuzzy-skin state could still be treated as active, Orca could fall back to a coarser simplification.
> 
> In practice, this could slightly reduce contour fidelity and arc-fitting opportunities even when fuzzy skin was disabled.