### PR TITLE
Fix crash when selecting or moving wipe tower

### DIFF
--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -600,7 +600,9 @@ void Selection::set_printable(bool printable)
 }
 
 bool Selection::get_auto_drop() const {
-    if (!m_valid)
+    // The wipe tower is not a ModelObject and has no per-instance auto_drop;
+    // return the default to avoid indexing m_model->objects with its synthetic id.
+    if (!m_valid || is_wipe_tower())
         return true;
 
     std::set<std::pair<int, int>> instances_idxs;


### PR DESCRIPTION
# Description

Selecting or dragging the wipe tower crashes OrcaSlicer on current `main` (regression from #11801, merged 2026-04-15).

`Selection::get_auto_drop()` iterates `m_cache.content` and does `m_model->objects[obj_idx]`. The wipe tower has a synthetic `obj_idx = 1000 + plate_idx`, which is out of range for `m_model->objects`, so the lookup returns a garbage pointer and the next field dereference segfaults. `Selection::render()` calls `get_auto_drop()` every idle frame, so the crash fires as soon as the wipe tower is selected.

Fix: early-return the default (`true`) from `get_auto_drop()` when the selection is a wipe tower, before the `m_model->objects` lookup. A wipe-tower selection is always a pure single-volume selection (enforced at `Selection.cpp:167`, `175`, `2315`), so `is_wipe_tower()` is sufficient. The wipe tower has no `ModelInstance::auto_drop`, so returning the default matches the intended semantics.

Stack trace:
```
0  Slic3r::GUI::Selection::get_auto_drop() const
1  Slic3r::GUI::Selection::render(float)
2  Slic3r::GUI::GLCanvas3D::render(bool)
3  Slic3r::GUI::GLCanvas3D::on_idle(wxIdleEvent&)
```

No breaking changes. No new dependencies.

# Screenshots/Recordings/Graphs

N/A

## Tests

Tested manually on macOS arm64:

- Select the wipe tower — no crash
- Drag the wipe tower with the Move gizmo — no crash, moves freely
- Select a regular object and toggle auto-drop off via context menu — bounding-box arrow indicator from #11801 still renders correctly (feature preserved for `ModelObject` instances)
- Slice after selecting/moving the wipe tower — normal output
