### PR TITLE
W10 double window fix

### DIFF
--- a/src/slic3r/GUI/BBLTopbar.cpp
+++ b/src/slic3r/GUI/BBLTopbar.cpp
@@ -748,7 +748,7 @@ wxAuiToolBarItem* BBLTopbar::FindToolByCurrentPosition()
     return this->FindToolByPosition(client_pos.x, client_pos.y);
 }
 
-#ifdef _WIN32
+#ifdef __WXMSW__
 WXLRESULT CenteredTitle::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
 {
     switch (nMsg) {

--- a/src/slic3r/GUI/BBLTopbar.cpp
+++ b/src/slic3r/GUI/BBLTopbar.cpp
@@ -748,7 +748,7 @@ wxAuiToolBarItem* BBLTopbar::FindToolByCurrentPosition()
     return this->FindToolByPosition(client_pos.x, client_pos.y);
 }
 
-#ifdef __WIN32__
+#ifdef _WIN32
 WXLRESULT CenteredTitle::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
 {
     switch (nMsg) {

--- a/src/slic3r/GUI/BBLTopbar.hpp
+++ b/src/slic3r/GUI/BBLTopbar.hpp
@@ -19,7 +19,7 @@ public:
     wxSize DoGetBestSize() const override;
 
 protected:
-#ifdef _WIN32
+#ifdef __WXMSW__
     WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;
 #endif
 
@@ -75,7 +75,7 @@ public:
     void ShowCalibrationButton(bool show = true);
 
 protected:
-#ifdef _WIN32
+#ifdef __WXMSW__
     WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;
 #endif
 

--- a/src/slic3r/GUI/BBLTopbar.hpp
+++ b/src/slic3r/GUI/BBLTopbar.hpp
@@ -19,7 +19,7 @@ public:
     wxSize DoGetBestSize() const override;
 
 protected:
-#ifdef __WIN32__
+#ifdef _WIN32
     WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;
 #endif
 
@@ -75,7 +75,7 @@ public:
     void ShowCalibrationButton(bool show = true);
 
 protected:
-#ifdef __WIN32__
+#ifdef _WIN32
     WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;
 #endif
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -535,6 +535,28 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
     update_layout();
     sizer->SetSizeHints(this);
 
+    #ifdef __WXMSW__
+    // SetMaximize causes the window to overlap the taskbar, due to the fact this window has wxMAXIMIZE_BOX off
+    // https://forums.wxwidgets.org/viewtopic.php?t=50634
+    // Fix it here
+    this->Bind(wxEVT_MAXIMIZE, [this](auto &e) {
+        wxDisplay display(this);
+        auto      size = display.GetClientArea().GetSize();
+        auto      pos  = display.GetClientArea().GetPosition();
+        HWND      hWnd = GetHandle();
+        RECT      borderThickness;
+        SetRectEmpty(&borderThickness);
+        AdjustWindowRectEx(&borderThickness, GetWindowLongPtr(hWnd, GWL_STYLE), FALSE, 0);
+        const auto max_size = size + wxSize{-borderThickness.left + borderThickness.right, -borderThickness.top + borderThickness.bottom};
+        const auto current_size = GetSize();
+        SetSize({std::min(max_size.x, current_size.x), std::min(max_size.y, current_size.y)});
+        Move(pos + wxPoint{borderThickness.left, borderThickness.top});
+        e.Skip();
+    });
+
+#endif // __WXMSW__
+ 
+
     // BBS
     Fit();
 

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -758,7 +758,7 @@ void MainFrame::bind_diff_dialog()
 }
 
 
-#ifdef __WIN32__
+#ifdef _WIN32
 
 // Orca: Fix maximized window overlaps taskbar when taskbar auto hide is enabled (#8085)
 // Adopted from https://gist.github.com/MortenChristiansen/6463580

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -310,7 +310,7 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
     m_edge_right  = new ResizeEdgePanel(this, ResizeEdgePanel::Right);
 #endif
 
-#ifdef _WIN32
+#ifdef __WXMSW__
     if (HWND hWnd = GetHandle(); hWnd != nullptr) {
         LONG_PTR style = GetWindowLongPtr(hWnd, GWL_STYLE);
         if ((style & WS_CAPTION) != 0) {
@@ -769,7 +769,7 @@ void MainFrame::bind_diff_dialog()
 }
 
 
-#ifdef _WIN32
+#ifdef __WXMSW__
 
 // Orca: Fix maximized window overlaps taskbar when taskbar auto hide is enabled (#8085)
 // Adopted from https://gist.github.com/MortenChristiansen/6463580

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -310,6 +310,17 @@ DPIFrame(NULL, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, BORDERLESS_FRAME_
     m_edge_right  = new ResizeEdgePanel(this, ResizeEdgePanel::Right);
 #endif
 
+#ifdef _WIN32
+    if (HWND hWnd = GetHandle(); hWnd != nullptr) {
+        LONG_PTR style = GetWindowLongPtr(hWnd, GWL_STYLE);
+        if ((style & WS_CAPTION) != 0) {
+            SetWindowLongPtr(hWnd, GWL_STYLE, style & ~WS_CAPTION);
+            SetWindowPos(hWnd, nullptr, 0, 0, 0, 0,
+                         SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+        }
+    }
+#endif
+
     if (!wxGetApp().app_config->has("user_mode")) {
         wxGetApp().app_config->set("user_mode", "simple");
         wxGetApp().app_config->set_bool("developer_mode", false);

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -204,7 +204,7 @@ protected:
     virtual void on_dpi_changed(const wxRect &suggested_rect) override;
     virtual void on_sys_color_changed() override;
 
-#ifdef _WIN32
+#ifdef __WXMSW__
     WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;
 #endif
 

--- a/src/slic3r/GUI/MainFrame.hpp
+++ b/src/slic3r/GUI/MainFrame.hpp
@@ -204,7 +204,7 @@ protected:
     virtual void on_dpi_changed(const wxRect &suggested_rect) override;
     virtual void on_sys_color_changed() override;
 
-#ifdef __WIN32__
+#ifdef _WIN32
     WXLRESULT MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam) override;
 #endif
 


### PR DESCRIPTION
Changed the preprocessor macro used to detect Windows builds from `__WIN32__` to `__WXMSW__`.
Added a Windows-specific fix to remove the window caption style in `MainFrame.cpp`, addressing UI issues on Windows10.

Also had to partially restore https://github.com/OrcaSlicer/OrcaSlicer/pull/12941/changes/eefdabcd987ed301ac6c4347fc21c3a0c086f631 due taskbar issues.

Before/After
<img width="1921" height="834" alt="260401_111118_orca-slicer" src="https://github.com/user-attachments/assets/f6d607af-0cb6-488b-977d-b53db0622dcd" />
<img width="1921" height="811" alt="260401_134620_devenv" src="https://github.com/user-attachments/assets/ccf2ecee-14c8-404d-a387-92781aea7bb7" />
