### PR TITLE
Restrict label bot to external PRs

### DIFF
--- a/.github/workflows/pr-label-bot.yml
+++ b/.github/workflows/pr-label-bot.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   request-label:
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && github.event.pull_request.author_association != 'MEMBER'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Update .github/workflows/pr-label-bot.yml to add author_association checks so the request-label job only runs for pull_request_target events where the PR author is not COLLABORATOR, OWNER, or MEMBER.
This prevents the labeling job from running on PRs created by repo members/maintainers and limits the action to external contributors.