### PR TITLE
Fix typo in Spanish translation: G-Cpde → G-code

### DIFF
--- a/localization/i18n/es/OrcaSlicer_es.po
+++ b/localization/i18n/es/OrcaSlicer_es.po
@@ -12435,7 +12435,7 @@ msgid ""
 "Orca Slicer can upload G-code files to a printer host. This field should "
 "contain the API Key or the password required for authentication."
 msgstr ""
-"OrcaSlicer puede cargar archivos G-Cpde a un host de impresora. Este campo "
+"OrcaSlicer puede cargar archivos G-Code a un host de impresora. Este campo "
 "debería contener una clave API o una contraseña requerida para la "
 "autenticación."
 


### PR DESCRIPTION
### Summary
Fixes a typo in the Spanish UI.

### Details
"G-Cpde" → "G-code"

No functional changes.