### PR TITLE
💥Fix crash open double clicking  file

### DIFF
--- a/src/slic3r/GUI/PartPlate.cpp
+++ b/src/slic3r/GUI/PartPlate.cpp
@@ -5707,6 +5707,16 @@ bool PartPlateList::set_shapes(const Pointfs              &shape,
 
 	update_logo_texture_filename(texture_filename);
 
+	// Keep SceneRaycaster Bed entries in sync with PickingModel raycasters rebuilt by set_shape().
+	// Without this, SceneRaycasterItem may keep dangling MeshRaycaster* pointers.
+	if (m_plater != nullptr) {
+		GLCanvas3D* canvas = m_plater->get_view3D_canvas3D();
+		if (canvas != nullptr) {
+			canvas->remove_raycasters_for_picking(SceneRaycaster::EType::Bed);
+			register_raycasters_for_picking(*canvas);
+		}
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Fix crash when open a project file by double clicking it.
This pull request addresses a bug related to 3D picking and raycasting in the plater UI. The main change ensures that the `SceneRaycaster` entries for the bed are kept in sync with the picking model's raycasters whenever the shape is updated. This prevents potential crashes or undefined behavior due to dangling pointers.

**3D Picking and Raycaster Synchronization:**

* Ensured that `SceneRaycaster` bed entries are properly removed and re-registered in `set_shapes` to avoid dangling `MeshRaycaster*` pointers when the picking model is rebuilt. (`src/slic3r/GUI/PartPlate.cpp`)


maybe related to #12944 (testing)