### PR TITLE
fix seams glitch linux

### DIFF
--- a/src/libvgcode/src/OptionTemplate.cpp
+++ b/src/libvgcode/src/OptionTemplate.cpp
@@ -13,41 +13,55 @@
 namespace libvgcode {
 
 // Geometry:
-// diamond with 'resolution' sides, centered at (0.0, 0.0, 0.0)
-// height and width of the diamond are equal to 1.0
+// two opposing cones forming a diamond, centered at (0.0, 0.0, 0.0)
+// height and width are equal to 1.0
 void OptionTemplate::init(uint8_t resolution)
 {
     if (m_top_vao_id != 0)
         return;
 
     m_resolution = std::max<uint8_t>(resolution, 3);
-    m_vertices_count = 2 + resolution;
+    m_vertices_count = static_cast<uint16_t>(3 * m_resolution);
     const float step = 2.0f * PI / float(m_resolution);
 
     //
-    // top fan
+    // top cone
     //
     std::vector<float> top_vertices;
     top_vertices.reserve(6 * m_vertices_count);
-    add_vertex({ 0.0f, 0.0f, 0.5f }, { 0.0f, 0.0f, 1.0f }, top_vertices);
-    for (uint8_t i = 0; i <= m_resolution; ++i) {
-        const float ii = float(i) * step;
-        const Vec3 pos = { 0.5f * std::cos(ii), 0.5f * std::sin(ii), 0.0f };
-        const Vec3 norm = normalize(pos);
-        add_vertex(pos, norm, top_vertices);
+    const Vec3 top_apex = { 0.0f, 0.0f, 0.5f };
+    const Vec3 top_apex_normal = { 0.0f, 0.0f, 1.0f };
+    for (uint8_t i = 0; i < m_resolution; ++i) {
+        const float curr_angle = float(i) * step;
+        const float next_angle = float(i + 1) * step;
+        const Vec3 curr_pos = { 0.5f * std::cos(curr_angle), 0.5f * std::sin(curr_angle), 0.0f };
+        const Vec3 next_pos = { 0.5f * std::cos(next_angle), 0.5f * std::sin(next_angle), 0.0f };
+        const Vec3 curr_norm = normalize(curr_pos);
+        const Vec3 next_norm = normalize(next_pos);
+
+        add_vertex(top_apex, top_apex_normal, top_vertices);
+        add_vertex(curr_pos, curr_norm, top_vertices);
+        add_vertex(next_pos, next_norm, top_vertices);
     }
 
     //
-    // bottom fan
+    // bottom cone
     //
     std::vector<float> bottom_vertices;
     bottom_vertices.reserve(6 * m_vertices_count);
-    add_vertex({ 0.0f, 0.0f, -0.5f }, { 0.0f, 0.0f, -1.0f }, bottom_vertices);
-    for (uint8_t i = 0; i <= m_resolution; ++i) {
-        const float ii = -float(i) * step;
-        const Vec3 pos = { 0.5f * std::cos(ii), 0.5f * std::sin(ii), 0.0f };
-        const Vec3 norm = normalize(pos);
-        add_vertex(pos, norm, bottom_vertices);
+    const Vec3 bottom_apex = { 0.0f, 0.0f, -0.5f };
+    const Vec3 bottom_apex_normal = { 0.0f, 0.0f, -1.0f };
+    for (uint8_t i = 0; i < m_resolution; ++i) {
+        const float curr_angle = float(i) * step;
+        const float next_angle = float(i + 1) * step;
+        const Vec3 curr_pos = { 0.5f * std::cos(curr_angle), 0.5f * std::sin(curr_angle), 0.0f };
+        const Vec3 next_pos = { 0.5f * std::cos(next_angle), 0.5f * std::sin(next_angle), 0.0f };
+        const Vec3 curr_norm = normalize(curr_pos);
+        const Vec3 next_norm = normalize(next_pos);
+
+        add_vertex(bottom_apex, bottom_apex_normal, bottom_vertices);
+        add_vertex(next_pos, next_norm, bottom_vertices);
+        add_vertex(curr_pos, curr_norm, bottom_vertices);
     }
 
     m_size_in_bytes_gpu += top_vertices.size() * sizeof(float);
@@ -117,9 +131,9 @@ void OptionTemplate::render(size_t count)
     glsafe(glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &curr_vertex_array));
 
     glsafe(glBindVertexArray(m_top_vao_id));
-    glsafe(glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, static_cast<GLsizei>(m_vertices_count), static_cast<GLsizei>(count)));
+    glsafe(glDrawArraysInstanced(GL_TRIANGLES, 0, static_cast<GLsizei>(m_vertices_count), static_cast<GLsizei>(count)));
     glsafe(glBindVertexArray(m_bottom_vao_id));
-    glsafe(glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, static_cast<GLsizei>(m_vertices_count), static_cast<GLsizei>(count)));
+    glsafe(glDrawArraysInstanced(GL_TRIANGLES, 0, static_cast<GLsizei>(m_vertices_count), static_cast<GLsizei>(count)));
     glsafe(glBindVertexArray(curr_vertex_array));
 }
 

--- a/src/libvgcode/src/OptionTemplate.cpp
+++ b/src/libvgcode/src/OptionTemplate.cpp
@@ -20,7 +20,7 @@ void OptionTemplate::init(uint8_t resolution)
     if (m_top_vao_id != 0)
         return;
 
-    m_resolution = std::max<uint8_t>(resolution, 3);
+    m_resolution = std::clamp<uint8_t>(resolution, 3, 85);
     m_vertices_count = static_cast<uint8_t>(3 * m_resolution);
     const float step = 2.0f * PI / float(m_resolution);
 

--- a/src/libvgcode/src/OptionTemplate.cpp
+++ b/src/libvgcode/src/OptionTemplate.cpp
@@ -13,8 +13,8 @@
 namespace libvgcode {
 
 // Geometry:
-// two opposing cones forming a diamond, centered at (0.0, 0.0, 0.0)
-// height and width are equal to 1.0
+// diamond with 'resolution' sides, centered at (0.0, 0.0, 0.0)
+// height and width of the diamond are equal to 1.0
 void OptionTemplate::init(uint8_t resolution)
 {
     if (m_top_vao_id != 0)

--- a/src/libvgcode/src/OptionTemplate.cpp
+++ b/src/libvgcode/src/OptionTemplate.cpp
@@ -21,7 +21,7 @@ void OptionTemplate::init(uint8_t resolution)
         return;
 
     m_resolution = std::max<uint8_t>(resolution, 3);
-    m_vertices_count = static_cast<uint16_t>(3 * m_resolution);
+    m_vertices_count = static_cast<uint8_t>(3 * m_resolution);
     const float step = 2.0f * PI / float(m_resolution);
 
     //

--- a/src/libvgcode/src/OptionTemplate.cpp
+++ b/src/libvgcode/src/OptionTemplate.cpp
@@ -25,12 +25,17 @@ void OptionTemplate::init(uint8_t resolution)
     const float step = 2.0f * PI / float(m_resolution);
 
     //
-    // top cone
+    // top and bottom cones (paired wedges)
     //
     std::vector<float> top_vertices;
     top_vertices.reserve(6 * m_vertices_count);
+    std::vector<float> bottom_vertices;
+    bottom_vertices.reserve(6 * m_vertices_count);
+
     const Vec3 top_apex = { 0.0f, 0.0f, 0.5f };
     const Vec3 top_apex_normal = { 0.0f, 0.0f, 1.0f };
+    const Vec3 bottom_apex = { 0.0f, 0.0f, -0.5f };
+    const Vec3 bottom_apex_normal = { 0.0f, 0.0f, -1.0f };
     for (uint8_t i = 0; i < m_resolution; ++i) {
         const float curr_angle = float(i) * step;
         const float next_angle = float(i + 1) * step;
@@ -42,22 +47,6 @@ void OptionTemplate::init(uint8_t resolution)
         add_vertex(top_apex, top_apex_normal, top_vertices);
         add_vertex(curr_pos, curr_norm, top_vertices);
         add_vertex(next_pos, next_norm, top_vertices);
-    }
-
-    //
-    // bottom cone
-    //
-    std::vector<float> bottom_vertices;
-    bottom_vertices.reserve(6 * m_vertices_count);
-    const Vec3 bottom_apex = { 0.0f, 0.0f, -0.5f };
-    const Vec3 bottom_apex_normal = { 0.0f, 0.0f, -1.0f };
-    for (uint8_t i = 0; i < m_resolution; ++i) {
-        const float curr_angle = float(i) * step;
-        const float next_angle = float(i + 1) * step;
-        const Vec3 curr_pos = { 0.5f * std::cos(curr_angle), 0.5f * std::sin(curr_angle), 0.0f };
-        const Vec3 next_pos = { 0.5f * std::cos(next_angle), 0.5f * std::sin(next_angle), 0.0f };
-        const Vec3 curr_norm = normalize(curr_pos);
-        const Vec3 next_norm = normalize(next_pos);
 
         add_vertex(bottom_apex, bottom_apex_normal, bottom_vertices);
         add_vertex(next_pos, next_norm, bottom_vertices);

--- a/src/libvgcode/src/OptionTemplate.hpp
+++ b/src/libvgcode/src/OptionTemplate.hpp
@@ -37,7 +37,7 @@ public:
 
 private:
     uint8_t m_resolution{ 0 };
-    uint16_t m_vertices_count{ 0 };
+    uint8_t m_vertices_count{ 0 };
     //
     // gpu buffers ids.
     //

--- a/src/libvgcode/src/OptionTemplate.hpp
+++ b/src/libvgcode/src/OptionTemplate.hpp
@@ -37,7 +37,7 @@ public:
 
 private:
     uint8_t m_resolution{ 0 };
-    uint8_t m_vertices_count{ 0 };
+    uint16_t m_vertices_count{ 0 };
     //
     // gpu buffers ids.
     //


### PR DESCRIPTION
# Description

Fixes the glitch causing missing faces in seam geometry on Linux
Tested on windows and linux
Note: this glitch occurs when using a virtual machine; I’m not sure if it occurs on native Linux, in which case this change might not be necessary.

 # Before:
<img width="2052" height="1211" alt="image" src="https://github.com/user-attachments/assets/8d44eaec-4324-4f98-8467-3b38a84620db" />

 # After:
<img width="1632" height="965" alt="image" src="https://github.com/user-attachments/assets/7c14e8ff-ea4d-4e2a-97d1-3193d01bf2a7" />
