### PR TITLE
CalibUtils: Center mesh models

### DIFF
--- a/src/slic3r/Utils/CalibUtils.cpp
+++ b/src/slic3r/Utils/CalibUtils.cpp
@@ -458,8 +458,14 @@ static void read_model_from_file(const std::string& input_file, Model& model)
         &is_bbl_3mf, &file_version, nullptr, nullptr, nullptr, plate_to_slice);
 
     model.add_default_instances();
-    for (auto object : model.objects)
-        object->ensure_on_bed();
+
+    const std::string extension      = fs::path(input_file).extension().string();
+    const bool        is_project_file = extension == ".3mf" || extension == ".3MF" || extension == ".amf" || extension == ".AMF";
+    for (auto object : model.objects) {
+        if (!is_project_file)
+            object->center_around_origin(false);
+        object->ensure_on_bed(is_project_file);
+    }
 }
 
 std::array<Vec3d, 4> get_cut_plane_points(const BoundingBoxf3 &bbox, const double &cut_height)


### PR DESCRIPTION
Closes #12645 
For non-project files, objects are centered around the origin and then placed on the bed as before. The call to ensure_on_bed now receives a flag indicating whether the file is a project, allowing different placement behavior. When reading a model file, detect project file extensions (.3mf/.amf, case-insensitive) and avoid re-centering those objects so their scene placement is preserved.