### PR TITLE
WipeTower move crash fix w more filaments than physical tools

### DIFF
--- a/src/slic3r/GUI/Selection.cpp
+++ b/src/slic3r/GUI/Selection.cpp
@@ -34,6 +34,66 @@ static const Slic3r::ColorRGBA TRANSPARENT_PLANE_COLOR = { 0.8f, 0.8f, 0.8f, 0.5
 namespace Slic3r {
 namespace GUI {
 
+namespace {
+
+constexpr int WIPE_TOWER_OBJECT_IDX_BASE = 1000;
+
+bool is_wipe_tower_proxy_object_idx(int obj_idx)
+{
+    Plater *plater = wxGetApp().plater();
+    if (plater == nullptr)
+        return false;
+
+    const int plate_count = plater->get_partplate_list().get_plate_count();
+    return obj_idx >= WIPE_TOWER_OBJECT_IDX_BASE && obj_idx < WIPE_TOWER_OBJECT_IDX_BASE + plate_count;
+}
+
+ModelObject *checked_model_object(Model *model, int obj_idx, const char *caller)
+{
+    if (model == nullptr) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection has no model";
+        return nullptr;
+    }
+
+    if (obj_idx < 0 || size_t(obj_idx) >= model->objects.size()) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection references invalid object index " << obj_idx
+                                 << " while model contains " << model->objects.size() << " objects";
+        return nullptr;
+    }
+
+    ModelObject *object = model->objects[obj_idx];
+    if (object == nullptr) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection references null object at index " << obj_idx;
+        return nullptr;
+    }
+
+    return object;
+}
+
+const ModelObject *checked_model_object(const Model *model, int obj_idx, const char *caller)
+{
+    if (model == nullptr) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection has no model";
+        return nullptr;
+    }
+
+    if (obj_idx < 0 || size_t(obj_idx) >= model->objects.size()) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection references invalid object index " << obj_idx
+                                 << " while model contains " << model->objects.size() << " objects";
+        return nullptr;
+    }
+
+    const ModelObject *object = model->objects[obj_idx];
+    if (object == nullptr) {
+        BOOST_LOG_TRIVIAL(error) << caller << ": selection references null object at index " << obj_idx;
+        return nullptr;
+    }
+
+    return object;
+}
+
+} // namespace
+
 Selection::VolumeCache::TransformCache::TransformCache()
     : position(Vec3d::Zero())
     , rotation_matrix(Transform3d::Identity())
@@ -586,7 +646,11 @@ void Selection::set_printable(bool printable)
     // set printable value for all instances in object
     for (const auto& [obj_idx, inst_idx] : instances_idxs)
     {
-        ModelObject* object = m_model->objects[obj_idx];
+        if (is_wipe_tower_proxy_object_idx(obj_idx))
+            continue;
+        ModelObject* object = checked_model_object(m_model, obj_idx, __FUNCTION__);
+        if (object == nullptr)
+            continue;
         for (auto inst : object->instances)
             inst->printable = printable;
         wxGetApp().obj_list()->update_printable_state(obj_idx, inst_idx);
@@ -612,7 +676,11 @@ bool Selection::get_auto_drop() const {
 
     // return false, if one of the instances in the selection has auto_drop disabled, otherwise return true
     for (const auto& [obj_idx, inst_idx] : instances_idxs) {
-        ModelObject* object = m_model->objects[obj_idx];
+        if (is_wipe_tower_proxy_object_idx(obj_idx))
+            continue;
+        const ModelObject* object = checked_model_object(m_model, obj_idx, __FUNCTION__);
+        if (object == nullptr)
+            return false;
         for (const auto* inst : object->instances) {
             if (!inst->auto_drop) {
                 return false;
@@ -640,7 +708,11 @@ void Selection::set_auto_drop(bool enabled)
 
     // set auto_drop value for all instances in object
     for (const auto& [obj_idx, inst_idx] : instances_idxs) {
-        ModelObject* object = m_model->objects[obj_idx];
+        if (is_wipe_tower_proxy_object_idx(obj_idx))
+            continue;
+        ModelObject* object = checked_model_object(m_model, obj_idx, __FUNCTION__);
+        if (object == nullptr)
+            continue;
         for (auto* inst : object->instances) {
             inst->auto_drop = enabled;
         }
@@ -2290,6 +2362,10 @@ void Selection::update_type()
         const GLVolume* volume = (*m_volumes)[i];
         int obj_idx = volume->object_idx();
         int inst_idx = volume->instance_idx();
+        if (!volume->is_wipe_tower && checked_model_object(m_model, obj_idx, __FUNCTION__) == nullptr) {
+            m_type = Invalid;
+            return;
+        }
         ObjectIdxsToInstanceIdxsMap::iterator obj_it = m_cache.content.find(obj_idx);
         if (obj_it == m_cache.content.end())
             obj_it = m_cache.content.insert(ObjectIdxsToInstanceIdxsMap::value_type(obj_idx, InstanceIdxsList())).first;
@@ -2317,7 +2393,11 @@ void Selection::update_type()
             }
             else
             {
-                const ModelObject* model_object = m_model->objects[first->object_idx()];
+                const ModelObject* model_object = checked_model_object(m_model, first->object_idx(), __FUNCTION__);
+                if (model_object == nullptr) {
+                    m_type = Invalid;
+                    return;
+                }
                 unsigned int volumes_count = (unsigned int)model_object->volumes.size();
                 unsigned int instances_count = (unsigned int)model_object->instances.size();
                 if (volumes_count * instances_count == 1)
@@ -2350,7 +2430,11 @@ void Selection::update_type()
 
             if (m_cache.content.size() == 1) // single object
             {
-                const ModelObject* model_object = m_model->objects[m_cache.content.begin()->first];
+                const ModelObject* model_object = checked_model_object(m_model, m_cache.content.begin()->first, __FUNCTION__);
+                if (model_object == nullptr) {
+                    m_type = Invalid;
+                    return;
+                }
                 unsigned int model_volumes_count = (unsigned int)model_object->volumes.size();
 
                 unsigned int instances_count = (unsigned int)model_object->instances.size();


### PR DESCRIPTION
# Description

Unfortunately  I cannot share the 3mf this time to reproduce the bug as it is a model from Patreon.

In short: 
- Opened 3mf file from BambuStudio with 7 filaments which is the culprit because see next point
- Me has Snapmaker U1 tool changer machine profile with **4 physical tools**. 
- Moving the WipeTower on the build plate causes a crash

## Example screenshot:

<img width="2052" height="1267" alt="Screenshot 2026-04-17 at 10 38 27" src="https://github.com/user-attachments/assets/5506b587-8a99-4750-a2d9-58165b52df34" />

## Error output
lldb error:
Process 61666 stopped
* thread # 1, name = 'orcaslicer_main', queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x58)
    frame #0: 0x00000001015087fc OrcaSlicerSlic3r::GUI::Selection::get_auto_drop() const + 896
OrcaSlicerSlic3r::GUI::Selection::get_auto_drop:
->  0x1015087fc <+896>: ldp    x9, x10, [x10, #0x58]
    0x101508800 <+900>: cmp    x9, x10
    0x101508804 <+904>: b.eq   0x101508844    ; <+968>
    0x101508808 <+908>: sub    x11, x10, x9
Target 0: (OrcaSlicer) stopped.

macOS logs showed a segfault error

## "Fix"

I'd call this a dirty fix as it only causes Orca not to crash but does not fix the root cause. Basically we now guard stale selection object lookups and explicitly skip the virtual wipe tower proxy entries, so the invalid selection state no longer dereferences a non existent ModelObject.

I'd like to share it anyways as I use this now so I can slice my Charmander :D




