### PR TITLE
关掉减小填充回抽功能

### DIFF
--- a/resources/profiles/Qidi/process/0.12mm Fine @Qidi X3.json
+++ b/resources/profiles/Qidi/process/0.12mm Fine @Qidi X3.json
@@ -35,7 +35,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.12mm Fine @Qidi XCFPro.json
+++ b/resources/profiles/Qidi/process/0.12mm Fine @Qidi XCFPro.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.12mm Fine @Qidi XMax.json
+++ b/resources/profiles/Qidi/process/0.12mm Fine @Qidi XMax.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.12mm Fine @Qidi XPlus.json
+++ b/resources/profiles/Qidi/process/0.12mm Fine @Qidi XPlus.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.16mm Optimal @Qidi X3.json
+++ b/resources/profiles/Qidi/process/0.16mm Optimal @Qidi X3.json
@@ -32,7 +32,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.16mm Optimal @Qidi XCFPro.json
+++ b/resources/profiles/Qidi/process/0.16mm Optimal @Qidi XCFPro.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.16mm Optimal @Qidi XMax.json
+++ b/resources/profiles/Qidi/process/0.16mm Optimal @Qidi XMax.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.16mm Optimal @Qidi XPlus.json
+++ b/resources/profiles/Qidi/process/0.16mm Optimal @Qidi XPlus.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.20mm Standard @Qidi XCFPro.json
+++ b/resources/profiles/Qidi/process/0.20mm Standard @Qidi XCFPro.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.20mm Standard @Qidi XMax.json
+++ b/resources/profiles/Qidi/process/0.20mm Standard @Qidi XMax.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.20mm Standard @Qidi XPlus.json
+++ b/resources/profiles/Qidi/process/0.20mm Standard @Qidi XPlus.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.24mm Draft @Qidi X3.json
+++ b/resources/profiles/Qidi/process/0.24mm Draft @Qidi X3.json
@@ -30,7 +30,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi Q1 Pro.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi Q1 Pro.json
@@ -35,7 +35,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi Q2.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi Q2.json
@@ -36,7 +36,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi Q2C.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi Q2C.json
@@ -36,7 +36,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi XCFPro.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi XCFPro.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi XMax.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi XMax.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi XMax3.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi XMax3.json
@@ -35,7 +35,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi XPlus.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi XPlus.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi XPlus3.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi XPlus3.json
@@ -35,7 +35,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi XPlus4.json
@@ -36,7 +36,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.25mm Draft @Qidi XSmart3.json
+++ b/resources/profiles/Qidi/process/0.25mm Draft @Qidi XSmart3.json
@@ -35,7 +35,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.28mm Extra Draft @Qidi X3.json
+++ b/resources/profiles/Qidi/process/0.28mm Extra Draft @Qidi X3.json
@@ -30,7 +30,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi Q1 Pro.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi Q1 Pro.json
@@ -35,7 +35,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi Q2.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi Q2.json
@@ -36,7 +36,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi Q2C.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi Q2C.json
@@ -36,7 +36,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XCFPro.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XCFPro.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XMax.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XMax.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XMax3.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XMax3.json
@@ -35,7 +35,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XPlus.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XPlus.json
@@ -43,7 +43,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XPlus3.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XPlus3.json
@@ -35,7 +35,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XPlus4.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XPlus4.json
@@ -36,7 +36,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XSmart3.json
+++ b/resources/profiles/Qidi/process/0.30mm Extra Draft @Qidi XSmart3.json
@@ -35,7 +35,7 @@
 	"ironing_flow": "15%",
 	"ironing_spacing": "0.1",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/fdm_process_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_common.json
@@ -44,7 +44,7 @@
 	"sparse_infill_speed": "50",
 	"interface_shells": "0",
 	"detect_overhang_wall": "0",
-	"reduce_infill_retraction": "0",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{print_time}.gcode",
 	"wall_loops": "2",
 	"inner_wall_line_width": "0.45",

--- a/resources/profiles/Qidi/process/fdm_process_n_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_n_common.json
@@ -116,7 +116,7 @@
 	"print_settings_id": "",
 	"raft_layers": "0",
 	"reduce_crossing_wall": "0",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"resolution": "0.012",
 	"seam_position": "aligned",
 	"seam_placement_away_from_overhangs": "0",

--- a/resources/profiles/Qidi/process/fdm_process_qidi_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_qidi_common.json
@@ -41,7 +41,7 @@
 	"ironing_spacing": "0.1",
 	"ironing_speed": "15",
 	"ironing_type": "no ironing",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[initial_tool]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",

--- a/resources/profiles/Qidi/process/fdm_process_qidi_x3_common.json
+++ b/resources/profiles/Qidi/process/fdm_process_qidi_x3_common.json
@@ -62,7 +62,7 @@
 	"ironing_speed": "30",
 	"ironing_type": "no ironing",
 	"layer_height": "0.2",
-	"reduce_infill_retraction": "1",
+	"reduce_infill_retraction": "false",
 	"filename_format": "{input_filename_base}_{filament_type[0]}_{print_time}.gcode",
 	"detect_overhang_wall": "1",
 	"overhang_1_4_speed": "0",


### PR DESCRIPTION
关掉减小填充回抽功能，防止打印大模型时，喷嘴可能撞到填充导致偏移