### PR TITLE
Fallback to per-move validation when bbox outside

### DIFF
--- a/src/libslic3r/BuildVolume.cpp
+++ b/src/libslic3r/BuildVolume.cpp
@@ -527,6 +527,9 @@ bool BuildVolume::all_paths_inside(const GCodeProcessorResult& paths, const Boun
             build_volume.max.z() = std::numeric_limits<double>::max();
         if (ignore_bottom)
             build_volume.min.z() = -std::numeric_limits<double>::max();
+        // BBox-only callers may provide no moves. Validate bbox corners regardless of paths_bbox.defined.
+        if (paths.moves.empty())
+            return build_volume.contains(paths_bbox.min) && build_volume.contains(paths_bbox.max);
         if (paths_bbox.defined && build_volume.contains(paths_bbox))
             return true;
 

--- a/src/libslic3r/BuildVolume.cpp
+++ b/src/libslic3r/BuildVolume.cpp
@@ -527,7 +527,13 @@ bool BuildVolume::all_paths_inside(const GCodeProcessorResult& paths, const Boun
             build_volume.max.z() = std::numeric_limits<double>::max();
         if (ignore_bottom)
             build_volume.min.z() = -std::numeric_limits<double>::max();
-        return build_volume.contains(paths_bbox);
+        if (paths_bbox.defined && build_volume.contains(paths_bbox))
+            return true;
+
+        // Fallback: validate only relevant extrusion moves.
+        const BoundingBox3Base<Vec3f> build_volumef(build_volume.min.cast<float>(), build_volume.max.cast<float>());
+        return std::all_of(paths.moves.begin(), paths.moves.end(), [move_valid, build_volumef](const GCodeProcessorResult::MoveVertex &move)
+            { return !move_valid(move) || build_volumef.contains(move.position); });
     }
     case BuildVolume_Type::Circle:
     {


### PR DESCRIPTION
Fixes #11965
Improve all_paths_inside to handle cases where the aggregate paths bbox lies outside the build volume but individual extrusion moves are inside (same semantics as circle/convex checks).
If paths_bbox is defined and contained in the build volume, return true as before; otherwise construct a float-based build_volumef and use std::all_of to ensure each move is either non-extrusion (via move_valid) or its position is contained in build_volumef.
This makes validation more robust for mixed or clipped paths.