### PR TITLE
deps builld: Try to honour CMAKE_BUILD_PARALLEL_LEVEL

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -215,7 +215,7 @@ if [[ -n "${BUILD_DEPS}" ]] ; then
     fi
 
     print_and_run cmake -S deps -B deps/$BUILD_DIR "${CMAKE_C_CXX_COMPILER_CLANG[@]}" "${CMAKE_LLD_LINKER_ARGS[@]}" -G Ninja "${COLORED_OUTPUT}" "${BUILD_ARGS[@]}"
-    print_and_run cmake --build deps/$BUILD_DIR
+    print_and_run cmake --build deps/$BUILD_DIR -j1
 fi
 
 if [[ -n "${BUILD_ORCA}" ]] || [[ -n "${BUILD_TESTS}" ]] ; then

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -166,11 +166,18 @@ function(orcaslicer_add_cmake_project projectname)
         endif ()
     endif ()
 
-    set(_gen "")
-    set(_build_j "-j${NPROC}")
     if (MSVC)
-        set(_gen CMAKE_GENERATOR "${DEP_MSVC_GEN}" CMAKE_GENERATOR_PLATFORM "${DEP_PLATFORM}")
-        set(_build_j "/m")
+      set(_gen CMAKE_GENERATOR "${DEP_MSVC_GEN}" CMAKE_GENERATOR_PLATFORM "${DEP_PLATFORM}")
+    else()
+      set(_gen "")
+    endif()
+
+    if ($ENV{CMAKE_BUILD_PARALLEL_LEVEL})
+      set(_build_j "")  # assume environment will control --build parallel setting
+    elseif(MSVC)
+      set(_build_j "/m")
+    else()
+      set(_build_j "-j${NPROC}")
     endif ()
 
 if (NOT IS_CROSS_COMPILE OR NOT APPLE)


### PR DESCRIPTION
# Description

[CMAKE_BUILD_PARALLEL_LEVEL](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html#envvar:CMAKE_BUILD_PARALLEL_LEVEL) may be set by the top-level `build_linux.sh` script (and may also be set by a CMake user), but `deps/CMakeLists.txt` would always override this by setting an explicit `-j${NPROC}` for the individual dependency sub-builds.

This PR contains two commits:

* deps/CMakeLists: Don't override the number of parallel jobs in sub-builds if `CMAKE_BUILD_PARALLEL_LEVEL` is set for the first CMake run.
* `build_linux.sh` script: Run the top-level deps build as `cmake --build -j1`. This means the sub-builds will run one at a time, because otherwise the number of parallel jobs is squared (parallelised in the top-level build and the sub-builds).

## Tests

* Ran some builds locally (with `build_linux.sh` and via CMake), verified the number of concurrent jobs matched `CMAKE_BUILD_PARALLEL_LEVEL` when set.

Thanks for all your work developing Orca Slicer!