### PR TITLE
JD profiles from Marlin repo

### DIFF
--- a/resources/profiles/Anet/machine/Anet A8 Plus 0.4 nozzle.json
+++ b/resources/profiles/Anet/machine/Anet A8 Plus 0.4 nozzle.json
@@ -100,7 +100,7 @@
 		"0.2"
 	],
 	"machine_max_junction_deviation": [
-		"0",
+		"0.10",
 		"0"
 	],
 	"machine_max_speed_e": [

--- a/resources/profiles/Anycubic/machine/Anycubic Chiron 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/machine/Anycubic Chiron 0.4 nozzle.json
@@ -79,6 +79,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.028",
+		"0"
+	],
 	"max_layer_height": [
 		"0.3"
 	],

--- a/resources/profiles/Anycubic/machine/Anycubic Vyper 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/machine/Anycubic Vyper 0.4 nozzle.json
@@ -75,6 +75,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Anycubic/machine/Anycubic i3 Mega S 0.4 nozzle.json
+++ b/resources/profiles/Anycubic/machine/Anycubic i3 Mega S 0.4 nozzle.json
@@ -79,6 +79,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.36"
 	],

--- a/resources/profiles/Artillery/machine/Artillery Genius 0.4 nozzle.json
+++ b/resources/profiles/Artillery/machine/Artillery Genius 0.4 nozzle.json
@@ -78,6 +78,10 @@
 		"0.2",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.032",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Artillery/machine/Artillery Genius Pro 0.4 nozzle.json
+++ b/resources/profiles/Artillery/machine/Artillery Genius Pro 0.4 nozzle.json
@@ -78,6 +78,10 @@
 		"0.2",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.032",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Artillery/machine/Artillery Hornet 0.4 nozzle.json
+++ b/resources/profiles/Artillery/machine/Artillery Hornet 0.4 nozzle.json
@@ -78,6 +78,10 @@
 		"0.2",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.032",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Artillery/machine/Artillery Sidewinder X1 0.4 nozzle.json
+++ b/resources/profiles/Artillery/machine/Artillery Sidewinder X1 0.4 nozzle.json
@@ -78,6 +78,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Artillery/machine/Artillery Sidewinder X2 0.4 nozzle.json
+++ b/resources/profiles/Artillery/machine/Artillery Sidewinder X2 0.4 nozzle.json
@@ -78,6 +78,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.032",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/BIQU/machine/BIQU B1 (0.4 nozzle).json
+++ b/resources/profiles/BIQU/machine/BIQU B1 (0.4 nozzle).json
@@ -65,6 +65,10 @@
 	"machine_max_jerk_z": [
 		"0.3"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/BIQU/machine/BIQU BX (0.4 nozzle).json
+++ b/resources/profiles/BIQU/machine/BIQU BX (0.4 nozzle).json
@@ -65,6 +65,10 @@
 	"machine_max_jerk_z": [
 		"0.3"
 	],
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/BIQU/machine/BIQU Hurakan (0.4 nozzle).json
+++ b/resources/profiles/BIQU/machine/BIQU Hurakan (0.4 nozzle).json
@@ -79,6 +79,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"machine_min_extruding_rate": [
 		"0",
 		"0"

--- a/resources/profiles/Creality/machine/Creality CR-10 Max 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-10 Max 0.4 nozzle.json
@@ -22,5 +22,9 @@
 	],
 	"printable_height": "470",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality CR-10 V2 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-10 V2 0.4 nozzle.json
@@ -76,6 +76,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.36"
 	],

--- a/resources/profiles/Creality/machine/Creality CR-10 V3 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-10 V3 0.4 nozzle.json
@@ -76,6 +76,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.36"
 	],

--- a/resources/profiles/Creality/machine/Creality CR-10 V3 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-10 V3 0.6 nozzle.json
@@ -76,6 +76,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.42"
 	],

--- a/resources/profiles/Creality/machine/Creality CR-6 SE 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 SE 0.2 nozzle.json
@@ -23,5 +23,9 @@
 	],
 	"printable_height": "250",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.05",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality CR-6 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 SE 0.4 nozzle.json
@@ -22,5 +22,9 @@
 	],
 	"printable_height": "250",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.05",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality CR-6 SE 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 SE 0.6 nozzle.json
@@ -23,5 +23,9 @@
 	],
 	"printable_height": "250",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.05",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality CR-6 SE 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality CR-6 SE 0.8 nozzle.json
@@ -23,5 +23,9 @@
 	],
 	"printable_height": "250",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.05",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality Ender-3 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 0.2 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.16"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 0.4 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.36"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 0.6 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.48"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 0.8 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.64"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 Pro 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 Pro 0.2 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.16"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 Pro 0.4 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.36"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 Pro 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 Pro 0.6 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.48"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 Pro 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 Pro 0.8 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.64"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 S1 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 S1 0.4 nozzle.json
@@ -76,6 +76,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.36"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 S1 Plus 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 S1 Plus 0.2 nozzle.json
@@ -77,6 +77,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.16"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 S1 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 S1 Plus 0.4 nozzle.json
@@ -77,6 +77,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.36"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 S1 Plus 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 S1 Plus 0.6 nozzle.json
@@ -77,6 +77,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.48"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 S1 Plus 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 S1 Plus 0.8 nozzle.json
@@ -78,6 +78,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.64"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 S1 Pro 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 S1 Pro 0.4 nozzle.json
@@ -76,6 +76,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.36"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 V2 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V2 0.4 nozzle.json
@@ -21,5 +21,9 @@
 	],
 	"printable_height": "250",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality Ender-3 V2 Neo 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V2 Neo 0.4 nozzle.json
@@ -79,6 +79,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"machine_start_gcode": "M220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nM140 S[bed_temperature_initial_layer_single] ;Set final bed temp\nM104 S[nozzle_temperature_initial_layer] ;Set final nozzle temp\n\nG28 ;Home\nG29 ;Auto bed leveling (create mesh if not already stored)\nM420 S1 ;Enable mesh leveling\n\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 X10.1 Y20 Z0.28 F5000.0 ;Move to start position\nM190 S[bed_temperature_initial_layer_single] ;Wait for bed temp to stabilize\nM109 S[nozzle_temperature_initial_layer] ;Wait for nozzle temp to stabilize\nG1 X10.1 Y145.0 Z0.28 F1500.0 E15 ;Draw the first line\nG1 X10.4 Y145.0 Z0.28 F5000.0 ;Move to side a little\nG1 X10.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line\nG92 E0  ;Reset Extruder\nG1 E-1.0000 F1800 ;Retract a bit\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 E0.0000 F1800",
 	"machine_end_gcode": "G91 ;Relative positionning\nG1 E-2 F2700 ;Retract a bit\nG1 E-2 Z0.2 F2400 ;Retract and raise Z\nG1 X5 Y5 F3000 ;Wipe out\nG1 Z10 ;Raise Z more\nG90 ;Absolute positionning\n\nG1 X0 Y0 ;Present print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\n\nM84 X Y E ;Disable all steppers but Z",
 	"thumbnails_format": "JPG",

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.2 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.1",
+		"0"
+	],
 	"max_layer_height": [
 		"0.16"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.4 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.1",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.6 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.1",
+		"0"
+	],
 	"max_layer_height": [
 		"0.48"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-3 V3 SE 0.8 nozzle.json
@@ -82,6 +82,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.1",
+		"0"
+	],
 	"max_layer_height": [
 		"0.64"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-5 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 0.4 nozzle.json
@@ -75,6 +75,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-5 Plus 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 Plus 0.4 nozzle.json
@@ -78,6 +78,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.15",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.2 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.2 nozzle.json
@@ -28,5 +28,9 @@
 	],
 	"printable_height": "300",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.25 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.25 nozzle.json
@@ -28,5 +28,9 @@
 	],
 	"printable_height": "300",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.3 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.3 nozzle.json
@@ -28,5 +28,9 @@
 	],
 	"printable_height": "300",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.4 nozzle.json
@@ -21,5 +21,9 @@
 	],
 	"printable_height": "300",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.5 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.5 nozzle.json
@@ -28,5 +28,9 @@
 	],
 	"printable_height": "300",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.6 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.6 nozzle.json
@@ -28,5 +28,9 @@
 	],
 	"printable_height": "300",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.8 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 0.8 nozzle.json
@@ -28,5 +28,9 @@
 	],
 	"printable_height": "300",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 1.0 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 Pro (2019) 1.0 nozzle.json
@@ -28,5 +28,9 @@
 	],
 	"printable_height": "300",
 	"nozzle_type": "undefine",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.08",
+		"0"
+	]
 }

--- a/resources/profiles/Creality/machine/Creality Ender-5 S1 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-5 S1 0.4 nozzle.json
@@ -75,6 +75,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Creality/machine/Creality Ender-6 0.4 nozzle.json
+++ b/resources/profiles/Creality/machine/Creality Ender-6 0.4 nozzle.json
@@ -75,6 +75,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.02",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Elegoo/machine/EN2SERIES/Elegoo Neptune 2 0.4 nozzle.json
+++ b/resources/profiles/Elegoo/machine/EN2SERIES/Elegoo Neptune 2 0.4 nozzle.json
@@ -63,6 +63,10 @@
 		"5",
 		"5"
 	],
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	],
 	"machine_max_jerk_x": [
 		"8",
 		"8"

--- a/resources/profiles/Folgertech/machine/Folgertech i3 0.4 nozzle.json
+++ b/resources/profiles/Folgertech/machine/Folgertech i3 0.4 nozzle.json
@@ -18,5 +18,9 @@
 	"printable_height": "175",
 	"nozzle_type": "undefine",
 	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.058",
+		"0"
+	],
 	"default_print_profile": "0.20mm Standard @FT"
 }

--- a/resources/profiles/Folgertech/machine/Folgertech i3 0.6 nozzle.json
+++ b/resources/profiles/Folgertech/machine/Folgertech i3 0.6 nozzle.json
@@ -19,5 +19,9 @@
 	"printable_height": "175",
 	"nozzle_type": "undefine",
 	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.058",
+		"0"
+	],
 	"default_print_profile": "0.30mm Standard @FT 0.6 Nozzle"
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A10 M 0.4 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A10 M 0.4 nozzle.json
@@ -48,5 +48,9 @@
 	"machine_start_gcode": ";Geeetech official wiki homepage for A10M: https://www.geeetech.com/wiki/index.php/Geeetech_A10M_3D_printer \nM104 S[nozzle_temperature_initial_layer] ; set extruder temp\nM140 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; set bed temp\nM190 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; wait for bed temp\nM109 S[nozzle_temperature_initial_layer] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nT[initial_no_support_extruder] ; Choose initial filament for the first line\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "{if max_layer_z < printable_height}G1 Z{z_offset+min(max_layer_z+2, printable_height)} F600 ; Move print head up{endif}\nG1 X5 Y{print_bed_max[1]*0.8} F{travel_speed*60} ; present print\n{if max_layer_z < printable_height-10}G1 Z{z_offset+min(max_layer_z+70, printable_height-10)} F600 ; Move print head further up{endif}\n{if max_layer_z < max_print_height*0.6}G1 Z{printable_height*0.6} F600 ; Move print head further up{endif}\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A10 Pro 0.2 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A10 Pro 0.2 nozzle.json
@@ -36,5 +36,9 @@
 	"machine_start_gcode": ";Geeetech official wiki homepage for A10: https://www.geeetech.com/wiki/index.php/Geeetech_A10_3D_Printer \nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "G1 E-2.5 F2100 ; Retract filament\nG92 E0.0\nG1{if max_layer_z < printable_height} Z{z_offset+min(max_layer_z+30, printable_height+0.2)}{endif} E-1.5 F720 ; Retract and raise Z\nG4 ; wait\nM104 S0 ; Cooldown hotend\nM140 S0 ; Cooldown bed\nM107 ; off fan\nG1 X0 Y100 F3000 ; park print head\nM84 ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A10 Pro 0.4 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A10 Pro 0.4 nozzle.json
@@ -36,5 +36,9 @@
 	"machine_start_gcode": ";Geeetech official wiki homepage for A10: https://www.geeetech.com/wiki/index.php/Geeetech_A10_3D_Printer \nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "G1 E-2.5 F2100 ; Retract filament\nG92 E0.0\nG1{if max_layer_z < printable_height} Z{z_offset+min(max_layer_z+30, printable_height+0.2)}{endif} E-1.5 F720 ; Retract and raise Z\nG4 ; wait\nM104 S0 ; Cooldown hotend\nM140 S0 ; Cooldown bed\nM107 ; off fan\nG1 X0 Y100 F3000 ; park print head\nM84 ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A10 Pro 0.6 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A10 Pro 0.6 nozzle.json
@@ -36,5 +36,9 @@
 	"machine_start_gcode": ";Geeetech official wiki homepage for A10: https://www.geeetech.com/wiki/index.php/Geeetech_A10_3D_Printer \nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "G1 E-2.5 F2100 ; Retract filament\nG92 E0.0\nG1{if max_layer_z < printable_height} Z{z_offset+min(max_layer_z+30, printable_height+0.2)}{endif} E-1.5 F720 ; Retract and raise Z\nG4 ; wait\nM104 S0 ; Cooldown hotend\nM140 S0 ; Cooldown bed\nM107 ; off fan\nG1 X0 Y100 F3000 ; park print head\nM84 ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A10 Pro 0.8 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A10 Pro 0.8 nozzle.json
@@ -36,5 +36,9 @@
 	"machine_start_gcode": ";Geeetech official wiki homepage for A10: https://www.geeetech.com/wiki/index.php/Geeetech_A10_3D_Printer \nM104 S[first_layer_temperature] ; set extruder temp\nM140 S[first_layer_bed_temperature] ; set bed temp\nM190 S[first_layer_bed_temperature] ; wait for bed temp\nM109 S[first_layer_temperature] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "G1 E-2.5 F2100 ; Retract filament\nG92 E0.0\nG1{if max_layer_z < printable_height} Z{z_offset+min(max_layer_z+30, printable_height+0.2)}{endif} E-1.5 F720 ; Retract and raise Z\nG4 ; wait\nM104 S0 ; Cooldown hotend\nM140 S0 ; Cooldown bed\nM107 ; off fan\nG1 X0 Y100 F3000 ; park print head\nM84 ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A10 T 0.4 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A10 T 0.4 nozzle.json
@@ -48,5 +48,9 @@
 	"machine_start_gcode": ";Custom Start G-code\nM104 S[nozzle_temperature_initial_layer] ; set extruder temp\nM140 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; set bed temp\nM190 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; wait for bed temp\nM109 S[nozzle_temperature_initial_layer] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nT[initial_no_support_extruder] ; Choose initial filament for the first line\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "{if max_layer_z < printable_height}G1 Z{z_offset+min(max_layer_z+2, printable_height)} F600 ; Move print head up{endif}\nG1 X5 Y{print_bed_max[1]*0.8} F{travel_speed*60} ; present print\n{if max_layer_z < printable_height-10}G1 Z{z_offset+min(max_layer_z+70, printable_height-10)} F600 ; Move print head further up{endif}\n{if max_layer_z < max_print_height*0.6}G1 Z{printable_height*0.6} F600 ; Move print head further up{endif}\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A20 0.2 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A20 0.2 nozzle.json
@@ -36,5 +36,9 @@
 	"machine_start_gcode": ";Geeetech official wiki homepage for A20: https://www.geeetech.com/wiki/index.php/Geeetech_A20_3D_printer \nM104 S[nozzle_temperature_initial_layer] ; set extruder temp\nM140 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; set bed temp\nM190 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; wait for bed temp\nM109 S[nozzle_temperature_initial_layer] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nT[initial_no_support_extruder] ; Choose initial filament for the first line\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "G1 E-2.5 F2100 ; Retract filament\nG92 E0.0\nG1{if max_layer_z < printable_height} Z{z_offset+min(max_layer_z+30, printable_height+0.2)}{endif} E-1.5 F720 ; Retract and raise Z\nG4 ; wait\nM104 S0 ; Cooldown hotend\nM140 S0 ; Cooldown bed\nM107 ; off fan\nG1 X0 Y100 F3000 ; park print head\nM84 ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A20 0.4 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A20 0.4 nozzle.json
@@ -36,5 +36,9 @@
 	"machine_start_gcode": ";Geeetech official wiki homepage for A20: https://www.geeetech.com/wiki/index.php/Geeetech_A20_3D_printer \nM104 S[nozzle_temperature_initial_layer] ; set extruder temp\nM140 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; set bed temp\nM190 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; wait for bed temp\nM109 S[nozzle_temperature_initial_layer] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nT[initial_no_support_extruder] ; Choose initial filament for the first line\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "G1 E-2.5 F2100 ; Retract filament\nG92 E0.0\nG1{if max_layer_z < printable_height} Z{z_offset+min(max_layer_z+30, printable_height+0.2)}{endif} E-1.5 F720 ; Retract and raise Z\nG4 ; wait\nM104 S0 ; Cooldown hotend\nM140 S0 ; Cooldown bed\nM107 ; off fan\nG1 X0 Y100 F3000 ; park print head\nM84 ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A20 0.6 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A20 0.6 nozzle.json
@@ -36,5 +36,9 @@
 	"machine_start_gcode": ";Geeetech official wiki homepage for A20: https://www.geeetech.com/wiki/index.php/Geeetech_A20_3D_printer \nM104 S[nozzle_temperature_initial_layer] ; set extruder temp\nM140 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; set bed temp\nM190 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; wait for bed temp\nM109 S[nozzle_temperature_initial_layer] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nT[initial_no_support_extruder] ; Choose initial filament for the first line\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "G1 E-2.5 F2100 ; Retract filament\nG92 E0.0\nG1{if max_layer_z < printable_height} Z{z_offset+min(max_layer_z+30, printable_height+0.2)}{endif} E-1.5 F720 ; Retract and raise Z\nG4 ; wait\nM104 S0 ; Cooldown hotend\nM140 S0 ; Cooldown bed\nM107 ; off fan\nG1 X0 Y100 F3000 ; park print head\nM84 ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A20 0.8 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A20 0.8 nozzle.json
@@ -36,5 +36,9 @@
 	"machine_start_gcode": ";Geeetech official wiki homepage for A20: https://www.geeetech.com/wiki/index.php/Geeetech_A20_3D_printer \nM104 S[nozzle_temperature_initial_layer] ; set extruder temp\nM140 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; set bed temp\nM190 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; wait for bed temp\nM109 S[nozzle_temperature_initial_layer] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nT[initial_no_support_extruder] ; Choose initial filament for the first line\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "G1 E-2.5 F2100 ; Retract filament\nG92 E0.0\nG1{if max_layer_z < printable_height} Z{z_offset+min(max_layer_z+30, printable_height+0.2)}{endif} E-1.5 F720 ; Retract and raise Z\nG4 ; wait\nM104 S0 ; Cooldown hotend\nM140 S0 ; Cooldown bed\nM107 ; off fan\nG1 X0 Y100 F3000 ; park print head\nM84 ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A20 M 0.4 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A20 M 0.4 nozzle.json
@@ -48,5 +48,9 @@
 	"machine_start_gcode": ";Geeetech official wiki homepage for A20M: https://www.geeetech.com/wiki/index.php/Geeetech_A20M_3D_printer \nM104 S[nozzle_temperature_initial_layer] ; set extruder temp\nM140 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; set bed temp\nM190 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; wait for bed temp\nM109 S[nozzle_temperature_initial_layer] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nT[initial_no_support_extruder] ; Choose initial filament for the first line\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "{if max_layer_z < printable_height}G1 Z{z_offset+min(max_layer_z+2, printable_height)} F600 ; Move print head up{endif}\nG1 X5 Y{print_bed_max[1]*0.8} F{travel_speed*60} ; present print\n{if max_layer_z < printable_height-10}G1 Z{z_offset+min(max_layer_z+70, printable_height-10)} F600 ; Move print head further up{endif}\n{if max_layer_z < max_print_height*0.6}G1 Z{printable_height*0.6} F600 ; Move print head further up{endif}\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A20 T 0.4 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A20 T 0.4 nozzle.json
@@ -48,5 +48,9 @@
 	"machine_start_gcode": ";Custom Start G-code\nM104 S[nozzle_temperature_initial_layer] ; set extruder temp\nM140 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; set bed temp\nM190 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; wait for bed temp\nM109 S[nozzle_temperature_initial_layer] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nT[initial_no_support_extruder] ; Choose initial filament for the first line\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "{if max_layer_z < printable_height}G1 Z{z_offset+min(max_layer_z+2, printable_height)} F600 ; Move print head up{endif}\nG1 X5 Y{print_bed_max[1]*0.8} F{travel_speed*60} ; present print\n{if max_layer_z < printable_height-10}G1 Z{z_offset+min(max_layer_z+70, printable_height-10)} F600 ; Move print head further up{endif}\n{if max_layer_z < max_print_height*0.6}G1 Z{printable_height*0.6} F600 ; Move print head further up{endif}\nM140 S0 ; turn off heatbed\nM104 S0 ; turn off temperature\nM107 ; turn off fan\nM84 X Y E ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.04",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A30 M 0.4 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A30 M 0.4 nozzle.json
@@ -48,5 +48,9 @@
 	"machine_start_gcode": ";Custom Start G-code\nM104 S[nozzle_temperature_initial_layer] ; set extruder temp\nM140 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; set bed temp\nM190 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; wait for bed temp\nM109 S[nozzle_temperature_initial_layer] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nT[initial_no_support_extruder] ; Choose initial filament for the first line\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "G1 E-2.5 F2100 ; Retract filament\nG92 E0.0\nG1{if max_layer_z < printable_height} Z{z_offset+min(max_layer_z+30, printable_height+0.2)}{endif} E-1.5 F720 ; Retract and raise Z\nG4 ; wait\nM104 S0 ; Cooldown hotend\nM140 S0 ; Cooldown bed\nM107 ; off fan\nG1 X0 Y100 F3000 ; park print head\nM84 ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	]
 }

--- a/resources/profiles/Geeetech/machine/Geeetech A30 T 0.4 nozzle.json
+++ b/resources/profiles/Geeetech/machine/Geeetech A30 T 0.4 nozzle.json
@@ -48,5 +48,9 @@
 	"machine_start_gcode": ";Custom Start G-code\nM104 S[nozzle_temperature_initial_layer] ; set extruder temp\nM140 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; set bed temp\nM190 S[bed_temperature_initial_layer[initial_no_support_extruder]] ; wait for bed temp\nM109 S[nozzle_temperature_initial_layer] ; wait for extruder temp\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nM107 ;Off Fan\nG1 Z5.0 F3000 ;Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z1.4 F6000 ; Move to start position\nT[initial_no_support_extruder] ; Choose initial filament for the first line\nG1 X0.1 Y80.0 Z1.4 F1000 E25 ; Draw the first line\nG92 E0 ; Reset Extruder\nG1 X0.4 Y80.0 Z1.4 F6000 ; Move to side a little\nG1 X1.4 Y20 Z1.4 F1000 E20 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.28 F3000.0 ; Move over to prevent blob squish\nG92 E0",
 	"machine_end_gcode": "G1 E-2.5 F2100 ; Retract filament\nG92 E0.0\nG1{if max_layer_z < printable_height} Z{z_offset+min(max_layer_z+30, printable_height+0.2)}{endif} E-1.5 F720 ; Retract and raise Z\nG4 ; wait\nM104 S0 ; Cooldown hotend\nM140 S0 ; Cooldown bed\nM107 ; off fan\nG1 X0 Y100 F3000 ; park print head\nM84 ; disable motors",
 	"nozzle_type": "brass",
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	]
 }

--- a/resources/profiles/Lulzbot/machine/Lulzbot Taz 4 or 5 0.5 nozzle.json
+++ b/resources/profiles/Lulzbot/machine/Lulzbot Taz 4 or 5 0.5 nozzle.json
@@ -76,6 +76,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.051",
+		"0"
+	],
 	"max_layer_height": [
 		"0.4"
 	],

--- a/resources/profiles/Prusa/machine/Prusa MK3S 0.25 nozzle.json
+++ b/resources/profiles/Prusa/machine/Prusa MK3S 0.25 nozzle.json
@@ -60,5 +60,9 @@
 	"thumbnails": [
 		"160x120"
 	],
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.02",
+		"0"
+	]
 }

--- a/resources/profiles/Prusa/machine/Prusa MK3S 0.4 nozzle.json
+++ b/resources/profiles/Prusa/machine/Prusa MK3S 0.4 nozzle.json
@@ -60,5 +60,9 @@
 	"thumbnails": [
 		"160x120"
 	],
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.02",
+		"0"
+	]
 }

--- a/resources/profiles/Prusa/machine/Prusa MK3S 0.6 nozzle.json
+++ b/resources/profiles/Prusa/machine/Prusa MK3S 0.6 nozzle.json
@@ -60,5 +60,9 @@
 	"thumbnails": [
 		"160x120"
 	],
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.02",
+		"0"
+	]
 }

--- a/resources/profiles/Prusa/machine/Prusa MK3S 0.8 nozzle.json
+++ b/resources/profiles/Prusa/machine/Prusa MK3S 0.8 nozzle.json
@@ -60,5 +60,9 @@
 	"thumbnails": [
 		"160x120"
 	],
-	"auxiliary_fan": "0"
+	"auxiliary_fan": "0",
+	"machine_max_junction_deviation": [
+		"0.02",
+		"0"
+	]
 }

--- a/resources/profiles/Sovol/machine/Sovol SV02 0.4 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV02 0.4 nozzle.json
@@ -84,6 +84,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.06",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32",
 		"0.32"

--- a/resources/profiles/Sovol/machine/Sovol SV05 0.4 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV05 0.4 nozzle.json
@@ -75,6 +75,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.32"
 	],

--- a/resources/profiles/Sovol/machine/Sovol SV06 Plus 0.4 nozzle.json
+++ b/resources/profiles/Sovol/machine/Sovol SV06 Plus 0.4 nozzle.json
@@ -75,6 +75,10 @@
 		"2",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.06",
+		"0"
+	],
 	"max_layer_height": [
 		"0.25"
 	],

--- a/resources/profiles/UltiMaker/machine/UltiMaker 2 0.4 nozzle.json
+++ b/resources/profiles/UltiMaker/machine/UltiMaker 2 0.4 nozzle.json
@@ -75,6 +75,10 @@
 		"0.4",
 		"0.4"
 	],
+	"machine_max_junction_deviation": [
+		"0.013",
+		"0"
+	],
 	"max_layer_height": [
 		"0.3"
 	],

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3063,7 +3063,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Marlin Firmware Junction Deviation (replaces the traditional XY Jerk setting).");
     def->sidetext = L("mm");	// milimeters, CIS languages need translation
     def->min = 0.f;
-    def->max = 0.5f;
+    def->max = 0.3f;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloat(0.f));
 
@@ -4218,7 +4218,7 @@ void PrintConfigDef::init_fff_params()
     def->tooltip = L("Maximum junction deviation (M205 J, only apply if JD > 0 for Marlin Firmware\nIf your Marlin 2 printer uses Classic Jerk set this value to 0.)");
     def->sidetext = L("mm");	// milimeters, CIS languages need translation
     def->min = 0.f;
-    def->max = 0.5f;
+    def->max = 0.3f;
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionFloats{ 0.01f });
 


### PR DESCRIPTION
Closes #13213
The main goal here was to load proper JD values from https://github.com/MarlinFirmware/Configurations.
Did it manually and if a conflict between boards was present i used the lowest value.
Also for Ender 3V3 SE used the official repo reference https://github.com/CrealityOfficial/Ender-3V3-SE
It uses a high value (0.1) but it seams to be due some kind of issue.
Max value limited to 0.3 due https://github.com/MarlinFirmware/Marlin/blob/26b3f0b0/Marlin/src/gcode/config/M200-M205.cpp#L308-L316

Current default for Marlin2 printers is 0.01 while Marlin base profile is 0.013.
Still there are a lot of 0.08 profiles so keeping it at 0.01 should be ok unless some extraordinary cases like the E3V3SE.
