### PR TITLE
PR #11674 follow-up - toggle first layer accel&jerk

### DIFF
--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -667,7 +667,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
 
     bool have_default_acceleration = config->opt_float("default_acceleration") > 0;
 
-    for (auto el : {"outer_wall_acceleration", "inner_wall_acceleration", "initial_layer_acceleration",
+    for (auto el : {"outer_wall_acceleration", "inner_wall_acceleration", "initial_layer_acceleration", "initial_layer_travel_acceleration",
         "top_surface_acceleration", "travel_acceleration", "bridge_acceleration", "sparse_infill_acceleration", "internal_solid_infill_acceleration"})
         toggle_field(el, have_default_acceleration);
 
@@ -681,13 +681,13 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig *config, co
     if (machine_supports_junction_deviation) {
         toggle_field("default_junction_deviation", true);
         toggle_field("default_jerk", false);
-        for (auto el : { "outer_wall_jerk", "inner_wall_jerk", "initial_layer_jerk", "top_surface_jerk", "travel_jerk", "infill_jerk"})
-        toggle_line(el, false);
+        for (auto el : { "outer_wall_jerk", "inner_wall_jerk", "initial_layer_jerk", "initial_layer_travel_jerk", "top_surface_jerk", "travel_jerk", "infill_jerk"})
+            toggle_line(el, false);
     } else {
         toggle_field("default_junction_deviation", false);
         toggle_field("default_jerk", true);
         bool have_default_jerk = config->has("default_jerk") && config->opt_float("default_jerk") > 0;
-        for (auto el : { "outer_wall_jerk", "inner_wall_jerk", "initial_layer_jerk", "top_surface_jerk", "travel_jerk", "infill_jerk"}) {
+        for (auto el : { "outer_wall_jerk", "inner_wall_jerk", "initial_layer_jerk", "initial_layer_travel_jerk", "top_surface_jerk", "travel_jerk", "infill_jerk"}) {
             toggle_line(el, true);
             toggle_field(el, have_default_jerk);
         }


### PR DESCRIPTION
### **Summary**

This follows up on **#11674** by extending the toggle logic to also cover the **first layer travel acceleration and jerk** settings.

These were previously missing from the grouped handling, so they did not follow the same enable/disable behavior as the rest of the first layer motion settings.

---

### **Details**

- Include **first layer travel acceleration** in the acceleration toggle group  
- Include **first layer travel jerk** in the jerk toggle group (both **junction deviation** and **classic jerk** paths)

---

### **Rationale**

Without this, the UI could end up in a **partially toggled state**, where most first layer settings were disabled, but the corresponding travel settings remained active and editable.

This aligns the behavior across all first layer motion settings and avoids exposing values that are effectively inactive.

---

### Screenshots

_______________________ **Before** ___________________________________________________________________ **After** _______________________

<img width="1245" height="1282" alt="image" src="https://github.com/user-attachments/assets/56a6cab2-7f10-4e48-958d-1f4c7666c978" />
