### PR TITLE
Bump GitHub Actions: Node 20 deprecation

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -136,7 +136,7 @@ jobs:
           files: "ctest_results.xml"
       - name: Delete Test Artifact
         if: success()
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: ${{ github.sha }}-tests
   flatpak:

--- a/.github/workflows/build_deps.yml
+++ b/.github/workflows/build_deps.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: setup dev on Windows
         if: runner.os == 'Windows'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Get the date on Ubuntu and macOS
         if: runner.os != 'Windows'

--- a/.github/workflows/build_orca.yml
+++ b/.github/workflows/build_orca.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Delete intermediate per-arch artifacts
         if: runner.os == 'macOS' && inputs.macos-combine-only
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: |
             OrcaSlicer_Mac_bundle_arm64_${{ github.sha }}
@@ -275,7 +275,7 @@ jobs:
 # Windows
       - name: setup MSVC
         if: runner.os == 'Windows'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Install nsis
         if: runner.os == 'Windows' && !vars.SELF_HOSTED


### PR DESCRIPTION
Due https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
Update workflow action versions: upgrade geekyeggo/delete-artifact from v5 to v6 and microsoft/setup-msbuild from v2 to v3 across .github/workflows/build_all.yml, build_deps.yml, and build_orca.yml. This brings workflows to newer action releases for compatibility and fixes.

<img width="767" height="337" alt="imagen" src="https://github.com/user-attachments/assets/627bd833-9c64-434c-8d57-03c878134f00" />
